### PR TITLE
feat(cua-driver): configure embedded daemon overlay

### DIFF
--- a/libs/cua-driver/python/src/cua_driver/_native.py
+++ b/libs/cua-driver/python/src/cua_driver/_native.py
@@ -2993,7 +2993,7 @@ class _UniffiFfiConverterOptionalTypeEmbeddedPermissionMode(_UniffiConverterRust
 
 @dataclass
 class EmbeddedDriverHostOptions:
-    def __init__(self, *, binary_path:str, host_bundle_id:str, socket_path:typing.Optional[str], startup_timeout_ms:typing.Optional[int], shutdown_timeout_ms:typing.Optional[int], permission_mode:typing.Optional[EmbeddedPermissionMode], capability_manifest_path:typing.Optional[str] = _DEFAULT, approve_capability_manifest:bool = False, session_policy_path:typing.Optional[str], approve_session_policy:bool, dangerously_bypass_approvals:bool, environment:typing.List[EmbeddedEnvironmentVariable], inherit_stderr:bool):
+    def __init__(self, *, binary_path:str, host_bundle_id:str, socket_path:typing.Optional[str], startup_timeout_ms:typing.Optional[int], shutdown_timeout_ms:typing.Optional[int], permission_mode:typing.Optional[EmbeddedPermissionMode], capability_manifest_path:typing.Optional[str] = _DEFAULT, approve_capability_manifest:bool = False, session_policy_path:typing.Optional[str], approve_session_policy:bool, dangerously_bypass_approvals:bool, environment:typing.List[EmbeddedEnvironmentVariable], inherit_stderr:bool, no_overlay:bool = False):
         self.binary_path = binary_path
         self.host_bundle_id = host_bundle_id
         self.socket_path = socket_path
@@ -3010,12 +3010,13 @@ class EmbeddedDriverHostOptions:
         self.dangerously_bypass_approvals = dangerously_bypass_approvals
         self.environment = environment
         self.inherit_stderr = inherit_stderr
+        self.no_overlay = no_overlay
 
 
 
 
     def __str__(self):
-        return "EmbeddedDriverHostOptions(binary_path={}, host_bundle_id={}, socket_path={}, startup_timeout_ms={}, shutdown_timeout_ms={}, permission_mode={}, capability_manifest_path={}, approve_capability_manifest={}, session_policy_path={}, approve_session_policy={}, dangerously_bypass_approvals={}, environment={}, inherit_stderr={})".format(self.binary_path, self.host_bundle_id, self.socket_path, self.startup_timeout_ms, self.shutdown_timeout_ms, self.permission_mode, self.capability_manifest_path, self.approve_capability_manifest, self.session_policy_path, self.approve_session_policy, self.dangerously_bypass_approvals, self.environment, self.inherit_stderr)
+        return "EmbeddedDriverHostOptions(binary_path={}, host_bundle_id={}, socket_path={}, startup_timeout_ms={}, shutdown_timeout_ms={}, permission_mode={}, capability_manifest_path={}, approve_capability_manifest={}, session_policy_path={}, approve_session_policy={}, dangerously_bypass_approvals={}, environment={}, inherit_stderr={}, no_overlay={})".format(self.binary_path, self.host_bundle_id, self.socket_path, self.startup_timeout_ms, self.shutdown_timeout_ms, self.permission_mode, self.capability_manifest_path, self.approve_capability_manifest, self.session_policy_path, self.approve_session_policy, self.dangerously_bypass_approvals, self.environment, self.inherit_stderr, self.no_overlay)
     def __eq__(self, other):
         if self.binary_path != other.binary_path:
             return False
@@ -3043,6 +3044,8 @@ class EmbeddedDriverHostOptions:
             return False
         if self.inherit_stderr != other.inherit_stderr:
             return False
+        if self.no_overlay != other.no_overlay:
+            return False
         return True
 
 class _UniffiFfiConverterTypeEmbeddedDriverHostOptions(_UniffiConverterRustBuffer):
@@ -3062,6 +3065,7 @@ class _UniffiFfiConverterTypeEmbeddedDriverHostOptions(_UniffiConverterRustBuffe
             dangerously_bypass_approvals=_UniffiFfiConverterBoolean.read(buf),
             environment=_UniffiFfiConverterSequenceTypeEmbeddedEnvironmentVariable.read(buf),
             inherit_stderr=_UniffiFfiConverterBoolean.read(buf),
+            no_overlay=_UniffiFfiConverterBoolean.read(buf),
         )
 
     @staticmethod
@@ -3079,6 +3083,7 @@ class _UniffiFfiConverterTypeEmbeddedDriverHostOptions(_UniffiConverterRustBuffe
         _UniffiFfiConverterBoolean.check_lower(value.dangerously_bypass_approvals)
         _UniffiFfiConverterSequenceTypeEmbeddedEnvironmentVariable.check_lower(value.environment)
         _UniffiFfiConverterBoolean.check_lower(value.inherit_stderr)
+        _UniffiFfiConverterBoolean.check_lower(value.no_overlay)
 
     @staticmethod
     def write(value, buf):
@@ -3095,6 +3100,7 @@ class _UniffiFfiConverterTypeEmbeddedDriverHostOptions(_UniffiConverterRustBuffe
         _UniffiFfiConverterBoolean.write(value.dangerously_bypass_approvals, buf)
         _UniffiFfiConverterSequenceTypeEmbeddedEnvironmentVariable.write(value.environment, buf)
         _UniffiFfiConverterBoolean.write(value.inherit_stderr, buf)
+        _UniffiFfiConverterBoolean.write(value.no_overlay, buf)
 
 @dataclass
 class ImageContent:

--- a/libs/cua-driver/python/tests/test_uniffi_loader.py
+++ b/libs/cua-driver/python/tests/test_uniffi_loader.py
@@ -24,6 +24,31 @@ LIBRARY = Path(__file__).parents[1] / "src" / "cua_driver" / _library_name()
 
 
 @unittest.skipUnless(LIBRARY.exists(), "host-native UniFFI library is not staged")
+class GeneratedOptionsTests(unittest.TestCase):
+    def test_embedded_overlay_option_defaults_false_and_accepts_true(self) -> None:
+        from cua_driver import EmbeddedDriverHostOptions
+
+        required = {
+            "binary_path": "/example/cua-driver",
+            "host_bundle_id": "com.example.host",
+            "socket_path": None,
+            "startup_timeout_ms": None,
+            "shutdown_timeout_ms": None,
+            "permission_mode": None,
+            "session_policy_path": None,
+            "approve_session_policy": False,
+            "dangerously_bypass_approvals": False,
+            "environment": [],
+            "inherit_stderr": False,
+        }
+
+        self.assertFalse(EmbeddedDriverHostOptions(**required).no_overlay)
+        self.assertTrue(
+            EmbeddedDriverHostOptions(**required, no_overlay=True).no_overlay
+        )
+
+
+@unittest.skipUnless(LIBRARY.exists(), "host-native UniFFI library is not staged")
 @unittest.skipIf(os.name == "nt", "Unix socket fixture")
 class SdkLoaderTests(unittest.TestCase):
     def test_generated_python_embedded_host_owns_the_rust_lifecycle(self) -> None:

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/embedded.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/embedded.rs
@@ -53,6 +53,8 @@ pub struct EmbeddedDriverHostOptions {
     pub dangerously_bypass_approvals: bool,
     pub environment: Vec<EmbeddedEnvironmentVariable>,
     pub inherit_stderr: bool,
+    #[uniffi(default = false)]
+    pub no_overlay: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
@@ -121,6 +123,7 @@ struct ValidatedOptions {
     dangerously_bypass_approvals: bool,
     environment: Vec<EmbeddedEnvironmentVariable>,
     inherit_stderr: bool,
+    no_overlay: bool,
 }
 
 #[cfg(unix)]
@@ -263,6 +266,7 @@ impl EmbeddedCuaDriverHost {
             dangerously_bypass_approvals: false,
             environment: Vec::new(),
             inherit_stderr: true,
+            no_overlay: false,
         })
     }
 
@@ -648,6 +652,9 @@ impl EmbeddedCuaDriverHost {
         if self.options.dangerously_bypass_approvals {
             args.push("--dangerously-bypass-approvals".into());
         }
+        if self.options.no_overlay {
+            args.push("--no-overlay".into());
+        }
         args
     }
 
@@ -815,6 +822,7 @@ fn validate_options(
         dangerously_bypass_approvals: options.dangerously_bypass_approvals,
         environment: options.environment,
         inherit_stderr: options.inherit_stderr,
+        no_overlay: options.no_overlay,
     })
 }
 
@@ -1148,6 +1156,7 @@ mod tests {
             dangerously_bypass_approvals: false,
             environment: Vec::new(),
             inherit_stderr: false,
+            no_overlay: false,
         }
     }
 
@@ -1178,6 +1187,22 @@ mod tests {
         unrestricted_manifest.capability_manifest_path = Some("capabilities.yaml".into());
         unrestricted_manifest.approve_capability_manifest = true;
         assert!(validate_options(unrestricted_manifest).is_ok());
+    }
+
+    #[test]
+    fn no_overlay_is_opt_in_on_the_owned_daemon() {
+        let default_host =
+            EmbeddedCuaDriverHost::with_options(options(EmbeddedPermissionMode::Standard)).unwrap();
+        assert!(!default_host
+            .serve_args("/tmp/cua-default.sock")
+            .contains(&"--no-overlay".into()));
+
+        let mut configured = options(EmbeddedPermissionMode::Standard);
+        configured.no_overlay = true;
+        let configured_host = EmbeddedCuaDriverHost::with_options(configured).unwrap();
+        assert!(configured_host
+            .serve_args("/tmp/cua-no-overlay.sock")
+            .contains(&"--no-overlay".into()));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/tests/private_worker_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/private_worker_test.rs
@@ -252,6 +252,7 @@ async fn embedded_service_binds_authority_to_the_original_host_connection() {
         dangerously_bypass_approvals: false,
         environment: Vec::<EmbeddedEnvironmentVariable>::new(),
         inherit_stderr: true,
+        no_overlay: false,
     })
     .unwrap();
     let connection = host.clone().start().await.unwrap();

--- a/libs/cua-driver/typescript/src/native/cua_driver_sdk.ts
+++ b/libs/cua-driver/typescript/src/native/cua_driver_sdk.ts
@@ -917,7 +917,8 @@ export type EmbeddedDriverHostOptions = {
     approveSessionPolicy: boolean,
     dangerouslyBypassApprovals: boolean,
     environment: Array<EmbeddedEnvironmentVariable>,
-    inheritStderr: boolean
+    inheritStderr: boolean,
+    noOverlay: boolean
 }
 
 /**
@@ -927,6 +928,7 @@ export const EmbeddedDriverHostOptions = (() => {
     const defaults = () => ({
         capabilityManifestPath: undefined,
         approveCapabilityManifest: false,
+        noOverlay: false
     });
     const create = (() => {
         return uniffiCreateRecord<EmbeddedDriverHostOptions, ReturnType<typeof defaults>>(defaults);
@@ -955,7 +957,8 @@ const FfiConverterTypeEmbeddedDriverHostOptions = (() => {
                 approveSessionPolicy: FfiConverterBool.read(from),
                 dangerouslyBypassApprovals: FfiConverterBool.read(from),
                 environment: FfiConverterSequenceTypeEmbeddedEnvironmentVariable.read(from),
-                inheritStderr: FfiConverterBool.read(from)
+                inheritStderr: FfiConverterBool.read(from),
+                noOverlay: FfiConverterBool.read(from)
             };
         }
         write(value: TypeName, into: RustBuffer): void {
@@ -972,6 +975,7 @@ const FfiConverterTypeEmbeddedDriverHostOptions = (() => {
             FfiConverterBool.write(value.dangerouslyBypassApprovals, into);
             FfiConverterSequenceTypeEmbeddedEnvironmentVariable.write(value.environment, into);
             FfiConverterBool.write(value.inheritStderr, into);
+            FfiConverterBool.write(value.noOverlay, into);
         }
         allocationSize(value: TypeName): number {
             return FfiConverterString.allocationSize(value.binaryPath) +
@@ -986,7 +990,8 @@ const FfiConverterTypeEmbeddedDriverHostOptions = (() => {
              FfiConverterBool.allocationSize(value.approveSessionPolicy) +
              FfiConverterBool.allocationSize(value.dangerouslyBypassApprovals) +
              FfiConverterSequenceTypeEmbeddedEnvironmentVariable.allocationSize(value.environment) +
-             FfiConverterBool.allocationSize(value.inheritStderr);
+             FfiConverterBool.allocationSize(value.inheritStderr) +
+             FfiConverterBool.allocationSize(value.noOverlay);
 
         }
     };

--- a/libs/cua-driver/typescript/test/embedded.test.mjs
+++ b/libs/cua-driver/typescript/test/embedded.test.mjs
@@ -34,6 +34,27 @@ test(
     assert.equal(embedded.EmbeddedCuaDriverHost, root.EmbeddedCuaDriverHost)
     assert.equal(embedded.EmbeddedDriverHostOptions, root.EmbeddedDriverHostOptions)
     assert.equal(embedded.EmbeddedPermissionMode, root.EmbeddedPermissionMode)
+
+    const requiredOptions = {
+      binaryPath: "/example/cua-driver",
+      hostBundleId: "com.example.host",
+      approveSessionPolicy: false,
+      dangerouslyBypassApprovals: false,
+      environment: [],
+      inheritStderr: false,
+    }
+    assert.equal(
+      embedded.EmbeddedDriverHostOptions.new(requiredOptions).noOverlay,
+      false,
+    )
+    assert.equal(
+      embedded.EmbeddedDriverHostOptions.new({
+        ...requiredOptions,
+        noOverlay: true,
+      }).noOverlay,
+      true,
+    )
+
     assert.throws(
       () => new embedded.EmbeddedCuaDriverHost("", "com.example.host"),
       error => error?.inner?.reason === "binary_path must not be empty",


### PR DESCRIPTION
## summary

- add a default-false `no_overlay` option to `EmbeddedDriverHostOptions`
- apply `--no-overlay` to the SDK-owned `serve` process only when requested
- regenerate Python and TypeScript bindings and cover default/enabled arguments

Refs #3278.

## candidate

- exact SHA: `f7ed2fd4250153e93b43c84baa31bb589a49e1a0`
- rebased onto `ee09e869727ce1f80793b0dd830a29139cb6fffa`

## validation

- focused Rust default-behavior test: 1 passed
- TypeScript generated SDK and lifecycle suite: 6 passed
- Python generated SDK and lifecycle suite on Python 3.12: 4 passed
- UniFFI generated-binding drift check: passed
- `git diff --check`: passed

The base advances contained only unrelated docs-validation and local-signing changes, so they did not invalidate the focused local runtime evidence. Fresh Windows and Linux GitHub checks are required on this exact rebased candidate before merge. Existing macOS duplicate Swift-symbol linker warnings remained non-fatal during local binding generation; no macOS certification is claimed.