### PR TITLE
test(cua-sandbox): tolerate Fleet 403 for not-yet-created pool namespaces

### DIFF
--- a/.github/scripts/tests/test_cua_fleet_release_wiring.py
+++ b/.github/scripts/tests/test_cua_fleet_release_wiring.py
@@ -3,21 +3,20 @@
 from pathlib import Path
 import unittest
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 class TestCuaFleetReleaseWiring(unittest.TestCase):
     """Keep Fleet's promotion workflow aligned with canonical SDK wheels."""
 
-    def test_publisher_promotes_cua_fleet_0_1_11(self) -> None:
+    def test_publisher_promotes_cua_fleet_0_1_12(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/cd-py-fleet.yml").read_text()
         expected_sources = {
-            "cua_fleet-0.1.11-py3-none-manylinux_2_34_x86_64.whl": "0539a40aac915368362dd2f3e90d4b6d233e7bece77d13a5733d8cecb7298731",
-            "cua_fleet-0.1.11-py3-none-manylinux_2_34_aarch64.whl": "c76052d9cb1710936a59709fd5a2894fe9fb43fe89e2a0313ad0b88faf4c2b1e",
-            "cua_fleet-0.1.11-py3-none-macosx_10_12_x86_64.whl": "5884a26388b44e9cf59314d20b9aae34f278c48b108d927ebaf802b8d5b7d7f6",
-            "cua_fleet-0.1.11-py3-none-macosx_11_0_arm64.whl": "1f6d1532f76166fe30001c68765c4f3fcb94e9b713751f7a009d3780f523aa9c",
-            "cua_fleet-0.1.11-py3-none-win_amd64.whl": "da8e1c40abcd3fee5cdab48801d4bd43a277ecddb7afebcba3d9885d9ec5d431",
+            "cua_fleet-0.1.12-py3-none-manylinux_2_34_x86_64.whl": "d8ef6a0c8ac6e6f8dda937e3aebeef7f5b4fa9e3f29edc55a602a1c874f3f96a",
+            "cua_fleet-0.1.12-py3-none-manylinux_2_34_aarch64.whl": "0a39e52cbec94a2bc71f45282dd34c896fd154bc7f7a137fc6ceff82edfc0973",
+            "cua_fleet-0.1.12-py3-none-macosx_10_12_x86_64.whl": "d5114ba97ef208e257bef261f6d3585b265f1f2c32cb627bcc9f44d753e60b75",
+            "cua_fleet-0.1.12-py3-none-macosx_11_0_arm64.whl": "82762fae4943b20aae05b39362f5bd0c179f84c16dac1e948debb3d58db5adc2",
+            "cua_fleet-0.1.12-py3-none-win_amd64.whl": "c280d7ceadedc1d5c4c59869940c3390aac321f12ac9c9ee52250f212b6aac75",
         }
 
         self.assertIn("https://wheels.cua.ai/simple/cua-fleet/$WHEEL", workflow)

--- a/.github/scripts/tests/test_periodic_cua_sandbox_live.py
+++ b/.github/scripts/tests/test_periodic_cua_sandbox_live.py
@@ -370,6 +370,7 @@ class TestPeriodicCuaSandboxLive(unittest.TestCase):
         self.assertIn("unexpected_inventory", pool_test)
         self.assertIn("module_origins", pool_test)
         self.assertIn("pool_pre_existed", pool_test)
+        self.assertIn("is_pool_missing_error", pool_test)
         self.assertNotIn("pool.delete(", pool_test)
         self.assertNotIn("delete_pool", pool_test)
         self.assertNotIn("delete_namespace", pool_test)

--- a/docs/superpowers/plans/2026-08-09-periodic-cua-sandbox-live-e2e.md
+++ b/docs/superpowers/plans/2026-08-09-periodic-cua-sandbox-live-e2e.md
@@ -930,8 +930,11 @@ The warm pool keeps `replicas=1` so claims bind to pre-provisioned capacity;
 the cold pool expresses scale-to-zero with
 `WarmPoolAutoscaling(min_pool_size=0, initial_pool_size=0, max_pool_size=1)`
 because pool reconciliation rejects `replicas` below one. Each run records
-`pool_pre_existed` and replica counts from `Pool.get`, reconciles the pinned
-configuration idempotently with `Pool.apply`, claims through
+`pool_pre_existed` and replica counts from `Pool.get`, treating both 403 and
+404 as not-pre-existed (`is_pool_missing_error`) because Fleet evaluates
+authorization before existence for namespaces that have not been created
+yet, reconciles the pinned configuration idempotently with `Pool.apply`,
+claims through
 `Sandbox.ephemeral(pool=..., name=...)` with the claim name fixed to the
 namespace, and exits with a claim-only release. After release the monitor
 polls until claims are absent and requires the reconciled inventory to contain

--- a/docs/superpowers/specs/2026-08-09-periodic-cua-sandbox-live-e2e-design.md
+++ b/docs/superpowers/specs/2026-08-09-periodic-cua-sandbox-live-e2e-design.md
@@ -203,7 +203,12 @@ cold-starts capacity through autoscaler demand.
 Each run observes the pool first with `Pool.get`, recording
 `pool_pre_existed` and the replica counts, then reconciles the pinned
 configuration with `Pool.apply` using the same certified image digest,
-`cpu=4`, and `memory_mb=4096`. Reconciliation is idempotent: it bootstraps a
+`cpu=4`, and `memory_mb=4096`. Fleet evaluates authorization before
+existence, so reading a pool in a namespace that has not been created yet
+returns 403 rather than 404; the observe step treats both statuses as
+not-pre-existed (`is_pool_missing_error`), mirroring the SDK's reconcile
+semantics, and a genuine access denial still fails the run at `Pool.apply`
+with the canonical `PoolAccessDenied` guidance. Reconciliation is idempotent: it bootstraps a
 missing pool, heals drift, and never deletes. The claim uses
 `Sandbox.ephemeral(pool=..., name=...)` with the claim name fixed to the
 namespace, so an interrupted run's claim is adopted and released by the next

--- a/libs/python/cua-sandbox/.bumpversion.cfg
+++ b/libs/python/cua-sandbox/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.6
+current_version = 0.4.1
 commit = True
 tag = True
 tag_name = sandbox-v{new_version}

--- a/libs/python/cua-sandbox/tests/live/fleet_e2e_support.py
+++ b/libs/python/cua-sandbox/tests/live/fleet_e2e_support.py
@@ -98,6 +98,13 @@ def is_not_found_error(error: BaseException) -> bool:
     return isinstance(error, SdkError.Status) and error.status == 404
 
 
+def is_pool_missing_error(error: BaseException) -> bool:
+    # Fleet evaluates RBAC before existence, so reading a pool in a namespace
+    # that has not been created yet returns 403 rather than 404. Mirror the
+    # SDK's reconcile semantics, which create the pool on either status.
+    return isinstance(error, SdkError.Status) and error.status in (403, 404)
+
+
 async def wait_claims_absent(
     client: CyclopsClient,
     name: str,

--- a/libs/python/cua-sandbox/tests/live/test_fleet_pool_persistent.py
+++ b/libs/python/cua-sandbox/tests/live/test_fleet_pool_persistent.py
@@ -16,7 +16,7 @@ from tests.live.fleet_e2e_support import (
     build_pool_namespace_name,
     collect_resource_inventory,
     has_oauth_credentials,
-    is_not_found_error,
+    is_pool_missing_error,
     wait_claims_absent,
     write_summary,
 )
@@ -103,7 +103,7 @@ async def run_fleet_pool_live(mode: str) -> None:
         try:
             existing = await Pool.get(namespace)
         except BaseException as error:
-            if not is_not_found_error(error):
+            if not is_pool_missing_error(error):
                 raise
             summary["pool_pre_existed"] = False
         else:

--- a/libs/python/cua-sandbox/tests/test_live_fleet_e2e_support.py
+++ b/libs/python/cua-sandbox/tests/test_live_fleet_e2e_support.py
@@ -14,6 +14,7 @@ from tests.live.fleet_e2e_support import (
     build_pool_namespace_name,
     collect_resource_inventory,
     has_oauth_credentials,
+    is_pool_missing_error,
     wait_claims_absent,
     write_summary,
 )
@@ -72,6 +73,21 @@ def test_build_pool_namespace_name_normalizes_invalid_overlong_input() -> None:
     assert len(name) <= 63
     assert re.fullmatch(r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", name)
     assert name.startswith("cua-live-pool-warm-published-package-")
+
+
+@pytest.mark.parametrize(
+    ("error", "missing"),
+    [
+        (SdkError.Status("get pool", 404, b"not found"), True),
+        (SdkError.Status("get pool", 403, b"forbidden"), True),
+        (SdkError.Status("get pool", 500, b"failure"), False),
+        (RuntimeError("transport down"), False),
+    ],
+)
+def test_is_pool_missing_error_mirrors_reconcile_semantics(
+    error: BaseException, missing: bool
+) -> None:
+    assert is_pool_missing_error(error) is missing
 
 
 def test_support_has_oauth_credentials_requires_both_values(monkeypatch) -> None:

--- a/libs/python/cua-sandbox/tests/test_live_fleet_pool_support.py
+++ b/libs/python/cua-sandbox/tests/test_live_fleet_pool_support.py
@@ -22,6 +22,12 @@ def not_found(operation: str = "get pool") -> SdkError.Status:
     return SdkError.Status(operation, 404, b"not found")
 
 
+def forbidden(operation: str = "get pool") -> SdkError.Status:
+    # Fleet returns 403 for pool reads in namespaces that have not been
+    # created yet, because RBAC is evaluated before existence.
+    return SdkError.Status(operation, 403, b"forbidden")
+
+
 class FakePoolHandle:
     def __init__(self, resource) -> None:
         self._resource = resource
@@ -227,6 +233,36 @@ async def test_pool_pre_existed_false_is_recorded_for_public_sdk_404(monkeypatch
     assert summary["pool_pre_existed"] is False
     assert "ready_replicas_before" not in summary
     assert summary["warm_bind_sla_applied"] is False
+
+
+@pytest.mark.asyncio
+async def test_pool_pre_existed_false_is_recorded_for_uncreated_namespace_403(
+    monkeypatch, tmp_path
+) -> None:
+    namespace = "cua-live-pool-warm-test-schedule"
+    harness = install_pool_runner(monkeypatch, tmp_path, mode="warm", namespace=namespace)
+    harness.get_results = [forbidden(), make_pool_resource(namespace)]
+
+    await pool_live.run_fleet_pool_live("warm")
+
+    summary = harness.summaries["summary-pool-warm.json"]
+    assert summary["pool_pre_existed"] is False
+    assert "ready_replicas_before" not in summary
+    assert summary["warm_bind_sla_applied"] is False
+
+
+@pytest.mark.asyncio
+async def test_observe_propagates_non_missing_pool_errors(monkeypatch, tmp_path) -> None:
+    namespace = "cua-live-pool-warm-test-schedule"
+    harness = install_pool_runner(monkeypatch, tmp_path, mode="warm", namespace=namespace)
+    harness.get_results = [SdkError.Status("get pool", 500, b"failure")]
+
+    with pytest.raises(SdkError.Status):
+        await pool_live.run_fleet_pool_live("warm")
+
+    assert harness.apply_calls == []
+    summary = harness.summaries["summary-pool-warm.json"]
+    assert summary["error"] == {"type": "Status"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Problem this solves: The persistent pool suite added in #3218 failed its first scheduled runs at the observe step. `Pool.get` on a pool namespace that has not been created yet returns **403**, not 404, because Fleet evaluates authorization before existence — and the suite only tolerated 404, so both pool lanes failed in seconds and fired critical alerts every 15-minute tick.
- What changed: The observe step now treats 403 and 404 as "pool not pre-existed" via a new `is_pool_missing_error` helper, mirroring the SDK's own `reconcile_pool` semantics (pools.rs treats `403 | 404` as create). A genuine access denial still fails the run at `Pool.apply` with the canonical `PoolAccessDenied` guidance introduced by cua-fleet 0.1.12 (#3234).

## Related work

Refs #3218, #3234

RFC: Not required; this fixes the live-test bootstrap path of existing test infrastructure.

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: None. Test infrastructure only.
- Risk and rollback: Low. The 403-tolerance is scoped to the observe step of the pool suite; real RBAC failures still surface at `Pool.apply` with an actionable message.

## Validation

- Focused tests and checks:
  - New unit tests: 403 observe case records `pool_pre_existed=false` and proceeds; 500 still propagates and skips `Pool.apply`; `is_pool_missing_error` parametrized over 403/404/500/non-SDK errors.
  - Workflow contract test now pins `is_pool_missing_error` as a required content marker of the pool live test.
  - Superpowers spec/plan docs describe the 403-before-existence semantics.
- Ride-along fixes for two latent scripts-suite drifts exposed by this branch (the suite only runs on PRs touching `.github/scripts/**`): the cua-fleet release wiring test now pins the 0.1.12 wheel set promoted by `cd-py-fleet.yml` since #3234, and `.bumpversion.cfg` tracks the 0.4.1 cua-sandbox version.
- Local: 238 scripts-suite tests pass, 64 sandbox offline tests pass (3 expected live skips), isort/black clean.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [x] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZC4ofqRTQ52tH9TTRQwKc

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZC4ofqRTQ52tH9TTRQwKc)_