### PR TITLE
docs(sandbox): split pool/claim TTL into its own how-to guide

### DIFF
--- a/docs/content/docs/how-to-guides/sandbox/create-pool-with-python.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/create-pool-with-python.mdx
@@ -143,54 +143,9 @@ first claim after an idle period cold-starts a sandbox.
 
 ## Expire pools and claims automatically
 
-Pools and claims accept an optional creation-age TTL. Pass
-`ttl_seconds_after_created=` (requires `cua-sandbox>=0.4.2`) and the resource
-is deleted once it has existed that many seconds, whether or not it is in use:
-
-```python
-# Delete the whole pool 24 hours after it was first created.
-pool = await Pool.apply(
-    Image.from_registry(IMAGE),
-    name=POOL_NAME,
-    replicas=1,
-    ttl_seconds_after_created=86400,
-)
-
-# Delete this claim and its sandbox one hour after the claim was created.
-async with pool.claim(
-    name=CLAIM_NAME,
-    ttl_seconds_after_created=3600,
-) as sandbox:
-    ...
-```
-
-The clock starts at the resource's original creation, not its last use:
-re-running `Pool.apply()` reconciles the existing pool without resetting its
-age, and reconnecting to a named claim keeps the deadline set when the claim
-was first created. Without the argument nothing is reaped — pools and claims
-live until you delete them.
-
-A claim TTL fills in the claim's lifecycle shutdown time with a `Delete`
-policy; a claim that already carries an explicit lifecycle keeps it. When you
-build a claim spec by hand, put the TTL inside it — passing both
-`spec=` and `ttl_seconds_after_created=` raises `ValueError`:
-
-```python
-spec = ClaimSpec(
-    sandbox_template_ref=pool.resource.spec.sandbox_template_ref,
-    warmpool=None,
-    bind_deadline=None,
-    lifecycle=None,
-    ttl_seconds_after_created=3600,
-)
-async with pool.claim(spec=spec) as sandbox:
-    ...
-```
-
-Treat a pool TTL that can expire while claims are held as a capacity event,
-not just cleanup: deleting the pool drains its sandboxes, and a claim that
-outlives its pool destroys its sandbox on release instead of returning it to
-the pool.
+Pools and claims accept an optional creation-age TTL that deletes them a
+fixed time after creation. See
+[Expire pools and claims automatically](/how-to-guides/sandbox/expire-pools-and-claims).
 
 ## Choose pool and claim names
 

--- a/docs/content/docs/how-to-guides/sandbox/expire-pools-and-claims.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/expire-pools-and-claims.mdx
@@ -1,0 +1,84 @@
+---
+title: Expire pools and claims automatically
+description: Set a creation-age TTL so sandbox pools and claims delete themselves.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Pools and claims accept an optional creation-age TTL. Pass
+`ttl_seconds_after_created=` (requires `cua-sandbox>=0.4.2`) and the resource
+is deleted once it has existed that many seconds, whether or not it is in use.
+Without the argument nothing is reaped — pools and claims live until you
+delete them.
+
+This guide assumes a pool created as in
+[Create a sandbox pool with Python](/how-to-guides/sandbox/create-pool-with-python).
+
+## Expire a pool
+
+Pass the TTL to `Pool.apply()` to delete the whole pool — its warm replicas
+and its template — a fixed time after the pool was first created:
+
+```python
+from cua_sandbox import Image, Pool
+
+# Delete the whole pool 24 hours after it was first created.
+pool = await Pool.apply(
+    Image.from_registry(IMAGE),
+    name=POOL_NAME,
+    replicas=1,
+    ttl_seconds_after_created=86400,
+)
+```
+
+## Expire a claim
+
+Pass the same argument to `pool.claim()` (or `pool.create_claim()`) to delete
+one claim and its sandbox a fixed time after the claim was created:
+
+```python
+# Delete this claim and its sandbox one hour after the claim was created.
+async with pool.claim(
+    name=CLAIM_NAME,
+    ttl_seconds_after_created=3600,
+) as sandbox:
+    ...
+```
+
+A claim TTL fills in the claim's lifecycle shutdown time with a `Delete`
+policy; a claim that already carries an explicit lifecycle keeps it.
+
+## The clock starts at creation
+
+The TTL counts from the resource's original creation, not its last use:
+re-running `Pool.apply()` reconciles the existing pool without resetting its
+age, and reconnecting to a named claim keeps the deadline set when the claim
+was first created.
+
+## Hand-built claim specs
+
+When you build a claim spec by hand, put the TTL inside it — passing both
+`spec=` and `ttl_seconds_after_created=` raises `ValueError`:
+
+```python
+from cua_sandbox import ClaimSpec
+
+spec = ClaimSpec(
+    sandbox_template_ref=pool.resource.spec.sandbox_template_ref,
+    warmpool=None,
+    bind_deadline=None,
+    lifecycle=None,
+    ttl_seconds_after_created=3600,
+)
+async with pool.claim(spec=spec) as sandbox:
+    ...
+```
+
+## Pool expiry under live claims
+
+<Callout type="warn">
+  Treat a pool TTL that can expire while claims are held as a capacity event,
+  not just cleanup: deleting the pool drains its sandboxes, and a claim that
+  outlives its pool destroys its sandbox on release instead of returning it
+  to the pool.
+</Callout>

--- a/docs/content/docs/how-to-guides/sandbox/meta.json
+++ b/docs/content/docs/how-to-guides/sandbox/meta.json
@@ -4,6 +4,7 @@
     "lifecycle",
     "configure-pool-with-terraform",
     "create-pool-with-python",
+    "expire-pools-and-claims",
     "secrets",
     "scale-out",
     "tunneling",


### PR DESCRIPTION
Moves the "Expire pools and claims automatically" section (added in #3256) out of `create-pool-with-python` into a standalone guide at `how-to-guides/sandbox/expire-pools-and-claims`:

- New page covers pool TTL, claim TTL, the creation-clock semantics, hand-built `ClaimSpec` usage, and the pool-expiry-under-live-claims capacity warning (as a callout).
- The pool guide keeps a short pointer section linking to the new page.
- Added to the sandbox section nav in `meta.json`, right after the pool guide.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)