### PR TITLE
fix(cua-driver): print skill path from singular command

### DIFF
--- a/docs/content/docs/reference/cua-driver/cli-reference.mdx
+++ b/docs/content/docs/reference/cua-driver/cli-reference.mdx
@@ -463,6 +463,12 @@ Report local skill-pack and per-agent link state.
 
 Print the local skill-pack path.
 
+### `cua-driver skill`
+
+Print the local agent skill-pack path.
+
+Read-only singular alias for cua-driver skills path.
+
 ### `cua-driver manifest`
 
 Emit a stable JSON description of the CLI surface.

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -319,7 +319,7 @@ fn finite_command_name_from_args(args: &[String]) -> Option<&'static str> {
         Some("diagnose") => Some("diagnose"),
         Some("permissions") => Some("permissions"),
         Some("autostart") => Some("autostart"),
-        Some("skills") => Some("skills"),
+        Some("skill" | "skills") => Some("skills"),
         Some("cursor-theme") => Some("cursor_theme"),
         Some("browser-approve") => Some("browser_approve"),
         Some("config") => Some("config"),
@@ -399,6 +399,7 @@ fn finite_operation_from_args(args: &[String]) -> &'static str {
             "kick" => "kick",
             _ => "other",
         },
+        Some("skills") if positionals.first().copied() == Some("skill") => "path",
         Some("skills") => match subcommand.unwrap_or("status") {
             "install" => "install",
             "update" => "update",
@@ -483,7 +484,7 @@ pub fn parse_command() -> Command {
             env!("CARGO_PKG_VERSION")
         );
         println!("Usage: cua-driver [SUBCOMMAND] [OPTIONS]");
-        println!("Subcommands: mcp, list-tools, describe, call, serve, stop, revoke, status, config, telemetry, recording, update, check-update, doctor, diagnose, permissions, autostart, skills, browser-approve, manifest, channel, cursor-theme, sessions");
+        println!("Subcommands: mcp, list-tools, describe, call, serve, stop, revoke, status, config, telemetry, recording, update, check-update, doctor, diagnose, permissions, autostart, skills, browser-approve, manifest, channel, cursor-theme, sessions, skill");
         println!();
         println!("permissions options (macOS):");
         println!("  cua-driver permissions status   Report Accessibility + Screen Recording status. Read-only (no prompt).");
@@ -522,6 +523,9 @@ pub fn parse_command() -> Command {
         println!("  cua-driver skills uninstall     Remove the agent symlinks. Add --all to also delete the local copy.");
         println!("  cua-driver skills status        Report local install state + per-agent link state. Read-only.");
         println!("  cua-driver skills path          Print where the local skill pack lives.");
+        println!(
+            "  cua-driver skill                Print the same path (read-only singular shortcut)."
+        );
         println!("  --from main                     (install only) Fetch latest from main branch instead of the tagged release.");
         println!();
         println!("browser preparation approval:");
@@ -944,6 +948,16 @@ pub fn parse_command() -> Command {
                 process::exit(64);
             }
             Command::Autostart { subcommand }
+        }
+        Some("skill") => {
+            if pos.next().is_some() {
+                eprintln!("Usage: cua-driver skill");
+                process::exit(64);
+            }
+            Command::Skills {
+                subcommand: "path".to_owned(),
+                flags: Vec::new(),
+            }
         }
         Some("skills") => {
             // Skills subcommand. Default is `status` so plain `cua-driver
@@ -1702,7 +1716,10 @@ pub fn build_manifest() -> serde_json::Value {
               "args": [ { "name": "subcommand", "type": "positional-string", "description": "enable | disable | status | kick" } ] },
             { "name": "skills",
               "description": "Manage the cua-driver agent skill pack (install / update / uninstall / status / path).",
-              "args": [ { "name": "subcommand", "type": "positional-string", "description": "install | update | uninstall | status | path. Default: status." } ] }
+              "args": [ { "name": "subcommand", "type": "positional-string", "description": "install | update | uninstall | status | path. Default: status." } ] },
+            { "name": "skill",
+              "description": "Print the local cua-driver agent skill-pack path (read-only alias for skills path).",
+              "args": [] }
         ]
     })
 }
@@ -3506,6 +3523,15 @@ fn cli_docs_json() -> serde_json::Value {
                 ]
             },
             {
+                "name": "skill",
+                "abstract": "Print the local agent skill-pack path.",
+                "discussion": "Read-only singular alias for cua-driver skills path.",
+                "arguments": no_args,
+                "options": no_options,
+                "flags": no_flags,
+                "subcommands": no_subcommands
+            },
+            {
                 "name": "manifest",
                 "abstract": "Emit a stable JSON description of the CLI surface.",
                 "discussion": "Consumers can use this instead of hardcoding launch arguments such as the MCP invocation.",
@@ -4165,6 +4191,14 @@ mod tests {
     }
 
     #[test]
+    fn singular_skill_alias_is_the_reviewed_read_only_path_operation() {
+        let argv = args(&["skill"]);
+        assert_eq!(finite_command_name_from_args(&argv), Some("skills"));
+        assert_eq!(finite_tool_name_from_args(&argv), None);
+        assert_eq!(finite_operation_from_args(&argv), "path");
+    }
+
+    #[test]
     fn finite_computer_action_discards_arguments_after_fixed_classification() {
         assert!(finite_computer_action_from_args(&args(&[
             "call",
@@ -4396,6 +4430,7 @@ mod tests {
             "status",
             "mcp-config",
             "manifest",
+            "skill",
         ] {
             assert!(names.contains(&need), "missing subcommand '{need}'");
         }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/skills_cli_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/skills_cli_test.rs
@@ -1,0 +1,62 @@
+//! Focused coverage for the read-only skill-path CLI shortcuts.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn run_driver(home: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_cua-driver"))
+        .args(args)
+        .env("CUA_DRIVER_RS_HOME", home)
+        .env("CUA_DRIVER_RS_TELEMETRY_ENABLED", "false")
+        .output()
+        .expect("run cua-driver")
+}
+
+#[test]
+fn singular_skill_prints_the_same_path_as_plural_skills_path() {
+    let home = tempfile::tempdir().expect("create isolated Cua Driver home");
+    let expected = home.path().join("skills").join("cua-driver");
+
+    let singular = run_driver(home.path(), &["skill"]);
+    assert!(
+        singular.status.success(),
+        "singular skill command failed: {}",
+        String::from_utf8_lossy(&singular.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(singular.stdout).expect("UTF-8 singular path"),
+        format!("{}\n", expected.display())
+    );
+
+    let plural = run_driver(home.path(), &["skills", "path"]);
+    assert!(
+        plural.status.success(),
+        "plural skills path command failed: {}",
+        String::from_utf8_lossy(&plural.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(plural.stdout).expect("UTF-8 plural path"),
+        format!("{}\n", expected.display())
+    );
+}
+
+#[test]
+fn bare_plural_skills_keeps_its_status_behavior() {
+    let home = tempfile::tempdir().expect("create isolated Cua Driver home");
+    let output = run_driver(home.path(), &["skills"]);
+
+    assert!(
+        output.status.success(),
+        "bare plural skills command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 skills status");
+    assert!(
+        stdout.contains("Local skill pack: not installed"),
+        "unexpected status output: {stdout}"
+    );
+    assert!(
+        stdout.contains("Agent links:"),
+        "unexpected status output: {stdout}"
+    );
+}


### PR DESCRIPTION
## What changed

- route the exact singular command `cua-driver skill` to the existing read-only `skills path` implementation
- classify the alias as the reviewed finite `skills/path` operation instead of an implicit MCP tool call
- advertise the alias in `--help`, the CLI manifest, generated CLI docs, and the checked-in CLI reference
- add focused binary-level coverage while preserving bare plural `cua-driver skills` status behavior

## Why

Unknown top-level verbs currently fall through to the implicit MCP tool-call route. As a result, `skill` reaches authorization as an unclassified tool and fails with `Permission denied: tool 'skill' has no reviewed risk classification` instead of serving the natural read-only discovery request.

## User impact

Agents and users can run `cua-driver skill` to print the installed skill-pack directory. Existing plural skill management commands are unchanged.

## Validation

Candidate `4b2ea303e48b37a00b9b2772076e3cc6592193d3`:

- `cargo fmt --all -- --check`
- `cargo test -p cua-driver`
- `npx tsx scripts/docs-generators/cua-driver.ts --check`
- ordinary pull request CI, including `CI: Release metadata`
- Linux exact-SHA canonical matrix: passed (https://github.com/trycua/cua/actions/runs/31882701192)
- Windows exact-SHA canonical matrix: passed (https://github.com/trycua/cua/actions/runs/31882701387)

## Known gaps / blockers

The canonical macOS Lume runner cannot start on this host because strict preflight requires the private signing keychain at `~/Library/Keychains/cua-driver-signing.keychain-db`, which is not present. No partial macOS result is being treated as certification.

Fixes #3181