### PR TITLE
feat(sandbox): construct Fleet requests through HttpRequestBuilder

### DIFF
--- a/libs/python/cua-sandbox/.bumpversion.cfg
+++ b/libs/python/cua-sandbox/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.5
+current_version = 0.3.6
 commit = True
 tag = True
 tag_name = sandbox-v{new_version}

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Any, Dict, Optional
+import math
+from typing import Any, Dict, List, Optional
 
 import httpx
 from cua_sandbox.transport.base import Transport
@@ -13,10 +14,38 @@ from cua_sandbox.transport.computer_server import (
     normalize_screen_size,
     parse_command_response,
 )
-from fleet_sdk import HttpHeader, HttpRequest
+from fleet_sdk import HttpHeader, HttpRequest, HttpRequestBuilder
 
 _CMD_MAX_RETRIES = 3
 _CMD_RETRY_BACKOFF_S = 0.5
+
+
+def build_http_request(
+    *,
+    method: str,
+    url: str,
+    headers: Optional[List[Any]] = None,
+    body: Optional[bytes] = None,
+    timeout_secs: Optional[int] = None,
+) -> HttpRequest:
+    """Construct ``fleet_sdk.HttpRequest`` through the builder API.
+
+    The builder treats optional record fields as skippable, so request
+    construction keeps working when the Fleet SDK adds fields. An absent
+    ``timeout_secs`` falls back to the native client's 30-second default.
+    """
+    builder = HttpRequestBuilder().method(method).url(url).headers(headers or [])
+    if body is not None:
+        builder = builder.body(body)
+    if timeout_secs is not None:
+        builder = builder.timeout_secs(timeout_secs)
+    return builder.build()
+
+
+def _whole_seconds(timeout: Optional[float]) -> Optional[int]:
+    if timeout is None or timeout <= 0:
+        return None
+    return math.ceil(timeout)
 
 
 class FleetTransport(Transport):
@@ -89,12 +118,12 @@ class FleetTransport(Transport):
             self._bound,
             service_name or self._service_name,
             path,
-            HttpRequest(
+            build_http_request(
                 method=method,
                 url=f"https://service.invalid{path}",
                 headers=headers,
                 body=body,
-                timeout_secs=30,
+                timeout_secs=_whole_seconds(self._timeout),
             ),
         )
         request = httpx.Request(method, f"https://service.invalid{path}")

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -21,7 +21,7 @@ from cua_sandbox._config import (
 )
 from cua_sandbox.image import Image, cloud_registry_image
 from cua_sandbox.transport.cyclops_http_client import CyclopsHttpClient
-from cua_sandbox.transport.fleet import FleetTransport
+from cua_sandbox.transport.fleet import FleetTransport, build_http_request
 from fleet_sdk import (
     AccessTokenProvider,
     AccessTokenProviderError,
@@ -53,6 +53,10 @@ logger = logging.getLogger(__name__)
 
 _DNS_LABEL_MAX_LENGTH = 63
 _CLAIM_HASH_LENGTH = 16
+# Bounds each readiness probe so one stalled /status round-trip cannot eat the
+# whole wait_service_ready deadline. Ignored by cua-fleet <= 0.1.8, whose
+# native client applies the same 30-second default.
+_READINESS_PROBE_TIMEOUT_SECS = 30
 
 
 def _claim_name(pool_name: str) -> str:
@@ -308,12 +312,10 @@ class _FleetClient:
                 sandbox,
                 service,
                 "/status",
-                HttpRequest(
+                build_http_request(
                     method="GET",
                     url="https://service.invalid/status",
-                    headers=[],
-                    body=None,
-                    timeout_secs=30,
+                    timeout_secs=_READINESS_PROBE_TIMEOUT_SECS,
                 ),
             )
             if 200 <= response.status < 500:

--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-sandbox"
-version = "0.3.5"
+version = "0.3.6"
 description = "CUA Sandbox — ephemeral and persistent sandboxed computer environments"
 readme = "README.md"
 license = "MIT"
@@ -29,7 +29,7 @@ requires-python = ">=3.11,<3.14"
 dependencies = [
     "cua-core>=0.3.0,<0.4.0",
     "cua-auto>=0.1.2",
-    "cua-fleet==0.1.10",
+    "cua-fleet==0.1.11",
     "websockets>=12.0",
     "httpx>=0.27.0",
     "oras>=0.2.40",

--- a/libs/python/cua-sandbox/tests/test_fleet_sdk_distribution.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_sdk_distribution.py
@@ -10,6 +10,6 @@ def test_fleet_sdk_is_provided_by_published_fleet_distribution():
     distribution_root = Path(cua_fleet_distribution.locate_file(".")).resolve()
     binding_path = Path(fleet_sdk.__file__).resolve()
 
-    assert cua_fleet_distribution.version == "0.1.10"
+    assert cua_fleet_distribution.version == "0.1.11"
     assert "fleet_sdk/__init__.py" in installed_files
     assert binding_path.is_relative_to(distribution_root)

--- a/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
@@ -18,7 +18,7 @@ class FleetSdkPackagingTests(unittest.TestCase):
             project = tomllib.load(pyproject_file)
 
         dependencies = project["project"]["dependencies"]
-        self.assertIn("cua-fleet==0.1.10", dependencies)
+        self.assertIn("cua-fleet==0.1.11", dependencies)
         self.assertFalse(any(dependency.startswith("cua-train") for dependency in dependencies))
         self.assertNotIn("cua-fleet", project["tool"]["uv"]["sources"])
         self.assertNotIn("cua-train", project["tool"]["uv"]["sources"])
@@ -49,7 +49,7 @@ class FleetSdkPackagingTests(unittest.TestCase):
         self.assertNotIn("cua-train", sandbox_dependencies)
         self.assertIn("cua-fleet", sandbox_requires_dist)
         self.assertNotIn("cua-train", sandbox_requires_dist)
-        self.assertEqual(packages["cua-fleet"]["version"], "0.1.10")
+        self.assertEqual(packages["cua-fleet"]["version"], "0.1.11")
         self.assertEqual(
             packages["cua-fleet"]["source"], {"registry": "https://wheels.cua.ai/simple"}
         )

--- a/libs/python/cua-sandbox/tests/test_fleet_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_transport.py
@@ -2,8 +2,8 @@ import base64
 import json
 
 import pytest
-from cua_sandbox.transport.fleet import FleetTransport
-from fleet_sdk import HttpResponse, Sandbox
+from cua_sandbox.transport.fleet import FleetTransport, build_http_request
+from fleet_sdk import HttpRequest, HttpResponse, Sandbox
 
 
 class FakeSDK:
@@ -64,3 +64,30 @@ async def test_connect_rejects_missing_service():
     )
     with pytest.raises(ValueError, match="does not expose service"):
         await transport.connect()
+
+
+def test_build_http_request_constructs_the_record_through_the_builder():
+    bounded = build_http_request(
+        method="GET", url="https://service.invalid/status", timeout_secs=30
+    )
+    unbounded = build_http_request(method="GET", url="https://service.invalid/status")
+
+    assert isinstance(bounded, HttpRequest)
+    assert (bounded.method, bounded.headers, bounded.body) == ("GET", [], None)
+    assert bounded.timeout_secs == 30
+    assert unbounded.timeout_secs is None
+
+
+@pytest.mark.asyncio
+async def test_requests_are_bounded_by_the_transport_timeout():
+    sdk = FakeSDK([response(), response()])
+    transport = FleetTransport(sdk=sdk, bound=sandbox())
+    await transport.connect()
+    fractional = FleetTransport(sdk=sdk, bound=sandbox(), timeout=0.5)
+    await fractional.connect()
+
+    await transport.request_service("api", method="GET", path="/status")
+    await fractional.request_service("api", method="GET", path="/status")
+
+    assert sdk.calls[0][3].timeout_secs == 30
+    assert sdk.calls[1][3].timeout_secs == 1

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -133,15 +133,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asyncio"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/ea/26c489a11f7ca862d5705db67683a7361ce11c23a7b98fc6c2deaeccede2/asyncio-4.0.0.tar.gz", hash = "sha256:570cd9e50db83bc1629152d4d0b7558d6451bb1bfd5dfc2e935d96fc2f40329b", size = 5371, upload-time = "2025-08-05T02:51:46.605Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/64/eff2564783bd650ca25e15938d1c5b459cda997574a510f7de69688cb0b4/asyncio-4.0.0-py3-none-any.whl", hash = "sha256:c1eddb0659231837046809e68103969b2bef8b0400d59cfa6363f6b5ed8cc88b", size = 5555, upload-time = "2025-08-05T02:51:45.767Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -419,7 +410,6 @@ source = { editable = "../agent" }
 dependencies = [
     { name = "aiohttp" },
     { name = "anyio" },
-    { name = "asyncio" },
     { name = "certifi" },
     { name = "cua-core" },
     { name = "httpx" },
@@ -441,7 +431,6 @@ requires-dist = [
     { name = "accelerate", marker = "extra == 'uitars-hf'" },
     { name = "aiohttp", specifier = ">=3.9.3" },
     { name = "anyio", specifier = ">=4.4.1" },
-    { name = "asyncio" },
     { name = "blobfile", marker = "extra == 'all'", specifier = ">=3.0.0" },
     { name = "blobfile", marker = "extra == 'opencua-hf'", specifier = ">=3.0.0" },
     { name = "certifi", specifier = ">=2024.2.2" },
@@ -539,19 +528,19 @@ dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
 name = "cua-fleet"
-version = "0.1.10"
+version = "0.1.11"
 source = { registry = "https://wheels.cua.ai/simple" }
 wheels = [
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:de4bffe01a1284e754da1f78c51beb09cc5d51d2ee74d804b8396e355a7938d0" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:55b7581c7ced27ea66723ce1618bcb340e5eae91597f1cfbada4fed52913a21a" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.10-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:89b8ea4455af973a7c4e1f6f02159ebb45f5302f61642b6b41a7cbfa56fbf110" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.10-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:c0290ffb839a5901abee39a8c800ea9b0ddcf3a3555a67795189e04c247283d0" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.10-py3-none-win_amd64.whl", hash = "sha256:38aaeced50971506205b9c056de992d29fcbb936f921850e1937e1e787819ee3" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5884a26388b44e9cf59314d20b9aae34f278c48b108d927ebaf802b8d5b7d7f6" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1f6d1532f76166fe30001c68765c4f3fcb94e9b713751f7a009d3780f523aa9c" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.11-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:c76052d9cb1710936a59709fd5a2894fe9fb43fe89e2a0313ad0b88faf4c2b1e" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.11-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:0539a40aac915368362dd2f3e90d4b6d233e7bece77d13a5733d8cecb7298731" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.11-py3-none-win_amd64.whl", hash = "sha256:da8e1c40abcd3fee5cdab48801d4bd43a277ecddb7afebcba3d9885d9ec5d431" },
 ]
 
 [[package]]
 name = "cua-sandbox"
-version = "0.1.28"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "cua-auto" },
@@ -588,7 +577,7 @@ dev = [
 requires-dist = [
     { name = "cua-auto", specifier = ">=0.1.2" },
     { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
-    { name = "cua-fleet", specifier = "==0.1.10" },
+    { name = "cua-fleet", specifier = "==0.1.11" },
     { name = "grpcio", specifier = "==1.78.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "oras", specifier = ">=0.2.40" },
@@ -631,7 +620,7 @@ name = "ewmhlib"
 version = "0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "python-xlib" },
+    { name = "python-xlib", marker = "sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [


### PR DESCRIPTION
## Summary

- Problem this solves: cua-sandbox constructed Fleet `HttpRequest` records through the raw UniFFI constructor, whose shape changes whenever the Fleet SDK adds a record field — the version-skew failure class behind #3159, worked around in 0.3.5 by hard-pinning and always passing `timeout_secs`.
- What changed: all Fleet request construction now goes through `build_http_request`, which uses the `HttpRequestBuilder` API shipped in cua-fleet 0.1.11 (trycua/cloud#6998). Optional fields are skippable at the builder, so future SDK field additions cannot break construction. `wait_service_ready` probes and `FleetTransport` requests keep their 30-second bound (fractional transport timeouts round up). The pin moves to `cua-fleet==0.1.11`, `libs/fleet` is synced with the upstream SDK (optional `timeout_secs` + generated builders in all four language bindings), and cua-sandbox is bumped to 0.3.6.

## Related work

Refs #3159

RFC: not required — no public API shape changes in cua-sandbox; the SDK contract change landed upstream in trycua/cloud#6998 with the record constructor remaining available and backward compatible.

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: none at the cua-sandbox API surface. Wire behavior unchanged: absent timeout still falls back to the native client's 30-second default; readiness probes and transport requests carry the same explicit bound as 0.3.5.
- Risk and rollback: low — construction-path refactor with identical built records (verified by tests asserting method/headers/body/timeout on the built record). Rollback is reverting to the 0.3.5 direct-constructor call sites; cua-fleet 0.1.11 accepts both styles.

## Validation

- Focused tests and checks: 151 passed across `test_fleet_transport`, `test_fleet_cloud_client`, `test_fleet_cloud_transport`, `test_pool`, `test_sandbox_fleet_lifecycle`, `test_fleet_builder_usage`, `test_fleet_sdk_distribution`, `test_fleet_sdk_packaging` against the published `cua-fleet==0.1.11` wheel; `ruff check` clean; `uv.lock` resolves 0.1.11 from wheels.cua.ai.
- Manual or platform evidence: upstream trycua/cloud#6998 merged with all checks green, including live app-controlled examples in all seven languages exercising `HttpRequestBuilder` against the production control plane.
- Known gaps or CI still required: repository CI on this PR; post-merge periodic-cua-sandbox-live run against released 0.3.6 + 0.1.11.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [x] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_015mvgxXwVSX18pLXySr2ekA)_