### PR TITLE
fix(cua-driver): fail autostart enable when the UAC prompt is declined

### DIFF
--- a/.github/workflows/ci-rust-windows.yml
+++ b/.github/workflows/ci-rust-windows.yml
@@ -93,6 +93,13 @@ jobs:
       - name: Run Windows app-name lookup tests
         working-directory: libs/cua-driver/rust
         run: "cargo test -p platform-windows launch_uwp::tests:: --lib --locked"
+      - name: Run autostart registration and self-elevation tests
+        # The elevation tests drive the shipped PowerShell against a stubbed
+        # Start-Process, so they prove the exit-code contract (a declined UAC
+        # prompt must not exit 0 — trycua/cua#3179) without any real UAC
+        # prompt or an interactive desktop.
+        working-directory: libs/cua-driver/rust
+        run: "cargo test -p cua-driver --bin cua-driver autostart::tests:: --locked"
       - name: Prove unknown app launch stays bounded and responsive
         working-directory: libs/cua-driver/rust
         run: "cargo test -p cua-driver --test protocol_tools_call_test launch_unknown_app_is_bounded_and_keeps_mcp_session_responsive --locked -- --exact --nocapture"

--- a/libs/cua-driver/rust/crates/cua-driver/src/autostart.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/autostart.rs
@@ -91,6 +91,35 @@ const HRESULT_FILE_NOT_FOUND: u32 = 0x8007_0002;
 #[cfg(any(target_os = "windows", test))]
 const HRESULT_ACCESS_DENIED: u32 = 0x8007_0005;
 
+/// What a post-registration Task Scheduler query proves about `enable()`.
+///
+/// `enable()` used to report success whenever the elevation helper exited 0,
+/// and a declined UAC prompt exited 0 (#3179). Verifying the task independently
+/// of the exit code keeps that class of regression from surfacing as success
+/// again — but a query that cannot be answered must not be turned into a false
+/// failure either, hence the third variant.
+#[cfg(any(target_os = "windows", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RegistrationCheck {
+    /// The task exists: registration really happened.
+    Confirmed,
+    /// Task Scheduler answered, and the task is not there.
+    Missing,
+    /// Task Scheduler could not be inspected; neither prove nor disprove.
+    Unverifiable,
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn classify_registration_check(outcome: TaskQueryOutcome) -> RegistrationCheck {
+    match outcome {
+        TaskQueryOutcome::Registered => RegistrationCheck::Confirmed,
+        TaskQueryOutcome::NotRegistered => RegistrationCheck::Missing,
+        TaskQueryOutcome::PermissionDenied | TaskQueryOutcome::Unknown => {
+            RegistrationCheck::Unverifiable
+        }
+    }
+}
+
 #[cfg(any(target_os = "windows", test))]
 fn classify_task_query(success: bool, exit_code: Option<i32>) -> TaskQueryOutcome {
     if success {
@@ -184,6 +213,58 @@ fn starts_with_drive_letter(path: &str) -> bool {
     matches!(path.as_bytes(), [drive, b':', ..] if drive.is_ascii_alphabetic())
 }
 
+// ── Windows self-elevation helper script ──────────────────────────────────
+
+/// PowerShell that re-launches this executable elevated (UAC) and forwards the
+/// elevated child's exit code.
+///
+/// **Every failure path must exit non-zero.** The original one-liner was
+/// `$p = Start-Process ... -Verb RunAs -Wait -PassThru; exit $p.ExitCode`.
+/// A declined UAC prompt makes `Start-Process` raise a *non-terminating*
+/// error, so `$p` stayed unset, `$null.ExitCode` was `$null`, and `exit $null`
+/// exits **0** — a dismissed prompt was reported as a registered autostart
+/// entry (#3179). Two independent guards now cover that:
+///
+/// 1. `-ErrorAction Stop` promotes the declined-UAC error to a terminating one
+///    so the `catch` runs and exits 1.
+/// 2. The explicit `$null` check, because `exit $null` silently meaning
+///    `exit 0` is precisely the trap that produced the bug. It also covers a
+///    process object that came back without an exit code.
+///
+/// `__INNER_COMMAND__` is substituted with the single-quoted PowerShell string
+/// holding the elevated child's `-Command` argument.
+#[cfg(any(target_os = "windows", test))]
+const ELEVATE_PS: &str = r#"
+$p = $null
+try {
+    $p = Start-Process -FilePath 'powershell.exe' -ArgumentList @('-NoProfile','-NonInteractive','-Command',__INNER_COMMAND__) -Verb RunAs -Wait -PassThru -ErrorAction Stop
+} catch {
+    [Console]::Error.WriteLine("cua-driver: UAC elevation for autostart registration failed: " + $_.Exception.Message)
+    exit 1
+}
+if ($null -eq $p -or $null -eq $p.ExitCode) {
+    [Console]::Error.WriteLine("cua-driver: UAC elevation for autostart registration returned no process.")
+    exit 1
+}
+exit $p.ExitCode
+"#;
+
+/// Build the self-elevation script for `exe`.
+///
+/// The elevated child runs `<exe> autostart enable` so the registration happens
+/// inside the elevated process, where the first (direct) attempt succeeds and
+/// does not re-enter the elevation branch.
+#[cfg(any(target_os = "windows", test))]
+fn elevation_script(exe: &str) -> String {
+    // `& "<exe>" autostart enable` — PowerShell escapes `"` as `` `" `` inside
+    // a double-quoted string.
+    let inner = format!("& \"{}\" autostart enable", exe.replace('"', "`\""));
+    // Embed that as a single-quoted PowerShell string (PS escapes `'` as `''`
+    // inside `'`-strings).
+    let inner_quoted = format!("'{}'", inner.replace('\'', "''"));
+    ELEVATE_PS.replace("__INNER_COMMAND__", &inner_quoted)
+}
+
 // ── Windows impl ──────────────────────────────────────────────────────────
 
 #[cfg(target_os = "windows")]
@@ -273,7 +354,7 @@ Register-ScheduledTask -TaskName $env:CUA_DRIVER_AS_TASK -Action $action -Trigge
             .output()
             .map_err(|e| anyhow!("failed to invoke powershell: {e}"))?;
         if out.status.success() {
-            return Ok(());
+            return confirm_registered();
         }
 
         let stderr = String::from_utf8_lossy(&out.stderr);
@@ -306,19 +387,10 @@ Register-ScheduledTask -TaskName $env:CUA_DRIVER_AS_TASK -Action $action -Trigge
             // via Start-Process -Verb RunAs's WindowStyle Hidden.
             const CREATE_NO_WINDOW: u32 = 0x08000000;
 
-            // PowerShell incantation: Start-Process -Verb RunAs to elevate,
-            // run our own exe with `autostart enable` so the registration
-            // happens INSIDE the elevated process (where it'll succeed on
-            // the first attempt and not re-enter this branch). -Wait so we
-            // can capture the child's exit code.
-            let inner = format!("& \"{}\" autostart enable", exe.replace('"', "`\""));
-            let outer = format!(
-                "$p = Start-Process -FilePath '{}' -ArgumentList @('-NoProfile','-NonInteractive','-Command',{}) -Verb RunAs -Wait -PassThru; exit $p.ExitCode",
-                "powershell.exe",
-                // Embed the inner command as a single-quoted PowerShell string
-                // (PS escapes ' as '' inside ''-strings).
-                format!("'{}'", inner.replace('\'', "''"))
-            );
+            // Start-Process -Verb RunAs elevates; -Wait so we can capture the
+            // child's exit code. See `ELEVATE_PS` for why every failure path
+            // there has to exit non-zero.
+            let outer = elevation_script(exe);
             Command::new("powershell")
                 .args(["-NoProfile", "-NonInteractive", "-Command", &outer])
                 .creation_flags(CREATE_NO_WINDOW)
@@ -327,7 +399,7 @@ Register-ScheduledTask -TaskName $env:CUA_DRIVER_AS_TASK -Action $action -Trigge
         };
 
         if elevated_status.success() {
-            Ok(())
+            confirm_registered()
         } else {
             Err(anyhow!(
                 "self-elevation for autostart registration failed (exit {}). The UAC \
@@ -336,6 +408,81 @@ Register-ScheduledTask -TaskName $env:CUA_DRIVER_AS_TASK -Action $action -Trigge
                  same self-elevation flow. See https://github.com/trycua/cua/issues/1602.",
                 elevated_status.code().unwrap_or(-1)
             ))
+        }
+    }
+
+    /// Result of one `schtasks /Query` against the autostart task.
+    struct TaskQuery {
+        outcome: TaskQueryOutcome,
+        exit_code: Option<i32>,
+        diagnostic: String,
+    }
+
+    /// Ask Task Scheduler whether the autostart task exists.
+    ///
+    /// Without `/HRESULT`, schtasks collapses "task not found", permission
+    /// failures, and other Task Scheduler errors to exit 1. `/HRESULT` keeps
+    /// those cases distinct and is locale-independent: ERROR_FILE_NOT_FOUND
+    /// means the named task is absent, while ERROR_PATH_NOT_FOUND means the
+    /// scheduler namespace could not be inspected and therefore stays unknown.
+    fn query_task() -> Result<TaskQuery> {
+        let out = Command::new("schtasks")
+            .args(["/Query", "/TN", task_name(), "/HRESULT"])
+            .output()
+            .map_err(|e| anyhow!("failed to invoke schtasks: {e}"))?;
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let diagnostic = match (stdout.trim(), stderr.trim()) {
+            ("", "") => "no diagnostic output".to_owned(),
+            (stdout, "") => stdout.to_owned(),
+            ("", stderr) => stderr.to_owned(),
+            (stdout, stderr) => format!("{stdout}\n{stderr}"),
+        };
+        Ok(TaskQuery {
+            outcome: classify_task_query(out.status.success(), out.status.code()),
+            exit_code: out.status.code(),
+            diagnostic,
+        })
+    }
+
+    /// Postcondition for `enable`: the task has to actually exist afterwards.
+    ///
+    /// Reporting success is a promise that `cua-driver serve` will come up at
+    /// the next logon, and until #3179 that promise rested entirely on the exit
+    /// code of the elevation helper — which a declined UAC prompt left at 0.
+    /// Asking Task Scheduler directly makes the promise independent of the
+    /// exit-code plumbing. A query that cannot be answered (permission denied,
+    /// scheduler unreachable) is reported as unverified rather than converted
+    /// into a failure: registration may well have succeeded, and a false
+    /// negative here is its own kind of misleading.
+    fn confirm_registered() -> Result<()> {
+        let query = match query_task() {
+            Ok(query) => query,
+            Err(e) => {
+                eprintln!("cua-driver: could not verify autostart registration: {e}");
+                return Ok(());
+            }
+        };
+        match classify_registration_check(query.outcome) {
+            RegistrationCheck::Confirmed => Ok(()),
+            RegistrationCheck::Missing => Err(anyhow!(
+                "autostart registration reported success but scheduled task '{}' does not \
+                 exist. If a UAC prompt appeared, it was dismissed or the elevated \
+                 registration failed. Re-run `{} autostart enable` from an elevated shell. \
+                 See https://github.com/trycua/cua/issues/3179.",
+                task_name(),
+                crate::bundle::cli_name()
+            )),
+            RegistrationCheck::Unverifiable => {
+                eprintln!(
+                    "cua-driver: registered autostart task '{}' but could not verify it with \
+                     schtasks: {}",
+                    task_name(),
+                    query.diagnostic
+                );
+                Ok(())
+            }
         }
     }
 
@@ -379,20 +526,8 @@ Register-ScheduledTask -TaskName $env:CUA_DRIVER_AS_TASK -Action $action -Trigge
     }
 
     pub fn status() -> Result<Status> {
-        // Without /HRESULT, schtasks collapses "task not found", permission
-        // failures, and other Task Scheduler errors to exit 1. /HRESULT keeps
-        // those cases distinct and is locale-independent: ERROR_FILE_NOT_FOUND
-        // means the named task is absent, while ERROR_PATH_NOT_FOUND means the
-        // scheduler namespace could not be inspected and therefore stays
-        // unknown.
-        let out = Command::new("schtasks")
-            .args(["/Query", "/TN", task_name(), "/HRESULT"])
-            .output()
-            .map_err(|e| anyhow!("unknown: failed to invoke schtasks: {e}"))?;
-
-        let stdout = String::from_utf8_lossy(&out.stdout);
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        match classify_task_query(out.status.success(), out.status.code()) {
+        let query = query_task().map_err(|e| anyhow!("unknown: {e}"))?;
+        match query.outcome {
             TaskQueryOutcome::Registered => {}
             TaskQueryOutcome::NotRegistered => return Ok(Status::NotRegistered),
             outcome @ (TaskQueryOutcome::PermissionDenied | TaskQueryOutcome::Unknown) => {
@@ -401,15 +536,9 @@ Register-ScheduledTask -TaskName $env:CUA_DRIVER_AS_TASK -Action $action -Trigge
                     TaskQueryOutcome::Unknown => "unknown",
                     _ => unreachable!(),
                 };
-                let diagnostic = match (stdout.trim(), stderr.trim()) {
-                    ("", "") => "no diagnostic output".to_owned(),
-                    (stdout, "") => stdout.to_owned(),
-                    ("", stderr) => stderr.to_owned(),
-                    (stdout, stderr) => format!("{stdout}\n{stderr}"),
-                };
-                let hresult = out
-                    .status
-                    .code()
+                let diagnostic = query.diagnostic;
+                let hresult = query
+                    .exit_code
                     .map(|code| format!("0x{:08X}", code as u32))
                     .unwrap_or_else(|| "unavailable".to_owned());
                 return Err(anyhow!(
@@ -621,6 +750,143 @@ mod tests {
             observed.to_ascii_lowercase(),
             expected.to_ascii_lowercase(),
             "Windows resolved the invoked installer junction path to a release path"
+        );
+    }
+
+    // ── Self-elevation exit-code semantics (#3179) ────────────────────────
+
+    #[test]
+    fn elevation_script_guards_every_failure_path() {
+        let script = elevation_script(r"C:\Cua\cua-driver.exe");
+
+        // Promotes the declined-UAC non-terminating error to a terminating one.
+        assert!(script.contains("-ErrorAction Stop"), "{script}");
+        assert!(script.contains("catch {"), "{script}");
+        // Defence in depth: `exit $null` exits 0, which is the trap that made a
+        // dismissed prompt look like a successful registration.
+        assert!(
+            script.contains("if ($null -eq $p -or $null -eq $p.ExitCode)"),
+            "{script}"
+        );
+        assert!(!script.contains("__INNER_COMMAND__"), "{script}");
+        assert!(
+            script.contains(r#"'& "C:\Cua\cua-driver.exe" autostart enable'"#),
+            "{script}"
+        );
+    }
+
+    #[test]
+    fn elevation_script_escapes_quotes_in_the_executable_path() {
+        let script = elevation_script("C:\\o'brien\\a\"b\\cua-driver.exe");
+
+        // `'` doubled for the single-quoted PowerShell string, `"` backtick-
+        // escaped for the double-quoted call operator argument.
+        assert!(script.contains("o''brien"), "{script}");
+        assert!(script.contains("a`\"b"), "{script}");
+    }
+
+    /// Run the shipped elevation script against a stubbed `Start-Process`.
+    ///
+    /// A PowerShell function shadows the cmdlet of the same name, so the script
+    /// under test runs verbatim — no real UAC prompt, which is what makes the
+    /// exit-code contract testable in CI at all.
+    #[cfg(target_os = "windows")]
+    fn elevation_script_exit_code(stub_body: &str) -> i32 {
+        use std::process::Command;
+
+        let temp = tempfile::tempdir().unwrap();
+        let script_path = temp.path().join("elevation-probe.ps1");
+        let contents = format!(
+            "function Start-Process {{\n\
+             [CmdletBinding()]\n\
+             param([string]$FilePath,[string[]]$ArgumentList,[string]$Verb,\
+             [switch]$Wait,[switch]$PassThru)\n\
+             {stub_body}\n\
+             }}\n{}",
+            elevation_script(r"C:\Cua\cua-driver.exe")
+        );
+        std::fs::write(&script_path, contents).unwrap();
+
+        let status = Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+            ])
+            .arg(&script_path)
+            .status()
+            .unwrap();
+        status.code().expect("powershell reported no exit code")
+    }
+
+    /// The regression itself: declining UAC raises a non-terminating error, so
+    /// the pre-fix `$p = Start-Process ...; exit $p.ExitCode` exited 0 and
+    /// `enable()` reported a registered autostart entry (#3179).
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn declined_uac_exits_non_zero() {
+        let declined = "Write-Error 'This command cannot be run due to the error: \
+                        The operation was canceled by the user.'";
+        assert_eq!(elevation_script_exit_code(declined), 1);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn absent_process_object_exits_non_zero() {
+        assert_eq!(elevation_script_exit_code("return $null"), 1);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn absent_child_exit_code_exits_non_zero() {
+        assert_eq!(
+            elevation_script_exit_code("return [pscustomobject]@{ ExitCode = $null }"),
+            1
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn accepted_uac_forwards_the_child_exit_code() {
+        assert_eq!(
+            elevation_script_exit_code("return [pscustomobject]@{ ExitCode = 0 }"),
+            0
+        );
+        assert_eq!(
+            elevation_script_exit_code("return [pscustomobject]@{ ExitCode = 3 }"),
+            3
+        );
+    }
+
+    // ── Post-registration verification ────────────────────────────────────
+
+    #[test]
+    fn present_task_confirms_registration() {
+        assert_eq!(
+            classify_registration_check(TaskQueryOutcome::Registered),
+            RegistrationCheck::Confirmed
+        );
+    }
+
+    #[test]
+    fn absent_task_contradicts_reported_success() {
+        assert_eq!(
+            classify_registration_check(TaskQueryOutcome::NotRegistered),
+            RegistrationCheck::Missing
+        );
+    }
+
+    #[test]
+    fn unanswerable_query_is_never_a_false_failure() {
+        assert_eq!(
+            classify_registration_check(TaskQueryOutcome::PermissionDenied),
+            RegistrationCheck::Unverifiable
+        );
+        assert_eq!(
+            classify_registration_check(TaskQueryOutcome::Unknown),
+            RegistrationCheck::Unverifiable
         );
     }
 

--- a/libs/cua-driver/scripts/install-local.ps1
+++ b/libs/cua-driver/scripts/install-local.ps1
@@ -309,10 +309,17 @@ Write-Host "  exe:    $(Join-Path $VisibleBinDir $BinaryName)"
 Write-Host "  source: $installedBinary"
 Write-Host ""
 
+# Tracks whether registration actually happened, so the closing summary
+# reports the outcome instead of merely restating that -AutoStart was
+# requested. A declined UAC prompt used to leave the summary claiming the
+# task was registered (trycua/cua#3179).
+$AutoStartRegistered = $false
+
 if ($AutoStart) {
     Write-Step "registering Scheduled Task 'cua-driver-local-serve'"
     try {
         Register-CuaDriverAutostart -InstalledBinary (Join-Path $VisibleBinDir $BinaryName)
+        $AutoStartRegistered = $true
         Write-Host "  Registered. cua-driver-local serve auto-starts at every interactive logon." -ForegroundColor Green
     }
     catch {
@@ -388,15 +395,24 @@ if (-not (Test-Path -LiteralPath $releaseBinary -PathType Leaf)) {
 }
 
 # Windows-specific autostart hint (kept inline; per-shell natural location).
-if ($AutoStart) {
-    # Default branch: autostart was enabled (either by default or explicitly).
-    # Surface the management subcommands so the user knows how to inspect /
-    # disable later without digging through Task Scheduler.
+if ($AutoStartRegistered) {
+    # Registration was requested AND succeeded. Surface the management
+    # subcommands so the user knows how to inspect / disable later without
+    # digging through Task Scheduler.
     Write-Host ""
     Write-Host "Auto-start: 'cua-driver-local-serve' is registered at RunLevel=Highest." -ForegroundColor Cyan
     Write-Host "  cua-driver-local autostart status    (inspect)" -ForegroundColor Cyan
     Write-Host "  cua-driver-local autostart disable   (remove)" -ForegroundColor Cyan
     Write-Host "  cua-driver-local autostart kick      (start now without re-logging)" -ForegroundColor Cyan
+    Write-Host ""
+} elseif ($AutoStart) {
+    # Requested but not registered — the failure was already reported above
+    # (declined UAC prompt, or the registration itself errored). Never claim
+    # the task exists here (trycua/cua#3179).
+    Write-Host ""
+    Write-Host "Auto-start: 'cua-driver-local-serve' is NOT registered - registration failed above." -ForegroundColor Yellow
+    Write-Host "  cua-driver-local autostart enable    (retry; accept the UAC prompt)" -ForegroundColor Yellow
+    Write-Host "  cua-driver-local autostart status    (inspect)" -ForegroundColor Yellow
     Write-Host ""
 } else {
     # Opt-out branch (-NoAutoStart or -AutoStart:`$false`).

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -1678,11 +1678,18 @@ Write-Host "Stopping any previous cua-driver processes (best-effort; High-IL nee
 # instructions, same as the previous behavior.
 $null = Repair-CuaDriverStaleDaemon
 
+# Tracks whether registration actually happened, so the closing summary
+# reports the outcome instead of merely restating that -AutoStart was
+# requested. A declined UAC prompt used to leave the summary claiming the
+# task was registered (trycua/cua#3179).
+$AutoStartRegistered = $false
+
 if ($AutoStart) {
     Write-Host ""
     Write-Host "Registering auto-start (cua-driver autostart enable)..." -ForegroundColor Cyan
     try {
         Register-CuaDriverAutostart -InstalledBinary $installedBinary
+        $AutoStartRegistered = $true
         Write-Host "  cua-driver serve will auto-start at every interactive logon (RunLevel=Highest)." -ForegroundColor Green
     }
     catch {
@@ -1738,11 +1745,17 @@ catch {
 
 # Windows-specific autostart hint (kept inline; OS-natural location).
 Write-Host ""
-if ($AutoStart) {
+if ($AutoStartRegistered) {
     Write-Host "Auto-start: 'cua-driver-serve' is registered at RunLevel=Highest." -ForegroundColor Cyan
     Write-Host "  cua-driver autostart status    (inspect)" -ForegroundColor Cyan
     Write-Host "  cua-driver autostart disable   (remove)" -ForegroundColor Cyan
     Write-Host "  cua-driver autostart kick      (start now without re-logging)" -ForegroundColor Cyan
+} elseif ($AutoStart) {
+    # Requested but not registered — the failure was already reported above.
+    # Never claim the task exists here (trycua/cua#3179).
+    Write-Host "Auto-start: 'cua-driver-serve' is NOT registered - registration failed above." -ForegroundColor Yellow
+    Write-Host "  cua-driver autostart enable    (retry; accept the UAC prompt)" -ForegroundColor Yellow
+    Write-Host "  cua-driver autostart status    (inspect)" -ForegroundColor Yellow
 } else {
     Write-Host "Auto-start at logon (NOT enabled - re-run without -NoAutoStart to register, or:):" -ForegroundColor Cyan
     Write-Host "  cua-driver autostart enable    (Scheduled Task at RunLevel=Highest)" -ForegroundColor Cyan

--- a/libs/cua-driver/scripts/tests/test_install_autostart_summary.py
+++ b/libs/cua-driver/scripts/tests/test_install_autostart_summary.py
@@ -1,0 +1,91 @@
+"""The Windows installers must not claim autostart is registered when it isn't.
+
+Both installers used to gate their closing `Auto-start: '...' is registered at
+RunLevel=Highest.` line on the `-AutoStart` *request* rather than on the
+registration *outcome*, so a declined UAC prompt produced an install transcript
+that confirmed a task which was never created (trycua/cua#3179).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+
+# (installer, closing summary line, task name)
+INSTALLERS = [
+    pytest.param(
+        SCRIPTS / "install.ps1",
+        "Auto-start: 'cua-driver-serve' is registered at RunLevel=Highest.",
+        id="install.ps1",
+    ),
+    pytest.param(
+        SCRIPTS / "install-local.ps1",
+        "Auto-start: 'cua-driver-local-serve' is registered at RunLevel=Highest.",
+        id="install-local.ps1",
+    ),
+]
+
+# A branch opener in these scripts, at the granularity this test cares about.
+BRANCH_PREFIXES = ("if (", "} elseif (", "elseif (", "} else", "else {")
+
+
+def _guard_for(lines: list[str], index: int) -> str:
+    """The nearest branch opener above `index`."""
+    for line in reversed(lines[:index]):
+        stripped = line.strip()
+        if stripped.startswith(BRANCH_PREFIXES):
+            return stripped
+    raise AssertionError(f"no enclosing branch found above line {index + 1}")
+
+
+@pytest.mark.parametrize(("installer", "summary"), INSTALLERS)
+def test_registered_summary_is_gated_on_the_registration_outcome(
+    installer: Path, summary: str
+) -> None:
+    lines = installer.read_text(encoding="utf-8").splitlines()
+
+    matches = [index for index, line in enumerate(lines) if summary in line]
+    assert len(matches) == 1, f"expected exactly one summary line, found {len(matches)}"
+
+    guard = _guard_for(lines, matches[0])
+    assert guard == "if ($AutoStartRegistered) {", (
+        f"{installer.name} prints {summary!r} under {guard!r}; it must be gated on "
+        "the registration outcome, not on the -AutoStart request"
+    )
+
+
+@pytest.mark.parametrize(("installer", "summary"), INSTALLERS)
+def test_registration_outcome_is_only_recorded_after_a_successful_call(
+    installer: Path, summary: str
+) -> None:
+    lines = installer.read_text(encoding="utf-8").splitlines()
+    text = "\n".join(lines)
+
+    assert "$AutoStartRegistered = $false" in text, "the flag must start out false"
+
+    successes = [
+        index for index, line in enumerate(lines) if line.strip() == "$AutoStartRegistered = $true"
+    ]
+    assert len(successes) == 1, f"expected one success assignment, found {len(successes)}"
+
+    # Only the statement directly after a returning Register-CuaDriverAutostart
+    # call may flip the flag; anything else would re-introduce a summary that
+    # does not depend on the outcome.
+    previous = lines[successes[0] - 1].strip()
+    assert previous.startswith("Register-CuaDriverAutostart"), (
+        f"{installer.name} sets $AutoStartRegistered after {previous!r}; it must be set "
+        "only after Register-CuaDriverAutostart returns without throwing"
+    )
+
+
+@pytest.mark.parametrize(("installer", "summary"), INSTALLERS)
+def test_failed_registration_is_reported_in_the_summary(installer: Path, summary: str) -> None:
+    text = installer.read_text(encoding="utf-8")
+
+    assert "is NOT registered - registration failed above." in text, (
+        f"{installer.name} must tell the user autostart is missing when -AutoStart was "
+        "requested but registration failed"
+    )


### PR DESCRIPTION
Closes #3179

## Scope

A declined UAC prompt during `cua-driver autostart enable` was reported as a successful registration with exit 0, and no scheduled task was created. This makes every failure path of the Windows self-elevation helper exit non-zero, verifies the postcondition independently of the exit code, and stops the installers from confirming a task that was never created.

Windows-only elevation plumbing. The macOS/Linux `platform` stubs are untouched, so no cross-platform autostart semantics change.

## Root cause

`autostart.rs` built the helper as:

```powershell
$p = Start-Process -FilePath 'powershell.exe' -ArgumentList @(...) -Verb RunAs -Wait -PassThru; exit $p.ExitCode
```

No `-ErrorAction Stop`. A declined UAC raises a **non-terminating** error, so `$p` stays unset, `$null.ExitCode` is `$null`, and `exit $null` exits **0**. `elevated_status.success()` was therefore true and `enable()` returned `Ok(())`. The actionable error that already says "The UAC prompt was probably dismissed" was unreachable on exactly the path it was written for.

## Changes

**`libs/cua-driver/rust/crates/cua-driver/src/autostart.rs`**

- The helper script moves into `ELEVATE_PS` + `elevation_script(exe)`, gated `#[cfg(any(target_os = "windows", test))]` so the exit-code contract is testable on every host. It now uses `-ErrorAction Stop` inside a `try`/`catch { exit 1 }`, **and** keeps an explicit `if ($null -eq $p -or $null -eq $p.ExitCode) { exit 1 }`. Both guards are deliberate: `exit $null` silently meaning `exit 0` is the trap that produced this bug, so the null check stays even though `-ErrorAction Stop` alone would cover the declined case.
- `confirm_registered()` runs after registration reports success (both the already-elevated direct path and the elevated path) and queries Task Scheduler. A missing task is now an error even if the exit code said otherwise, which makes the guarantee independent of the exit-code plumbing. A query that cannot be answered (permission denied, scheduler unreachable) prints an "unverified" note and stays `Ok` — a false negative here would be its own kind of misleading.
- `status()` and the new postcondition share one `query_task()` helper; the `/HRESULT` classification is unchanged.

**`libs/cua-driver/scripts/install.ps1`, `install-local.ps1`**

Both printed the closing `Auto-start: '<task>' is registered at RunLevel=Highest.` line under `if ($AutoStart)` — the *request*, not the *outcome* — so the declined run in #3179 also produced a confirming installer transcript. Both now track `$AutoStartRegistered`, set only after `Register-CuaDriverAutostart` returns without throwing, and print a `NOT registered` line with a retry hint otherwise.

`uninstall.ps1` and `uninstall-local.ps1` are deliberately untouched (in flight as #3176 / #3178).

**`.github/workflows/ci-rust-windows.yml`**

The lane compiled `cua-driver`'s bin tests with `--all-targets --no-run` but only *ran* an explicit filter list, so `autostart::tests::` never executed in CI (the pre-existing ones included). Added one step that runs them. They need no UAC prompt and no interactive desktop. The cross-platform subset already runs on the Linux lane, which invokes `cargo test -p cua-driver ... --all-targets` unfiltered.

## Validation

Executed, on Windows 11 Enterprise 10.0.26200 / PowerShell 5.1:

- `cargo test -p cua-driver --bins autostart::` → **18 passed, 0 failed**.
  - `declined_uac_exits_non_zero`, `absent_process_object_exits_non_zero`, `absent_child_exit_code_exits_non_zero`, `accepted_uac_forwards_the_child_exit_code` execute the **shipped** script text against a stubbed `Start-Process` (a PowerShell function shadows the cmdlet of the same name, so no real UAC prompt is involved) and assert exit 1 / 1 / 1 / 0 and 3.
  - `elevation_script_guards_every_failure_path`, `elevation_script_escapes_quotes_in_the_executable_path`, and the three `classify_registration_check` tests run on every platform, including the Linux CI lane.
- `cargo fmt -p cua-driver -- --check` → clean. `cargo clippy -p cua-driver --bins --all-targets` → no lints in `autostart.rs`.
- `pytest libs/cua-driver/scripts/tests/test_install_autostart_summary.py` → **6 passed**. Verified as a real regression test: run against the pre-fix `install.ps1` / `install-local.ps1` from `main`, all 6 fail (e.g. `prints "Auto-start: ... is registered ..." under 'if ($AutoStart) {'`).
- Root cause reproduced directly: the pre-fix one-liner with a stub raising the declined-UAC error exits **0**; the new script shape under the identical stub exits **1**.

On CI, at `f32d5ff3e`: `Rust Windows unit and compile` **pass** — the new step's log shows `test result: ok. 18 passed; 0 failed`, with `declined_uac_exits_non_zero`, `absent_process_object_exits_non_zero`, `absent_child_exit_code_exits_non_zero` and `accepted_uac_forwards_the_child_exit_code` all `ok` on a GitHub-hosted Windows runner.

At `2934b1623` (before the workflow step was added): `Rust Linux unit and compile` **pass** — its log shows `autostart::tests::elevation_script_guards_every_failure_path`, `..._escapes_quotes_in_the_executable_path`, `present_task_confirms_registration`, `absent_task_contradicts_reported_success` and `unanswerable_query_is_never_a_false_failure` all `ok`. `Rust Windows unit and compile`, `Rustfmt (ubuntu-latest)`, `CI: Test Scripts`, and `Check SPDX headers (warn-only)` also pass.

Per AGENTS.md this is focused-unit-test level work, so the full cross-platform desktop E2E matrix was not run.

## Hardware verification

Both outcomes have since been exercised against a binary built from this branch
at `f32d5ff3e`, installed via `install-local.ps1 -AutoStart`, on Windows 11
Enterprise 10.0.26200 / PowerShell 5.1, from a non-elevated shell (Medium IL;
user in `BUILTIN\Administrators`; `EnableLUA=1`, `ConsentPromptBehaviorAdmin=5`,
`PromptOnSecureDesktop=1`; interactive Session 2), with a human answering the
real consent dialog.

**UAC declined** — `cua-driver-local autostart enable`, prompt dismissed:

```
cua-driver: registering autostart at RunLevel=Highest needs admin.
cua-driver: triggering UAC prompt — accept it to register the task.
cua-driver: UAC elevation for autostart registration failed: This command cannot be run due to the error: The operation was canceled by the user.
cua-driver autostart enable: self-elevation for autostart registration failed (exit 1). The UAC prompt was probably dismissed. Re-run `cua-driver autostart enable` and accept the prompt, or run install.ps1 -AutoStart which has the same self-elevation flow. See https://github.com/trycua/cua/issues/1602.
EXITCODE=1
```

Exit **1**, and the diagnostic at `autostart.rs:333` — unreachable before this
change — is now reached verbatim. The scheduled task was confirmed absent
afterwards, so the reported failure matches reality. On `main` the identical
decline produced `Registered autostart entry` and exit **0**.

**UAC approved** — the same install path with the prompt accepted registered the
task, confirmed independently by `Get-ScheduledTask` (`RunLevel=Highest`,
`State=Ready`) and `schtasks /Query` (exit 0), and was reported as success.

That pair is the regression this PR closes: before, both outcomes returned exit
0 with identical output; now they diverge correctly.

`confirm_registered()` ran against a genuinely present task on the approved run
and did not produce a false negative. Its *absent*-task and
permission-denied/unknown branches were not reached on hardware — the declined
run fails earlier, at the elevation step, so the postcondition check is never
consulted.

## Not verified

- `confirm_registered()`'s absent-task error branch and its
  permission-denied/unknown degradation path were not exercised against a real
  `schtasks` invocation; those remain covered only at the classification level.
- The rest of `libs/cua-driver/scripts/tests/` cannot run on this Windows host (POSIX-shell fixtures, `/bin/sh` not found); those failures are pre-existing and unrelated, and the suite runs on the Ubuntu `CI: Test Scripts` lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

