### PR TITLE
docs(cua-driver): accept every supported platform in the history event schema

### DIFF
--- a/libs/cua-driver/docs/computer-history-event-v0.schema.json
+++ b/libs/cua-driver/docs/computer-history-event-v0.schema.json
@@ -45,7 +45,7 @@
         "session_id": { "$ref": "#/$defs/opaqueId" },
         "action_id": { "$ref": "#/$defs/opaqueId" },
         "sequence": { "type": "integer", "minimum": 1 },
-        "platform": { "const": "macos" },
+        "platform": { "enum": ["macos", "windows", "linux"] },
         "process_model": { "const": "in_daemon" },
         "capability": { "type": "string", "minLength": 1, "maxLength": 128 },
         "caller_category": { "const": "cua_runtime" },


### PR DESCRIPTION
## Summary

- widen `data.platform` in the published Computer History event schema from `{"const": "macos"}` to the set the emitter actually produces

The schema predates the Windows/Linux extension in #3189. `platform_name()` in `history_runtime.rs` returns exactly one of `macos | windows | linux`, so any consumer validating real events against the published v0 schema rejects everything produced off macOS.

## Validation

- schema parses as valid JSON after the edit
- verified against a live Windows event from cua-driver `0.20.1-nightly.20260817.31994594712`, which carries `"platform": "windows"` and previously failed validation
- `enum` mirrors `platform_name()` exactly, so no value can validate that the emitter cannot produce

## Scope

Documentation only, no product behavior change — `docs:` type, non-releasing.

The two substantive Windows bugs found in the same investigation are filed separately and are **not** addressed here: #3220 (history records no action events when the MCP host predates `history enable`) and #3221 (ApplicationFrameHost-hosted apps all attribute to the host).

## Note for reviewers

Opened for review, not merged. The desktop E2E matrix in `AGENTS.md` has not been run for this change; it is docs-only, so please confirm whether that gate applies before merging.

Closes #3222

🤖 Generated with [Claude Code](https://claude.com/claude-code)