### PR TITLE
feat(cua-driver): report embedded contract compatibility

### DIFF
--- a/libs/cua-driver/python/src/cua_driver/_native.py
+++ b/libs/cua-driver/python/src/cua_driver/_native.py
@@ -648,6 +648,8 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_connection() != 44467:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_last_compatibility_report() != 57156:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_last_diagnostics() != 57979:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_restart() != 27248:
@@ -1446,6 +1448,11 @@ _UniffiLib.uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_connection.argt
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_connection.restype = _UniffiRustBuffer
+_UniffiLib.uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_last_compatibility_report.argtypes = (
+    ctypes.c_uint64,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_last_compatibility_report.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_last_diagnostics.argtypes = (
     ctypes.c_uint64,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -1728,6 +1735,9 @@ _UniffiLib.uniffi_cua_driver_sdk_checksum_constructor_embeddedcuadriverhost_with
 _UniffiLib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_connection.argtypes = (
 )
 _UniffiLib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_connection.restype = ctypes.c_uint16
+_UniffiLib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_last_compatibility_report.argtypes = (
+)
+_UniffiLib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_last_compatibility_report.restype = ctypes.c_uint16
 _UniffiLib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_last_diagnostics.argtypes = (
 )
 _UniffiLib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_last_diagnostics.restype = ctypes.c_uint16
@@ -2655,6 +2665,96 @@ class _UniffiFfiConverterTypeDriverOptions(_UniffiConverterRustBuffer):
     @staticmethod
     def write(value, buf):
         _UniffiFfiConverterBoolean.write(value.claude_code_compatibility, buf)
+
+@dataclass
+class EmbeddedDriverCompatibilityReport:
+    def __init__(self, *, compatible:bool, expected_driver_version:str, observed_driver_version:str, expected_contract_version:str, observed_contract_version:str, expected_tools_list_schema_version:str, observed_tools_list_schema_version:str, expected_capability_version:str, observed_capability_version:str, expected_mcp_protocol_version:str, observed_mcp_protocol_version:str):
+        self.compatible = compatible
+        self.expected_driver_version = expected_driver_version
+        self.observed_driver_version = observed_driver_version
+        self.expected_contract_version = expected_contract_version
+        self.observed_contract_version = observed_contract_version
+        self.expected_tools_list_schema_version = expected_tools_list_schema_version
+        self.observed_tools_list_schema_version = observed_tools_list_schema_version
+        self.expected_capability_version = expected_capability_version
+        self.observed_capability_version = observed_capability_version
+        self.expected_mcp_protocol_version = expected_mcp_protocol_version
+        self.observed_mcp_protocol_version = observed_mcp_protocol_version
+
+
+
+
+    def __str__(self):
+        return "EmbeddedDriverCompatibilityReport(compatible={}, expected_driver_version={}, observed_driver_version={}, expected_contract_version={}, observed_contract_version={}, expected_tools_list_schema_version={}, observed_tools_list_schema_version={}, expected_capability_version={}, observed_capability_version={}, expected_mcp_protocol_version={}, observed_mcp_protocol_version={})".format(self.compatible, self.expected_driver_version, self.observed_driver_version, self.expected_contract_version, self.observed_contract_version, self.expected_tools_list_schema_version, self.observed_tools_list_schema_version, self.expected_capability_version, self.observed_capability_version, self.expected_mcp_protocol_version, self.observed_mcp_protocol_version)
+    def __eq__(self, other):
+        if self.compatible != other.compatible:
+            return False
+        if self.expected_driver_version != other.expected_driver_version:
+            return False
+        if self.observed_driver_version != other.observed_driver_version:
+            return False
+        if self.expected_contract_version != other.expected_contract_version:
+            return False
+        if self.observed_contract_version != other.observed_contract_version:
+            return False
+        if self.expected_tools_list_schema_version != other.expected_tools_list_schema_version:
+            return False
+        if self.observed_tools_list_schema_version != other.observed_tools_list_schema_version:
+            return False
+        if self.expected_capability_version != other.expected_capability_version:
+            return False
+        if self.observed_capability_version != other.observed_capability_version:
+            return False
+        if self.expected_mcp_protocol_version != other.expected_mcp_protocol_version:
+            return False
+        if self.observed_mcp_protocol_version != other.observed_mcp_protocol_version:
+            return False
+        return True
+
+class _UniffiFfiConverterTypeEmbeddedDriverCompatibilityReport(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        return EmbeddedDriverCompatibilityReport(
+            compatible=_UniffiFfiConverterBoolean.read(buf),
+            expected_driver_version=_UniffiFfiConverterString.read(buf),
+            observed_driver_version=_UniffiFfiConverterString.read(buf),
+            expected_contract_version=_UniffiFfiConverterString.read(buf),
+            observed_contract_version=_UniffiFfiConverterString.read(buf),
+            expected_tools_list_schema_version=_UniffiFfiConverterString.read(buf),
+            observed_tools_list_schema_version=_UniffiFfiConverterString.read(buf),
+            expected_capability_version=_UniffiFfiConverterString.read(buf),
+            observed_capability_version=_UniffiFfiConverterString.read(buf),
+            expected_mcp_protocol_version=_UniffiFfiConverterString.read(buf),
+            observed_mcp_protocol_version=_UniffiFfiConverterString.read(buf),
+        )
+
+    @staticmethod
+    def check_lower(value):
+        _UniffiFfiConverterBoolean.check_lower(value.compatible)
+        _UniffiFfiConverterString.check_lower(value.expected_driver_version)
+        _UniffiFfiConverterString.check_lower(value.observed_driver_version)
+        _UniffiFfiConverterString.check_lower(value.expected_contract_version)
+        _UniffiFfiConverterString.check_lower(value.observed_contract_version)
+        _UniffiFfiConverterString.check_lower(value.expected_tools_list_schema_version)
+        _UniffiFfiConverterString.check_lower(value.observed_tools_list_schema_version)
+        _UniffiFfiConverterString.check_lower(value.expected_capability_version)
+        _UniffiFfiConverterString.check_lower(value.observed_capability_version)
+        _UniffiFfiConverterString.check_lower(value.expected_mcp_protocol_version)
+        _UniffiFfiConverterString.check_lower(value.observed_mcp_protocol_version)
+
+    @staticmethod
+    def write(value, buf):
+        _UniffiFfiConverterBoolean.write(value.compatible, buf)
+        _UniffiFfiConverterString.write(value.expected_driver_version, buf)
+        _UniffiFfiConverterString.write(value.observed_driver_version, buf)
+        _UniffiFfiConverterString.write(value.expected_contract_version, buf)
+        _UniffiFfiConverterString.write(value.observed_contract_version, buf)
+        _UniffiFfiConverterString.write(value.expected_tools_list_schema_version, buf)
+        _UniffiFfiConverterString.write(value.observed_tools_list_schema_version, buf)
+        _UniffiFfiConverterString.write(value.expected_capability_version, buf)
+        _UniffiFfiConverterString.write(value.observed_capability_version, buf)
+        _UniffiFfiConverterString.write(value.expected_mcp_protocol_version, buf)
+        _UniffiFfiConverterString.write(value.observed_mcp_protocol_version, buf)
 
 @dataclass
 class EmbeddedEnvironmentVariable:
@@ -6262,6 +6362,31 @@ class _UniffiFfiConverterOptionalTypeEmbeddedDriverConnection(_UniffiConverterRu
         else:
             raise InternalError("Unexpected flag byte for optional type")
 
+class _UniffiFfiConverterOptionalTypeEmbeddedDriverCompatibilityReport(_UniffiConverterRustBuffer):
+    @classmethod
+    def check_lower(cls, value):
+        if value is not None:
+            _UniffiFfiConverterTypeEmbeddedDriverCompatibilityReport.check_lower(value)
+
+    @classmethod
+    def write(cls, value, buf):
+        if value is None:
+            buf.write_u8(0)
+            return
+
+        buf.write_u8(1)
+        _UniffiFfiConverterTypeEmbeddedDriverCompatibilityReport.write(value, buf)
+
+    @classmethod
+    def read(cls, buf):
+        flag = buf.read_u8()
+        if flag == 0:
+            return None
+        elif flag == 1:
+            return _UniffiFfiConverterTypeEmbeddedDriverCompatibilityReport.read(buf)
+        else:
+            raise InternalError("Unexpected flag byte for optional type")
+
 class _UniffiFfiConverterOptionalTypeEmbeddedDriverDiagnostics(_UniffiConverterRustBuffer):
     @classmethod
     def check_lower(cls, value):
@@ -6291,6 +6416,8 @@ class _UniffiFfiConverterOptionalTypeEmbeddedDriverDiagnostics(_UniffiConverterR
 class EmbeddedCuaDriverHostProtocol(typing.Protocol):
 
     def connection(self, ) -> typing.Optional[EmbeddedDriverConnection]:
+        raise NotImplementedError
+    def last_compatibility_report(self, ) -> typing.Optional[EmbeddedDriverCompatibilityReport]:
         raise NotImplementedError
     def last_diagnostics(self, ) -> typing.Optional[EmbeddedDriverDiagnostics]:
         raise NotImplementedError
@@ -6367,6 +6494,18 @@ class EmbeddedCuaDriverHost(EmbeddedCuaDriverHostProtocol):
         _uniffi_ffi_result = _uniffi_rust_call_with_error(
             _uniffi_error_converter,
             _UniffiLib.uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_connection,
+            *_uniffi_lowered_args,
+        )
+        return _uniffi_lift_return(_uniffi_ffi_result)
+    def last_compatibility_report(self, ) -> typing.Optional[EmbeddedDriverCompatibilityReport]:
+        _uniffi_lowered_args = (
+            self._uniffi_clone_handle(),
+        )
+        _uniffi_lift_return = _UniffiFfiConverterOptionalTypeEmbeddedDriverCompatibilityReport.lift
+        _uniffi_error_converter = None
+        _uniffi_ffi_result = _uniffi_rust_call_with_error(
+            _uniffi_error_converter,
+            _UniffiLib.uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_last_compatibility_report,
             *_uniffi_lowered_args,
         )
         return _uniffi_lift_return(_uniffi_ffi_result)
@@ -6598,6 +6737,7 @@ __all__ = [
     "DriverAuthorizationRequest",
     "DriverMetadata",
     "DriverOptions",
+    "EmbeddedDriverCompatibilityReport",
     "EmbeddedEnvironmentVariable",
     "EmbeddedMcpConfiguration",
     "EmbeddedDriverConnection",

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/embedded.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/embedded.rs
@@ -101,6 +101,21 @@ pub struct EmbeddedDriverDiagnostics {
     pub stderr_truncated: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct EmbeddedDriverCompatibilityReport {
+    pub compatible: bool,
+    pub expected_driver_version: String,
+    pub observed_driver_version: String,
+    pub expected_contract_version: String,
+    pub observed_contract_version: String,
+    pub expected_tools_list_schema_version: String,
+    pub observed_tools_list_schema_version: String,
+    pub expected_capability_version: String,
+    pub observed_capability_version: String,
+    pub expected_mcp_protocol_version: String,
+    pub observed_mcp_protocol_version: String,
+}
+
 #[derive(Debug, Error, uniffi::Error)]
 pub enum EmbeddedDriverError {
     #[error("invalid embedded host configuration: {reason}")]
@@ -216,6 +231,7 @@ pub struct EmbeddedCuaDriverHost {
     options: ValidatedOptions,
     inner: Mutex<HostInner>,
     diagnostics: Arc<Mutex<Option<DiagnosticCapture>>>,
+    compatibility_report: Mutex<Option<EmbeddedDriverCompatibilityReport>>,
     changed: Notify,
 }
 
@@ -333,6 +349,7 @@ impl EmbeddedCuaDriverHost {
                 last_exit: None,
             }),
             diagnostics: Arc::new(Mutex::new(None)),
+            compatibility_report: Mutex::new(None),
             changed: Notify::new(),
         }))
     }
@@ -357,6 +374,10 @@ impl EmbeddedCuaDriverHost {
         }
     }
 
+    pub fn last_compatibility_report(&self) -> Option<EmbeddedDriverCompatibilityReport> {
+        self.compatibility_report.lock().unwrap().clone()
+    }
+
     pub fn last_diagnostics(&self) -> Option<EmbeddedDriverDiagnostics> {
         self.diagnostics
             .lock()
@@ -376,6 +397,7 @@ impl EmbeddedCuaDriverHost {
                     HostPhase::Stopped => {
                         *self.diagnostics.lock().unwrap() =
                             self.options.capture_stderr.then(DiagnosticCapture::default);
+                        *self.compatibility_report.lock().unwrap() = None;
                         let generation = Uuid::new_v4().to_string();
                         let cancel = Arc::new(AtomicBool::new(false));
                         inner.phase = HostPhase::Starting {
@@ -614,6 +636,7 @@ impl EmbeddedCuaDriverHost {
             tokio::time::sleep(Duration::from_millis(50)).await;
         };
 
+        *self.compatibility_report.lock().unwrap() = Some(compatibility_report(&metadata));
         let endpoint_identity = match capture_endpoint_identity(&socket_path) {
             Ok(identity) => identity,
             Err(error) => {
@@ -1012,6 +1035,25 @@ fn merge_safe_environment(
         }
     }
     values.into_values().collect()
+}
+
+fn compatibility_report(metadata: &DaemonMetadata) -> EmbeddedDriverCompatibilityReport {
+    EmbeddedDriverCompatibilityReport {
+        compatible: metadata.contract_version == CONTRACT_VERSION
+            && metadata.tools_list_schema_version == TOOLS_LIST_SCHEMA_VERSION
+            && metadata.capability_version == CAPABILITY_VERSION
+            && metadata.mcp_protocol_version == MCP_PROTOCOL_VERSION,
+        expected_driver_version: env!("CARGO_PKG_VERSION").into(),
+        observed_driver_version: metadata.driver_version.clone(),
+        expected_contract_version: CONTRACT_VERSION.into(),
+        observed_contract_version: metadata.contract_version.clone(),
+        expected_tools_list_schema_version: TOOLS_LIST_SCHEMA_VERSION.into(),
+        observed_tools_list_schema_version: metadata.tools_list_schema_version.clone(),
+        expected_capability_version: CAPABILITY_VERSION.into(),
+        observed_capability_version: metadata.capability_version.clone(),
+        expected_mcp_protocol_version: MCP_PROTOCOL_VERSION.into(),
+        observed_mcp_protocol_version: metadata.mcp_protocol_version.clone(),
+    }
 }
 
 fn validate_metadata(
@@ -1452,6 +1494,17 @@ mod tests {
             embedded: true,
             host_bundle_id: Some("com.example.host".into()),
         };
+        let report = compatibility_report(&metadata);
+        assert!(report.compatible);
+        assert_eq!(report.observed_contract_version, CONTRACT_VERSION);
+
+        let mut mismatched = metadata.clone();
+        mismatched.contract_version = "future-contract".into();
+        let mismatch = compatibility_report(&mismatched);
+        assert!(!mismatch.compatible);
+        assert_eq!(mismatch.expected_contract_version, CONTRACT_VERSION);
+        assert_eq!(mismatch.observed_contract_version, "future-contract");
+
         assert!(validate_metadata(&metadata, 42, "com.example.host").is_ok());
         assert!(validate_metadata(&metadata, 43, "com.example.host").is_err());
         assert!(validate_metadata(&metadata, 42, "com.other").is_err());

--- a/libs/cua-driver/typescript/src/native/cua_driver_sdk-ffi.ts
+++ b/libs/cua-driver/typescript/src/native/cua_driver_sdk-ffi.ts
@@ -743,6 +743,11 @@ const DEFINITIONS = {
       ret: FfiType.RustBuffer,
       hasRustCallStatus: true,
     },
+    "uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_last_compatibility_report": {
+      args: [FfiType.Handle],
+      ret: FfiType.RustBuffer,
+      hasRustCallStatus: true,
+    },
     "uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_last_diagnostics": {
       args: [FfiType.Handle],
       ret: FfiType.RustBuffer,
@@ -1198,6 +1203,11 @@ const DEFINITIONS = {
       ret: FfiType.UInt16,
       hasRustCallStatus: false,
     },
+    "uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_last_compatibility_report": {
+      args: [],
+      ret: FfiType.UInt16,
+      hasRustCallStatus: false,
+    },
     "uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_last_diagnostics": {
       args: [],
       ret: FfiType.UInt16,
@@ -1445,6 +1455,7 @@ interface NativeModuleInterface {
     uniffi_cua_driver_sdk_fn_constructor_embeddedcuadriverhost_new(binaryPath: Uint8Array, hostBundleId: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     uniffi_cua_driver_sdk_fn_constructor_embeddedcuadriverhost_with_options(options: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_connection(uniffiSelf: bigint, uniffi_out_err: UniffiRustCallStatus): Uint8Array;
+    uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_last_compatibility_report(uniffiSelf: bigint, uniffi_out_err: UniffiRustCallStatus): Uint8Array;
     uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_last_diagnostics(uniffiSelf: bigint, uniffi_out_err: UniffiRustCallStatus): Uint8Array;
     uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_restart(uniffiSelf: bigint): bigint;
     uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_start(uniffiSelf: bigint): bigint;
@@ -1536,6 +1547,7 @@ interface NativeModuleInterface {
     uniffi_cua_driver_sdk_checksum_constructor_embeddedcuadriverhost_new(): number;
     uniffi_cua_driver_sdk_checksum_constructor_embeddedcuadriverhost_with_options(): number;
     uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_connection(): number;
+    uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_last_compatibility_report(): number;
     uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_last_diagnostics(): number;
     uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_restart(): number;
     uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_start(): number;

--- a/libs/cua-driver/typescript/src/native/cua_driver_sdk.ts
+++ b/libs/cua-driver/typescript/src/native/cua_driver_sdk.ts
@@ -669,6 +669,85 @@ const FfiConverterTypeDriverOptions = (() => {
     return new FFIConverter();
 })();
 
+export type EmbeddedDriverCompatibilityReport = {
+    compatible: boolean,
+    expectedDriverVersion: string,
+    observedDriverVersion: string,
+    expectedContractVersion: string,
+    observedContractVersion: string,
+    expectedToolsListSchemaVersion: string,
+    observedToolsListSchemaVersion: string,
+    expectedCapabilityVersion: string,
+    observedCapabilityVersion: string,
+    expectedMcpProtocolVersion: string,
+    observedMcpProtocolVersion: string
+}
+
+/**
+ * Generated factory for {@link EmbeddedDriverCompatibilityReport} record objects.
+ */
+export const EmbeddedDriverCompatibilityReport = (() => {
+    const defaults = () => ({
+    });
+    const create = (() => {
+        return uniffiCreateRecord<EmbeddedDriverCompatibilityReport, ReturnType<typeof defaults>>(defaults);
+    })();
+    return Object.freeze({
+        create,
+        new: create,
+        defaults: () => Object.freeze(defaults()) as Partial<EmbeddedDriverCompatibilityReport>,
+    });
+})();
+
+const FfiConverterTypeEmbeddedDriverCompatibilityReport = (() => {
+    type TypeName = EmbeddedDriverCompatibilityReport;
+    class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
+        read(from: RustBuffer): TypeName {
+            return {
+                compatible: FfiConverterBool.read(from),
+                expectedDriverVersion: FfiConverterString.read(from),
+                observedDriverVersion: FfiConverterString.read(from),
+                expectedContractVersion: FfiConverterString.read(from),
+                observedContractVersion: FfiConverterString.read(from),
+                expectedToolsListSchemaVersion: FfiConverterString.read(from),
+                observedToolsListSchemaVersion: FfiConverterString.read(from),
+                expectedCapabilityVersion: FfiConverterString.read(from),
+                observedCapabilityVersion: FfiConverterString.read(from),
+                expectedMcpProtocolVersion: FfiConverterString.read(from),
+                observedMcpProtocolVersion: FfiConverterString.read(from)
+            };
+        }
+        write(value: TypeName, into: RustBuffer): void {
+            FfiConverterBool.write(value.compatible, into);
+            FfiConverterString.write(value.expectedDriverVersion, into);
+            FfiConverterString.write(value.observedDriverVersion, into);
+            FfiConverterString.write(value.expectedContractVersion, into);
+            FfiConverterString.write(value.observedContractVersion, into);
+            FfiConverterString.write(value.expectedToolsListSchemaVersion, into);
+            FfiConverterString.write(value.observedToolsListSchemaVersion, into);
+            FfiConverterString.write(value.expectedCapabilityVersion, into);
+            FfiConverterString.write(value.observedCapabilityVersion, into);
+            FfiConverterString.write(value.expectedMcpProtocolVersion, into);
+            FfiConverterString.write(value.observedMcpProtocolVersion, into);
+        }
+        allocationSize(value: TypeName): number {
+            return FfiConverterBool.allocationSize(value.compatible) +
+             FfiConverterString.allocationSize(value.expectedDriverVersion) +
+             FfiConverterString.allocationSize(value.observedDriverVersion) +
+             FfiConverterString.allocationSize(value.expectedContractVersion) +
+             FfiConverterString.allocationSize(value.observedContractVersion) +
+             FfiConverterString.allocationSize(value.expectedToolsListSchemaVersion) +
+             FfiConverterString.allocationSize(value.observedToolsListSchemaVersion) +
+             FfiConverterString.allocationSize(value.expectedCapabilityVersion) +
+             FfiConverterString.allocationSize(value.observedCapabilityVersion) +
+             FfiConverterString.allocationSize(value.expectedMcpProtocolVersion) +
+             FfiConverterString.allocationSize(value.observedMcpProtocolVersion);
+
+        }
+    };
+    return new FFIConverter();
+})();
+
 export type EmbeddedEnvironmentVariable = {
     name: string,
     value: string
@@ -5427,6 +5506,7 @@ const uniffiCallbackInterfaceDriverAuthorizationHost: { vtable: any; register: (
 export interface EmbeddedCuaDriverHostLike {
 
     connection(): EmbeddedDriverConnection | undefined;
+    lastCompatibilityReport(): EmbeddedDriverCompatibilityReport | undefined;
     lastDiagnostics(): EmbeddedDriverDiagnostics | undefined;
     restart(asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<EmbeddedDriverConnection>;
     start(asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<EmbeddedDriverConnection>;
@@ -5487,6 +5567,23 @@ export class EmbeddedCuaDriverHost extends UniffiAbstractObject implements Embed
     })(uniffiCaller.rustCall(
             /*caller:*/ (callStatus) => {
                 return nativeModule().uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_connection(
+                uniffiTypeEmbeddedCuaDriverHostObjectFactory.clonePointer(this),
+                callStatus);
+            },
+            /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+    ));
+    }
+
+    lastCompatibilityReport(): EmbeddedDriverCompatibilityReport | undefined {
+    return ((__rb: Uint8Array) => {
+        try {
+            return FfiConverterOptionalTypeEmbeddedDriverCompatibilityReport.lift(__rb);
+        } finally {
+            nativeModule().rustbuffer_free(__rb);
+        }
+    })(uniffiCaller.rustCall(
+            /*caller:*/ (callStatus) => {
+                return nativeModule().uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_last_compatibility_report(
                 uniffiTypeEmbeddedCuaDriverHostObjectFactory.clonePointer(this),
                 callStatus);
             },
@@ -5763,6 +5860,9 @@ const FfiConverterOptionalTypeVerifyStateOutput = new FfiConverterOptional(FfiCo
 
 // FfiConverter for EmbeddedDriverConnection | undefined
 const FfiConverterOptionalTypeEmbeddedDriverConnection = new FfiConverterOptional(FfiConverterTypeEmbeddedDriverConnection);
+
+// FfiConverter for EmbeddedDriverCompatibilityReport | undefined
+const FfiConverterOptionalTypeEmbeddedDriverCompatibilityReport = new FfiConverterOptional(FfiConverterTypeEmbeddedDriverCompatibilityReport);
 
 // FfiConverter for EmbeddedDriverDiagnostics | undefined
 const FfiConverterOptionalTypeEmbeddedDriverDiagnostics = new FfiConverterOptional(FfiConverterTypeEmbeddedDriverDiagnostics);
@@ -6041,6 +6141,9 @@ function uniffiEnsureInitialized() {
     if (nativeModule().uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_connection() !== 44467) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_connection");
     }
+    if (nativeModule().uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_last_compatibility_report() !== 57156) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_last_compatibility_report");
+    }
     if (nativeModule().uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_last_diagnostics() !== 57979) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_last_diagnostics");
     }
@@ -6084,6 +6187,7 @@ export default Object.freeze({
     FfiConverterTypeDriverMetadata,
     FfiConverterTypeDriverOptions,
     FfiConverterTypeEmbeddedCuaDriverHost,
+    FfiConverterTypeEmbeddedDriverCompatibilityReport,
     FfiConverterTypeEmbeddedDriverConnection,
     FfiConverterTypeEmbeddedDriverDiagnostics,
     FfiConverterTypeEmbeddedDriverError,


### PR DESCRIPTION
## summary

- expose the expected and observed embedded driver, contract, tools-schema, capability, and MCP versions
- retain the metadata handshake as the sole compatibility authority
- clear stale reports before each generation and publish the latest handshake through generated bindings
- keep exact contract refusal unchanged

## stack

- base: #3281
- contract: #3279 / #3278
- next: host-only package artifacts

Refs #3278.

## validation

- focused metadata compatibility test passes
- UniFFI bindings regenerated
- `cargo fmt --all -- --check`
- `git diff --check`

Known draft gap: add a fixture-backed mismatch test that reads the report through Python and Node after `start()` refuses the daemon.
