### PR TITLE
fix(cua-sandbox): adopt upstream PoolAccessDenied via cua-fleet 0.1.12

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/pool.py
+++ b/libs/python/cua-sandbox/cua_sandbox/pool.py
@@ -11,6 +11,8 @@ from cua_sandbox.transport.fleet import FleetTransport
 from cua_sandbox.transport.fleet_cloud import (
     FleetCloudTransport,
     _FleetClient,
+    _NATIVE_POOL_ACCESS_DENIED,
+    _canonicalize_pool_access_denied,
     _pool_access_denied,
 )
 from fleet_sdk import (
@@ -76,6 +78,8 @@ class Template:
         try:
             try:
                 return cls(await client.reconcile_template(request))
+            except _NATIVE_POOL_ACCESS_DENIED as error:
+                raise _canonicalize_pool_access_denied(error)
             except SdkError.Status as error:
                 if error.status == 403:
                     raise _pool_access_denied(request.namespace, error) from error
@@ -223,6 +227,8 @@ class Pool:
         try:
             try:
                 return cls(await client.reconcile_pool(request))
+            except _NATIVE_POOL_ACCESS_DENIED as error:
+                raise _canonicalize_pool_access_denied(error)
             except SdkError.Status as error:
                 if error.status == 403:
                     raise _pool_access_denied(request.namespace, error) from error

--- a/libs/python/cua-sandbox/cua_sandbox/pool.py
+++ b/libs/python/cua-sandbox/cua_sandbox/pool.py
@@ -9,10 +9,10 @@ from cua_sandbox.image import Image
 from cua_sandbox.sandbox import Sandbox
 from cua_sandbox.transport.fleet import FleetTransport
 from cua_sandbox.transport.fleet_cloud import (
-    FleetCloudTransport,
-    _FleetClient,
     _NATIVE_POOL_ACCESS_DENIED,
+    FleetCloudTransport,
     _canonicalize_pool_access_denied,
+    _FleetClient,
     _pool_access_denied,
 )
 from fleet_sdk import (

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -74,20 +74,45 @@ else:
         """Fleet refused a pool or template operation for this credential."""
 
 
-def _pool_access_denied(namespace: str, error: SdkError.Status) -> Exception:
-    if _UPSTREAM_POOL_ACCESS_DENIED is not None:
-        return _UPSTREAM_POOL_ACCESS_DENIED(
-            operation=error.operation,
-            namespace=namespace,
-            status=error.status,
-            body=error.body,
-        )
-    return PoolAccessDeniedError(
-        f"Fleet denied {error.operation} on pool namespace '{namespace}' "
-        f"(HTTP {error.status}: {error.body}). Pool names are globally unique "
+# Catch tuple for pool-access denials raised natively by newer Fleet SDKs;
+# empty when the installed cua-fleet predates the upstream variant.
+_NATIVE_POOL_ACCESS_DENIED = (
+    () if _UPSTREAM_POOL_ACCESS_DENIED is None else (_UPSTREAM_POOL_ACCESS_DENIED,)
+)
+
+
+def _pool_access_denied_message(operation: str, namespace: str, status: int, body: str) -> str:
+    return (
+        f"Fleet denied {operation} on pool namespace '{namespace}' "
+        f"(HTTP {status}: {body}). Pool names are globally unique "
         "across accounts, so this name may already be taken — try a new pool "
         "name. If that does not work, contact support on Discord: "
         "https://discord.gg/mVnXXpdE85"
+    )
+
+
+def _canonicalize_pool_access_denied(error: Exception) -> Exception:
+    # The uniffi-generated exception renders as a field dump
+    # (operation=..., namespace=..., ...); restore the Rust Display message so
+    # both raise paths read identically.
+    error.args = (
+        _pool_access_denied_message(error.operation, error.namespace, error.status, error.body),
+    )
+    return error
+
+
+def _pool_access_denied(namespace: str, error: SdkError.Status) -> Exception:
+    if _UPSTREAM_POOL_ACCESS_DENIED is not None:
+        return _canonicalize_pool_access_denied(
+            _UPSTREAM_POOL_ACCESS_DENIED(
+                operation=error.operation,
+                namespace=namespace,
+                status=error.status,
+                body=error.body,
+            )
+        )
+    return PoolAccessDeniedError(
+        _pool_access_denied_message(error.operation, namespace, error.status, error.body)
     )
 
 
@@ -492,6 +517,8 @@ class FleetCloudTransport(FleetTransport):
                             self._template = await self._sdk.reconcile_template(
                                 self._template_request()
                             )
+                        except _NATIVE_POOL_ACCESS_DENIED as error:
+                            raise _canonicalize_pool_access_denied(error)
                         except SdkError.Status as error:
                             if error.status == 403:
                                 raise _pool_access_denied(self._pool_name, error) from error

--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-sandbox"
-version = "0.4.0"
+version = "0.4.1"
 description = "CUA Sandbox — ephemeral and persistent sandboxed computer environments"
 readme = "README.md"
 license = "MIT"
@@ -29,7 +29,7 @@ requires-python = ">=3.11,<3.14"
 dependencies = [
     "cua-core>=0.3.0,<0.4.0",
     "cua-auto>=0.1.2",
-    "cua-fleet==0.1.11",
+    "cua-fleet==0.1.12",
     "websockets>=12.0",
     "httpx>=0.27.0",
     "oras>=0.2.40",

--- a/libs/python/cua-sandbox/tests/test_pool.py
+++ b/libs/python/cua-sandbox/tests/test_pool.py
@@ -986,6 +986,33 @@ async def test_pool_apply_maps_forbidden_template_reconcile_and_still_rolls_back
 
 
 @pytest.mark.asyncio
+async def test_pool_apply_canonicalizes_native_pool_access_denied(monkeypatch):
+    upstream = getattr(SdkError, "PoolAccessDenied", None)
+    if upstream is None:
+        pytest.skip("installed cua-fleet predates SdkError.PoolAccessDenied")
+
+    native = upstream(
+        operation="create pool",
+        namespace="workspace",
+        status=403,
+        body="k8s request is not allowed",
+    )
+    clients = [FakeFleetClient(reconcile_error=native)]
+    iterator = iter(clients)
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: next(iterator))
+
+    with pytest.raises(PoolAccessDeniedError, match="globally unique") as error:
+        await Pool.apply(
+            Image.from_registry("registry.example/workspace:latest"),
+            name="workspace",
+        )
+
+    assert error.value is native
+    assert "Fleet denied create pool on pool namespace 'workspace'" in str(error.value)
+    assert "https://discord.gg/mVnXXpdE85" in str(error.value)
+
+
+@pytest.mark.asyncio
 async def test_pool_apply_rollback_failure_does_not_mask_template_error(monkeypatch):
     class DeleteDeniedClient(FakeFleetClient):
         async def delete_pool(self, pool: object) -> None:

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -528,19 +528,19 @@ dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
 name = "cua-fleet"
-version = "0.1.11"
+version = "0.1.12"
 source = { registry = "https://wheels.cua.ai/simple" }
 wheels = [
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5884a26388b44e9cf59314d20b9aae34f278c48b108d927ebaf802b8d5b7d7f6" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1f6d1532f76166fe30001c68765c4f3fcb94e9b713751f7a009d3780f523aa9c" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.11-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:c76052d9cb1710936a59709fd5a2894fe9fb43fe89e2a0313ad0b88faf4c2b1e" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.11-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:0539a40aac915368362dd2f3e90d4b6d233e7bece77d13a5733d8cecb7298731" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.11-py3-none-win_amd64.whl", hash = "sha256:da8e1c40abcd3fee5cdab48801d4bd43a277ecddb7afebcba3d9885d9ec5d431" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d5114ba97ef208e257bef261f6d3585b265f1f2c32cb627bcc9f44d753e60b75" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:82762fae4943b20aae05b39362f5bd0c179f84c16dac1e948debb3d58db5adc2" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.12-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:0a39e52cbec94a2bc71f45282dd34c896fd154bc7f7a137fc6ceff82edfc0973" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.12-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:d8ef6a0c8ac6e6f8dda937e3aebeef7f5b4fa9e3f29edc55a602a1c874f3f96a" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.12-py3-none-win_amd64.whl", hash = "sha256:c280d7ceadedc1d5c4c59869940c3390aac321f12ac9c9ee52250f212b6aac75" },
 ]
 
 [[package]]
 name = "cua-sandbox"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "cua-auto" },
@@ -577,7 +577,7 @@ dev = [
 requires-dist = [
     { name = "cua-auto", specifier = ">=0.1.2" },
     { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
-    { name = "cua-fleet", specifier = "==0.1.11" },
+    { name = "cua-fleet", specifier = "==0.1.12" },
     { name = "grpcio", specifier = "==1.78.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "oras", specifier = ">=0.2.40" },


### PR DESCRIPTION
Pins `cua-fleet==0.1.12`, whose native client raises `SdkError.PoolAccessDenied` for 403s on pool-namespace writes (trycua/cloud#7013). `PoolAccessDeniedError` now aliases the upstream variant via the existing shim.

One behavior the shim alone could not cover: the uniffi-generated Python exception renders as a field dump (`operation='create pool', namespace=...`) rather than the Rust `Display` message — both when constructed Python-side and when raised natively across the FFI. This PR canonicalizes the exception's `args` at construction and at the three write-path catch sites, so the user-facing message stays byte-identical to the Rust SDK's ("…globally unique across accounts… Discord…"). A new test pins the native-raise path; the existing 403-mapping tests pin the shim path.

Also bumps the package version to 0.4.1 for release (tag `sandbox-v0.4.1` after merge).

Verification: `uv run --frozen pytest tests/test_pool.py tests/test_fleet_cloud_transport.py tests/test_sandbox_fleet_lifecycle.py tests/test_vm_cleanup.py tests/test_cloud.py -q` → 175 passed, 8 skipped; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)