### PR TITLE
fix(cua-driver): preserve embedded telemetry preference

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/embedded.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/embedded.rs
@@ -852,6 +852,8 @@ pub(crate) fn allowed_environment_name(name: &str) -> bool {
                 | "DBUS_SESSION_BUS_ADDRESS"
                 | "XAUTHORITY"
                 | "CUA_LOG"
+                | "CUA_DRIVER_RS_TELEMETRY_ENABLED"
+                | "CUA_TELEMETRY_ENABLED"
         )
 }
 
@@ -1194,6 +1196,45 @@ mod tests {
         assert!(!allowed_environment_name("CUA_DRIVER_PERMISSION_MODE"));
         assert!(!allowed_environment_name("LD_PRELOAD"));
         assert!(!allowed_environment_name("NODE_OPTIONS"));
+    }
+
+    #[test]
+    fn telemetry_preferences_are_inherited_and_overridable() {
+        assert!(allowed_environment_name("CUA_DRIVER_RS_TELEMETRY_ENABLED"));
+        assert!(allowed_environment_name("cua_telemetry_enabled"));
+
+        let inherited = [
+            ("CUA_DRIVER_RS_TELEMETRY_ENABLED".into(), "1".into()),
+            ("CUA_TELEMETRY_ENABLED".into(), "true".into()),
+        ];
+        let values = merge_safe_environment(inherited.clone(), &[]);
+        assert!(values.iter().any(|variable| {
+            variable.name == "CUA_DRIVER_RS_TELEMETRY_ENABLED" && variable.value == "1"
+        }));
+        assert!(values.iter().any(|variable| {
+            variable.name == "CUA_TELEMETRY_ENABLED" && variable.value == "true"
+        }));
+
+        let values = merge_safe_environment(
+            inherited,
+            &[
+                EmbeddedEnvironmentVariable {
+                    name: "CUA_DRIVER_RS_TELEMETRY_ENABLED".into(),
+                    value: "0".into(),
+                },
+                EmbeddedEnvironmentVariable {
+                    name: "CUA_TELEMETRY_ENABLED".into(),
+                    value: "false".into(),
+                },
+            ],
+        );
+
+        assert!(values.iter().any(|variable| {
+            variable.name == "CUA_DRIVER_RS_TELEMETRY_ENABLED" && variable.value == "0"
+        }));
+        assert!(values.iter().any(|variable| {
+            variable.name == "CUA_TELEMETRY_ENABLED" && variable.value == "false"
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## summary

- preserve `CUA_DRIVER_RS_TELEMETRY_ENABLED` when an SDK-owned embedded host builds the private daemon environment
- preserve the supported `CUA_TELEMETRY_ENABLED` compatibility name as well
- cover inherited preferences and explicit host-option overrides

## why

`EmbeddedCuaDriverHost` clears the child environment and restores an allowlisted subset. Both supported Cua Driver telemetry settings were missing from that allowlist, so embedding hosts could not carry their telemetry preference into the private daemon. Passing either name through `EmbeddedDriverHostOptions.environment` also failed because explicit overrides use the same filter.

This is the first focused fix found while evaluating replacement of downstream private-daemon lifecycle code with the SDK-owned host. Overlay controls and stderr diagnostics remain separate focused changes in the dependent PRs. Host-process ownership remains unchanged.


Closes #3276.

## validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p cua-driver-sdk` — 52 passed
- `git diff --check`

The macOS linker emitted the existing duplicate Swift symbol warnings; the test suite passed. No desktop E2E is required because this change only modifies the SDK child-environment allowlist and has deterministic unit coverage.