### PR TITLE
ci: promote the cua-fleet 0.1.14 wheel set to PyPI

### DIFF
--- a/.github/workflows/cd-py-fleet.yml
+++ b/.github/workflows/cd-py-fleet.yml
@@ -9,7 +9,7 @@ on:
       version:
         description: "Canonical cua-fleet version to publish"
         required: true
-        default: "0.1.12"
+        default: "0.1.14"
   workflow_call:
     inputs:
       version:
@@ -49,8 +49,8 @@ jobs:
             exit 1
           fi
 
-          if [[ "$VERSION" != "0.1.12" ]]; then
-            echo "::error::This workflow promotes the hash-pinned cua-fleet 0.1.12 wheel set, not $VERSION."
+          if [[ "$VERSION" != "0.1.14" ]]; then
+            echo "::error::This workflow promotes the hash-pinned cua-fleet 0.1.14 wheel set, not $VERSION."
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -65,32 +65,32 @@ jobs:
         include:
           - platform: linux-x86_64
             runner: ubuntu-22.04
-            wheel: cua_fleet-0.1.12-py3-none-manylinux_2_34_x86_64.whl
-            sha256: d8ef6a0c8ac6e6f8dda937e3aebeef7f5b4fa9e3f29edc55a602a1c874f3f96a
+            wheel: cua_fleet-0.1.14-py3-none-manylinux_2_34_x86_64.whl
+            sha256: 2dc70e98b3e8c691bf0fff0494b0a85d2405e872f1ca99dbfa2680473cea565b
             native_library: libcyclops_sdk.so
             audit: auditwheel
           - platform: linux-aarch64
             runner: ubuntu-24.04-arm
-            wheel: cua_fleet-0.1.12-py3-none-manylinux_2_34_aarch64.whl
-            sha256: 0a39e52cbec94a2bc71f45282dd34c896fd154bc7f7a137fc6ceff82edfc0973
+            wheel: cua_fleet-0.1.14-py3-none-manylinux_2_34_aarch64.whl
+            sha256: d6ea25902cf9ffc89779530b6ae7cff5413383ea7dc3c632a4fb47e00699a6d4
             native_library: libcyclops_sdk.so
             audit: auditwheel
           - platform: macos-x86_64
             runner: macos-15-intel
-            wheel: cua_fleet-0.1.12-py3-none-macosx_10_12_x86_64.whl
-            sha256: d5114ba97ef208e257bef261f6d3585b265f1f2c32cb627bcc9f44d753e60b75
+            wheel: cua_fleet-0.1.14-py3-none-macosx_10_12_x86_64.whl
+            sha256: d370f83773574da8edcca080e9d86aec8eb7ed758d6c551b900482a8575f6810
             native_library: libcyclops_sdk.dylib
             audit: delocate
           - platform: macos-arm64
             runner: macos-14
-            wheel: cua_fleet-0.1.12-py3-none-macosx_11_0_arm64.whl
-            sha256: 82762fae4943b20aae05b39362f5bd0c179f84c16dac1e948debb3d58db5adc2
+            wheel: cua_fleet-0.1.14-py3-none-macosx_11_0_arm64.whl
+            sha256: e19784c0ce8aa2d9a77bf096fc6ff10e990842f05c67bdfb96a16ecd5e7123e2
             native_library: libcyclops_sdk.dylib
             audit: delocate
           - platform: windows-x86_64
             runner: windows-latest
-            wheel: cua_fleet-0.1.12-py3-none-win_amd64.whl
-            sha256: c280d7ceadedc1d5c4c59869940c3390aac321f12ac9c9ee52250f212b6aac75
+            wheel: cua_fleet-0.1.14-py3-none-win_amd64.whl
+            sha256: 3e73327b7c99dc95a4b4194628d3575a8707cab77d6929ed1bf34a82192a4464
             native_library: cyclops_sdk.dll
             audit: none
     steps:
@@ -246,11 +246,11 @@ jobs:
 
           version, dist_directory = sys.argv[1:]
           expected = {
-              f"cua_fleet-{version}-py3-none-manylinux_2_34_x86_64.whl": "d8ef6a0c8ac6e6f8dda937e3aebeef7f5b4fa9e3f29edc55a602a1c874f3f96a",
-              f"cua_fleet-{version}-py3-none-manylinux_2_34_aarch64.whl": "0a39e52cbec94a2bc71f45282dd34c896fd154bc7f7a137fc6ceff82edfc0973",
-              f"cua_fleet-{version}-py3-none-macosx_10_12_x86_64.whl": "d5114ba97ef208e257bef261f6d3585b265f1f2c32cb627bcc9f44d753e60b75",
-              f"cua_fleet-{version}-py3-none-macosx_11_0_arm64.whl": "82762fae4943b20aae05b39362f5bd0c179f84c16dac1e948debb3d58db5adc2",
-              f"cua_fleet-{version}-py3-none-win_amd64.whl": "c280d7ceadedc1d5c4c59869940c3390aac321f12ac9c9ee52250f212b6aac75",
+              f"cua_fleet-{version}-py3-none-manylinux_2_34_x86_64.whl": "2dc70e98b3e8c691bf0fff0494b0a85d2405e872f1ca99dbfa2680473cea565b",
+              f"cua_fleet-{version}-py3-none-manylinux_2_34_aarch64.whl": "d6ea25902cf9ffc89779530b6ae7cff5413383ea7dc3c632a4fb47e00699a6d4",
+              f"cua_fleet-{version}-py3-none-macosx_10_12_x86_64.whl": "d370f83773574da8edcca080e9d86aec8eb7ed758d6c551b900482a8575f6810",
+              f"cua_fleet-{version}-py3-none-macosx_11_0_arm64.whl": "e19784c0ce8aa2d9a77bf096fc6ff10e990842f05c67bdfb96a16ecd5e7123e2",
+              f"cua_fleet-{version}-py3-none-win_amd64.whl": "3e73327b7c99dc95a4b4194628d3575a8707cab77d6929ed1bf34a82192a4464",
           }
           wheels = {wheel.name: wheel for wheel in Path(dist_directory).glob("*.whl")}
           assert set(wheels) == set(expected), (set(wheels), set(expected))


### PR DESCRIPTION
Repins `cd-py-fleet.yml` from the 0.1.12 wheel set to **0.1.14**, built from trycua/cloud tag `cua-fleet-sdk/v0.1.14` (trycua/cloud#7058: `ttl_seconds_after_created` on `OSGymSandboxWarmPoolSpec` and `ClaimSpec`).

- workflow_dispatch default and version guard → 0.1.14
- five matrix wheel filenames + sha256 digests → the wheels now published on wheels.cua.ai
- validate-step digest map → same five digests

Digests computed locally from the wheels.cua.ai downloads. After merge, tagging `fleet-v0.1.14` promotes the set to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)