### PR TITLE
fix(cua-driver): drop the stale 0.17 version from element_index messages

### DIFF
--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -240,7 +240,7 @@ from_zoom: set true after a zoom call to auto-translate zoom-image pixel coordin
 - `count` (integer, optional): Click count (pixel path only). Default 1.
 - `debug_image_out` (string, optional): Optional file path. When set on a pixel-addressed click, captures a fresh screenshot, draws a red crosshair at (x, y), and writes the PNG. Use to verify coordinate spaces. Requires window_id; incompatible with from_zoom.
 - `delivery_mode` (string, optional): Best-effort-background ladder rung (default "background"). "background": perform the AX action or post the CGEvent without fronting. "foreground": briefly front the window, act, let transient UI settle, then restore the prior frontmost app. Requires window_id. Modified clicks require "foreground" so macOS observes physical modifier-key state. A generic click has no independent postcondition read-back, except selection of list-like AX rows whose AXSelected state can be confirmed; otherwise confirm the effect from a fresh state snapshot. Use the agent loop: background AX (element_index) → snapshot → background pixel (x/y) → snapshot → delivery_mode:"foreground".
-- `element_index` (integer, optional): Element index from get_window_state. Cua Driver 0.17 requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
+- `element_index` (integer, optional): Element index from get_window_state. Requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
 - `element_token` (string, optional): Opaque per-snapshot element handle from `structuredContent.elements[].element_token`. If element_index, snapshot_id, or window_id are also supplied they must agree. Returns an explicit stale error once a newer snapshot supersedes it.
 - `from_zoom` (boolean, optional): When true, x and y are in the last zoom image for this pid; driver translates back to full-window coordinates.
 - `modifier` (array of string, optional): Modifier keys: cmd, shift, option/alt, ctrl.
@@ -268,7 +268,7 @@ Pixel path (x, y provided): two down/up pairs ~80 ms apart at the given coordina
 **Arguments:**
 
 - `delivery_mode` (string, optional): Best-effort-background ladder rung (default "background"). "background": inject without fronting or raising the target — no focus steal. "foreground": briefly front the target, act, then restore the prior frontmost — the explicit last resort when a background attempt didn't land. Re-call with "foreground" only for the action that needs it.
-- `element_index` (integer, optional): Element index from get_window_state. Cua Driver 0.17 requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
+- `element_index` (integer, optional): Element index from get_window_state. Requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
 - `element_token` (string, optional): Opaque per-snapshot element handle from `structuredContent.elements[].element_token`. If element_index, snapshot_id, or window_id are also supplied they must agree. Returns an explicit stale error once a newer snapshot supersedes it.
 - `pid` (integer, required)
 - `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
@@ -294,7 +294,7 @@ Exactly one of `element_index` or (`x` AND `y`) must be provided. `pid` always r
 **Arguments:**
 
 - `delivery_mode` (string, optional): Best-effort-background ladder rung (default "background"). "background": inject without fronting or raising the target — no focus steal. "foreground": briefly front the target, act, then restore the prior frontmost — the explicit last resort when a background attempt didn't land. Re-call with "foreground" only for the action that needs it.
-- `element_index` (integer, optional): Element index from get_window_state. Cua Driver 0.17 requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
+- `element_index` (integer, optional): Element index from get_window_state. Requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
 - `element_token` (string, optional): Opaque per-snapshot element handle from `structuredContent.elements[].element_token`. If element_index, snapshot_id, or window_id are also supplied they must agree. Returns an explicit stale error once a newer snapshot supersedes it.
 - `modifier` (array of string, optional): Modifier keys held during the right-click: cmd/shift/option/ctrl. Pixel path only.
 - `pid` (integer, required): Target process ID.
@@ -358,7 +358,7 @@ WEB CONTENT (Chromium/WebKit/Electron — browser tabs, Slack, VS Code, X's comp
 
 - `delay_ms` (integer, optional): Milliseconds between characters in the CGEvent fallback path. Default 30. Ignored when the AX path succeeds. range: 0–200
 - `delivery_mode` (string, optional): Best-effort-background ladder rung (default "background"). "background": AX insert, then CGEvent keystrokes if needed — no focus steal; native controls can be confirmed via AXValue read-back, while web-content writes remain effect:"unverifiable". "foreground": briefly front the window, type, restore the prior frontmost — the explicit last resort for focus-sensitive surfaces (e.g. WhatsApp/Catalyst) where background keystrokes don't land. Re-call with "foreground" when a background attempt remains unverifiable and a fresh snapshot shows the text did not appear.
-- `element_index` (integer, optional): Element index from get_window_state. Cua Driver 0.17 requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
+- `element_index` (integer, optional): Element index from get_window_state. Requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
 - `element_token` (string, optional): Opaque per-snapshot element handle from `structuredContent.elements[].element_token`. If element_index, snapshot_id, or window_id are also supplied they must agree. Returns an explicit stale error once a newer snapshot supersedes it.
 - `pid` (integer, optional): Target process ID.
 - `scope` (string, optional): Use desktop with no pid/window_id to type into the frontmost application. default: `"window"`
@@ -389,7 +389,7 @@ A key press is confirmed only when a bounded native AX value/selection read-back
 **Arguments:**
 
 - `delivery_mode` (string, optional): Best-effort-background ladder rung (default "background"). "background": inject without fronting or raising the target — no focus steal. "foreground": briefly front the target, act, then restore the prior frontmost — the explicit last resort when a background attempt didn't land. Re-call with "foreground" only for the action that needs it.
-- `element_index` (integer, optional): Element index from get_window_state. Cua Driver 0.17 requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
+- `element_index` (integer, optional): Element index from get_window_state. Requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
 - `element_token` (string, optional): Opaque per-snapshot element handle from `structuredContent.elements[].element_token`. If element_index, snapshot_id, or window_id are also supplied they must agree. Returns an explicit stale error once a newer snapshot supersedes it.
 - `key` (string, required): Key name: return, tab, escape, up, down, etc.
 - `modifiers` (array of string, optional): Modifier keys: cmd, shift, option/alt, ctrl, fn.
@@ -423,7 +423,7 @@ Recognized modifiers: cmd/command, shift, option/alt, ctrl/control, fn. Non-modi
 **Arguments:**
 
 - `delivery_mode` (string, optional): Best-effort-background ladder rung (default "background"). "background": inject without fronting or raising the target — no focus steal. "foreground": briefly front the target, act, then restore the prior frontmost — the explicit last resort when a background attempt didn't land. Re-call with "foreground" only for the action that needs it.
-- `element_index` (integer, optional): Element index from get_window_state. Cua Driver 0.17 requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
+- `element_index` (integer, optional): Element index from get_window_state. Requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
 - `element_token` (string, optional): Opaque per-snapshot element handle from `structuredContent.elements[].element_token`. If element_index, snapshot_id, or window_id are also supplied they must agree. Returns an explicit stale error once a newer snapshot supersedes it.
 - `keys` (array of string, required): Modifier(s) and one non-modifier key, e.g. ["cmd", "c"]. items: 2–unbounded
 - `pid` (integer, optional): Target process ID.
@@ -455,7 +455,7 @@ For free-form text entry into web inputs, prefer `type_text_chars` which synthes
 
 **Arguments:**
 
-- `element_index` (integer, optional): Element index from get_window_state. Cua Driver 0.17 requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
+- `element_index` (integer, optional): Element index from get_window_state. Requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
 - `element_token` (string, optional): Opaque per-snapshot element handle from `structuredContent.elements[].element_token`. If element_index, snapshot_id, or window_id are also supplied they must agree. Returns an explicit stale error once a newer snapshot supersedes it.
 - `pid` (integer, required)
 - `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
@@ -483,7 +483,7 @@ Mapping: by='page' → larger step; by='line' → smaller step; amount = number 
 - `by` (string, optional): Scroll granularity. Default: line.
 - `delivery_mode` (string, optional): Best-effort-background ladder rung (default "background"). "background": inject without fronting or raising the target — no focus steal. "foreground": briefly front the target, act, then restore the prior frontmost — the explicit last resort when a background attempt didn't land. Re-call with "foreground" only for the action that needs it.
 - `direction` (string, required): Scroll direction.
-- `element_index` (integer, optional): Element index from get_window_state. Cua Driver 0.17 requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
+- `element_index` (integer, optional): Element index from get_window_state. Requires the matching `snapshot_id` alongside it. Prefer `element_token`, which carries both values.
 - `element_token` (string, optional): Opaque per-snapshot element handle from `structuredContent.elements[].element_token`. If element_index, snapshot_id, or window_id are also supplied they must agree. Returns an explicit stale error once a newer snapshot supersedes it.
 - `pid` (integer, optional)
 - `scope` (string, optional): Use desktop with x,y and no pid/window_id for native get_desktop_state screenshot coordinates. default: `"window"`

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/element_token.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/element_token.rs
@@ -386,7 +386,7 @@ pub fn resolve_element_args(
         (Some(_), None, None) => Err(refusal(
             "snapshot_id_required",
             format!(
-                "{tool_name}: bare element_index is not accepted in Cua Driver 0.17; pass element_token or snapshot_id with element_index"
+                "{tool_name}: bare element_index is not accepted; pass element_token, or snapshot_id together with element_index"
             ),
         )),
         (Some(idx), None, Some(snapshot_handle)) => {

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool_schema.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool_schema.rs
@@ -95,9 +95,9 @@ pub fn scope_schema() -> Value {
 pub fn element_index_schema() -> Value {
     json!({
         "type": "integer",
-        "description": "Element index from get_window_state. Cua Driver 0.17 \
-            requires the matching `snapshot_id` alongside it. Prefer \
-            `element_token`, which carries both values."
+        "description": "Element index from get_window_state. Requires the \
+            matching `snapshot_id` alongside it. Prefer `element_token`, \
+            which carries both values."
     })
 }
 


### PR DESCRIPTION
## Problem

Two user-visible strings hardcode `Cua Driver 0.17`:

- `cua-driver-core/src/element_token.rs` — the `snapshot_id_required` refusal
- `cua-driver-core/src/tool_schema.rs` — the `element_index` schema description

On a correctly installed **0.20.0**, passing a bare `element_index` returns:

```text
click: bare element_index is not accepted in Cua Driver 0.17;
pass element_token or snapshot_id with element_index
```

A three-minor-old version number in a message emitted by the current build reads as a host/driver version mismatch, and sends whoever is triaging it looking for a stale binary that isn't there. It did exactly that to me during Cua Driver 0.20 convergence testing on Windows — the driver was 0.20.0 the whole time.

The constraint isn't "as of 0.17". It's how the driver behaves now, and it holds for every version that emits the message.

## Change

Drop the version rather than bump it, so the text can't rot again.

```text
click: bare element_index is not accepted; pass element_token,
or snapshot_id together with element_index
```

Behavior is unchanged — same refusal code, same required arguments, same element resolution. Only the message text and the schema description differ.

Second commit syncs the generated MCP reference, where that description is echoed into eight tool entries.

## Validation

- `cargo check -p cua-driver-core` — clean
- `cargo test -p cua-driver-core element_token` — 23 passed, 0 failed
- No test, fixture, or snapshot asserts the old string (`git grep "not accepted in Cua Driver"` returns only the source line this PR changes)
- `Check Documentation Sync` regenerates on macOS and diffs, so the docs commit is verified by CI rather than asserted

Per `AGENTS.md`, the desktop E2E matrix belongs on the candidate SHA before this is marked ready. I haven't run it: this is a message-text change with no executable behavior, but I'm not claiming that exemption unilaterally — flagging it for a maintainer call.

## A note on the generated docs

`docs/content/docs/reference/cua-driver/mcp-tools.mdx` is generated by `scripts/docs-generators/cua-driver.ts` from a **built driver**, so it captures the platform of whatever machine runs it. The committed file and the CI check are both macOS.

Regenerating on Windows rewrites every platform-conditional description — `list_apps`, `list_windows`, `get_window_state` all flip from macOS to Windows wording — and changes the tool count 56 → 57, which would bury this four-line change under a ~430-line unrelated diff. So rather than commit a Windows regeneration, the new description string was taken from `cua-driver dump-docs --type mcp` and applied to exactly the eight lines the schema change affects. Nothing else in the file is touched, and CI's macOS regeneration is the check on that.

### Incidental: the generator silently degrades on Windows

`getLatestReleasedVersion()` shells out to `git tag | grep "^cua-driver-rs-v" | sort -V | tail -1`. On Windows those utilities aren't on `PATH`, the call throws, and the `catch` falls through to `return '0.0.0'` — which is interpolated straight into the generated `Version:` headers. So a Windows run doesn't fail loudly; it quietly writes `Version: 0.0.0` into the docs. Prepending Git's `usr/bin` to `PATH` makes it resolve correctly (`cua-driver-rs-v0.20.0`).

Not fixed here to keep this PR narrow — happy to open a separate one if that's wanted.

## Context

Found while testing the Cua Driver 0.20 runtime-contract work in NousResearch/hermes-agent#87646. Not linked to an existing issue — I searched open issues and PRs and found no duplicate for this string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
