### PR TITLE
fix(cua-driver): honor disabled UIA ancestors

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/browser_consent_ui.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/browser_consent_ui.rs
@@ -27,12 +27,6 @@ fn refusal(code: BrowserRefusalCode, message: impl Into<String>) -> BrowserRefus
     BrowserRefusal::new(code, message)
 }
 
-fn release_nodes(nodes: &[UiaNode]) {
-    for node in nodes.iter().filter(|node| node.element_ptr != 0) {
-        unsafe { drop(IUIAutomationElement::from_raw(node.element_ptr as *mut _)) };
-    }
-}
-
 fn is_in_web_content(nodes: &[UiaNode], node: &UiaNode) -> bool {
     let mut parent = node.parent_element_index;
     for _ in 0..nodes.len() {
@@ -390,7 +384,6 @@ pub fn dismiss(pid: u32, hwnd: u64) -> Result<bool, BrowserRefusal> {
         let tree = crate::uia::walk_tree(hwnd, None);
         let prompt_present = native_prompt_surface_present(&tree.nodes);
         if !prompt_present {
-            release_nodes(&tree.nodes);
             return Ok(dismissed);
         }
         let cancel = exact_cancel_button(&tree.nodes);
@@ -402,7 +395,6 @@ pub fn dismiss(pid: u32, hwnd: u64) -> Result<bool, BrowserRefusal> {
             )),
             Err(error) => Err(error),
         };
-        release_nodes(&tree.nodes);
         invoked?;
         dismissed = true;
         if Instant::now() >= deadline {
@@ -443,15 +435,11 @@ pub async fn handle(
         match exact_allow_button(&tree.nodes) {
             Ok(Some(element)) => {
                 let invoked = unsafe { invoke(element) };
-                release_nodes(&tree.nodes);
                 invoked?;
                 return Ok(BrowserConsentOutcome::Accepted);
             }
-            Ok(None) => release_nodes(&tree.nodes),
-            Err(error) => {
-                release_nodes(&tree.nodes);
-                return Err(error);
-            }
+            Ok(None) => {}
+            Err(error) => return Err(error),
         }
         if saw_prompt && !prompt_present {
             return Err(refusal(

--- a/libs/cua-driver/rust/crates/platform-windows/src/browser_setup_ui.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/browser_setup_ui.rs
@@ -31,12 +31,6 @@ fn refusal(code: BrowserRefusalCode, message: impl Into<String>) -> BrowserRefus
     BrowserRefusal::new(code, message)
 }
 
-fn release_nodes(nodes: &[UiaNode]) {
-    for node in nodes.iter().filter(|node| node.element_ptr != 0) {
-        unsafe { drop(IUIAutomationElement::from_raw(node.element_ptr as *mut _)) };
-    }
-}
-
 fn unique_web_actionable(
     nodes: &[UiaNode],
     control_type: &str,
@@ -178,7 +172,6 @@ fn stable_native_tab_count(hwnd: u64, initial_count: usize) -> Result<usize, Bro
         std::thread::sleep(Duration::from_millis(100));
         let tree = crate::uia::walk_tree(hwnd, None);
         let current = native_tab_count(&tree.nodes);
-        release_nodes(&tree.nodes);
         if current > 0 && current == previous {
             return Ok(current);
         }
@@ -393,7 +386,6 @@ impl SetupUiHandle {
             },
             _ => false,
         };
-        release_nodes(&tree.nodes);
         if restored {
             self.enabled_remote_debugging = false;
         }
@@ -430,7 +422,6 @@ impl SetupUiHandle {
         }
         let tree = crate::uia::walk_tree(self.hwnd, None);
         let proven = setup_page_proven(&tree.nodes, self.descriptor);
-        release_nodes(&tree.nodes);
         if !proven {
             let error = refusal(
                 BrowserRefusalCode::BrowserWrongTargetRefused,
@@ -456,7 +447,6 @@ impl SetupUiHandle {
         }
         let tree = crate::uia::walk_tree(self.hwnd, None);
         let proven = setup_page_proven(&tree.nodes, self.descriptor);
-        release_nodes(&tree.nodes);
         Some(
             proven
                 && crate::input::keyboard::send_key_synthesized(self.hwnd, "w", &["ctrl"]).is_ok(),
@@ -525,7 +515,6 @@ fn set_remote_debugging(
         },
         Ok(None) => {
             let initial_tab_count = native_tab_count(&initial.nodes);
-            release_nodes(&initial.nodes);
             let tab_count_before = stable_native_tab_count(hwnd, initial_tab_count)?;
 
             let mut handle = SetupUiHandle {
@@ -542,7 +531,6 @@ fn set_remote_debugging(
             let new_tab_button = match exact_native_new_tab_button(&tab_tree.nodes) {
                 Ok(Some(element)) => element,
                 Ok(None) => {
-                    release_nodes(&tab_tree.nodes);
                     return Err(handle.abort(refusal(
                         BrowserRefusalCode::BrowserWrongTargetRefused,
                         format!(
@@ -552,15 +540,12 @@ fn set_remote_debugging(
                     )));
                 }
                 Err(error) => {
-                    release_nodes(&tab_tree.nodes);
                     return Err(handle.abort(error));
                 }
             };
             if let Err(error) = unsafe { invoke(new_tab_button, "native new-tab button") } {
-                release_nodes(&tab_tree.nodes);
                 return Err(handle.abort(error));
             }
-            release_nodes(&tab_tree.nodes);
             handle.opened_setup_page = true;
 
             let deadline = Instant::now() + Duration::from_secs(3);
@@ -570,7 +555,6 @@ fn set_remote_debugging(
                 if tab_count_after == tab_count_before + 1 {
                     break tree;
                 }
-                release_nodes(&tree.nodes);
                 if Instant::now() >= deadline {
                     return Err(handle.abort(refusal(
                         BrowserRefusalCode::BrowserWrongTargetRefused,
@@ -585,7 +569,6 @@ fn set_remote_debugging(
             let omnibox = match unique_native_actionable(&created.nodes, "Edit", "set_value") {
                 Ok(Some(element)) => element,
                 Ok(None) => {
-                    release_nodes(&created.nodes);
                     return Err(handle.abort(refusal(
                         BrowserRefusalCode::BrowserWrongTargetRefused,
                         format!(
@@ -595,15 +578,12 @@ fn set_remote_debugging(
                     )));
                 }
                 Err(error) => {
-                    release_nodes(&created.nodes);
                     return Err(handle.abort(error));
                 }
             };
             if let Err(error) = unsafe { set_value(omnibox, descriptor.setup_url) } {
-                release_nodes(&created.nodes);
                 return Err(handle.abort(error));
             }
-            release_nodes(&created.nodes);
             created = crate::uia::walk_tree(hwnd, None);
             let refreshed_omnibox =
                 match unique_native_actionable(&created.nodes, "Edit", "set_value") {
@@ -618,14 +598,12 @@ fn set_remote_debugging(
                         element
                     }
                     Ok(_) => {
-                        release_nodes(&created.nodes);
                         return Err(handle.abort(refusal(
                             BrowserRefusalCode::BrowserWrongTargetRefused,
                             "the unique native address field did not retain the exact setup URL",
                         )));
                     }
                     Err(error) => {
-                        release_nodes(&created.nodes);
                         return Err(handle.abort(error));
                     }
                 };
@@ -636,21 +614,14 @@ fn set_remote_debugging(
                 &mut handle.injected_global_input,
                 &mut handle.focused_setup_address_field,
             ) {
-                release_nodes(&created.nodes);
                 return Err(handle.abort(error));
             }
-            release_nodes(&created.nodes);
             handle
         }
         Err(error) => {
-            release_nodes(&initial.nodes);
             return Err(error);
         }
     };
-    if !handle.opened_setup_page {
-        release_nodes(&initial.nodes);
-    }
-
     let deadline = Instant::now() + EXISTING_PROFILE_SETUP_READY_TIMEOUT;
     loop {
         let tree = crate::uia::walk_tree(hwnd, None);
@@ -671,16 +642,14 @@ fn set_remote_debugging(
                     Ok(_) => Ok(false),
                     Err(error) => Err(error),
                 };
-                release_nodes(&tree.nodes);
                 match outcome {
                     Ok(true) => return Ok(handle),
                     Ok(false) => handle.enable_attempted = true,
                     Err(error) => return Err(handle.abort(error)),
                 }
             }
-            Ok(None) => release_nodes(&tree.nodes),
+            Ok(None) => {}
             Err(error) => {
-                release_nodes(&tree.nodes);
                 return Err(handle.abort(error));
             }
         }
@@ -732,7 +701,7 @@ mod tests {
             actions: actions.iter().map(|value| (*value).to_owned()).collect(),
             enabled: None,
             selected: None,
-            element_ptr: 7,
+            element_ptr: if actions.is_empty() { 0 } else { 7 },
             center_x: 0,
             center_y: 0,
             rect: None,

--- a/libs/cua-driver/rust/crates/platform-windows/src/msaa.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/msaa.rs
@@ -170,60 +170,45 @@ unsafe fn walk(
     let has_content = name.is_some();
 
     if is_actionable || has_content {
-        // Retain the IAccessible pointer for the cache. Mirror what the UIA
-        // walker does: clone, get raw, forget the local — the cache's Drop
-        // releases via IUnknown.
-        let retained: IAccessible = acc.clone();
-        let ptr = retained.as_raw() as usize;
-        std::mem::forget(retained);
-
-        let (center_x, center_y) = rect
-            .map(|(l, t, r, b)| ((l + r) / 2, (t + b) / 2))
-            .unwrap_or((0, 0));
-
-        let node = if is_actionable {
+        let element_index = if is_actionable {
             let idx = *counter;
             *counter += 1;
-            UiaNode {
-                element_index: Some(idx),
-                control_type: control_type.clone(),
-                name: name.clone(),
-                value: None,
-                automation_id: None,
-                help_text: None,
-                actions: actions.clone(),
-                enabled: None,
-                selected: None,
-                element_ptr: ptr,
-                center_x,
-                center_y,
-                rect,
-                msaa_role: role_int,
-                depth,
-                parent_element_index: parent_index,
-                in_web_content: false,
-            }
+            Some(idx)
         } else {
-            UiaNode {
-                element_index: None,
-                control_type: control_type.clone(),
-                name: name.clone(),
-                value: None,
-                automation_id: None,
-                help_text: None,
-                actions: Vec::new(),
-                enabled: None,
-                selected: None,
-                element_ptr: ptr,
-                center_x: 0,
-                center_y: 0,
-                rect,
-                msaa_role: role_int,
-                depth,
-                parent_element_index: parent_index,
-                in_web_content: false,
-            }
+            None
         };
+        let (element_ptr, center_x, center_y) = if element_index.is_some() {
+            // The cache adopts this reference when the walk becomes a snapshot.
+            let retained: IAccessible = acc.clone();
+            let ptr = retained.as_raw() as usize;
+            std::mem::forget(retained);
+            let (center_x, center_y) = rect
+                .map(|(l, t, r, b)| ((l + r) / 2, (t + b) / 2))
+                .unwrap_or((0, 0));
+            (ptr, center_x, center_y)
+        } else {
+            (0, 0, 0)
+        };
+        let node = UiaNode {
+            element_index,
+            control_type: control_type.clone(),
+            name: name.clone(),
+            value: None,
+            automation_id: None,
+            help_text: None,
+            actions: actions.clone(),
+            enabled: None,
+            selected: None,
+            element_ptr,
+            center_x,
+            center_y,
+            rect,
+            msaa_role: role_int,
+            depth,
+            parent_element_index: parent_index,
+            in_web_content: false,
+        };
+        debug_assert_eq!(node.element_ptr != 0, node.element_index.is_some());
         // Track this node as the parent_index for its descendants only when
         // it received an element_index (mirrors what the markdown shows:
         // only indexed rows are addressable).

--- a/libs/cua-driver/rust/crates/platform-windows/src/recording_hooks.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/recording_hooks.rs
@@ -107,7 +107,7 @@ pub fn app_state_json_for(window_id: Option<u64>, pid: Option<i64>) -> Option<Ve
         "pid": pid,
         "window_id": hwnd,
         "element_count": element_count,
-        "tree_markdown": result.tree_markdown,
+        "tree_markdown": &result.tree_markdown,
     });
     serde_json::to_vec_pretty(&payload).ok()
 }

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -1299,7 +1299,7 @@ impl Tool for GetWindowStateTool {
                 let mut content = Vec::new();
                 let mut structured = json!({ "window_id": hwnd, "pid": pid });
 
-                if let Some(tr) = tree_opt {
+                if let Some(mut tr) = tree_opt {
                     let is_msaa = tr.nodes.iter().any(|n| n.msaa_role.is_some());
                     let count = tr
                         .nodes
@@ -1315,18 +1315,14 @@ impl Tool for GetWindowStateTool {
                     // walker, so the entire snapshot must Drop via
                     // IAccessible and click must dispatch through MSAA.
                     if !observation_only {
-                        if is_msaa {
-                            state.element_cache.update_msaa(pid, hwnd, &tr.nodes);
-                        } else {
-                            state.element_cache.update(pid, hwnd, &tr.nodes);
-                        }
+                        state.element_cache.adopt_walk(pid, hwnd, &mut tr);
                     }
                     structured["element_count"] = json!(count);
                     // UIA currently does not expose whether a bounded walk
                     // exhausted every subtree. Keep negative existence
                     // conservative until that proof is available.
                     structured["elements_complete"] = json!(false);
-                    structured["tree_markdown"] = json!(tr.tree_markdown);
+                    structured["tree_markdown"] = json!(&tr.tree_markdown);
 
                     // Surface 6: register a snapshot in the global token
                     // registry. Windows uses u64 HWND but the registry

--- a/libs/cua-driver/rust/crates/platform-windows/src/uia/cache.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/uia/cache.rs
@@ -5,22 +5,23 @@
 //! path, or `IAccessible` for the MSAA fallback used on SAL/VCL targets).
 //!
 //! Memory contract: `UiaNode::element_ptr` is a raw COM vtable pointer with
-//! an extra AddRef from `clone()+forget()` in the walker. `CachedSnapshot::Drop`
-//! calls `Release()` via the kind-appropriate vtable to balance.
+//! an extra AddRef from `clone()+forget()` in the walker. `UiaTreeResult`
+//! releases it unless `ElementCache::adopt_walk` transfers it into a
+//! `CachedSnapshot`, whose `Drop` then balances the reference.
 //!
 //! The locked-HashMap plumbing lives in `cua_driver_core::element_cache` — see
 //! `docs/dedup-audit.md` item #3. This module owns the Windows-specific
 //! `CacheKey`, `CachedSnapshot`, and the `Drop` impl that fires COM `Release`
 //! when an entry is replaced or removed.
 
-use super::UiaNode;
+use super::{UiaNode, UiaTreeResult};
 use cua_driver_core::element_cache::ElementCacheCore;
 use windows::core::Interface;
 use windows::Win32::UI::Accessibility::{IAccessible, IUIAutomationElement};
 
 /// A cached element pointer borrowed out of the cache with an extra COM
 /// `AddRef`, so it stays alive for the duration of a UIA/MSAA action even if a
-/// concurrent `get_window_state` (→ [`ElementCache::update`]) replaces and
+/// concurrent `get_window_state` (→ [`ElementCache::adopt_walk`]) replaces and
 /// drops the snapshot it came from. Without this, the snapshot's `Drop` could
 /// `Release` the element to zero while an in-flight click / SetValue was still
 /// dereferencing the raw COM vtable pointer — a use-after-free. This is the
@@ -148,44 +149,52 @@ impl ElementCache {
         }
     }
 
-    /// Update the snapshot for (pid, hwnd) with the actionable elements
-    /// from a UIA walk. Mirrors `update_msaa` for the MSAA path.
-    pub fn update(&self, pid: u32, hwnd: u64, nodes: &[UiaNode]) {
-        self.update_with_kind(pid, hwnd, nodes, SnapshotKind::Uia);
+    /// Adopt the actionable element references from a completed walk.
+    ///
+    /// Each pointer moves into the cache by being replaced with zero in the
+    /// walk result. Any pointer not transferred remains owned by
+    /// [`UiaTreeResult`] and is released when the result is dropped.
+    pub fn adopt_walk(&self, pid: u32, hwnd: u64, walk: &mut UiaTreeResult) {
+        let kind = if walk.nodes.iter().any(|node| node.msaa_role.is_some()) {
+            SnapshotKind::Msaa
+        } else {
+            SnapshotKind::Uia
+        };
+        self.adopt_nodes(pid, hwnd, &mut walk.nodes, kind);
     }
 
-    /// Same as `update` but tags the snapshot as MSAA so Drop releases the
-    /// pointers as `IAccessible` and the click tool routes through the
-    /// MSAA dispatch path.
-    pub fn update_msaa(&self, pid: u32, hwnd: u64, nodes: &[UiaNode]) {
-        self.update_with_kind(pid, hwnd, nodes, SnapshotKind::Msaa);
-    }
-
-    fn update_with_kind(&self, pid: u32, hwnd: u64, nodes: &[UiaNode], kind: SnapshotKind) {
-        let actionable: Vec<&UiaNode> =
-            nodes.iter().filter(|n| n.element_index.is_some()).collect();
-        let elements: Vec<usize> = actionable.iter().map(|n| n.element_ptr).collect();
-        let centers: Vec<(i32, i32)> = actionable
-            .iter()
-            .map(|n| (n.center_x, n.center_y))
-            .collect();
-        let rects: Vec<Option<(i32, i32, i32, i32)>> = actionable.iter().map(|n| n.rect).collect();
-        let msaa_roles: Vec<Option<i32>> = actionable.iter().map(|n| n.msaa_role).collect();
-        self.core.insert(
-            CacheKey { pid, hwnd },
-            CachedSnapshot {
-                kind,
-                elements,
-                centers,
-                rects,
-                msaa_roles,
-            },
+    fn adopt_nodes(&self, pid: u32, hwnd: u64, nodes: &mut [UiaNode], kind: SnapshotKind) {
+        debug_assert!(
+            nodes
+                .iter()
+                .all(|node| (node.element_ptr != 0) == node.element_index.is_some()),
+            "UiaNode element pointer/index invariant violated"
         );
+        let actionable_count = nodes
+            .iter()
+            .filter(|node| node.element_index.is_some())
+            .count();
+        let mut snapshot = CachedSnapshot {
+            kind,
+            elements: Vec::with_capacity(actionable_count),
+            centers: Vec::with_capacity(actionable_count),
+            rects: Vec::with_capacity(actionable_count),
+            msaa_roles: Vec::with_capacity(actionable_count),
+        };
+        for node in nodes.iter_mut().filter(|node| node.element_index.is_some()) {
+            snapshot
+                .elements
+                .push(std::mem::take(&mut node.element_ptr));
+            snapshot.centers.push((node.center_x, node.center_y));
+            snapshot.rects.push(node.rect);
+            snapshot.msaa_roles.push(node.msaa_role);
+        }
+        self.core.insert(CacheKey { pid, hwnd }, snapshot);
     }
 
     /// Look up + COM-`AddRef` the element for `element_index` in (pid, hwnd),
     /// returning a guard that `Release`s on drop. The `AddRef` happens **under
-    /// the cache lock**, so a concurrent [`update`](Self::update) (which
+    /// the cache lock**, so a concurrent [`adopt_walk`](Self::adopt_walk) (which
     /// replaces the snapshot and `Release`s its pointers in
     /// `CachedSnapshot::drop`) cannot free the element between the lookup and
     /// the `AddRef`. Hold the returned guard for the entire UIA/MSAA action —

--- a/libs/cua-driver/rust/crates/platform-windows/src/uia/cache_uaf_repro.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/uia/cache_uaf_repro.rs
@@ -3,7 +3,7 @@
 //!
 //! THE RACE (what these tests model):
 //!   Two concurrent sessions drive the same (pid, hwnd).
-//!   - Session A: `get_window_state` → `ElementCache::update` → `core.insert`
+//!   - Session A: `get_window_state` → `ElementCache::adopt_walk` → `core.insert`
 //!     replaces the snapshot → old `CachedSnapshot::drop` → COM `Release` on
 //!     every cached `IUIAutomationElement`.
 //!   - Session B: `click` / `type_text` / `set_value` looked the element up out
@@ -36,6 +36,7 @@
 //! BEFORE deterministically trips and AFTER deterministically survives.
 
 use super::{CacheKey, CachedSnapshot, ElementCache, SnapshotKind};
+use crate::uia::{tests::node, UiaNode, UiaTreeResult};
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicIsize, AtomicUsize, Ordering};
 use std::sync::mpsc;
@@ -132,6 +133,20 @@ fn snapshot_with(ptrs: Vec<usize>) -> CachedSnapshot {
     }
 }
 
+fn walk_with(ptr: usize) -> UiaTreeResult {
+    UiaTreeResult {
+        tree_markdown: String::new(),
+        nodes: vec![UiaNode {
+            element_ptr: ptr,
+            ..node(Some(0), "Button", "", None, Some(true), None, &["invoke"])
+        }],
+    }
+}
+
+fn fake_refcount(ptr: usize) -> isize {
+    unsafe { (*(ptr as *const FakeObj)).refcount.load(Ordering::SeqCst) }
+}
+
 /// Pre-fix accessor, restored verbatim: a bare `usize` copy with NO AddRef
 /// under the lock. This is exactly the `get_element_ptr` body deleted by
 /// d95b89a1 — the vulnerable path.
@@ -216,6 +231,34 @@ fn run_forced_interleave(use_retained: bool, poison_on_zero: bool) -> usize {
 }
 
 // ---- Regression guards (run in the normal suite) ----------------------------
+
+#[test]
+fn walk_result_releases_unadopted_references_on_drop() {
+    let uaf_hits: &'static AtomicUsize = Box::leak(Box::new(AtomicUsize::new(0)));
+    let ptr = make_fake(uaf_hits, false);
+
+    drop(walk_with(ptr));
+
+    assert_eq!(fake_refcount(ptr), 0);
+    assert_eq!(uaf_hits.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn cache_adoption_transfers_reference_ownership() {
+    let uaf_hits: &'static AtomicUsize = Box::leak(Box::new(AtomicUsize::new(0)));
+    let ptr = make_fake(uaf_hits, false);
+    let cache = ElementCache::new();
+    let mut walk = walk_with(ptr);
+
+    cache.adopt_walk(PID, HWND, &mut walk);
+    assert_eq!(walk.nodes[0].element_ptr, 0);
+    drop(walk);
+    assert_eq!(fake_refcount(ptr), 1);
+
+    drop(cache);
+    assert_eq!(fake_refcount(ptr), 0);
+    assert_eq!(uaf_hits.load(Ordering::SeqCst), 0);
+}
 
 /// AFTER: the fixed `get_element_retained` path survives the exact dangerous
 /// interleave with zero use-after-free touches.

--- a/libs/cua-driver/rust/crates/platform-windows/src/uia/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/uia/mod.rs
@@ -66,8 +66,9 @@ pub struct UiaNode {
     /// Toggle/selection state when the element exposes one of those patterns.
     pub selected: Option<bool>,
     /// Raw COM pointer (IUIAutomationElement for UIA path, IAccessible for
-    /// MSAA path) as usize. Retained — `ElementCache` Drop releases it via
-    /// the `kind`-appropriate vtable.
+    /// MSAA path) as usize. Non-zero if and only if `element_index` is `Some`.
+    /// `UiaTreeResult` owns the retained reference until a stored snapshot
+    /// explicitly adopts it.
     pub element_ptr: usize,
     /// Screen-coordinate center, captured at walk time to avoid later COM calls.
     pub center_x: i32,
@@ -96,6 +97,26 @@ pub struct UiaNode {
 pub struct UiaTreeResult {
     pub tree_markdown: String,
     pub nodes: Vec<UiaNode>,
+}
+
+impl Drop for UiaTreeResult {
+    fn drop(&mut self) {
+        use windows::Win32::UI::Accessibility::IAccessible;
+
+        for node in &mut self.nodes {
+            let element_ptr = std::mem::take(&mut node.element_ptr);
+            if element_ptr == 0 {
+                continue;
+            }
+            unsafe {
+                if node.msaa_role.is_some() {
+                    drop(IAccessible::from_raw(element_ptr as *mut _));
+                } else {
+                    drop(IUIAutomationElement::from_raw(element_ptr as *mut _));
+                }
+            }
+        }
+    }
 }
 
 /// Walk the UIA tree for the window with the given HWND.
@@ -146,20 +167,6 @@ fn exact_menu_path_matches(nodes: &[UiaNode], path: &[String]) -> Vec<usize> {
         .collect()
 }
 
-unsafe fn release_walk_nodes(nodes: Vec<UiaNode>) {
-    use windows::Win32::UI::Accessibility::IAccessible;
-    for node in nodes {
-        if node.element_ptr == 0 {
-            continue;
-        }
-        if node.msaa_role.is_some() {
-            drop(IAccessible::from_raw(node.element_ptr as *mut _));
-        } else {
-            drop(IUIAutomationElement::from_raw(node.element_ptr as *mut _));
-        }
-    }
-}
-
 unsafe fn invoke_menu_element(element_ptr: usize, final_segment: bool) -> Result<(), String> {
     let element =
         std::mem::ManuallyDrop::new(IUIAutomationElement::from_raw(element_ptr as *mut _));
@@ -199,14 +206,8 @@ pub fn invoke_menu_path(hwnd: u64, path: &[String]) -> Result<(), String> {
         let matches = exact_menu_path_matches(&result.nodes, &path[..=depth]);
         let target_index = match matches.as_slice() {
             [index] => *index,
-            [] => {
-                unsafe { release_walk_nodes(result.nodes) };
-                return Err(format!("menu path segment {depth} was not found"));
-            }
-            _ => {
-                unsafe { release_walk_nodes(result.nodes) };
-                return Err(format!("menu path segment {depth} is ambiguous"));
-            }
+            [] => return Err(format!("menu path segment {depth} was not found")),
+            _ => return Err(format!("menu path segment {depth} is ambiguous")),
         };
         let target = &result.nodes[target_index];
         let error = if target.enabled == Some(false) {
@@ -218,7 +219,6 @@ pub fn invoke_menu_path(hwnd: u64, path: &[String]) -> Result<(), String> {
         } else {
             unsafe { invoke_menu_element(target.element_ptr, depth + 1 == path.len()) }.err()
         };
-        unsafe { release_walk_nodes(result.nodes) };
         if let Some(error) = error {
             return Err(format!("menu path segment {depth}: {error}"));
         }
@@ -394,6 +394,7 @@ unsafe fn walk_tree_unsafe(
         0,
         None,
         false,
+        true,
         &mut nodes,
         &mut lines,
         &mut counter,
@@ -615,6 +616,7 @@ unsafe fn walk_root_by_pid(
             0,
             None,
             false,
+            true,
             nodes,
             lines,
             counter,
@@ -639,6 +641,7 @@ unsafe fn walk_cached(
         depth,
         None,
         false,
+        true,
         nodes,
         lines,
         counter,
@@ -654,6 +657,7 @@ unsafe fn walk_cached_bounded(
     depth: usize,
     parent_index: Option<usize>,
     in_web_content: bool,
+    ancestors_enabled: bool,
     nodes: &mut Vec<UiaNode>,
     lines: &mut Vec<(usize, String)>,
     counter: &mut usize,
@@ -671,10 +675,12 @@ unsafe fn walk_cached_bounded(
     let value = read_cached_bstr_value(element);
     let automation_id = read_cached_bstr(element, UIA_AutomationIdPropertyId);
     let help_text = read_cached_bstr(element, UIA_HelpTextPropertyId);
-    let enabled = read_cached_bool(element, UIA_IsEnabledPropertyId);
-    // Missing UIA state must remain unknown on the structured observation
-    // surface. Action discovery keeps its historical best-effort assumption.
-    let is_enabled = enabled.unwrap_or(true);
+    let reported_enabled = read_cached_bool(element, UIA_IsEnabledPropertyId);
+    // UIA providers may report enabled children beneath a disabled parent.
+    // Those children cannot actually be acted on, so expose and index them
+    // according to their effective state. Missing state remains unknown only
+    // while every known ancestor is enabled.
+    let (enabled, is_enabled) = effective_enabled(reported_enabled, ancestors_enabled);
     let selected = read_cached_selected(element);
     let actions = detect_cached_actions(element, &control_type, is_enabled);
     let is_actionable = !actions.is_empty() && is_enabled;
@@ -689,55 +695,43 @@ unsafe fn walk_cached_bounded(
 
     let mut emitted_parent: Option<usize> = parent_index;
     if is_actionable || has_content {
-        let retained: IUIAutomationElement = element.clone();
-        let ptr = retained.as_raw() as usize;
-        std::mem::forget(retained);
-
-        let node = if is_actionable {
+        let element_index = if is_actionable {
             let idx = *counter;
             *counter += 1;
-            let (center_x, center_y, rect) = read_cached_bounding_rect_full(element);
             emitted_parent = Some(idx);
-            UiaNode {
-                element_index: Some(idx),
-                control_type: control_type.clone(),
-                name: name.clone(),
-                value: value.clone(),
-                automation_id: automation_id.clone(),
-                help_text: help_text.clone(),
-                actions: actions.clone(),
-                enabled,
-                selected,
-                element_ptr: ptr,
-                center_x,
-                center_y,
-                rect,
-                msaa_role: None,
-                depth,
-                parent_element_index: parent_index,
-                in_web_content,
-            }
+            Some(idx)
         } else {
-            UiaNode {
-                element_index: None,
-                control_type: control_type.clone(),
-                name: name.clone(),
-                value: value.clone(),
-                automation_id: automation_id.clone(),
-                help_text: help_text.clone(),
-                actions: vec![],
-                enabled,
-                selected,
-                element_ptr: ptr,
-                center_x: 0,
-                center_y: 0,
-                rect: None,
-                msaa_role: None,
-                depth,
-                parent_element_index: parent_index,
-                in_web_content,
-            }
+            None
         };
+        let (element_ptr, center_x, center_y, rect) = if element_index.is_some() {
+            let retained: IUIAutomationElement = element.clone();
+            let ptr = retained.as_raw() as usize;
+            std::mem::forget(retained);
+            let (center_x, center_y, rect) = read_cached_bounding_rect_full(element);
+            (ptr, center_x, center_y, rect)
+        } else {
+            (0, 0, 0, None)
+        };
+        let node = UiaNode {
+            element_index,
+            control_type: control_type.clone(),
+            name: name.clone(),
+            value: value.clone(),
+            automation_id: automation_id.clone(),
+            help_text: help_text.clone(),
+            actions: actions.clone(),
+            enabled,
+            selected,
+            element_ptr,
+            center_x,
+            center_y,
+            rect,
+            msaa_role: None,
+            depth,
+            parent_element_index: parent_index,
+            in_web_content,
+        };
+        debug_assert_eq!(node.element_ptr != 0, node.element_index.is_some());
 
         lines.push((depth, format_node_line(&node)));
         nodes.push(node);
@@ -753,6 +747,7 @@ unsafe fn walk_cached_bounded(
                     depth + 1,
                     emitted_parent,
                     in_web_content || control_type.eq_ignore_ascii_case("Document"),
+                    is_enabled,
                     nodes,
                     lines,
                     counter,
@@ -763,6 +758,16 @@ unsafe fn walk_cached_bounded(
             }
         }
     }
+}
+
+fn effective_enabled(
+    reported_enabled: Option<bool>,
+    ancestors_enabled: bool,
+) -> (Option<bool>, bool) {
+    if !ancestors_enabled {
+        return (Some(false), false);
+    }
+    (reported_enabled, reported_enabled.unwrap_or(true))
 }
 
 fn read_cached_control_type(element: &IUIAutomationElement) -> String {
@@ -984,6 +989,7 @@ pub(crate) fn format_node_line(node: &UiaNode) -> String {
         if let Some(h) = &node.help_text {
             attrs.push(format!("help=\"{}\"", h));
         }
+        attrs.extend(format_state_attrs(node));
         if !node.actions.is_empty() {
             attrs.push(format!("actions=[{}]", node.actions.join(",")));
         }
@@ -998,8 +1004,28 @@ pub(crate) fn format_node_line(node: &UiaNode) -> String {
         if let Some(v) = &node.value {
             s.push_str(&format!(" = \"{}\"", v));
         }
+        let attrs = format_state_attrs(node);
+        if !attrs.is_empty() {
+            s.push_str(&format!(" [{}]", attrs.join(" ")));
+        }
     }
     s
+}
+
+fn format_state_attrs(node: &UiaNode) -> Vec<String> {
+    let mut attrs = Vec::new();
+    if node.enabled == Some(false) {
+        attrs.push("enabled=false".into());
+    }
+    if let Some(selected) = node.selected {
+        let state = if node.control_type.eq_ignore_ascii_case("CheckBox") {
+            "checked"
+        } else {
+            "selected"
+        };
+        attrs.push(format!("{state}={selected}"));
+    }
+    attrs
 }
 
 fn render_lines(lines: &[(usize, String)]) -> String {
@@ -1054,4 +1080,98 @@ fn filter_tree(markdown: &str, query: &str) -> String {
     let mut r = output.join("\n");
     r.push('\n');
     r
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    pub(super) fn node(
+        element_index: Option<usize>,
+        control_type: &str,
+        name: &str,
+        value: Option<&str>,
+        enabled: Option<bool>,
+        selected: Option<bool>,
+        actions: &[&str],
+    ) -> UiaNode {
+        UiaNode {
+            element_index,
+            control_type: control_type.into(),
+            name: Some(name.into()),
+            value: value.map(Into::into),
+            automation_id: None,
+            help_text: None,
+            actions: actions.iter().map(|action| (*action).into()).collect(),
+            enabled,
+            selected,
+            element_ptr: usize::from(element_index.is_some()),
+            center_x: 0,
+            center_y: 0,
+            rect: None,
+            msaa_role: None,
+            depth: 0,
+            parent_element_index: None,
+            in_web_content: false,
+        }
+    }
+
+    #[test]
+    fn disabled_ancestor_overrides_enabled_and_unknown_descendants() {
+        let (parent_state, parent_is_enabled) = effective_enabled(Some(false), true);
+        assert_eq!(parent_state, Some(false));
+        assert!(!parent_is_enabled);
+
+        let (enabled_child_state, enabled_child_is_enabled) =
+            effective_enabled(Some(true), parent_is_enabled);
+        assert_eq!(enabled_child_state, Some(false));
+        assert!(!enabled_child_is_enabled);
+
+        let (unknown_grandchild_state, unknown_grandchild_is_enabled) =
+            effective_enabled(None, enabled_child_is_enabled);
+        assert_eq!(unknown_grandchild_state, Some(false));
+        assert!(!unknown_grandchild_is_enabled);
+    }
+
+    #[test]
+    fn markdown_preserves_nesting_and_explains_disabled_selection_state() {
+        let parent = node(None, "Group", "Graphics", None, Some(false), None, &[]);
+        let child = node(
+            None,
+            "ListItem",
+            "Very High",
+            None,
+            Some(false),
+            Some(true),
+            &[],
+        );
+
+        let markdown = render_lines(&[
+            (0, format_node_line(&parent)),
+            (1, format_node_line(&child)),
+        ]);
+
+        assert_eq!(
+            markdown,
+            "- Group \"Graphics\" [enabled=false]\n  - ListItem \"Very High\" [enabled=false selected=true]\n"
+        );
+    }
+
+    #[test]
+    fn markdown_labels_checkbox_toggle_state_as_checked() {
+        let checkbox = node(
+            Some(4),
+            "CheckBox",
+            "VSync",
+            None,
+            Some(true),
+            Some(false),
+            &["toggle"],
+        );
+
+        assert_eq!(
+            format_node_line(&checkbox),
+            "- [4] CheckBox \"VSync\" [checked=false actions=[toggle]]"
+        );
+    }
 }


### PR DESCRIPTION
Enabled UIA children of a disabled parent are not actionable (eg a nominally enabled checkbox inside a disabled container cannot be actually clicked), yet Cua reports them as such on Windows. This PR allows the information to propagate from parent to children.
Validation: cargo test -p platform-windows uia::tests --locked; cargo check -p platform-windows --locked; cargo fmt --all -- --check; git diff --check. Known gap: native behavior still depends on each provider reporting the disabled ancestor accurately.