### PR TITLE
fix(sandbox): support Fleet request timeouts

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
@@ -90,7 +90,11 @@ class FleetTransport(Transport):
             service_name or self._service_name,
             path,
             HttpRequest(
-                method=method, url=f"https://service.invalid{path}", headers=headers, body=body
+                method=method,
+                url=f"https://service.invalid{path}",
+                headers=headers,
+                body=body,
+                timeout_secs=30,
             ),
         )
         request = httpx.Request(method, f"https://service.invalid{path}")

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -309,7 +309,11 @@ class _FleetClient:
                 service,
                 "/status",
                 HttpRequest(
-                    method="GET", url="https://service.invalid/status", headers=[], body=None
+                    method="GET",
+                    url="https://service.invalid/status",
+                    headers=[],
+                    body=None,
+                    timeout_secs=30,
                 ),
             )
             if 200 <= response.status < 500:

--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">=3.11,<3.14"
 dependencies = [
     "cua-core>=0.3.0,<0.4.0",
     "cua-auto>=0.1.2",
-    "cua-fleet==0.1.8",
+    "cua-fleet==0.1.10",
     "websockets>=12.0",
     "httpx>=0.27.0",
     "oras>=0.2.40",

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
@@ -131,6 +131,23 @@ async def test_service_request_delegates_to_generated_client():
 
 
 @pytest.mark.asyncio
+async def test_wait_service_ready_sets_a_native_request_timeout():
+    client = _FleetClient.__new__(_FleetClient)
+    calls = []
+
+    async def service_request(sandbox, service, path, request):
+        calls.append((sandbox, service, path, request))
+        return HttpResponse(status=200, headers=[], body=b"")
+
+    client.service_request = service_request
+
+    await client.wait_service_ready("sandbox", "server")
+
+    _, _, _, request = calls[0]
+    assert request.timeout_secs == 30
+
+
+@pytest.mark.asyncio
 async def test_github_actions_token_provider_refreshes_and_caches_token():
     calls = []
 

--- a/libs/python/cua-sandbox/tests/test_fleet_sdk_distribution.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_sdk_distribution.py
@@ -10,6 +10,6 @@ def test_fleet_sdk_is_provided_by_published_fleet_distribution():
     distribution_root = Path(cua_fleet_distribution.locate_file(".")).resolve()
     binding_path = Path(fleet_sdk.__file__).resolve()
 
-    assert cua_fleet_distribution.version == "0.1.8"
+    assert cua_fleet_distribution.version == "0.1.10"
     assert "fleet_sdk/__init__.py" in installed_files
     assert binding_path.is_relative_to(distribution_root)

--- a/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
@@ -18,7 +18,7 @@ class FleetSdkPackagingTests(unittest.TestCase):
             project = tomllib.load(pyproject_file)
 
         dependencies = project["project"]["dependencies"]
-        self.assertIn("cua-fleet==0.1.8", dependencies)
+        self.assertIn("cua-fleet==0.1.10", dependencies)
         self.assertFalse(any(dependency.startswith("cua-train") for dependency in dependencies))
         self.assertNotIn("cua-fleet", project["tool"]["uv"]["sources"])
         self.assertNotIn("cua-train", project["tool"]["uv"]["sources"])
@@ -49,7 +49,7 @@ class FleetSdkPackagingTests(unittest.TestCase):
         self.assertNotIn("cua-train", sandbox_dependencies)
         self.assertIn("cua-fleet", sandbox_requires_dist)
         self.assertNotIn("cua-train", sandbox_requires_dist)
-        self.assertEqual(packages["cua-fleet"]["version"], "0.1.8")
+        self.assertEqual(packages["cua-fleet"]["version"], "0.1.10")
         self.assertEqual(
             packages["cua-fleet"]["source"], {"registry": "https://wheels.cua.ai/simple"}
         )

--- a/libs/python/cua-sandbox/tests/test_fleet_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_transport.py
@@ -34,6 +34,7 @@ async def test_service_request_forwards_command_json():
     _, service, path, request = sdk.calls[0]
     assert (service, path, request.method) == ("api", "/cmd", "POST")
     assert json.loads(request.body) == {"command": "shell.run", "params": {"timeout": 15}}
+    assert request.timeout_secs == 30
 
 
 @pytest.mark.asyncio

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -539,14 +539,14 @@ dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
 name = "cua-fleet"
-version = "0.1.8"
+version = "0.1.10"
 source = { registry = "https://wheels.cua.ai/simple" }
 wheels = [
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:20611a14c185157e6f41502e1bbdcc1e98663347e94463ca538755b0efc173bb" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7c21d0a36a8d74bfe0768422e4f3d9367ee51837920e2c22ee57521fc93c4f3b" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:d7604668a7186d06cefb2bd23974b033c0b2cda61ccbe88d944af622b37f58d3" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:0bac329552d351604ad15b7eb4f4f3ed944921083238d74f51277d657d8f0a34" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-win_amd64.whl", hash = "sha256:d78fe6934a2f650dcf5b105a08833418245c720765da9c3b40e160b86a3d203d" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:de4bffe01a1284e754da1f78c51beb09cc5d51d2ee74d804b8396e355a7938d0" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:55b7581c7ced27ea66723ce1618bcb340e5eae91597f1cfbada4fed52913a21a" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.10-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:89b8ea4455af973a7c4e1f6f02159ebb45f5302f61642b6b41a7cbfa56fbf110" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.10-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:c0290ffb839a5901abee39a8c800ea9b0ddcf3a3555a67795189e04c247283d0" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.10-py3-none-win_amd64.whl", hash = "sha256:38aaeced50971506205b9c056de992d29fcbb936f921850e1937e1e787819ee3" },
 ]
 
 [[package]]
@@ -588,7 +588,7 @@ dev = [
 requires-dist = [
     { name = "cua-auto", specifier = ">=0.1.2" },
     { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
-    { name = "cua-fleet", specifier = "==0.1.8" },
+    { name = "cua-fleet", specifier = "==0.1.10" },
     { name = "grpcio", specifier = "==1.78.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "oras", specifier = ">=0.2.40" },


### PR DESCRIPTION
Refs #3159

## Scope
- require `cua-fleet==0.1.10`, which contains the template merge-patch fix from trycua/cloud#6848
- pass the required `HttpRequest.timeout_secs=30` field from Sandbox service and readiness transports
- lock and verify the five-platform published Fleet distribution

## Verification
- `cua-fleet 0.1.10` release workflow: five wheel jobs + public index smoke passed
- focused Sandbox compatibility/packaging tests: 21 passed
- Ruff check and format: clean
- broad Sandbox suite: 443 passed, 84 skipped; remaining failures require local computer-server/registry environments and include pre-existing pytest-asyncio fixture errors

## Release plan
- squash merge this PR
- run the authorized patch release workflow for `pypi/sandbox` to publish `cua-sandbox 0.3.5`
- verify a clean install and repeated warm-pool create/screenshot flow