### PR TITLE
fix(cua-driver): tell operators to reconnect agent sessions after history enable

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -2542,6 +2542,14 @@ pub fn run_history_cmd(
                 println!(
                     "Controls: history pause | resume | status | list | disable | delete --yes"
                 );
+                // An MCP host that connected while history was unadmitted owns a
+                // direct in-process runtime for its whole lifetime, and that
+                // runtime never registers the history hook. Its actions are
+                // dropped silently while every status surface reports ready, so
+                // say so here rather than let the operator infer it. See #3220.
+                println!(
+                    "Reconnect any agent session that was already connected: sessions started before now do not record actions."
+                );
             } else {
                 println!("{}", serde_json::to_string_pretty(&value).unwrap());
             }


### PR DESCRIPTION
## Summary

- `history enable` now states that agent sessions connected before admission must reconnect before their actions can be recorded

## Root cause and supported behavior

A bare Windows/Linux MCP host owns a direct in-process runtime for its lifetime. If it started before Computer History was admitted, its registry has no history hook. Retrofitting that process would violate the direct-runtime/single-writer ownership boundary; the supported transition is reconnecting the agent so the replacement host observes admission and proxies through the admitted daemon.

Previously every status surface reported healthy while the old host silently omitted actions. The enable disclosure now makes the required lifecycle step explicit at the moment it matters.

## Validation

Candidate: `d42f99c73f9ab11f954c95b4047deaedf97322d1`

- `cargo fmt -p cua-driver -- --check`
- `cargo check -p cua-driver`
- full PR CI green, including Linux/Windows unit and compile, macOS/Linux/Windows rustfmt, and portable contract parity on all three platforms
- manual Windows replay confirmed actions are recorded after reconnect

This changes only operator output; desktop behavior is unchanged, so unrelated desktop E2E rows do not require recertification.

Closes #3220