### PR TITLE
fix(docs): resolve Cua Driver tags cross-platform

### DIFF
--- a/scripts/docs-generators/cua-driver.test.ts
+++ b/scripts/docs-generators/cua-driver.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getLatestReleasedVersion, selectLatestReleasedVersion } from './cua-driver';
+
+test('lists matching tags through git argv without invoking a shell', () => {
+  const calls: Array<{ command: string; args: readonly string[] }> = [];
+  const version = getLatestReleasedVersion((command, args) => {
+    calls.push({ command, args });
+    return 'cua-driver-rs-v0.9.1\r\ncua-driver-rs-v0.20.0\r\n';
+  });
+
+  assert.equal(version, '0.20.0');
+  assert.deepEqual(calls, [{ command: 'git', args: ['tag', '--list', 'cua-driver-rs-v*'] }]);
+});
+
+test('orders stable release tags by semantic version', () => {
+  assert.equal(
+    selectLatestReleasedVersion([
+      'cua-driver-rs-v0.2.9',
+      'cua-driver-rs-v0.20.0',
+      'cua-driver-rs-v0.2.10',
+      'cua-driver-rs-v0.9.1',
+    ]),
+    '0.20.0'
+  );
+});
+
+test('ignores unrelated, nightly, prerelease, and malformed tags', () => {
+  assert.equal(
+    selectLatestReleasedVersion([
+      'lume-v99.0.0',
+      'nightly-cua-driver-rs-v99.0.0-nightly.20260816.1',
+      'cua-driver-rs-v21.0.0-rc.1',
+      'cua-driver-rs-v21.0',
+      'prefix-cua-driver-rs-v22.0.0',
+      'cua-driver-rs-v20.3.4',
+    ]),
+    '20.3.4'
+  );
+});
+
+test('reports git failures instead of returning a placeholder version', () => {
+  assert.throws(
+    () =>
+      getLatestReleasedVersion(() => {
+        throw new Error('git is unavailable');
+      }),
+    /Failed to list Cua Driver release tags with git: git is unavailable/
+  );
+});
+
+test('reports when git returns no valid stable release tags', () => {
+  assert.throws(
+    () => getLatestReleasedVersion(() => 'nightly-cua-driver-rs-v0.21.0-nightly.20260816.1\n'),
+    /No stable Cua Driver release tag matching cua-driver-rs-v<major>\.<minor>\.<patch> was found/
+  );
+});

--- a/scripts/docs-generators/cua-driver.ts
+++ b/scripts/docs-generators/cua-driver.ts
@@ -328,9 +328,7 @@ export function generateCLIReferenceMDX(docs: CLIDocumentation, releasedVersion:
   lines.push(escapeMdxText(docs.abstract) + ' Install via the official script:');
   lines.push('');
   lines.push('```sh');
-  lines.push(
-    'curl -fsSL https://cua.ai/driver/install.sh | bash'
-  );
+  lines.push('curl -fsSL https://cua.ai/driver/install.sh | bash');
   lines.push('```');
   lines.push('');
   lines.push(
@@ -642,7 +640,7 @@ export function generateMCPToolsMDX(docs: MCPDocumentation, releasedVersion: str
   lines.push('');
   lines.push('<Callout type="info">');
   lines.push(
-    "  **Runtime ownership.** On Windows and Linux, bare `cua-driver mcp` owns its SDK runtime directly and shuts it down on stdin EOF. On macOS it proxies to the installed `CuaDriver.app` daemon so AX and Screen Recording grants retain the app-bundle identity. Passing `--socket` selects an explicit daemon/service endpoint on every platform. See the [process model](/reference/cua-driver/process-model) for the full lifecycle and wrapper-author guidance."
+    '  **Runtime ownership.** On Windows and Linux, bare `cua-driver mcp` owns its SDK runtime directly and shuts it down on stdin EOF. On macOS it proxies to the installed `CuaDriver.app` daemon so AX and Screen Recording grants retain the app-bundle identity. Passing `--socket` selects an explicit daemon/service endpoint on every platform. See the [process model](/reference/cua-driver/process-model) for the full lifecycle and wrapper-author guidance.'
   );
   lines.push('</Callout>');
   lines.push('');
@@ -708,12 +706,7 @@ export function generateMCPToolsMDX(docs: MCPDocumentation, releasedVersion: str
     },
     {
       title: 'Maintenance tools',
-      tools: [
-        'check_permissions',
-        'health_report',
-        'check_for_update',
-        'install_ffmpeg',
-      ],
+      tools: ['check_permissions', 'health_report', 'check_for_update', 'install_ffmpeg'],
     },
   ];
 

--- a/scripts/docs-generators/cua-driver.ts
+++ b/scripts/docs-generators/cua-driver.ts
@@ -11,7 +11,7 @@
  *   npx tsx scripts/docs-generators/cua-driver.ts --check  # Check for drift (CI mode)
  */
 
-import { execFileSync, execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -113,6 +113,8 @@ const CUA_DRIVER_BIN = path.join(
 const DOCS_OUTPUT_DIR = path.join(ROOT_DIR, 'docs', 'content', 'docs', 'reference', 'cua-driver');
 const TAG_PREFIX = 'cua-driver-rs-v';
 
+export type GitRunner = (command: string, args: readonly string[]) => string;
+
 // ============================================================================
 // Version Discovery
 // ============================================================================
@@ -141,22 +143,59 @@ function resolveCargoCommand(): string {
   throw new Error('cargo not found on PATH; install Rust or set CARGO=/path/to/cargo');
 }
 
+function runGit(command: string, args: readonly string[]): string {
+  return execFileSync(command, [...args], {
+    encoding: 'utf-8',
+    cwd: ROOT_DIR,
+  });
+}
+
 /**
- * Get the latest released version from git tags.
+ * Select the highest stable semantic version from Cua Driver release tags.
+ * Nightlies use their own `nightly-cua-driver-rs-v` prefix and must not affect
+ * the version recorded in stable reference docs.
  */
-export function getLatestReleasedVersion(): string {
-  try {
-    const output = execSync(`git tag | grep "^${TAG_PREFIX}" | sort -V | tail -1`, {
-      encoding: 'utf-8',
-      cwd: ROOT_DIR,
-    }).trim();
-    if (output) {
-      return output.replace(TAG_PREFIX, '');
+export function selectLatestReleasedVersion(tags: readonly string[]): string | undefined {
+  const versions = tags.flatMap((tag) => {
+    const match = tag.match(/^cua-driver-rs-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/);
+    if (!match) return [];
+
+    return [
+      {
+        version: tag.slice(TAG_PREFIX.length),
+        parts: [BigInt(match[1]), BigInt(match[2]), BigInt(match[3])] as const,
+      },
+    ];
+  });
+
+  versions.sort((a, b) => {
+    for (let index = 0; index < a.parts.length; index += 1) {
+      if (a.parts[index] < b.parts[index]) return -1;
+      if (a.parts[index] > b.parts[index]) return 1;
     }
-  } catch {
-    // Fall through
+    return 0;
+  });
+
+  return versions.at(-1)?.version;
+}
+
+/** Get the latest stable released version from git tags. */
+export function getLatestReleasedVersion(git: GitRunner = runGit): string {
+  let output: string;
+  try {
+    output = git('git', ['tag', '--list', `${TAG_PREFIX}*`]);
+  } catch (error) {
+    const detail = error instanceof Error ? `: ${error.message}` : '';
+    throw new Error(`Failed to list Cua Driver release tags with git${detail}`);
   }
-  return '0.0.0';
+
+  const version = selectLatestReleasedVersion(output.split(/\r?\n/).filter(Boolean));
+  if (!version) {
+    throw new Error(
+      `No stable Cua Driver release tag matching ${TAG_PREFIX}<major>.<minor>.<patch> was found`
+    );
+  }
+  return version;
 }
 
 // ============================================================================
@@ -870,7 +909,9 @@ function syntheticExampleValue(name: string, prop: MCPPropertyDoc): unknown {
 // Run
 // ============================================================================
 
-main().catch((error) => {
-  console.error('Error:', error);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('Error:', error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- replace the Unix `grep | sort -V | tail` pipeline with `git tag --list` argv execution
- select only stable `cua-driver-rs-v<major>.<minor>.<patch>` tags using semantic numeric ordering
- fail clearly when Git cannot list tags or no valid stable tag exists
- add deterministic regression tests for Windows-safe invocation, ordering, filtering, and failures

## Scope and exclusions

This changes only the Cua Driver documentation generator and its focused test. It does not change runtime release resolution, nightly publication, installer behavior, or generated reference content. The canonical sync check confirmed no generated docs update is required.

## Validation

Exact tested SHA: `0c6252972a2f1b73c4bba9678262d8caf0a7b151`

- `npx --yes tsx --test scripts/docs-generators/cua-driver.test.ts` (5 passed)
- `npx --yes prettier --check scripts/docs-generators/cua-driver.ts scripts/docs-generators/cua-driver.test.ts`
- `npx --yes tsx scripts/docs-generators/runner.ts --library cua-driver --check`
- `git diff --check origin/main...HEAD`

Fixes #3204