### PR TITLE
chore(cua-sandbox): bump version to 0.4.0

### DIFF
--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-sandbox"
-version = "0.3.6"
+version = "0.4.0"
 description = "CUA Sandbox — ephemeral and persistent sandboxed computer environments"
 readme = "README.md"
 license = "MIT"

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "cua-sandbox"
-version = "0.3.6"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cua-auto" },


### PR DESCRIPTION
Release bump for #3215 (`feat(cua-sandbox)!`): pool names are now required/explicit for Fleet images, and namespace-write 403s raise `PoolAccessDeniedError`. Breaking change → minor bump to 0.4.0.

After merge: publish via tag `sandbox-v0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)