### PR TITLE
feat(cua-driver): recognize Helium for Linux profile attachment

### DIFF
--- a/docs/content/docs/reference/cua-driver/browser-profile-attachment.mdx
+++ b/docs/content/docs/reference/cua-driver/browser-profile-attachment.mdx
@@ -190,15 +190,19 @@ The browser-setup route is implemented for Google Chrome and Microsoft Edge on
 macOS and Windows. Chrome and Edge have product-specific acceptance evidence
 on Linux X11. Chrome is also accepted on GNOME Wayland, and Chromium is
 accepted alongside Chrome and Edge on the validated native-Wayland Sway lane.
-The Chromium-family products use the same descriptor-backed Linux route, but
-still need product-specific acceptance evidence on each desktop before they
-are listed as validated. Every route
-requires an
-exact authorized PID and native window, one uniquely matched setup control, a
-loopback endpoint owned by that process, one exact browser-owned consent
-action, and a fresh native/CDP rebind.
+Helium is recognized as a distinct Chromium-family product on Linux, resolves
+its default profile from `~/.config/net.imput.helium`, and can attach when that
+profile already exposes a uniquely PID-owned `DevToolsActivePort` endpoint.
+Automated setup is not enabled for Helium until its branded internal page has
+product-specific acceptance evidence; a profile without an existing endpoint
+fails closed. Every attachment requires an exact authorized PID and native
+window, a loopback endpoint owned by that process, and a fresh native/CDP
+rebind. Routes that surface a browser-owned connection prompt require one exact
+consent action. Setup-capable routes additionally require one uniquely matched
+setup control.
 
-Linux additionally requires the browser's complete AT-SPI renderer tree. Start
+Linux automated setup additionally requires the browser's complete AT-SPI
+renderer tree. Start
 the Chromium-family process with `--force-renderer-accessibility`, or run a
 screen reader that enables full renderer accessibility. On Sway and validated
 GNOME Shell sessions, Cua Driver briefly focuses the exact
@@ -210,7 +214,7 @@ sessions that cannot prove exact process, window, and geometry identity.
 
 The setup adapters currently recognize the products' English accessibility
 labels. Other UI locales fail closed without toggling an unrecognized control.
-Safari, Firefox, Brave, Vivaldi, Opera, Arc, and Electron do not have an
+Safari, Firefox, Helium, Brave, Vivaldi, Opera, Arc, and Electron do not have an
 existing-profile setup descriptor and return a structured refusal. An already
 available endpoint does not bypass existing-profile authorization for a
 standalone consumer browser. Driver-owned profiles and supported embedded

--- a/docs/content/docs/reference/cua-driver/limits.mdx
+++ b/docs/content/docs/reference/cua-driver/limits.mdx
@@ -23,7 +23,7 @@ but they do not receive typed browser mutation capabilities.
 
 | Surface | Typed browser identity | Typed mutation | Available fallback |
 | --- | --- | --- | --- |
-| Chrome, Edge, Chromium, Electron | Chromium | Exact CDP binding or structured refusal | Native `get_window_state` and AX/PX actions |
+| Chrome, Edge, Chromium, Helium, Electron | Chromium | Exact CDP binding or structured refusal | Native `get_window_state` and AX/PX actions |
 | Firefox | Gecko | `browser_route_unavailable` in the current release | Native accessibility and legacy `page` routes where supported |
 | Safari | WebKit | `browser_route_unavailable` in the current release | Native accessibility and explicit legacy Apple Events routes |
 | Tauri, WKWebView, and WebKitGTK hosts | WebKit where the host can be identified | Structured refusal until an exact engine/native-window binding exists | Native accessibility and pixel actions |
@@ -48,6 +48,7 @@ claim.
 | Linux Sway with Chrome | Validated only when compositor identity, process, window, and geometry are exact. |
 | Generic GNOME or KDE Wayland | Read-only discovery or structured refusal; mutation is not claimed. |
 | Electron | Validated only for the bounded one-native-window to one-CDP-page shape. |
+| Helium on Linux | Recognized for authorized attachment when a uniquely PID-owned `DevToolsActivePort` endpoint already exists; automated setup and release acceptance are not claimed. |
 | Brave, Vivaldi, Opera, Arc, and other detected Chromium derivatives | Detected but not release-accepted; use at your own risk. |
 | Safari, Firefox, WebView2, Tauri, WKWebView, and WebKitGTK | Typed mutation unsupported. Use documented native AX/PX fallbacks where available. |
 

--- a/libs/cua-driver/rust/Skills/cua-driver/BROWSER.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/BROWSER.md
@@ -169,6 +169,9 @@ window, toggle its uniquely labelled per-instance checkbox, prove that the
 loopback endpoint belongs to the approved process, and close the temporary
 tab. The result reports all visible `side_effects`. Missing, localized, or
 ambiguous controls are refused; never click a similar-looking prompt yourself.
+Linux Helium resolves its default profile from `~/.config/net.imput.helium`
+but currently requires an already available PID-owned endpoint; automated
+setup of its branded internal page is not claimed.
 On current macOS Chrome, the internal page may omit its web AX subtree. The
 driver's bounded fallback is limited to a temporary tab it created and
 navigated. It requires the committed fixed URL, expected selected-tab title,

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/setup_descriptor.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/setup_descriptor.rs
@@ -82,6 +82,11 @@ mod tests {
     use super::*;
 
     #[test]
+    fn helium_requires_an_existing_endpoint_until_setup_is_validated() {
+        assert!(existing_profile_setup_descriptor(BrowserProduct::Helium).is_none());
+    }
+
+    #[test]
     fn setup_is_limited_to_products_with_exact_descriptors() {
         assert_eq!(
             existing_profile_setup_descriptor(BrowserProduct::GoogleChrome)
@@ -103,6 +108,7 @@ mod tests {
         );
         for product in [
             BrowserProduct::Brave,
+            BrowserProduct::Helium,
             BrowserProduct::Firefox,
             BrowserProduct::Safari,
             BrowserProduct::Electron,

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/types.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/types.rs
@@ -59,6 +59,7 @@ pub enum BrowserEngineFamily {
 pub enum BrowserProduct {
     GoogleChrome,
     Chromium,
+    Helium,
     MicrosoftEdge,
     Brave,
     Vivaldi,
@@ -345,6 +346,14 @@ mod tests {
         assert_eq!(
             serde_json::to_value(with_listener).expect("serialize listener proof")["listener_pid"],
             43
+        );
+    }
+
+    #[test]
+    fn browser_product_helium_has_stable_public_name() {
+        assert_eq!(
+            serde_json::to_value(BrowserProduct::Helium).expect("serialize Helium product"),
+            "helium"
         );
     }
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
@@ -28,10 +28,10 @@ fn refusal(code: BrowserRefusalCode, message: impl Into<String>) -> BrowserRefus
 }
 
 fn is_helium(name: &str) -> bool {
-    name.rsplit(['/', '\\'])
-        .next()
-        .unwrap_or(name)
-        .eq_ignore_ascii_case("helium")
+    std::path::Path::new(name)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("helium"))
 }
 
 fn is_chromium(name: &str) -> bool {
@@ -1233,6 +1233,7 @@ mod tests {
         assert!(is_chromium("/opt/helium-browser-bin/helium"));
         assert!(!is_chromium("/opt/helium/not-a-browser"));
         assert!(!is_chromium("helium-helper"));
+        assert!(!is_chromium(r"/opt/fake\helium"));
         assert!(!is_chromium("firefox"));
         assert!(!is_chromium("search-worker"));
         assert!(!is_chromium("ledger-service"));

--- a/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
@@ -131,67 +131,80 @@ fn command_line_arguments(bytes: &[u8]) -> Vec<String> {
         .collect()
 }
 
-fn command_line_has_process_type(bytes: &[u8]) -> bool {
-    command_line_arguments(bytes).iter().any(|arg| {
-        arg.as_bytes()
-            .strip_prefix(b"--type=")
+fn has_process_type(arguments: &[String]) -> bool {
+    arguments.iter().any(|argument| {
+        argument
+            .strip_prefix("--type=")
             .is_some_and(|kind| !kind.is_empty())
     })
 }
 
-fn packed_helium_process_type(bytes: &[u8]) -> bool {
+/// Recover argv from the single space-joined `/proc/<pid>/cmdline` record
+/// observed for Helium, which does not use the usual NUL delimiter.
+///
+/// This is deliberately narrow: it applies only to a one-record command line
+/// whose first word is the exact Helium executable, and it splits only at a
+/// ` --` switch boundary so a value containing spaces
+/// (`--user-data-dir=/tmp/helium profile`) survives intact. Every other
+/// process keeps ordinary NUL semantics.
+fn packed_helium_arguments(bytes: &[u8]) -> Option<Vec<String>> {
     let arguments = command_line_arguments(bytes);
     let [packed] = arguments.as_slice() else {
-        return false;
+        return None;
     };
-    let mut words = packed.split_ascii_whitespace();
-    let executable = words.next().unwrap_or_default();
-    let process_type = words.next().unwrap_or_default();
-    is_helium(executable)
-        && process_type
-            .strip_prefix("--type=")
-            .is_some_and(|kind| !kind.is_empty())
+    let (executable, switches) = packed.split_once(" --")?;
+    if !is_helium(executable) {
+        return None;
+    }
+    let mut recovered = Vec::new();
+    for switch in switches.split(" --") {
+        // Inside one switch record the boundary is already known, so a
+        // `--flag value` pair splits at its first space and everything after
+        // it is the value. `--flag=value` stays a single argument.
+        match switch.split_once(' ') {
+            Some((flag, value)) if !flag.contains('=') => {
+                recovered.push(format!("--{flag}"));
+                recovered.push(value.to_owned());
+            }
+            _ => recovered.push(format!("--{switch}")),
+        }
+    }
+    Some(recovered)
 }
 
-fn packed_helium_user_data_dir(bytes: &[u8]) -> Result<Option<PathBuf>, BrowserRefusal> {
-    let arguments = command_line_arguments(bytes);
-    let [packed] = arguments.as_slice() else {
-        return Ok(None);
-    };
-    let executable = packed.split_ascii_whitespace().next().unwrap_or_default();
-    if !is_helium(executable) {
-        return Ok(None);
+fn packed_helium_process_type(bytes: &[u8]) -> bool {
+    // Chromium helpers place `--type=` first, so only that position counts.
+    // A `--type=` later in a packed record can be text inside another value,
+    // and honoring it would misclassify the main browser process as a helper.
+    packed_helium_arguments(bytes).is_some_and(|arguments| {
+        arguments
+            .first()
+            .and_then(|argument| argument.strip_prefix("--type="))
+            .is_some_and(|kind| !kind.is_empty())
+    })
+}
+
+fn user_data_dir_arguments(arguments: &[String]) -> Vec<PathBuf> {
+    let mut directories = Vec::new();
+    for (index, argument) in arguments.iter().enumerate() {
+        if let Some(path) = argument.strip_prefix("--user-data-dir=") {
+            if !path.is_empty() {
+                directories.push(PathBuf::from(path));
+            }
+        } else if argument == "--user-data-dir" {
+            if let Some(path) = arguments.get(index + 1).filter(|path| !path.is_empty()) {
+                directories.push(PathBuf::from(path));
+            }
+        }
     }
-    let marker = "--user-data-dir=";
-    let mut matches = packed.match_indices(marker);
-    let Some((marker_start, _)) = matches.next() else {
-        return Ok(None);
-    };
-    if matches.next().is_some() {
-        return Err(refusal(
-            BrowserRefusalCode::BrowserBindingAmbiguous,
-            "packed Helium command line has multiple --user-data-dir arguments",
-        ));
-    }
-    if marker_start == 0 || !packed[..marker_start].ends_with(' ') {
-        return Ok(None);
-    }
-    let value = &packed[marker_start + marker.len()..];
-    let value = value.split_once(" --").map_or(value, |(value, _)| value);
-    if value.is_empty() {
-        return Err(refusal(
-            BrowserRefusalCode::BrowserBindingAmbiguous,
-            "packed Helium command line has an empty --user-data-dir value",
-        ));
-    }
-    Ok(Some(PathBuf::from(value)))
+    directories
 }
 
 fn process_role_for_pid(pid: i64, product: BrowserProduct) -> BrowserProcessRole {
     let helper = std::fs::read(format!("/proc/{pid}/cmdline"))
         .ok()
         .is_some_and(|bytes| {
-            command_line_has_process_type(&bytes)
+            has_process_type(&command_line_arguments(&bytes))
                 || (product == BrowserProduct::Helium && packed_helium_process_type(&bytes))
         });
     if helper {
@@ -376,22 +389,10 @@ fn user_data_dir_for_pid(pid: i64) -> Result<Option<PathBuf>, BrowserRefusal> {
         .as_deref()
         .map(browser_product)
         .unwrap_or(BrowserProduct::Other);
-    let args = command_line_arguments(&bytes);
-    let mut directories = Vec::new();
-    for (index, arg) in args.iter().enumerate() {
-        if let Some(path) = arg.strip_prefix("--user-data-dir=") {
-            if !path.is_empty() {
-                directories.push(PathBuf::from(path));
-            }
-        } else if arg == "--user-data-dir" {
-            if let Some(path) = args.get(index + 1).filter(|path| !path.is_empty()) {
-                directories.push(PathBuf::from(path));
-            }
-        }
-    }
+    let mut directories = user_data_dir_arguments(&command_line_arguments(&bytes));
     if directories.is_empty() && product == BrowserProduct::Helium {
-        if let Some(path) = packed_helium_user_data_dir(&bytes)? {
-            directories.push(path);
+        if let Some(packed) = packed_helium_arguments(&bytes) {
+            directories = user_data_dir_arguments(&packed);
         }
     }
     directories.sort();
@@ -830,11 +831,15 @@ impl BrowserPlatform for LinuxBrowserPlatform {
         &self,
         pid: i64,
     ) -> Result<Option<OwnedEndpoint>, BrowserRefusal> {
-        let classification = self.classify_browser(pid).await?;
         if let Some(endpoint) = active_port_endpoint(pid)? {
             return Ok(Some(endpoint));
         }
-        if classification.product_kind == BrowserProduct::Helium {
+        // Helium's documented Linux boundary is its own PID-owned
+        // DevToolsActivePort file. Without it, refuse instead of accepting an
+        // arbitrary PID-owned listener through generic /json/version
+        // discovery. Classification is deliberately deferred to here so the
+        // ordinary Chrome/Edge path does not pay a full /proc enumeration.
+        if self.classify_browser(pid).await?.product_kind == BrowserProduct::Helium {
             return Ok(None);
         }
         let ports = tokio::task::spawn_blocking(move || loopback_ports_for_pid(pid))
@@ -1340,13 +1345,17 @@ mod tests {
 
     #[test]
     fn process_type_detection_handles_nul_and_packed_command_lines() {
-        assert!(command_line_has_process_type(b"helium\0--type=renderer\0"));
+        assert!(has_process_type(&command_line_arguments(
+            b"helium\0--type=renderer\0"
+        )));
         assert!(packed_helium_process_type(
             b"/opt/helium-browser-bin/helium --type=gpu-process --utility-sub-type=test\0"
         ));
-        assert!(!command_line_has_process_type(
+        // Packed records are never split on whitespace by the NUL parser.
+        assert!(!has_process_type(&command_line_arguments(
             b"/opt/helium-browser-bin/helium --type=gpu-process --utility-sub-type=test\0"
-        ));
+        )));
+        // A `--type=` that is not the first switch is not a helper marker.
         assert!(!packed_helium_process_type(
             b"/opt/helium-browser-bin/helium --load-extension=/tmp/example --type=renderer\0"
         ));
@@ -1354,6 +1363,13 @@ mod tests {
             b"/opt/helium-browser-bin/helium --user-data-dir=/tmp/helium profile --type=renderer\0"
         ));
         assert!(!packed_helium_process_type(b"helium --type=\0"));
+        // The packed fallback is Helium-only and single-record only.
+        assert!(!packed_helium_process_type(
+            b"/opt/google/chrome/chrome --type=renderer\0"
+        ));
+        assert!(!packed_helium_process_type(
+            b"/opt/helium-browser-bin/helium\0--type=renderer\0"
+        ));
     }
 
     #[test]
@@ -1374,12 +1390,64 @@ mod tests {
                 "/tmp/helium-profile"
             ]
         );
+    }
+
+    #[test]
+    fn packed_helium_recovery_keeps_switch_boundaries_and_spaced_values() {
+        let packed = packed_helium_arguments(
+            b"/opt/helium-browser-bin/helium --user-data-dir=/tmp/helium profile --remote-debugging-port=0\0",
+        )
+        .expect("packed Helium argv");
         assert_eq!(
-            packed_helium_user_data_dir(
-                b"/opt/helium-browser-bin/helium --user-data-dir=/tmp/helium profile --remote-debugging-port=0\0"
-            )
-            .expect("packed profile argument"),
-            Some(PathBuf::from("/tmp/helium profile"))
+            packed,
+            [
+                "--user-data-dir=/tmp/helium profile",
+                "--remote-debugging-port=0"
+            ]
+        );
+        assert_eq!(
+            user_data_dir_arguments(&packed),
+            [PathBuf::from("/tmp/helium profile")]
+        );
+        // The separated form resolves through the same shared extractor.
+        assert_eq!(
+            user_data_dir_arguments(
+                &packed_helium_arguments(
+                    b"/opt/helium-browser-bin/helium --user-data-dir /tmp/helium profile --no-first-run\0"
+                )
+                .expect("packed Helium argv")
+            ),
+            [PathBuf::from("/tmp/helium profile")]
+        );
+        // Non-Helium executables and NUL-delimited records are not recovered.
+        assert!(
+            packed_helium_arguments(b"/opt/google/chrome/chrome --user-data-dir=/tmp/x\0")
+                .is_none()
+        );
+        assert!(
+            packed_helium_arguments(b"/opt/helium-browser-bin/helium\0--no-first-run\0").is_none()
+        );
+        assert!(packed_helium_arguments(b"/opt/helium-browser-bin/helium\0").is_none());
+    }
+
+    #[test]
+    fn user_data_dir_extraction_is_shared_by_both_argument_forms() {
+        let joined = ["--user-data-dir=/tmp/a".to_owned()];
+        let separated = ["--user-data-dir".to_owned(), "/tmp/b".to_owned()];
+        assert_eq!(user_data_dir_arguments(&joined), [PathBuf::from("/tmp/a")]);
+        assert_eq!(
+            user_data_dir_arguments(&separated),
+            [PathBuf::from("/tmp/b")]
+        );
+        assert!(user_data_dir_arguments(&["--user-data-dir=".to_owned()]).is_empty());
+        assert!(user_data_dir_arguments(&["--user-data-dir".to_owned()]).is_empty());
+        assert_eq!(
+            user_data_dir_arguments(&[
+                "--user-data-dir=/tmp/a".to_owned(),
+                "--user-data-dir=/tmp/b".to_owned()
+            ])
+            .len(),
+            2
         );
     }
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
@@ -264,6 +264,30 @@ fn parse_proc_net_loopback_listeners(text: &str) -> Vec<(u16, u64)> {
         .collect()
 }
 
+/// Resolve the kernel inode of the filesystem-bound AF_UNIX socket listening
+/// at exactly `target`, by scanning `/proc/net/unix`.
+///
+/// The kernel's `Inode` column is `%5lu`: right-justified in a minimum
+/// five-character field, so a small inode number is left-padded with extra
+/// spaces. Splitting on runs of whitespace (rather than a fixed column
+/// offset) is what keeps that padding from being misread as additional
+/// fields.
+fn unix_socket_inode(target: &std::path::Path) -> Option<u64> {
+    let text = std::fs::read_to_string("/proc/net/unix").ok()?;
+    text.lines().skip(1).find_map(|line| {
+        let mut fields = line.split_whitespace();
+        let inode = fields.nth(6)?.parse::<u64>().ok()?;
+        // Only a filesystem-bound socket carries a path column; an
+        // abstract-namespace socket has none and never matches an absolute
+        // target. A path containing internal runs of more than one space is
+        // an inherent ambiguity in this whitespace-delimited encoding, not
+        // one this parser can resolve — Chromium's own singleton-socket path
+        // is a single-token generated directory name and never hits it.
+        let rest: Vec<&str> = fields.collect();
+        (!rest.is_empty() && std::path::Path::new(&rest.join(" ")) == target).then_some(inode)
+    })
+}
+
 fn descendant_pids(root: i64, relationships: impl IntoIterator<Item = (i64, i64)>) -> HashSet<i64> {
     let mut children = HashMap::<i64, Vec<i64>>::new();
     for (pid, parent) in relationships {
@@ -382,19 +406,28 @@ fn default_user_data_dir(product: BrowserProduct) -> Option<PathBuf> {
 /// the process.
 ///
 /// A Chromium profile is not merely named on the command line; the running
-/// browser keeps files inside it open. Those descriptors, and the process
-/// working directory, are recorded by the kernel and cannot be forged by the
-/// contents of an argument value, which makes them independent evidence that a
-/// directory really is this process's profile.
-fn process_uses_directory(pid: i64, directory: &std::path::Path) -> bool {
-    if std::fs::read_link(format!("/proc/{pid}/cwd")).is_ok_and(|cwd| cwd.starts_with(directory)) {
-        return true;
-    }
-    std::fs::read_dir(format!("/proc/{pid}/fd")).is_ok_and(|entries| {
-        entries.flatten().any(|entry| {
-            std::fs::read_link(entry.path()).is_ok_and(|target| target.starts_with(directory))
-        })
-    })
+/// browser owns that profile's process-singleton listener. Chromium creates
+/// `<profile>/SingletonSocket` as a symlink to a private AF_UNIX socket and
+/// keeps it bound for the life of the browser, so the kernel's own listing of
+/// live sockets — not the process's ambient working directory or its
+/// unrelated open file descriptors — is what ties a directory to this exact
+/// process. An attacker who controls only argument text can name any path,
+/// including one the process's cwd or some incidental fd happens to fall
+/// under, but cannot inject a socket file descriptor into another process's
+/// fd table; only the kernel can put one there.
+fn process_owns_profile_directory(pid: i64, directory: &std::path::Path) -> bool {
+    let Ok(target) = std::fs::read_link(directory.join("SingletonSocket")) else {
+        return false;
+    };
+    let target = if target.is_absolute() {
+        target
+    } else {
+        directory.join(target)
+    };
+    let Some(inode) = unix_socket_inode(&target) else {
+        return false;
+    };
+    socket_inodes_for_process_tree(pid).is_ok_and(|inodes| inodes.contains(&inode))
 }
 
 fn user_data_dir_for_pid(pid: i64) -> Result<Option<PathBuf>, BrowserRefusal> {
@@ -447,10 +480,10 @@ fn user_data_dir_for_pid(pid: i64) -> Result<Option<PathBuf>, BrowserRefusal> {
         let Some(directory) = resolved.as_deref() else {
             return Ok(None);
         };
-        if !process_uses_directory(pid, directory) {
+        if !process_owns_profile_directory(pid, directory) {
             return Err(refusal(
                 BrowserRefusalCode::BrowserBindingAmbiguous,
-                "the browser's command line has no argument separators, so a --user-data-dir value read from it could not be distinguished from ordinary argument text and the process does not hold that directory open",
+                "the browser's command line has no argument separators, so a --user-data-dir value read from it could not be distinguished from ordinary argument text and the process does not own that directory's SingletonSocket",
             ));
         }
     }
@@ -1470,35 +1503,247 @@ mod tests {
     }
 
     #[test]
-    fn ordinary_argument_text_cannot_select_the_profile_directory() {
-        // Helium replaces the kernel's argument separators with spaces, so an
-        // ordinary file name or URL containing " --user-data-dir=" is textually
-        // identical to a real switch. This process supplied no profile option
-        // at all, and does not hold the forged directory open, so the value
-        // must be refused rather than accepted as the profile.
-        let attack = b"/opt/helium-browser-bin/helium /tmp/report --user-data-dir=/tmp/forged\0";
-        let recovered =
-            user_data_dir_arguments(&packed_helium_arguments(attack).expect("packed argv"));
-        assert_eq!(recovered, [PathBuf::from("/tmp/forged")]);
+    fn unix_socket_inode_resolves_only_a_live_kernel_listener() {
+        let directory = tempfile::tempdir().expect("temporary socket directory");
+        let sock_path = directory.path().join("probe.sock");
+        let listener =
+            std::os::unix::net::UnixListener::bind(&sock_path).expect("bind probe socket");
+        assert!(unix_socket_inode(&sock_path).is_some_and(|inode| inode > 0));
 
-        // The raw parse is deliberately credulous; the corroboration step is
-        // what makes it safe. This process holds no descriptor under the
-        // forged directory, so it is rejected.
+        // Dropping the listener closes its only fd. The bind path remains a
+        // socket special file on disk (Rust's UnixListener never unlinks on
+        // drop), but the live kernel object -- and its /proc/net/unix line
+        // -- is gone. A path that merely exists on disk must not resolve.
+        drop(listener);
+        assert!(sock_path.exists());
+        assert!(unix_socket_inode(&sock_path).is_none());
+
+        assert!(unix_socket_inode(&directory.path().join("never-bound.sock")).is_none());
+    }
+
+    #[test]
+    fn process_owns_profile_directory_requires_this_exact_process_to_hold_the_socket() {
         let pid = i64::from(std::process::id());
-        assert!(!process_uses_directory(
-            pid,
-            std::path::Path::new("/tmp/forged")
-        ));
-        assert!(!process_uses_directory(
-            pid,
-            std::path::Path::new("/definitely/not/open")
-        ));
 
-        // A directory the process genuinely uses is corroborated. The test
-        // process holds its own working directory, which is evidence of
-        // exactly the kind user_data_dir_for_pid relies on.
-        let cwd = std::fs::read_link(format!("/proc/{pid}/cwd")).expect("test process cwd");
-        assert!(process_uses_directory(pid, &cwd));
+        // No SingletonSocket symlink at all.
+        let bare = tempfile::tempdir().expect("bare candidate directory");
+        assert!(!process_owns_profile_directory(pid, bare.path()));
+
+        // A SingletonSocket symlink present, but its target names no live
+        // kernel socket (nothing currently holds it open).
+        let stale_root = tempfile::tempdir().expect("stale socket directory");
+        let stale_sock = stale_root.path().join("SingletonSocket");
+        drop(std::os::unix::net::UnixListener::bind(&stale_sock).expect("bind then drop"));
+        let stale_candidate = tempfile::tempdir().expect("stale candidate directory");
+        std::os::unix::fs::symlink(&stale_sock, stale_candidate.path().join("SingletonSocket"))
+            .expect("symlink stale SingletonSocket");
+        assert!(!process_owns_profile_directory(pid, stale_candidate.path()));
+
+        // A SingletonSocket symlink resolving to a socket this exact process
+        // genuinely holds open -- the only case that must corroborate.
+        let owned_root = tempfile::tempdir().expect("owned socket directory");
+        let owned_sock = owned_root.path().join("SingletonSocket");
+        let _listener =
+            std::os::unix::net::UnixListener::bind(&owned_sock).expect("bind owned socket");
+        let profile = tempfile::tempdir().expect("real candidate directory");
+        std::os::unix::fs::symlink(&owned_sock, profile.path().join("SingletonSocket"))
+            .expect("symlink real SingletonSocket");
+        assert!(process_owns_profile_directory(pid, profile.path()));
+    }
+
+    /// A disposable stand-in for `/opt/helium-browser-bin/helium`: a real
+    /// child process whose `/proc/<pid>/exe` basename is exactly `helium`
+    /// (satisfying `browser_product`) and whose `cmdline` is exactly one
+    /// packed record under the caller's control via `arg0`, mirroring the
+    /// observed Helium shape without needing a real browser installed.
+    ///
+    /// The stand-in executable is a copy of `cat` invoked with zero
+    /// arguments: `packed_helium_arguments` requires the *entire* recovered
+    /// argv to be a single NUL-terminated record, so the process must reach
+    /// `/proc/<pid>/cmdline` with nothing beyond the spoofed `arg0` in it.
+    /// Any additional positional argument -- e.g. a duration passed to
+    /// `sleep` -- would itself become a second record and silently defeat
+    /// the very packed-parsing path under test. `cat` blocks on its own
+    /// unclosed stdin instead, needing no arguments to stay alive.
+    struct FakeHeliumProcess {
+        child: std::process::Child,
+        // Keeping the child's stdin open is what keeps `cat` blocked; if
+        // this handle is dropped, stdin sees EOF and the process exits.
+        _stdin: std::process::ChildStdin,
+        _executable_directory: tempfile::TempDir,
+    }
+
+    impl FakeHeliumProcess {
+        fn spawn(
+            packed_cmdline: &str,
+            current_dir: &std::path::Path,
+            stdout: std::process::Stdio,
+        ) -> Self {
+            use std::os::unix::fs::PermissionsExt;
+            use std::os::unix::process::CommandExt;
+            let executable_directory =
+                tempfile::tempdir().expect("temporary fake-helium executable directory");
+            let executable = executable_directory.path().join("helium");
+            std::fs::copy(cat_executable_path(), &executable)
+                .expect("stage a `cat` stand-in as the fake Helium executable");
+            std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755))
+                .expect("make the fake Helium executable runnable");
+            let mut child = std::process::Command::new(&executable)
+                .arg0(packed_cmdline)
+                .current_dir(current_dir)
+                .stdin(std::process::Stdio::piped())
+                .stdout(stdout)
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .expect("spawn fake Helium process");
+            let stdin = child.stdin.take().expect("piped stdin handle");
+            // Give the kernel a moment to publish /proc/<pid>/{exe,cmdline,fd}
+            // before any assertion reads them.
+            std::thread::sleep(Duration::from_millis(30));
+            Self {
+                child,
+                _stdin: stdin,
+                _executable_directory: executable_directory,
+            }
+        }
+
+        fn pid(&self) -> i64 {
+            i64::from(self.child.id())
+        }
+    }
+
+    impl Drop for FakeHeliumProcess {
+        fn drop(&mut self) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+
+    fn cat_executable_path() -> PathBuf {
+        for candidate in ["/usr/bin/cat", "/bin/cat"] {
+            if std::path::Path::new(candidate).is_file() {
+                return PathBuf::from(candidate);
+            }
+        }
+        for directory in std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()) {
+            let candidate = directory.join("cat");
+            if candidate.is_file() {
+                return candidate;
+            }
+        }
+        panic!("no `cat` executable found to stage as the fake Helium process")
+    }
+
+    #[test]
+    fn user_data_dir_for_pid_refuses_ordinary_text_naming_the_processs_own_cwd() {
+        // The exact counterexample from review: Helium starts inside a
+        // directory reachable from ordinary argument text -- here a file
+        // positional argument that happens to contain
+        // " --user-data-dir=<that same directory>" -- with no real profile
+        // option ever supplied. The old working-directory check accepted
+        // this because the candidate merely had to prefix-match the
+        // process's ambient cwd, which ordinary argument text can trivially
+        // arrange without the process actually using that directory as its
+        // profile.
+        let attacker_dir = tempfile::tempdir().expect("attacker-reachable directory");
+        let packed = format!(
+            "/opt/helium-browser-bin/helium {}/report --user-data-dir={}",
+            attacker_dir.path().display(),
+            attacker_dir.path().display()
+        );
+        let process =
+            FakeHeliumProcess::spawn(&packed, attacker_dir.path(), std::process::Stdio::null());
+
+        // Precondition: the process's real cwd genuinely is the candidate
+        // directory, which is exactly what made the old cwd-based check
+        // wrongly corroborate it.
+        let cwd = std::fs::read_link(format!("/proc/{}/cwd", process.pid()))
+            .expect("fake Helium process cwd");
+        assert_eq!(cwd, attacker_dir.path());
+        // And no real SingletonSocket exists there.
+        assert!(!attacker_dir.path().join("SingletonSocket").exists());
+
+        let outcome = user_data_dir_for_pid(process.pid());
+        assert!(
+            matches!(
+                &outcome,
+                Err(refusal) if refusal.code == BrowserRefusalCode::BrowserBindingAmbiguous
+            ),
+            "expected a browser_binding_ambiguous refusal, got {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn user_data_dir_for_pid_corroborates_a_real_owned_singleton_socket() {
+        // The legitimate counterpart: a real `--user-data-dir` switch naming
+        // a profile directory with a space in its path, an unrelated
+        // working directory, and a SingletonSocket this exact process
+        // genuinely owns (mirroring Chromium's real process-singleton
+        // mechanism). This must attach.
+        let profile_root = tempfile::tempdir().expect("profile root");
+        let profile = profile_root.path().join("profile with space");
+        std::fs::create_dir_all(&profile).expect("create spaced profile directory");
+        let singleton_root = tempfile::tempdir().expect("singleton socket root");
+        let singleton_sock = singleton_root.path().join("SingletonSocket");
+        let listener =
+            std::os::unix::net::UnixListener::bind(&singleton_sock).expect("bind singleton");
+        std::os::unix::fs::symlink(&singleton_sock, profile.join("SingletonSocket"))
+            .expect("symlink real SingletonSocket into the profile");
+        let stdout = unsafe {
+            use std::os::fd::{FromRawFd, IntoRawFd};
+            std::process::Stdio::from_raw_fd(listener.into_raw_fd())
+        };
+
+        let unrelated_cwd = tempfile::tempdir().expect("unrelated working directory");
+        let packed = format!(
+            "/opt/helium-browser-bin/helium --user-data-dir={}",
+            profile.display()
+        );
+        let process = FakeHeliumProcess::spawn(&packed, unrelated_cwd.path(), stdout);
+
+        let cwd = std::fs::read_link(format!("/proc/{}/cwd", process.pid()))
+            .expect("fake Helium process cwd");
+        assert_ne!(cwd, profile, "the profile match must not depend on cwd");
+
+        assert_eq!(
+            user_data_dir_for_pid(process.pid()).expect("resolve the owned profile directory"),
+            Some(profile)
+        );
+    }
+
+    #[test]
+    fn user_data_dir_for_pid_refuses_a_singleton_socket_owned_by_a_different_process() {
+        // A directory can carry a real, live SingletonSocket -- just not one
+        // the candidate process holds. Planting someone else's socket must
+        // not be enough, mirroring the same ownership discipline the file
+        // already applies to a DevToolsActivePort's TCP listener.
+        let profile_root = tempfile::tempdir().expect("profile root");
+        let profile = profile_root.path().join("profile");
+        std::fs::create_dir_all(&profile).expect("create profile directory");
+        let singleton_root = tempfile::tempdir().expect("singleton socket root");
+        let singleton_sock = singleton_root.path().join("SingletonSocket");
+        // Bound and held by THIS test process (the harness), not by the
+        // fake Helium child spawned below.
+        let _listener_owned_by_harness =
+            std::os::unix::net::UnixListener::bind(&singleton_sock).expect("bind singleton");
+        std::os::unix::fs::symlink(&singleton_sock, profile.join("SingletonSocket"))
+            .expect("symlink real but foreign-owned SingletonSocket");
+
+        let packed = format!(
+            "/opt/helium-browser-bin/helium --user-data-dir={}",
+            profile.display()
+        );
+        let process =
+            FakeHeliumProcess::spawn(&packed, profile_root.path(), std::process::Stdio::null());
+
+        let outcome = user_data_dir_for_pid(process.pid());
+        assert!(
+            matches!(
+                &outcome,
+                Err(refusal) if refusal.code == BrowserRefusalCode::BrowserBindingAmbiguous
+            ),
+            "expected a browser_binding_ambiguous refusal, got {outcome:?}"
+        );
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
@@ -142,20 +142,25 @@ fn has_process_type(arguments: &[String]) -> bool {
 /// Recover argv from the single space-joined `/proc/<pid>/cmdline` record
 /// observed for Helium, which does not use the usual NUL delimiter.
 ///
-/// This is deliberately narrow: it applies only to a one-record command line
-/// whose first word is the exact Helium executable, and it splits only at a
-/// ` --` switch boundary so a value containing spaces
-/// (`--user-data-dir=/tmp/helium profile`) survives intact. Every other
-/// process keeps ordinary NUL semantics.
+/// This is deliberately narrow. It applies only to a one-record command line,
+/// and every caller gates it on the product already resolved from
+/// `/proc/<pid>/exe`, so no non-Helium process reaches it. Splitting happens
+/// only at a ` --` switch boundary, so a value containing spaces
+/// (`--user-data-dir=/tmp/helium profile`) survives intact, and leading
+/// positional arguments (`helium https://example.test --flag`) do not defeat
+/// recovery. Every other process keeps ordinary NUL semantics.
+///
+/// The packed encoding is inherently ambiguous: it carries no quoting or
+/// length information, so a value that itself contains ` --` is
+/// indistinguishable from a following switch. Where that ambiguity bites,
+/// this parser prefers the reading that refuses rather than the one that
+/// grants access.
 fn packed_helium_arguments(bytes: &[u8]) -> Option<Vec<String>> {
     let arguments = command_line_arguments(bytes);
     let [packed] = arguments.as_slice() else {
         return None;
     };
-    let (executable, switches) = packed.split_once(" --")?;
-    if !is_helium(executable) {
-        return None;
-    }
+    let (_leading, switches) = packed.split_once(" --")?;
     let mut recovered = Vec::new();
     for switch in switches.split(" --") {
         // Inside one switch record the boundary is already known, so a
@@ -173,15 +178,13 @@ fn packed_helium_arguments(bytes: &[u8]) -> Option<Vec<String>> {
 }
 
 fn packed_helium_process_type(bytes: &[u8]) -> bool {
-    // Chromium helpers place `--type=` first, so only that position counts.
-    // A `--type=` later in a packed record can be text inside another value,
-    // and honoring it would misclassify the main browser process as a helper.
-    packed_helium_arguments(bytes).is_some_and(|arguments| {
-        arguments
-            .first()
-            .and_then(|argument| argument.strip_prefix("--type="))
-            .is_some_and(|kind| !kind.is_empty())
-    })
+    // Any recovered `--type=` marks this as a helper, not just a leading one.
+    // Chromium emits it first in every helper observed here, but relying on
+    // that position would let an unexpected ordering promote a renderer, GPU,
+    // or utility process to the main-browser role. Reading a spurious
+    // `--type=` out of an exotic value only costs a refusal, so this
+    // deliberately errs toward Helper.
+    packed_helium_arguments(bytes).is_some_and(|arguments| has_process_type(&arguments))
 }
 
 fn user_data_dir_arguments(arguments: &[String]) -> Vec<PathBuf> {
@@ -1355,18 +1358,20 @@ mod tests {
         assert!(!has_process_type(&command_line_arguments(
             b"/opt/helium-browser-bin/helium --type=gpu-process --utility-sub-type=test\0"
         )));
-        // A `--type=` that is not the first switch is not a helper marker.
-        assert!(!packed_helium_process_type(
+        // A helper is a helper wherever `--type=` appears. Position is not a
+        // load-bearing assumption: an unexpected ordering must not promote a
+        // renderer, GPU, or utility process to the main-browser role.
+        assert!(packed_helium_process_type(
+            b"/opt/helium-browser-bin/helium --enable-logging --type=renderer\0"
+        ));
+        assert!(packed_helium_process_type(
             b"/opt/helium-browser-bin/helium --load-extension=/tmp/example --type=renderer\0"
         ));
+        // A real main process carries no `--type=` at all.
         assert!(!packed_helium_process_type(
-            b"/opt/helium-browser-bin/helium --user-data-dir=/tmp/helium profile --type=renderer\0"
+            b"/opt/helium-browser-bin/helium --user-data-dir=/tmp/helium profile --no-first-run\0"
         ));
         assert!(!packed_helium_process_type(b"helium --type=\0"));
-        // The packed fallback is Helium-only and single-record only.
-        assert!(!packed_helium_process_type(
-            b"/opt/google/chrome/chrome --type=renderer\0"
-        ));
         assert!(!packed_helium_process_type(
             b"/opt/helium-browser-bin/helium\0--type=renderer\0"
         ));
@@ -1419,15 +1424,36 @@ mod tests {
             ),
             [PathBuf::from("/tmp/helium profile")]
         );
-        // Non-Helium executables and NUL-delimited records are not recovered.
-        assert!(
-            packed_helium_arguments(b"/opt/google/chrome/chrome --user-data-dir=/tmp/x\0")
-                .is_none()
-        );
+        // NUL-delimited records are handled by the ordinary parser instead.
         assert!(
             packed_helium_arguments(b"/opt/helium-browser-bin/helium\0--no-first-run\0").is_none()
         );
         assert!(packed_helium_arguments(b"/opt/helium-browser-bin/helium\0").is_none());
+    }
+
+    #[test]
+    fn packed_recovery_survives_leading_positional_arguments() {
+        // Opening a URL or file puts a positional argument before the first
+        // switch. Recovery must still find the profile rather than silently
+        // falling back to the default directory.
+        assert_eq!(
+            user_data_dir_arguments(
+                &packed_helium_arguments(
+                    b"/opt/helium-browser-bin/helium https://example.test --user-data-dir=/tmp/p\0"
+                )
+                .expect("packed Helium argv with a leading positional")
+            ),
+            [PathBuf::from("/tmp/p")]
+        );
+        assert_eq!(
+            user_data_dir_arguments(
+                &packed_helium_arguments(
+                    b"/opt/helium-browser-bin/helium /home/u/a.html --user-data-dir=/tmp/spaced dir\0"
+                )
+                .expect("packed Helium argv with a leading file positional")
+            ),
+            [PathBuf::from("/tmp/spaced dir")]
+        );
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
@@ -378,6 +378,25 @@ fn default_user_data_dir(product: BrowserProduct) -> Option<PathBuf> {
     Some(home.join(relative))
 }
 
+/// Corroborate a candidate profile directory against the kernel's own view of
+/// the process.
+///
+/// A Chromium profile is not merely named on the command line; the running
+/// browser keeps files inside it open. Those descriptors, and the process
+/// working directory, are recorded by the kernel and cannot be forged by the
+/// contents of an argument value, which makes them independent evidence that a
+/// directory really is this process's profile.
+fn process_uses_directory(pid: i64, directory: &std::path::Path) -> bool {
+    if std::fs::read_link(format!("/proc/{pid}/cwd")).is_ok_and(|cwd| cwd.starts_with(directory)) {
+        return true;
+    }
+    std::fs::read_dir(format!("/proc/{pid}/fd")).is_ok_and(|entries| {
+        entries.flatten().any(|entry| {
+            std::fs::read_link(entry.path()).is_ok_and(|target| target.starts_with(directory))
+        })
+    })
+}
+
 fn user_data_dir_for_pid(pid: i64) -> Result<Option<PathBuf>, BrowserRefusal> {
     let bytes = std::fs::read(format!("/proc/{pid}/cmdline")).map_err(|_| {
         refusal(
@@ -393,14 +412,21 @@ fn user_data_dir_for_pid(pid: i64) -> Result<Option<PathBuf>, BrowserRefusal> {
         .map(browser_product)
         .unwrap_or(BrowserProduct::Other);
     let mut directories = user_data_dir_arguments(&command_line_arguments(&bytes));
+    // A NUL-delimited command line carries the kernel's own argument
+    // separators, so its switches are authoritative. A packed record has lost
+    // them: ordinary text inside a file name or URL is then indistinguishable
+    // from a real switch, so anything recovered from it is a candidate to be
+    // corroborated rather than a fact to be trusted.
+    let mut candidate_is_unseparated = false;
     if directories.is_empty() && product == BrowserProduct::Helium {
         if let Some(packed) = packed_helium_arguments(&bytes) {
             directories = user_data_dir_arguments(&packed);
+            candidate_is_unseparated = !directories.is_empty();
         }
     }
     directories.sort();
     directories.dedup();
-    match directories.as_slice() {
+    let resolved = match directories.as_slice() {
         [] => Ok(default_user_data_dir(product)),
         [path] if path.is_absolute() => Ok(Some(path.clone())),
         [path] => {
@@ -416,7 +442,19 @@ fn user_data_dir_for_pid(pid: i64) -> Result<Option<PathBuf>, BrowserRefusal> {
             BrowserRefusalCode::BrowserBindingAmbiguous,
             "browser process has multiple distinct --user-data-dir arguments",
         )),
+    }?;
+    if candidate_is_unseparated {
+        let Some(directory) = resolved.as_deref() else {
+            return Ok(None);
+        };
+        if !process_uses_directory(pid, directory) {
+            return Err(refusal(
+                BrowserRefusalCode::BrowserBindingAmbiguous,
+                "the browser's command line has no argument separators, so a --user-data-dir value read from it could not be distinguished from ordinary argument text and the process does not hold that directory open",
+            ));
+        }
     }
+    Ok(resolved)
 }
 
 fn active_port_endpoint(pid: i64) -> Result<Option<OwnedEndpoint>, BrowserRefusal> {
@@ -1429,6 +1467,38 @@ mod tests {
             packed_helium_arguments(b"/opt/helium-browser-bin/helium\0--no-first-run\0").is_none()
         );
         assert!(packed_helium_arguments(b"/opt/helium-browser-bin/helium\0").is_none());
+    }
+
+    #[test]
+    fn ordinary_argument_text_cannot_select_the_profile_directory() {
+        // Helium replaces the kernel's argument separators with spaces, so an
+        // ordinary file name or URL containing " --user-data-dir=" is textually
+        // identical to a real switch. This process supplied no profile option
+        // at all, and does not hold the forged directory open, so the value
+        // must be refused rather than accepted as the profile.
+        let attack = b"/opt/helium-browser-bin/helium /tmp/report --user-data-dir=/tmp/forged\0";
+        let recovered =
+            user_data_dir_arguments(&packed_helium_arguments(attack).expect("packed argv"));
+        assert_eq!(recovered, [PathBuf::from("/tmp/forged")]);
+
+        // The raw parse is deliberately credulous; the corroboration step is
+        // what makes it safe. This process holds no descriptor under the
+        // forged directory, so it is rejected.
+        let pid = i64::from(std::process::id());
+        assert!(!process_uses_directory(
+            pid,
+            std::path::Path::new("/tmp/forged")
+        ));
+        assert!(!process_uses_directory(
+            pid,
+            std::path::Path::new("/definitely/not/open")
+        ));
+
+        // A directory the process genuinely uses is corroborated. The test
+        // process holds its own working directory, which is evidence of
+        // exactly the kind user_data_dir_for_pid relies on.
+        let cwd = std::fs::read_link(format!("/proc/{pid}/cwd")).expect("test process cwd");
+        assert!(process_uses_directory(pid, &cwd));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
@@ -27,7 +27,17 @@ fn refusal(code: BrowserRefusalCode, message: impl Into<String>) -> BrowserRefus
     BrowserRefusal::new(code, message)
 }
 
+fn is_helium(name: &str) -> bool {
+    name.rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(name)
+        .eq_ignore_ascii_case("helium")
+}
+
 fn is_chromium(name: &str) -> bool {
+    if is_helium(name) {
+        return true;
+    }
     let name = name.to_ascii_lowercase();
     let products = [
         "chrome", "chromium", "electron", "brave", "edge", "msedge", "vivaldi", "opera", "arc",
@@ -48,6 +58,9 @@ fn is_firefox(name: &str) -> bool {
 }
 
 fn browser_product(identity: &str) -> BrowserProduct {
+    if is_helium(identity) {
+        return BrowserProduct::Helium;
+    }
     let tokens = identity
         .to_ascii_lowercase()
         .split(|ch: char| !ch.is_ascii_alphanumeric())
@@ -110,13 +123,29 @@ fn trusted_root_owned_installation(executable: &std::path::Path) -> bool {
         .is_ok_and(|metadata| metadata.is_file() && metadata.mode() & 0o111 != 0)
 }
 
+fn command_line_arguments(bytes: &[u8], allow_packed: bool) -> Vec<String> {
+    bytes
+        .split(|byte| *byte == 0 || (allow_packed && byte.is_ascii_whitespace()))
+        .filter(|arg| !arg.is_empty())
+        .map(|arg| String::from_utf8_lossy(arg).into_owned())
+        .collect()
+}
+
+fn command_line_has_process_type(bytes: &[u8], allow_packed: bool) -> bool {
+    command_line_arguments(bytes, allow_packed)
+        .iter()
+        .any(|arg| {
+            arg.as_bytes()
+                .strip_prefix(b"--type=")
+                .is_some_and(|kind| !kind.is_empty())
+        })
+}
+
 fn process_role_for_pid(pid: i64, product: BrowserProduct) -> BrowserProcessRole {
     let helper = std::fs::read(format!("/proc/{pid}/cmdline"))
         .ok()
         .is_some_and(|bytes| {
-            bytes.split(|byte| *byte == 0).any(|arg| {
-                arg.starts_with(b"--type=") && arg.get(7..).is_some_and(|kind| !kind.is_empty())
-            })
+            command_line_has_process_type(&bytes, product == BrowserProduct::Helium)
         });
     if helper {
         BrowserProcessRole::Helper
@@ -126,6 +155,7 @@ fn process_role_for_pid(pid: i64, product: BrowserProduct) -> BrowserProcessRole
         product,
         BrowserProduct::GoogleChrome
             | BrowserProduct::Chromium
+            | BrowserProduct::Helium
             | BrowserProduct::MicrosoftEdge
             | BrowserProduct::Brave
             | BrowserProduct::Vivaldi
@@ -279,6 +309,7 @@ fn default_user_data_dir(product: BrowserProduct) -> Option<PathBuf> {
         BrowserProduct::GoogleChrome => ".config/google-chrome",
         BrowserProduct::MicrosoftEdge => ".config/microsoft-edge",
         BrowserProduct::Chromium => ".config/chromium",
+        BrowserProduct::Helium => ".config/net.imput.helium",
         _ => return None,
     };
     Some(home.join(relative))
@@ -291,11 +322,14 @@ fn user_data_dir_for_pid(pid: i64) -> Result<Option<PathBuf>, BrowserRefusal> {
             format!("browser process {pid} is no longer available"),
         )
     })?;
-    let args = bytes
-        .split(|byte| *byte == 0)
-        .filter(|arg| !arg.is_empty())
-        .map(|arg| String::from_utf8_lossy(arg).into_owned())
-        .collect::<Vec<_>>();
+    let executable = std::fs::read_link(format!("/proc/{pid}/exe"))
+        .ok()
+        .map(|path| path.to_string_lossy().into_owned());
+    let product = executable
+        .as_deref()
+        .map(browser_product)
+        .unwrap_or(BrowserProduct::Other);
+    let args = command_line_arguments(&bytes, product == BrowserProduct::Helium);
     let mut directories = Vec::new();
     for (index, arg) in args.iter().enumerate() {
         if let Some(path) = arg.strip_prefix("--user-data-dir=") {
@@ -311,15 +345,7 @@ fn user_data_dir_for_pid(pid: i64) -> Result<Option<PathBuf>, BrowserRefusal> {
     directories.sort();
     directories.dedup();
     match directories.as_slice() {
-        [] => {
-            let Some(executable) = std::fs::read_link(format!("/proc/{pid}/exe"))
-                .ok()
-                .map(|path| path.to_string_lossy().into_owned())
-            else {
-                return Ok(None);
-            };
-            Ok(default_user_data_dir(browser_product(&executable)))
-        }
+        [] => Ok(default_user_data_dir(product)),
         [path] if path.is_absolute() => Ok(Some(path.clone())),
         [path] => {
             let cwd = std::fs::read_link(format!("/proc/{pid}/cwd")).map_err(|_| {
@@ -1202,6 +1228,11 @@ mod tests {
         assert!(is_chromium("chromium-browser"));
         assert!(is_chromium("msedge --remote-debugging-port=9222"));
         assert!(is_chromium("/opt/microsoft/msedge/msedge"));
+        assert!(is_chromium("helium"));
+        assert!(is_chromium("/opt/helium/helium"));
+        assert!(is_chromium("/opt/helium-browser-bin/helium"));
+        assert!(!is_chromium("/opt/helium/not-a-browser"));
+        assert!(!is_chromium("helium-helper"));
         assert!(!is_chromium("firefox"));
         assert!(!is_chromium("search-worker"));
         assert!(!is_chromium("ledger-service"));
@@ -1220,6 +1251,85 @@ mod tests {
         assert_eq!(
             browser_product("/opt/google/chrome/chrome"),
             BrowserProduct::GoogleChrome
+        );
+        assert_eq!(
+            browser_product("/opt/helium-browser-bin/helium"),
+            BrowserProduct::Helium
+        );
+        assert_eq!(
+            browser_product("/opt/helium/helium"),
+            BrowserProduct::Helium
+        );
+        assert_eq!(
+            browser_product("/opt/chromium/helium"),
+            BrowserProduct::Helium
+        );
+        assert_eq!(
+            browser_product("/opt/helium/not-a-browser"),
+            BrowserProduct::Other
+        );
+        assert_eq!(browser_product("helium-helper"), BrowserProduct::Other);
+    }
+
+    #[test]
+    fn helium_uses_its_branded_default_profile_directory() {
+        assert!(default_user_data_dir(BrowserProduct::Helium)
+            .expect("HOME-backed Helium profile directory")
+            .ends_with(".config/net.imput.helium"));
+    }
+
+    #[test]
+    fn process_type_detection_handles_nul_and_packed_command_lines() {
+        assert!(command_line_has_process_type(
+            b"helium\0--type=renderer\0",
+            false
+        ));
+        assert!(command_line_has_process_type(
+            b"/opt/helium-browser-bin/helium --type=gpu-process --utility-sub-type=test\0",
+            true
+        ));
+        assert!(!command_line_has_process_type(
+            b"/opt/helium-browser-bin/helium --type=gpu-process --utility-sub-type=test\0",
+            false
+        ));
+        assert!(!command_line_has_process_type(
+            b"/opt/helium-browser-bin/helium --load-extension=/tmp/example\0",
+            true
+        ));
+        assert!(!command_line_has_process_type(b"helium --type=\0", true));
+    }
+
+    #[test]
+    fn packed_helium_command_line_preserves_profile_arguments() {
+        assert_eq!(
+            command_line_arguments(
+                b"/opt/helium-browser-bin/helium --user-data-dir=/tmp/helium-profile --remote-debugging-port=0\0",
+                true
+            ),
+            [
+                "/opt/helium-browser-bin/helium",
+                "--user-data-dir=/tmp/helium-profile",
+                "--remote-debugging-port=0"
+            ]
+        );
+        assert_eq!(
+            command_line_arguments(
+                b"/opt/helium-browser-bin/helium\0--user-data-dir\0/tmp/helium-profile\0",
+                false
+            ),
+            [
+                "/opt/helium-browser-bin/helium",
+                "--user-data-dir",
+                "/tmp/helium-profile"
+            ]
+        );
+    }
+
+    #[test]
+    fn helium_is_a_standalone_consumer_browser() {
+        assert_eq!(
+            process_role_for_pid(i64::from(std::process::id()), BrowserProduct::Helium),
+            BrowserProcessRole::StandaloneConsumer
         );
     }
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
@@ -123,29 +123,76 @@ fn trusted_root_owned_installation(executable: &std::path::Path) -> bool {
         .is_ok_and(|metadata| metadata.is_file() && metadata.mode() & 0o111 != 0)
 }
 
-fn command_line_arguments(bytes: &[u8], allow_packed: bool) -> Vec<String> {
+fn command_line_arguments(bytes: &[u8]) -> Vec<String> {
     bytes
-        .split(|byte| *byte == 0 || (allow_packed && byte.is_ascii_whitespace()))
+        .split(|byte| *byte == 0)
         .filter(|arg| !arg.is_empty())
         .map(|arg| String::from_utf8_lossy(arg).into_owned())
         .collect()
 }
 
-fn command_line_has_process_type(bytes: &[u8], allow_packed: bool) -> bool {
-    command_line_arguments(bytes, allow_packed)
-        .iter()
-        .any(|arg| {
-            arg.as_bytes()
-                .strip_prefix(b"--type=")
-                .is_some_and(|kind| !kind.is_empty())
-        })
+fn command_line_has_process_type(bytes: &[u8]) -> bool {
+    command_line_arguments(bytes).iter().any(|arg| {
+        arg.as_bytes()
+            .strip_prefix(b"--type=")
+            .is_some_and(|kind| !kind.is_empty())
+    })
+}
+
+fn packed_helium_process_type(bytes: &[u8]) -> bool {
+    let arguments = command_line_arguments(bytes);
+    let [packed] = arguments.as_slice() else {
+        return false;
+    };
+    let mut words = packed.split_ascii_whitespace();
+    let executable = words.next().unwrap_or_default();
+    let process_type = words.next().unwrap_or_default();
+    is_helium(executable)
+        && process_type
+            .strip_prefix("--type=")
+            .is_some_and(|kind| !kind.is_empty())
+}
+
+fn packed_helium_user_data_dir(bytes: &[u8]) -> Result<Option<PathBuf>, BrowserRefusal> {
+    let arguments = command_line_arguments(bytes);
+    let [packed] = arguments.as_slice() else {
+        return Ok(None);
+    };
+    let executable = packed.split_ascii_whitespace().next().unwrap_or_default();
+    if !is_helium(executable) {
+        return Ok(None);
+    }
+    let marker = "--user-data-dir=";
+    let mut matches = packed.match_indices(marker);
+    let Some((marker_start, _)) = matches.next() else {
+        return Ok(None);
+    };
+    if matches.next().is_some() {
+        return Err(refusal(
+            BrowserRefusalCode::BrowserBindingAmbiguous,
+            "packed Helium command line has multiple --user-data-dir arguments",
+        ));
+    }
+    if marker_start == 0 || !packed[..marker_start].ends_with(' ') {
+        return Ok(None);
+    }
+    let value = &packed[marker_start + marker.len()..];
+    let value = value.split_once(" --").map_or(value, |(value, _)| value);
+    if value.is_empty() {
+        return Err(refusal(
+            BrowserRefusalCode::BrowserBindingAmbiguous,
+            "packed Helium command line has an empty --user-data-dir value",
+        ));
+    }
+    Ok(Some(PathBuf::from(value)))
 }
 
 fn process_role_for_pid(pid: i64, product: BrowserProduct) -> BrowserProcessRole {
     let helper = std::fs::read(format!("/proc/{pid}/cmdline"))
         .ok()
         .is_some_and(|bytes| {
-            command_line_has_process_type(&bytes, product == BrowserProduct::Helium)
+            command_line_has_process_type(&bytes)
+                || (product == BrowserProduct::Helium && packed_helium_process_type(&bytes))
         });
     if helper {
         BrowserProcessRole::Helper
@@ -329,7 +376,7 @@ fn user_data_dir_for_pid(pid: i64) -> Result<Option<PathBuf>, BrowserRefusal> {
         .as_deref()
         .map(browser_product)
         .unwrap_or(BrowserProduct::Other);
-    let args = command_line_arguments(&bytes, product == BrowserProduct::Helium);
+    let args = command_line_arguments(&bytes);
     let mut directories = Vec::new();
     for (index, arg) in args.iter().enumerate() {
         if let Some(path) = arg.strip_prefix("--user-data-dir=") {
@@ -340,6 +387,11 @@ fn user_data_dir_for_pid(pid: i64) -> Result<Option<PathBuf>, BrowserRefusal> {
             if let Some(path) = args.get(index + 1).filter(|path| !path.is_empty()) {
                 directories.push(PathBuf::from(path));
             }
+        }
+    }
+    if directories.is_empty() && product == BrowserProduct::Helium {
+        if let Some(path) = packed_helium_user_data_dir(&bytes)? {
+            directories.push(path);
         }
     }
     directories.sort();
@@ -778,8 +830,12 @@ impl BrowserPlatform for LinuxBrowserPlatform {
         &self,
         pid: i64,
     ) -> Result<Option<OwnedEndpoint>, BrowserRefusal> {
+        let classification = self.classify_browser(pid).await?;
         if let Some(endpoint) = active_port_endpoint(pid)? {
             return Ok(Some(endpoint));
+        }
+        if classification.product_kind == BrowserProduct::Helium {
+            return Ok(None);
         }
         let ports = tokio::task::spawn_blocking(move || loopback_ports_for_pid(pid))
             .await
@@ -834,6 +890,9 @@ impl BrowserPlatform for LinuxBrowserPlatform {
                 ));
             }
             return Ok(Some(endpoint));
+        }
+        if self.classify_browser(pid).await?.product_kind == BrowserProduct::Helium {
+            return Ok(None);
         }
         let ports = tokio::task::spawn_blocking(move || loopback_ports_for_pid(pid))
             .await
@@ -1281,48 +1340,46 @@ mod tests {
 
     #[test]
     fn process_type_detection_handles_nul_and_packed_command_lines() {
-        assert!(command_line_has_process_type(
-            b"helium\0--type=renderer\0",
-            false
-        ));
-        assert!(command_line_has_process_type(
-            b"/opt/helium-browser-bin/helium --type=gpu-process --utility-sub-type=test\0",
-            true
+        assert!(command_line_has_process_type(b"helium\0--type=renderer\0"));
+        assert!(packed_helium_process_type(
+            b"/opt/helium-browser-bin/helium --type=gpu-process --utility-sub-type=test\0"
         ));
         assert!(!command_line_has_process_type(
-            b"/opt/helium-browser-bin/helium --type=gpu-process --utility-sub-type=test\0",
-            false
+            b"/opt/helium-browser-bin/helium --type=gpu-process --utility-sub-type=test\0"
         ));
-        assert!(!command_line_has_process_type(
-            b"/opt/helium-browser-bin/helium --load-extension=/tmp/example\0",
-            true
+        assert!(!packed_helium_process_type(
+            b"/opt/helium-browser-bin/helium --load-extension=/tmp/example --type=renderer\0"
         ));
-        assert!(!command_line_has_process_type(b"helium --type=\0", true));
+        assert!(!packed_helium_process_type(
+            b"/opt/helium-browser-bin/helium --user-data-dir=/tmp/helium profile --type=renderer\0"
+        ));
+        assert!(!packed_helium_process_type(b"helium --type=\0"));
     }
 
     #[test]
     fn packed_helium_command_line_preserves_profile_arguments() {
         assert_eq!(
             command_line_arguments(
-                b"/opt/helium-browser-bin/helium --user-data-dir=/tmp/helium-profile --remote-debugging-port=0\0",
-                true
+                b"/opt/helium-browser-bin/helium --user-data-dir=/tmp/helium profile\0"
             ),
-            [
-                "/opt/helium-browser-bin/helium",
-                "--user-data-dir=/tmp/helium-profile",
-                "--remote-debugging-port=0"
-            ]
+            ["/opt/helium-browser-bin/helium --user-data-dir=/tmp/helium profile"]
         );
         assert_eq!(
             command_line_arguments(
-                b"/opt/helium-browser-bin/helium\0--user-data-dir\0/tmp/helium-profile\0",
-                false
+                b"/opt/helium-browser-bin/helium\0--user-data-dir\0/tmp/helium-profile\0"
             ),
             [
                 "/opt/helium-browser-bin/helium",
                 "--user-data-dir",
                 "/tmp/helium-profile"
             ]
+        );
+        assert_eq!(
+            packed_helium_user_data_dir(
+                b"/opt/helium-browser-bin/helium --user-data-dir=/tmp/helium profile --remote-debugging-port=0\0"
+            )
+            .expect("packed profile argument"),
+            Some(PathBuf::from("/tmp/helium profile"))
         );
     }
 


### PR DESCRIPTION
## Summary

- recognize the exact Linux Helium executable as a distinct Chromium-family browser product
- classify Helium as a standalone consumer and resolve `~/.config/net.imput.helium`
- recover argv from Helium's observed packed `/proc/<pid>/cmdline` record without disturbing normal NUL semantics
- attach only to an already-present, PID-owned `DevToolsActivePort`; automated setup remains fail-closed
- document the Linux endpoint-only support boundary

Fixes #3252

## Updated onto current `main` (2026-09-19)

The branch had drifted 334 commits behind `main` and GitHub reported the pull
request as conflicting. It is now merged up to `83f142c42`, and the pull request
reports `mergeable: true` again.

One file conflicted: `crates/platform-linux/src/browser_platform.rs`. Upstream
added `hyprland_identity_matches`, `hyprland_is_only_owned_window`, and
`run_existing_profile_cleanup` at the same insertion point as this branch's
`is_helium`. Both sides are kept. No upstream line was dropped: every `-` line
in this branch's diff against `upstream/main` is this branch's own consolidation
of the two bespoke scanners into the shared helpers below.

Upstream carries no Helium handling, so there is no competing implementation to
reconcile: `git grep -i helium upstream/main -- libs/cua-driver` is empty.

The merge was revalidated rather than assumed. `cargo fmt --all --check` is
clean, the Linux CI gate passes, `platform-linux` is at 464 passed / 0 failed,
the docs generator and link checks pass, and the ClawHub bundle dry-run reports
`"ok": true`. Details and the pre-existing host-specific failures are in the
Validation and Known local environment limits sections below.

Because `BrowserProduct` gains an additive variant, the other platform rows were
checked for exhaustive matches. `platform-windows` compiles on Linux as part of
`cargo check -p platform-windows --all-targets`, and its single `match product`
in `default_user_data_dir` has a `_` arm. The macOS `browser` module is
`target_os = "macos"`-gated and cannot be compiled on this host, so it was
audited by inspection: its one `match product` also has a `_` arm, and every
other `BrowserProduct` use is an equality check, a `matches!`, or an if/else
chain. The macOS row of `CI: Check Docs` builds the driver on `macos-latest` and
is the confirming gate.

## Review follow-up

Both points from @injaneity's first review are addressed.

**Packed command-line parsing is now narrow.** `command_line_arguments` is NUL-delimited again for every process, so no ordinary browser is affected. The packed shape is handled by one dedicated `packed_helium_arguments` step, reached only when the caller has already resolved `BrowserProduct::Helium` from `/proc/<pid>/exe`, and only when `/proc/<pid>/cmdline` holds exactly one record. Recovery splits at ` --` switch boundaries rather than on plain whitespace, which is what keeps `--user-data-dir=/tmp/helium profile` intact.

The packed encoding carries no quoting or length information, so it is inherently ambiguous: a value that itself contains ` --` cannot be distinguished from a following switch. Where that ambiguity bites, the parser now prefers the reading that refuses over the one that grants access.

**The documented endpoint boundary is now enforced.** `discover_existing_profile_endpoint` and `reprove_existing_profile_endpoint` return `Ok(None)` for Helium when no PID-owned `DevToolsActivePort` is present, instead of falling through to generic `LegacyJsonVersion` discovery. Classification happens after the `DevToolsActivePort` probe in both, so the ordinary Chrome/Edge path does not pay an extra `/proc` enumeration.

## Follow-up hardening from a second audit

An independent audit of the review fix found two further problems, both now fixed in `40b2fdcc5`:

**Helper detection no longer depends on switch position.** The first fix honored `--type=` only in first-switch position. That removed the main-to-helper misclassification but introduced the opposite risk: an unexpected ordering could promote a renderer, GPU, or utility process to the main-browser role. Any recovered `--type=` now marks a helper. Reading a spurious `--type=` out of an exotic value costs only a refusal, so this errs toward `Helper` deliberately.

**Leading positional arguments no longer defeat recovery.** `packed_helium_arguments` previously required the record to begin with the executable, so a perfectly ordinary command line (`helium https://example.test --user-data-dir=/tmp/profile`, which is what opening a URL or file produces) returned `None`. `user_data_dir_for_pid` then silently fell back to Helium's default profile and looked for `DevToolsActivePort` in the wrong directory. Recovery now tolerates leading positionals. The removed basename re-check was redundant rather than protective, since every caller already gates on the product resolved from `/proc/<pid>/exe`.

Empirical check against every Helium process on a live desktop (54 processes: 52 helpers across zygote, GPU, renderer, and utility roles, plus 2 main processes): **zero misclassifications** versus ground truth, and both main processes resolved their `--user-data-dir` correctly. In that sample every helper did place `--type=` first, so the original position assumption happened to hold, but it is no longer relied upon.

Two audit findings were investigated and deliberately not "fixed":

- *Values containing ` --` are ambiguous.* Correct, and unfixable from `/proc` data alone, because the kernel exposes no quoting for a packed record. The function contract documents this and the parser fails toward refusal.
- *Non-UTF-8 `/proc` bytes go through `from_utf8_lossy`.* Pre-existing behavior shared with the NUL path and every other platform backend, not introduced here. The practical outcome is a failed profile lookup, i.e. fail-closed.

## Third review: ordinary argument text could select the profile

@injaneity found that the packed parser could read a `--user-data-dir=` out of ordinary argument text. A process opening `/tmp/report --user-data-dir=/tmp/forged` as a *single file argument* supplied no profile option at all, yet that path was accepted as the browser profile. This was reachable specifically because the previous commit taught recovery to tolerate leading positional arguments.

The root cause is that Helium has already destroyed the kernel's argument separators by the time `/proc/<pid>/cmdline` is read. No amount of text analysis can reliably separate an option from ordinary text afterwards, so the parser now stops trying to decide it on text alone.

A value recovered from a packed record is treated as a **candidate**, not a fact. A Chromium process keeps files inside its real profile open, so the kernel's own view of that process is evidence that cannot be forged by the contents of an argument value. Unless the process holds the candidate directory open, or works inside it, the read is refused as unresolvable.

Values parsed from a NUL-delimited command line still carry the kernel's separators and remain authoritative, so no other browser changes behavior.

### Live verification of the fix (superseded, see the fourth review below)

The working-directory/open-fd corroboration in `8e73a2d82` was itself found to be too broad in the next review round. See below for the replacement.

## Fourth review: cwd/open-fd corroboration was not profile-specific

@injaneity: `process_uses_directory` treated the browser's working directory, or any open file below the proposed path, as proof that the path is the browser profile, which is too broad. Helium can start in `/tmp` with ordinary argument text containing ` --user-data-dir=/tmp`, and the working-directory check then accepted `/tmp` as the profile even though no profile option was ever supplied, while a planted `/tmp/DevToolsActivePort` could still select an endpoint the process happened to own.

Fixed in `6eb3d92df` by replacing `process_uses_directory` with `process_owns_profile_directory`, which requires evidence specific to a browser profile rather than an ambient process fact: Chromium's own process-singleton mechanism creates `<profile>/SingletonSocket` as a symlink to a private AF_UNIX socket it keeps bound for its own lifetime. The fix resolves that symlink, looks up the target's live kernel inode via `/proc/net/unix`, and checks that inode is actually held open in the candidate process's (or its process tree's) fd table, which is the same ownership discipline `active_port_endpoint` already applies to `DevToolsActivePort`'s TCP listener, just for the AF_UNIX singleton instead. An attacker who controls only argument text can name any path, including one the process's cwd or some incidental fd happens to fall under, but cannot inject a socket file descriptor into another process's fd table. Only the kernel can put one there.

One parsing subtlety: `/proc/net/unix`'s `Inode` column is `%5lu`, right-justified and space-padded for small inode numbers. A naive fixed-column split misreads that padding as extra fields; splitting on whitespace runs avoids it.

**Full-pipeline test, as requested.** The previous `ordinary_argument_text_cannot_select_the_profile_directory` test called the helper function directly and was replaced with three tests that drive the complete `user_data_dir_for_pid` pipeline against a real spawned process (a `cat` binary launched with a spoofed `arg0`, so its `/proc/<pid>/exe` basename is `helium` and its `cmdline` is exactly one packed record, which is the shape Helium is observed to produce):

- `user_data_dir_for_pid_refuses_ordinary_text_naming_the_processs_own_cwd` reproduces the exact review counterexample end to end (a process whose real cwd genuinely is the candidate directory, reached via ordinary argument text, with no real profile switch anywhere) and asserts a `browser_binding_ambiguous` refusal.
- `user_data_dir_for_pid_corroborates_a_real_owned_singleton_socket` proves the legitimate path still attaches: a real `--user-data-dir` switch, a profile path containing a space, an unrelated working directory, and a genuinely held SingletonSocket.
- `user_data_dir_for_pid_refuses_a_singleton_socket_owned_by_a_different_process` proves a real, live SingletonSocket is not sufficient by itself unless the exact candidate process holds it.

**Sabotage check:** replacing `process_owns_profile_directory`'s body with an unconditional `true` makes exactly the three pipeline-level guard tests fail, plus the helper-level unit test independently. Reverted after observation.

**Live verification:** ran a temporary `#[ignore]`d test against this development machine's real, currently-running Helium main process (a genuine single-packed-cmdline-record process, not a synthetic fixture). `user_data_dir_for_pid` resolved the real `~/.config/net.imput.helium`. `process_owns_profile_directory` corroborated it via the real live SingletonSocket, and `active_port_endpoint` then resolved the real owned DevTools websocket through the same process. The run was entirely read-only (no setup, navigation, restart, or foregrounding), and the test was removed before committing.

## Compatibility and risk

- Linux only; macOS and Windows identifiers and profile paths remain unchanged
- existing-profile authorization, native PID/window binding, loopback restriction, process fingerprinting, and endpoint ownership checks are unchanged
- `BrowserProduct` gains the additive serialized value `helium`
- Helium is not added to implicit PID-free launch candidates and receives no setup descriptor
- no behavior change for any non-Helium process: the packed path is gated on the exact Helium executable and a single-record command line

## Test harness determinism

The three tests that drive `user_data_dir_for_pid` against a real spawned
process share a helper that copies `cat` into a temporary directory and spawns
it. Run concurrently in one process, that helper was flaky, and the flakiness
was in the harness rather than in the behavior under test.

`Command::spawn` is fork plus exec, and the fork duplicates every descriptor its
thread can see, which produced two failures:

- a sibling fork landing while another test had its freshly copied stand-in open
  for writing handed that child a write descriptor to the executable, so
  `execve` failed with `ETXTBSY` ("Text file busy");
- the same kind of window lent
  `unix_socket_inode_resolves_only_a_live_kernel_listener` its listener, so the
  kernel kept that socket alive past the test's own `drop` and the "no live
  listener" assertion failed.

Measured before the fix: 6 `ETXTBSY` failures in 12 runs of the three concurrent
tests against 0 in 12 runs of one in isolation, and one socket-liveness failure
every 20 to 30 full-suite runs. For the second case, instrumenting the failure
showed the kernel entry clearing after 5.8 ms with no process holding it, which
identified a transiently borrowed descriptor rather than a leaked socket.

The fix is confined to the test module: a process-wide mutex keeps a sibling
fork out of the window in which a test measures socket liveness, and wraps each
copy-and-spawn sequence so that no two overlap. No production code changed.

Sabotage check: removing the mutex from the liveness test reproduces the failure
in 8 of 30 full-suite runs. With it in place, 45 consecutive full-suite runs
pass, and a second 45-run set on the final candidate is the evidence of record.

## Validation

Post-merge and post-harness-fix, on `3542ae045`:

- `cargo fmt --all --check`
- `cargo test -p platform-linux --locked`: 464 passed, 0 failed, 5 ignored
- `cargo test -p cua-driver-core --locked`: 632 unit plus the contract-parity
  and lifecycle targets, all passing
- the Linux CI gate exactly as `ci-rust-linux.yml` runs it: `cargo test -p
  cua-driver -p cua-driver-contract -p cua-driver-core -p cua-driver-testkit -p
  cursor-overlay -p cursor-theme-cli -p platform-linux --all-targets --locked`,
  which reports 1127 passed, 86 ignored, and the single pre-existing Wayland-host
  failure described below
- `cargo clippy -p platform-linux --all-targets --locked` reports nothing new
  from this diff. The one warning in `browser_platform.rs`
  (`useless_conversion`, `u64::from(window.xid)`) blames to upstream commit
  `0835daa6d4`, and `approx_constant` in `input/mod.rs` is likewise
  pre-existing
- docs: `check-links` (0 errored file, 0 errors), `check-hygiene`, generator
  routing plus `--test-routing`, and `runner.ts --library cua-driver --check`
  report native and shared references up to date
- ClawHub `clawhub@0.23.1 skill publish ... --dry-run` for the skill bundle this
  diff touches reports `"ok": true`, `"status": "would-publish"`, 8 files
- the two modified MDX pages pass Prettier
- `cargo test -p platform-linux --locked` under repetition: 45 consecutive
  full-suite runs with no failure, up from roughly one failure every 20 to
  30 runs before the harness fix above

Regression sabotage, all reverted after observation:

- splitting the packed record on plain whitespace makes `packed_helium_recovery_keeps_switch_boundaries_and_spaced_values` fail, recovering `["--user-data-dir=/tmp/helium", "--profile", ...]` instead of the intact value
- restoring the first-switch-only `--type=` rule makes `process_type_detection_handles_nul_and_packed_command_lines` fail on the `--enable-logging --type=renderer` helper case
- restoring the leading-executable requirement makes `packed_recovery_survives_leading_positional_arguments` fail, returning no profile for `helium https://example.test --user-data-dir=/tmp/p`
- replacing `process_owns_profile_directory` with an unconditional `true` makes the two refusal tests fail (`user_data_dir_for_pid_refuses_ordinary_text_naming_the_processs_own_cwd` and `user_data_dir_for_pid_refuses_a_singleton_socket_owned_by_a_different_process`) plus the helper-level unit test `process_owns_profile_directory_requires_this_exact_process_to_hold_the_socket`, while the corroboration test still passes because it guards the opposite direction. An unconditional `false` is what breaks that corroboration test, so both directions of the guard are pinned

Live source-built Linux validation with Helium 0.15.5.1 / Chromium 151, using a disposable profile whose path deliberately contains a space (`/tmp/cua-opt profile`), the exact value shape called out in review. The observed `/proc/<pid>/cmdline` was a single packed record:

```
/opt/helium-browser-bin/helium --ozone-platform=x11 --user-data-dir=/tmp/cua-opt profile --remote-debugging-port=0 ...
```

- `browser_prepare(existing_profile)` returned `attached_existing_profile`
- ownership method was `devtools_active_ports_file` for the exact PID
- fresh `get_browser_state` returned `binding_quality: exact`, `endpoint_transport: dev_tools_active_port`, `mutation_allowed: true`
- with only that profile's `DevToolsActivePort` hidden, the same call refused instead of falling through to `/json/version`
- no setup page, preference change, restart, profile copy, foregrounding, or injected input occurred
- the temporary browser, daemon, socket, and profile were removed afterwards; no user profile was touched

Separately, `user_data_dir_for_pid` / `process_owns_profile_directory` / `active_port_endpoint` were exercised read-only against this development machine's own real, currently-running Helium session (see the fourth-review section above). All three resolved correctly against the genuine `~/.config/net.imput.helium` profile and its live SingletonSocket and DevToolsActivePort.

## Known local environment limits

These are properties of this development host, not of this diff. Each is
reproduced or explained below, and none of them is part of the Linux CI gate.

- `cua-driver-testkit::e2e::tests::native_case_builders_encode_delivery_and_oracle_contracts`
  asserts the `Cursor` oracle is present, but `native_background_case` only adds
  that oracle when the display server is not Wayland (`e2e.rs:645`). This
  desktop is Niri/Wayland, so the assertion fails here; unsetting
  `WAYLAND_DISPLAY` makes the same test pass. `cua-driver-testkit` depends only
  on `image`, `libc`, `serde`, `serde_json`, `tempfile`, and `x11rb`, so it
  cannot be influenced by this diff. CI's X11 runners are not Wayland, so the
  oracle is present there and the assertion holds.
- `cargo test -p cua-driver --test embedded_host_sdk_mcp_test` fails here only
  because the fixture writer in that test prefers `$SHELL`
  (`embedded_host_sdk_mcp_test.rs:52`), which is fish on this machine, and its
  writer command is not fish-compatible. With `SHELL=/bin/bash` all five tests
  pass. Unrelated to this change.
- `cargo check -p platform-macos --all-targets` fails on
  `tests/cursor_hook_registry.rs:22`, which imports `platform_macos::cursor`
  while `lib.rs` gates that module behind `target_os = "macos"`. That is
  upstream breakage from `7fe7c33f7` (#3883), reproduces on `main`, and does not
  affect the Linux gate.
- the strict standalone-browser E2E reaches Helium but Niri tiles the sentinel and browser instead of geometrically occluding the target, so it refuses at `BackgroundVisible` before `browser_prepare`; the direct exact-PID live validation above exercises the attachment path
- on the generic Wayland path Niri cannot attest native-window cardinality, so binding degrades to `heuristic` and mutation is withheld; the X11 path on the same machine binds `exact`. This is the pre-existing documented Wayland limitation, not Helium-specific

## Contributor checks

- [x] focused diff; every production change traces to #3252
- [x] tests and public documentation included
- [x] Conventional Commit release title
- [x] no permission or endpoint-ownership boundary weakened

