### PR TITLE
fix(cua-driver): clarify Windows window-state coordinates

### DIFF
--- a/docs/content/docs/reference/cua-driver/limits.mdx
+++ b/docs/content/docs/reference/cua-driver/limits.mdx
@@ -268,8 +268,11 @@ When a pixel action is unavoidable, match the scope to the space:
 </Callout>
 
 On macOS, `get_window_state` also reports `window_bounds`, which may be used in
-place of `list_windows` there. Windows and Linux report `screenshot_width` and
-`screenshot_height` only.
+place of `list_windows` there. Windows reports exact physical-pixel
+`window_bounds` as well as `element_frame_coordinate_space`,
+`pixel_action_coordinate_space`, and `pixel_action_to_screen`; use those fields
+instead of inferring a screenshot origin from a separate `list_windows` call.
+Linux reports `screenshot_width` and `screenshot_height` only.
 
 ---
 

--- a/libs/cua-driver/docs/tool-output-format.md
+++ b/libs/cua-driver/docs/tool-output-format.md
@@ -35,3 +35,19 @@ Observation tools retain their typed tool-specific structured payloads.
 records in `structuredContent` and can attach a PNG as image content. A
 multimodal harness interprets the image; Cua Driver does not OCR it or assign
 task meaning.
+
+On Windows, `get_window_state` explicitly distinguishes the two coordinate
+spaces in its structured payload:
+
+- `elements[].frame` is in `screen_physical_px`, as declared by
+  `element_frame_coordinate_space`. Frames wholly outside the exact target
+  `window_bounds` are omitted and carry
+  `frame_reliability:"outside_target_window"` instead.
+- Pixel-action `x,y` values are in `window_screenshot_px`, as declared by
+  `pixel_action_coordinate_space`. When a screenshot is present,
+  `pixel_action_to_screen` gives its screen origin and physical-screen pixels
+  per action pixel. Convert with
+  `screen = screen_origin + action * screen_pixels_per_action_pixel`.
+
+The accessibility elements remain one structured `elements` array; coordinate
+metadata does not add a second rendering of the tree.

--- a/libs/cua-driver/rust/crates/platform-windows/src/lib.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/lib.rs
@@ -43,6 +43,11 @@ mod keycodes;
 // pass that lives in this commit).
 pub mod lparam;
 
+// Pure geometry and structured-output helpers for the Windows window-state
+// coordinate contract. Kept outside the Windows-only modules so unit tests can
+// validate the wire shape without a live HWND or interactive desktop.
+pub(crate) mod window_state_coordinates;
+
 #[cfg(target_os = "windows")]
 pub mod win32;
 

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -228,6 +228,44 @@ fn screen_to_bitmap(hwnd: u64, sx: i32, sy: i32) -> (i32, i32) {
     (sx - origin_x, sy - origin_y)
 }
 
+/// Read physical screen bounds only after revalidating the exact native
+/// `(pid, HWND)` identity. This closes the small race between the public
+/// ownership check and the blocking UIA/capture work, and ensures coordinate
+/// metadata never describes an HWND that was destroyed and reused.
+fn exact_target_window_bounds(
+    pid: u32,
+    hwnd: u64,
+) -> anyhow::Result<crate::window_state_coordinates::ScreenRect> {
+    use windows::Win32::Foundation::{HWND, RECT};
+    use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
+
+    let owner = crate::win32::window_owner_pid(hwnd)
+        .ok_or_else(|| anyhow::anyhow!("target window 0x{hwnd:x} no longer exists"))?;
+    if owner != pid {
+        anyhow::bail!(
+            "target window 0x{hwnd:x} now belongs to pid {owner}, not requested pid {pid}"
+        );
+    }
+    let mut rect = RECT::default();
+    unsafe { GetWindowRect(HWND(hwnd as *mut _), &mut rect) }
+        .map_err(|error| anyhow::anyhow!("could not read target window bounds: {error}"))?;
+    crate::window_state_coordinates::ScreenRect::from_edges(
+        rect.left,
+        rect.top,
+        rect.right,
+        rect.bottom,
+    )
+    .ok_or_else(|| {
+        anyhow::anyhow!(
+            "target window 0x{hwnd:x} has invalid bounds ({},{})-({},{})",
+            rect.left,
+            rect.top,
+            rect.right,
+            rect.bottom
+        )
+    })
+}
+
 /// Animate the agent cursor to (sx, sy) in screen coordinates and wait for the
 /// glide to finish before returning.  No-op when the overlay is not enabled.
 ///
@@ -1092,7 +1130,13 @@ impl Tool for GetWindowStateTool {
                 `selected`, `frame: {x,y,w,h}`, `parent_index`, `depth`). The markdown \
                 `tree_markdown` stays available \
                 and unchanged in shape for existing text-parsing callers — but new \
-                fields will only be added to the structured side.\n\n\
+                fields will only be added to the structured side. On Windows, valid \
+                element `frame` values are screen-absolute physical pixels; a provider \
+                frame wholly outside the exact target window is omitted and marked with \
+                `frame_reliability:\"outside_target_window\"`. \
+                `element_frame_coordinate_space`, `pixel_action_coordinate_space`, \
+                `window_bounds`, and `pixel_action_to_screen` make the distinct spaces \
+                and conversion explicit without duplicating the element tree.\n\n\
                 The UIA tree walked is the window's tree (HWND-scoped); the screenshot and \
                 window bounds reported come from the same `window_id`. This is the source of \
                 truth for which window the caller intends to reason about — the driver never \
@@ -1224,6 +1268,7 @@ impl Tool for GetWindowStateTool {
         let q = query.clone();
         let out_file = screenshot_out_file.clone();
         let blocking = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+            let window_bounds = exact_target_window_bounds(pid, hwnd)?;
             let tree_result = if do_tree {
                 Some(crate::uia::walk_tree_bounded(
                     hwnd,
@@ -1244,21 +1289,41 @@ impl Tool for GetWindowStateTool {
             let (screenshot, screenshot_err) = if do_shot {
                 match crate::capture::screenshot_window_bytes(hwnd) {
                     Ok(raw) => {
-                        let orig_w = crate::capture::png_dimensions_pub(&raw)
-                            .map(|(w, _)| w)
-                            .unwrap_or(0);
+                        let (orig_w, orig_h) = crate::capture::png_dimensions_pub(&raw)?;
                         let png = crate::capture::resize_png_if_needed(&raw, max_dim)?;
                         let (w, h) = crate::capture::png_dimensions_pub(&png)?;
-                        let original_w = if w < orig_w { Some(orig_w) } else { None };
+                        let original_dimensions =
+                            (w < orig_w || h < orig_h).then_some((orig_w, orig_h));
+                        let screenshot_origin = bitmap_to_screen(hwnd, 0, 0);
                         // `screenshot_out_file` set (any mode) → write to disk and
                         // surface the path, never embed bytes. Otherwise (vision,
                         // no out_file) → embed base64.
                         if let Some(ref path) = out_file {
                             std::fs::write(path, &png)?;
-                            (Some((None, Some(path.clone()), w, h, original_w)), None)
+                            (
+                                Some((
+                                    None,
+                                    Some(path.clone()),
+                                    w,
+                                    h,
+                                    original_dimensions,
+                                    screenshot_origin,
+                                )),
+                                None,
+                            )
                         } else {
                             use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
-                            (Some((Some(B64.encode(&png)), None, w, h, original_w)), None)
+                            (
+                                Some((
+                                    Some(B64.encode(&png)),
+                                    None,
+                                    w,
+                                    h,
+                                    original_dimensions,
+                                    screenshot_origin,
+                                )),
+                                None,
+                            )
                         }
                     }
                     Err(e) => (None, Some(format!("{e}"))),
@@ -1266,7 +1331,7 @@ impl Tool for GetWindowStateTool {
             } else {
                 (None, None)
             };
-            Ok((tree_result, screenshot, screenshot_err))
+            Ok((tree_result, screenshot, screenshot_err, window_bounds))
         });
         // Timeout: Chrome's UIA provider can block indefinitely on property reads.
         let result: Result<anyhow::Result<_>, _> =
@@ -1295,9 +1360,13 @@ impl Tool for GetWindowStateTool {
         let result = result.and_then(|r| r);
 
         match result {
-            Ok((tree_opt, screenshot_opt, screenshot_err)) => {
+            Ok((tree_opt, screenshot_opt, screenshot_err, window_bounds)) => {
                 let mut content = Vec::new();
                 let mut structured = json!({ "window_id": hwnd, "pid": pid });
+                crate::window_state_coordinates::annotate_coordinate_spaces(
+                    &mut structured,
+                    window_bounds,
+                );
 
                 if let Some(tr) = tree_opt {
                     let is_msaa = tr.nodes.iter().any(|n| n.msaa_role.is_some());
@@ -1392,13 +1461,12 @@ impl Tool for GetWindowStateTool {
                             if let Some(parent) = n.parent_element_index {
                                 entry["parent_index"] = json!(parent);
                             }
-                            if let Some((l, t, r, b)) = n.rect {
-                                entry["frame"] = json!({
-                                    "x": l,
-                                    "y": t,
-                                    "w": (r - l).max(0),
-                                    "h": (b - t).max(0),
-                                });
+                            if let Some(frame) = n.rect {
+                                crate::window_state_coordinates::annotate_element_frame(
+                                    &mut entry,
+                                    frame,
+                                    window_bounds,
+                                );
                             }
                             Some(entry)
                         })
@@ -1458,9 +1526,11 @@ impl Tool for GetWindowStateTool {
                     }
                 }
 
-                if let Some((b64_opt, file_path, w, h, orig_w)) = screenshot_opt {
+                if let Some((b64_opt, file_path, w, h, original_dimensions, screenshot_origin)) =
+                    screenshot_opt
+                {
                     if !observation_only {
-                        if let Some(ow) = orig_w {
+                        if let Some((ow, _)) = original_dimensions {
                             if w > 0 {
                                 state.resize_registry.set_ratio(pid, ow as f64 / w as f64);
                             }
@@ -1480,6 +1550,18 @@ impl Tool for GetWindowStateTool {
                     // the structured payload so consumers don't have to sniff
                     // magic bytes off the base64 to know the format.
                     structured["screenshot_mime_type"] = json!("image/png");
+                    // Pixel actions use ResizeRegistry's width-derived uniform
+                    // ratio for both axes. Report that exact actuator mapping
+                    // (including any one-pixel height rounding in the PNG), not
+                    // an independently inferred visual Y ratio.
+                    let action_scale = original_dimensions
+                        .map(|(ow, _)| ow as f64 / w as f64)
+                        .unwrap_or(1.0);
+                    crate::window_state_coordinates::annotate_pixel_action_transform(
+                        &mut structured,
+                        screenshot_origin,
+                        (action_scale, action_scale),
+                    );
                     if let Some(fp) = file_path {
                         structured["screenshot_file_path"] = json!(fp);
                     }

--- a/libs/cua-driver/rust/crates/platform-windows/src/window_state_coordinates.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/window_state_coordinates.rs
@@ -1,0 +1,191 @@
+//! Windows `get_window_state` coordinate-space contract.
+//!
+//! UIA `BoundingRectangle` values are screen-absolute physical pixels, while
+//! pixel actions consume coordinates in the (possibly resized) window PNG.
+//! This module keeps the geometry checks and structured-output shape pure so
+//! they can be tested without a live Windows desktop.
+
+use serde_json::{json, Value};
+
+pub(crate) const SCREEN_PHYSICAL_PX: &str = "screen_physical_px";
+pub(crate) const WINDOW_SCREENSHOT_PX: &str = "window_screenshot_px";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ScreenRect {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+impl ScreenRect {
+    pub(crate) fn from_edges(left: i32, top: i32, right: i32, bottom: i32) -> Option<Self> {
+        let width = right.checked_sub(left)?;
+        let height = bottom.checked_sub(top)?;
+        (width > 0 && height > 0).then_some(Self {
+            x: left,
+            y: top,
+            width,
+            height,
+        })
+    }
+
+    fn right(self) -> i64 {
+        i64::from(self.x) + i64::from(self.width)
+    }
+
+    fn bottom(self) -> i64 {
+        i64::from(self.y) + i64::from(self.height)
+    }
+
+    pub(crate) fn intersects(self, other: Self) -> bool {
+        i64::from(self.x) < other.right()
+            && self.right() > i64::from(other.x)
+            && i64::from(self.y) < other.bottom()
+            && self.bottom() > i64::from(other.y)
+    }
+}
+
+/// Add the invariant coordinate spaces and exact target-window bounds to a
+/// successful `get_window_state` structured payload.
+pub(crate) fn annotate_coordinate_spaces(structured: &mut Value, window_bounds: ScreenRect) {
+    structured["window_bounds"] = json!({
+        "x": window_bounds.x,
+        "y": window_bounds.y,
+        "width": window_bounds.width,
+        "height": window_bounds.height,
+        "coordinate_space": SCREEN_PHYSICAL_PX,
+    });
+    structured["element_frame_coordinate_space"] = json!(SCREEN_PHYSICAL_PX);
+    structured["pixel_action_coordinate_space"] = json!(WINDOW_SCREENSHOT_PX);
+}
+
+/// Describe the exact affine mapping the Windows pixel-action path applies:
+/// `screen = screen_origin + action_coordinate * screen_pixels_per_action_pixel`.
+pub(crate) fn annotate_pixel_action_transform(
+    structured: &mut Value,
+    screen_origin: (i32, i32),
+    screen_pixels_per_action_pixel: (f64, f64),
+) {
+    structured["pixel_action_to_screen"] = json!({
+        "screen_origin": {
+            "x": screen_origin.0,
+            "y": screen_origin.1,
+        },
+        "screen_pixels_per_action_pixel": {
+            "x": screen_pixels_per_action_pixel.0,
+            "y": screen_pixels_per_action_pixel.1,
+        },
+    });
+}
+
+/// Preserve the existing absolute `frame` for a UIA rectangle that intersects
+/// the validated target window. A wholly disjoint provider rectangle is not
+/// actionable evidence: omit its coordinates and mark why they were rejected.
+pub(crate) fn annotate_element_frame(
+    entry: &mut Value,
+    frame: (i32, i32, i32, i32),
+    window_bounds: ScreenRect,
+) {
+    if let Some(entry) = entry.as_object_mut() {
+        entry.remove("frame");
+        entry.remove("frame_reliability");
+    }
+    let Some(frame) = ScreenRect::from_edges(frame.0, frame.1, frame.2, frame.3) else {
+        entry["frame_reliability"] = json!("invalid_geometry");
+        return;
+    };
+    if frame.intersects(window_bounds) {
+        entry["frame"] = json!({
+            "x": frame.x,
+            "y": frame.y,
+            "w": frame.width,
+            "h": frame.height,
+        });
+    } else {
+        entry["frame_reliability"] = json!("outside_target_window");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target() -> ScreenRect {
+        ScreenRect {
+            x: 692,
+            y: 120,
+            width: 800,
+            height: 600,
+        }
+    }
+
+    #[test]
+    fn rectangle_intersection_accepts_partial_overlap_but_not_touching_edges() {
+        assert!(ScreenRect {
+            x: 680,
+            y: 200,
+            width: 20,
+            height: 40,
+        }
+        .intersects(target()));
+        assert!(!ScreenRect {
+            x: 600,
+            y: 200,
+            width: 92,
+            height: 40,
+        }
+        .intersects(target()));
+    }
+
+    #[test]
+    fn valid_element_frame_preserves_backwards_compatible_absolute_shape() {
+        let mut entry = json!({ "element_index": 1 });
+        annotate_element_frame(&mut entry, (700, 130, 780, 170), target());
+
+        assert_eq!(
+            entry["frame"],
+            json!({ "x": 700, "y": 130, "w": 80, "h": 40 })
+        );
+        assert!(entry.get("frame_reliability").is_none());
+    }
+
+    #[test]
+    fn wholly_disjoint_provider_frame_is_omitted_and_marked_unreliable() {
+        let mut entry = json!({
+            "element_index": 1,
+            "frame": { "x": 6, "y": 6, "w": 80, "h": 40 },
+        });
+        annotate_element_frame(&mut entry, (6, 6, 86, 46), target());
+
+        assert!(entry.get("frame").is_none());
+        assert_eq!(entry["frame_reliability"], "outside_target_window");
+    }
+
+    #[test]
+    fn coordinate_metadata_is_self_describing_without_another_element_tree() {
+        let mut structured = json!({ "elements": [{ "element_index": 1 }] });
+        annotate_coordinate_spaces(&mut structured, target());
+        annotate_pixel_action_transform(&mut structured, (693, 121), (2.0, 2.0));
+
+        assert_eq!(
+            structured,
+            json!({
+                "elements": [{ "element_index": 1 }],
+                "window_bounds": {
+                    "x": 692,
+                    "y": 120,
+                    "width": 800,
+                    "height": 600,
+                    "coordinate_space": SCREEN_PHYSICAL_PX,
+                },
+                "element_frame_coordinate_space": SCREEN_PHYSICAL_PX,
+                "pixel_action_coordinate_space": WINDOW_SCREENSHOT_PX,
+                "pixel_action_to_screen": {
+                    "screen_origin": { "x": 693, "y": 121 },
+                    "screen_pixels_per_action_pixel": { "x": 2.0, "y": 2.0 },
+                },
+            })
+        );
+    }
+}


### PR DESCRIPTION
Summary: exposes window-relative bounds and screenshot-to action transform for window-relative cua calls (as opposed to current alwaysscreen-relative bounds). Also, excludes UIA rectangles that lie completely outside the window bounds (this was a case I came across in a real app).  Validation: cargo test -p platform-windows window_state_coordinates --lib; cargo check -p platform-windows; cargo check -p cua-driver; cargo fmt --all -- --check; git diff --check. Known gap: the generic live protocol test selected an unrelated IslandWindow whose provider hit the existing four-second UIA timeout before structured output.