### PR TITLE
fix(cua-driver): preserve history admission on macOS relaunch

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -362,6 +362,27 @@ fn run_mcp_direct(compatibility_mode: bool) -> anyhow::Result<()> {
     runtime.block_on(proxy::run_direct(driver))
 }
 
+fn history_admission_requested(explicit: bool, persisted: bool) -> bool {
+    explicit || persisted
+}
+
+#[cfg(test)]
+mod history_admission_tests {
+    use super::history_admission_requested;
+
+    #[test]
+    fn persisted_preview_admission_survives_a_relaunch_without_the_cli_flag() {
+        assert!(history_admission_requested(false, true));
+    }
+
+    #[test]
+    fn admission_requires_an_explicit_or_persisted_request() {
+        assert!(!history_admission_requested(false, false));
+        assert!(history_admission_requested(true, false));
+        assert!(history_admission_requested(true, true));
+    }
+}
+
 fn mcp_uses_direct_runtime(socket: Option<&str>, direct: bool) -> anyhow::Result<bool> {
     mcp_uses_direct_runtime_for(
         cua_driver_core::embedded_mode(),
@@ -533,7 +554,10 @@ fn main() {
                 std::process::exit(64);
             }
             responsibility::reexec_disclaimed_if_needed();
-            if let Err(error) = history_runtime::configure_admission(experimental_history) {
+            if let Err(error) = history_runtime::configure_admission(history_admission_requested(
+                experimental_history,
+                history_runtime::preview_admitted_preference(),
+            )) {
                 eprintln!("cua-driver: Computer History admission error: {error}");
                 std::process::exit(1);
             }
@@ -929,9 +953,10 @@ fn main() -> anyhow::Result<()> {
                 &grants,
             )?;
             responsibility::reexec_disclaimed_if_needed();
-            history_runtime::configure_admission(
-                experimental_history || history_runtime::preview_admitted_preference(),
-            )?;
+            history_runtime::configure_admission(history_admission_requested(
+                experimental_history,
+                history_runtime::preview_admitted_preference(),
+            ))?;
             history_runtime::configure_daemon_launch_state(
                 permission_mode.as_deref(),
                 dangerously_bypass_approvals,


### PR DESCRIPTION
## Summary

- Problem this solves: the packaged macOS app could lose Computer History preview admission after `history enable` relaunched it without forwarding `--experimental-history`.
- What changed: both daemon entry paths now admit history from either the explicit flag or the persisted preview preference, with regression coverage for the persisted-only relaunch case.

## Related work

Fixes #3243

RFC: not required; this restores the already-documented preview behavior without changing the CLI, MCP, permission, or storage contract.

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: macOS packaged relaunches now preserve the admission requested by `history enable`; Windows and Linux retain their existing behavior.
- Risk and rollback: low; the change centralizes an existing boolean rule and can be reverted as one commit.

## Validation

- Focused tests and checks: `cargo fmt --all -- --check`; `cargo test -p cua-driver history_admission_tests --locked` (2 passed); `cargo check -p cua-driver --locked`; `git diff --check`.
- Manual or platform evidence: release-path verification will be performed against the resulting nightly artifact after merge.
- Known gaps or CI still required: ordinary pull-request CI. Per maintainer direction, the broader certification matrix is intentionally skipped for this narrow nightly hotfix.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [x] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.