### PR TITLE
fix(cua-driver): admit stable local history signatures

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/history_runtime.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/history_runtime.rs
@@ -267,7 +267,7 @@ pub fn verify_installed_app_for_history() -> anyhow::Result<()> {
         .lines()
         .find_map(|line| line.trim().strip_prefix("TeamIdentifier="))
         .filter(|value| !value.is_empty() && *value != "not set")
-        .ok_or_else(|| anyhow::anyhow!("installed Cua Driver signature has no team identifier"))?;
+        .unwrap_or("");
     let entitlements = Command::new("/usr/bin/codesign")
         .args(["-d", "--entitlements", "-", "--xml", helper.as_ref()])
         .output()?;
@@ -306,11 +306,15 @@ fn validate_history_app_signature(
     if !requirement.contains("certificate leaf") {
         anyhow::bail!("installed Cua Driver signature is not certificate-backed");
     }
-    if team_identifier.is_empty() || team_identifier == "not set" {
-        anyhow::bail!("installed Cua Driver signature has no team identifier");
-    }
+    // A stable self-signed local-development certificate has a certificate-leaf
+    // designated requirement but no Apple TeamIdentifier. That leaf pins local
+    // history to the same signing identity across rebuilds. Production still
+    // requires the exact Apple team and device-protected Keychain entitlements.
     if !require_release_entitlements {
         return Ok(());
+    }
+    if team_identifier.is_empty() || team_identifier == "not set" {
+        anyhow::bail!("installed Cua Driver signature has no team identifier");
     }
     if team_identifier != RELEASE_TEAM_IDENTIFIER {
         anyhow::bail!("installed Cua Driver signature does not match the release signing team");
@@ -554,11 +558,11 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "macos")]
-    fn local_history_accepts_exact_certificate_identity_without_release_entitlements() {
+    fn local_history_accepts_certificate_identity_without_apple_team_identifier() {
         validate_history_app_signature(
-            "Identifier=com.trycua.driver.local\nTeamIdentifier=TEAM123",
-            "designated => identifier \"com.trycua.driver.local\" and certificate leaf[subject.OU] = TEAM123",
-            "TEAM123",
+            "Identifier=com.trycua.driver.local\nTeamIdentifier=not set",
+            "designated => identifier \"com.trycua.driver.local\" and certificate leaf = H\"d2badc24c61056ede3b61724c54c5a7d1649ce4d\"",
+            "",
             "",
             "com.trycua.driver.local",
             false,
@@ -592,6 +596,15 @@ mod tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn release_history_still_requires_device_protected_keychain_entitlements() {
+        assert!(validate_history_app_signature(
+            "Identifier=com.trycua.driver\nTeamIdentifier=not set",
+            "designated => anchor apple generic and identifier \"com.trycua.driver\" and certificate leaf = H\"1234\"",
+            "",
+            "",
+            "com.trycua.driver",
+            true,
+        )
+        .is_err());
         let detail =
             format!("Identifier=com.trycua.driver\nTeamIdentifier={RELEASE_TEAM_IDENTIFIER}");
         let requirement = format!(


### PR DESCRIPTION
## Summary

- admit certificate-backed local development apps whose self-signed identity has no Apple TeamIdentifier
- keep production history admission pinned to the exact Apple release team, Apple trust anchor, and device-protected Keychain entitlements
- cover the real local codesign output and explicit release-without-team refusal

## Why

The canonical macOS Lume matrix could not start the unrestricted worker for 0.21.0 because `--experimental-history` rejected the stable local signing identity: `installed Cua Driver signature has no team identifier`.

The local app is not ad hoc: its designated requirement pins the exact certificate leaf hash. Apple reports `TeamIdentifier=not set` for that self-signed development certificate. Production remains unchanged and fail-closed.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cua-driver history_runtime::tests -- --nocapture` (7 passed)
- exact-source macOS Lume run at `d51943761f859a915f4c4aff95a12185d0df0c21` started the unrestricted worker and passed the real encrypted-history restart/cryptographic-purge test
- the canonical matrix completed all 120 shared-app rows and every native/capture/desktop lane; 119 shared rows passed, while one row was contaminated by the operator granting the one-time private-window capture prompt during its cursor oracle
- the runner’s exact retry-only path replayed only `macos-electron-double-click-ax-background`; it passed every fixture/focus/z-order/no-leaked-input/cursor oracle with recorded video

The standalone-browser release lane is tracked separately from this macOS-only admission fix.
