### PR TITLE
fix(cua-driver): tolerate missing local autostart task

### DIFF
--- a/libs/cua-driver/scripts/install-local.ps1
+++ b/libs/cua-driver/scripts/install-local.ps1
@@ -148,7 +148,18 @@ function Register-CuaDriverAutostart {
 }
 
 function Stop-CuaDriverLocalDaemons {
-    & schtasks.exe /End /TN "cua-driver-local-serve" 2>$null | Out-Null
+    # A missing task is the normal state for -NoAutoStart and for a first
+    # install. Windows PowerShell 5.1 promotes schtasks.exe stderr to an
+    # ErrorRecord, so temporarily relax the script-wide Stop preference for
+    # this deliberately best-effort cleanup.
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        & schtasks.exe /End /TN "cua-driver-local-serve" 2>$null | Out-Null
+    }
+    finally {
+        $ErrorActionPreference = $previousPreference
+    }
     Get-Process -Name "cua-driver-local","cua-driver-uia-local" -ErrorAction SilentlyContinue |
         Stop-Process -Force -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
## Summary

- make the Windows local installer's daemon cleanup tolerate an absent `cua-driver-local-serve` scheduled task
- preserve the script-wide strict error policy everywhere else

## Root cause

`Stop-CuaDriverLocalDaemons` documents task shutdown as best-effort, but Windows PowerShell 5.1 promotes `schtasks.exe` stderr into an `ErrorRecord`. With `$ErrorActionPreference = Stop`, the expected “task not found” result terminated a first install or any `-NoAutoStart` install after a successful release build.

## Validation

- PowerShell parser reports no syntax errors
- direct missing-task cleanup replay completes successfully under the same shell
- `git diff --check`

Closes #3228