### PR TITLE
docs: link GPU guide to canonical blog post

### DIFF
--- a/docs/content/docs/how-to-guides/lume/gpu-passthrough.mdx
+++ b/docs/content/docs/how-to-guides/lume/gpu-passthrough.mdx
@@ -13,7 +13,7 @@ the guest kernel. If you're looking for computer-use automation instead, start w
 [Cua Driver](/tutorials/drive-your-first-app) or
 [Cua Sandbox](/tutorials/your-first-local-sandbox).
 
-Read the [technical writeup](/blog/gpu-passthrough-macos-vms) for the mechanism, benchmark evidence,
+Read the [technical writeup](https://cua.ai/blog/gpu-passthrough-macos-vms) for the mechanism, benchmark evidence,
 and architectural context. Apple's [Metal capability tables](https://developer.apple.com/metal/capabilities/)
 and [feature-detection guide](https://developer.apple.com/documentation/metal/detecting-gpu-features-and-metal-software-versions)
 explain how applications select behavior from reported device support.
@@ -282,6 +282,6 @@ unrestricted feature level.
 ## See also
 
 - [Lume source tree](https://github.com/trycua/cua/tree/main/libs/lume)
-- [Technical writeup and benchmark evidence](/blog/gpu-passthrough-macos-vms)
+- [Technical writeup and benchmark evidence](https://cua.ai/blog/gpu-passthrough-macos-vms)
 - [Install and run Lume](/how-to-guides/lume/install-lume)
 - [How SIP works in Lume VMs](/concepts/how-sip-works-in-lume-vms)


### PR DESCRIPTION
## Summary

- replace two root-relative blog links in the GPU passthrough guide with the canonical absolute article URL
- prevent the production docs renderer from resolving them under `/docs/blog`, where they return 404

Closes #3230

## Confirmed reproduction

Before this change, both source links render as `https://cua.ai/docs/blog/gpu-passthrough-macos-vms` (404). The canonical destination `https://cua.ai/blog/gpu-passthrough-macos-vms` returns 200.

## Verification

- `npx --yes pnpm@9.0.4 docs:check`
- `npx --yes pnpm@9.0.4 docs:check-hygiene`
- `npx --yes pnpm@9.0.4 docs:check-links`
- `npx --yes pnpm@9.0.4 exec prettier --check content/docs/how-to-guides/lume/gpu-passthrough.mdx`
- `npx --yes pnpm@9.0.4 build`
- direct HTTP check: canonical article returns 200

`docs:check-links:external` was also run. It verified the new destination but the repository-wide command remains red on 13 unrelated pre-existing external URL failures (GitHub 404/502/503 responses and one fetch failure); none is in the changed file.

## Risk

Low. Documentation-only two-link correction; no application code, dependencies, lockfiles, generated files, product claims, or deployment configuration changed.