### PR TITLE
ci: verify Project Centennial helper without entitlements

### DIFF
--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -799,10 +799,15 @@ jobs:
             release/CuaDriver.app/Contents/MacOS/cua-cursor-theme \
             > release/actual-packaged-cursor-entitlements.plist
           python3 - <<'PY'
+          import os
           import plistlib
 
-          with open("release/actual-packaged-cursor-entitlements.plist", "rb") as handle:
-              actual = plistlib.load(handle)
+          path = "release/actual-packaged-cursor-entitlements.plist"
+          if os.path.getsize(path) == 0:
+              actual = {}
+          else:
+              with open(path, "rb") as handle:
+                  actual = plistlib.load(handle)
           assert "com.apple.application-identifier" not in actual
           assert "keychain-access-groups" not in actual
           PY


### PR DESCRIPTION
## Summary

- treat zero-byte `codesign --entitlements - --xml` output as an empty entitlement set
- continue parsing non-empty output and rejecting application or keychain entitlements on the nested helper

The macOS 26 runner emits zero bytes when a correctly signed helper has no entitlements. Parsing that output as a plist failed before notarization even though the helper signature and designated requirement had already verified.

## Validation

- real signed no-entitlement helper produces zero bytes and passes
- forbidden-entitlement fixture remains rejected
- workflow YAML parses
- `git diff --check`
