### PR TITLE
docs(cua-driver): lower Computer History guide priority

### DIFF
--- a/docs/content/docs/how-to-guides/driver/meta.json
+++ b/docs/content/docs/how-to-guides/driver/meta.json
@@ -2,7 +2,6 @@
   "title": "Driver",
   "pages": [
     "install",
-    "use-computer-history",
     "use-sdk-in-process",
     "verify-a-desktop-action",
     "use-claude-agent-sdk",
@@ -20,6 +19,7 @@
     "write-a-bounded-manifest",
     "personalize-cursor",
     "update",
+    "use-computer-history",
     "troubleshoot-stale-macos-permissions",
     "windows-ssh"
   ]


### PR DESCRIPTION
## Summary

- move the Computer History preview guide below the foundational Cua Driver how-to guides
- keep it ahead of troubleshooting and the platform-specific Windows guide

## Validation

- `jq empty docs/content/docs/how-to-guides/driver/meta.json`
- `git diff --check`