### PR TITLE
fix(lume): share SSH event loop infrastructure

### DIFF
--- a/libs/lume/Package.swift
+++ b/libs/lume/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
             dependencies: [
                 "lume",
                 .product(name: "NIOEmbedded", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "Testing", package: "swift-testing")
             ],
             path: "tests")

--- a/libs/lume/src/SSH/SSHClient.swift
+++ b/libs/lume/src/SSH/SSHClient.swift
@@ -22,7 +22,9 @@ public actor SSHClient {
     private let user: String
     private let password: String
     private let connectTimeout: TimeInterval
-    private let eventLoopGroup: MultiThreadedEventLoopGroup
+
+    /// Networking infrastructure has process lifetime, not client lifetime.
+    private static let sharedEventLoopGroup = MultiThreadedEventLoopGroup.singleton
 
     public init(
         host: String,
@@ -36,11 +38,6 @@ public actor SSHClient {
         self.user = user
         self.password = password
         self.connectTimeout = connectTimeout
-        self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-    }
-
-    deinit {
-        try? eventLoopGroup.syncShutdownGracefully()
     }
 
     /// Execute a command on the remote host
@@ -169,15 +166,17 @@ public actor SSHClient {
 
     /// Connect to the SSH server and return the channel
     private func connect() async throws -> Channel {
-        let bootstrap = ClientBootstrap(group: eventLoopGroup)
+        let user = self.user
+        let password = self.password
+        let bootstrap = ClientBootstrap(group: Self.sharedEventLoopGroup)
             .channelInitializer { channel in
                 channel.eventLoop.makeCompletedFuture {
                     let sshHandler = NIOSSHHandler(
                         role: .client(
                             .init(
                                 userAuthDelegate: PasswordAuthDelegate(
-                                    username: self.user,
-                                    password: self.password
+                                    username: user,
+                                    password: password
                                 ),
                                 serverAuthDelegate: AcceptAllHostKeysDelegate()
                             )

--- a/libs/lume/tests/SSHClientTests.swift
+++ b/libs/lume/tests/SSHClientTests.swift
@@ -1,6 +1,7 @@
 @preconcurrency import NIOCore
 @preconcurrency import NIOConcurrencyHelpers
 @preconcurrency import NIOEmbedded
+@preconcurrency import NIOPosix
 @preconcurrency import NIOSSH
 import Testing
 
@@ -8,6 +9,17 @@ import Testing
 
 private enum SSHClientFutureTestError: Error {
     case handlerLookupFailed
+}
+
+@Test("SSH client teardown is safe on a NIO event loop")
+func clientTeardownIsSafeOnEventLoop() async throws {
+    let client = NIOLockedValueBox<SSHClient?>(SSHClient(host: "127.0.0.1"))
+
+    try await MultiThreadedEventLoopGroup.singleton.next().submit {
+        client.withLockedValue { $0 = nil }
+    }.get()
+
+    #expect(client.withLockedValue { $0 == nil })
 }
 
 @Test("SSH child promise is not created when handler lookup fails")


### PR DESCRIPTION
## scope

- use SwiftNIO's process-wide singleton event-loop group for native SSH clients
- remove per-client event-loop creation and synchronous shutdown from `deinit`
- stop the channel initializer from retaining the `SSHClient` actor
- verify that the final client reference can be released on a NIO event loop without trapping

Fixes #3259

## validation

- [x] `cd libs/lume && swift test --filter SSHClientTests` (2 tests passed)
- [x] `cd libs/lume && swift test` (142 tests passed)

## known gaps

- the reporter's 10–20 minute disconnect scenario has not yet been replayed against a VM; the focused regression directly recreates the teardown thread condition that triggered SwiftNIO's shutdown precondition.

