### PR TITLE
fix(cua-driver): honor HERMES_HOME for skill links

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
@@ -49,9 +49,10 @@
 //! - Antigravity: `~/.gemini/skills/` — shared between Antigravity CLI
 //!   (`agy`) and Antigravity IDE; same dir Google Gemini CLI used before the
 //!   May-2026 transition, so existing installs migrate forward unchanged.
-//! - Hermes: `~/.hermes/skills/` — NousResearch/hermes-agent. The user-level
-//!   skill space Hermes resolves at agent load time (separate from the
-//!   repo-bundled `hermes-agent/skills/` tree, which is read-only and
+//! - Hermes: `$HERMES_HOME/skills/` when set, otherwise `~/.hermes/skills/` on
+//!   macOS/Linux or `%LOCALAPPDATA%\hermes\skills\` on Windows. This is the
+//!   user-level skill space Hermes resolves at agent load time (separate from
+//!   the repo-bundled `hermes-agent/skills/` tree, which is read-only and
 //!   version-controlled). Hermes' own `computer-use` skill teaches its wrapper
 //!   vocabulary; the cua-driver pack provides the platform deep dives.
 //!
@@ -263,7 +264,16 @@ fn resolve_hermes_skills_dir(
 
 #[cfg(not(windows))]
 fn default_hermes_home() -> Result<PathBuf> {
-    Ok(PathBuf::from(std::env::var("HOME").map_err(|_| anyhow!("HOME not set"))?).join(".hermes"))
+    unix_hermes_home(std::env::var("HOME").ok().as_deref())
+}
+
+#[cfg(any(not(windows), test))]
+fn unix_hermes_home(home: Option<&str>) -> Result<PathBuf> {
+    let home = home
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .ok_or_else(|| anyhow!("HOME not set"))?;
+    Ok(PathBuf::from(home).join(".hermes"))
 }
 
 #[cfg(windows)]
@@ -858,8 +868,8 @@ fn print_path() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        extract_tar_gz, resolve_hermes_skills_dir, skill_release_url, windows_hermes_home,
-        AgentParent, AGENTS, SKILL_FILES,
+        extract_tar_gz, resolve_hermes_skills_dir, skill_release_url, unix_hermes_home,
+        windows_hermes_home, AgentParent, AGENTS, SKILL_FILES,
     };
     use std::path::PathBuf;
     use tempfile::tempdir;
@@ -887,9 +897,64 @@ mod tests {
     }
 
     #[test]
-    fn hermes_target_uses_native_windows_home() {
+    fn hermes_target_ignores_empty_or_whitespace_override() {
+        for override_home in [None, Some(""), Some("  \t  ")] {
+            let path =
+                resolve_hermes_skills_dir(override_home, || Ok(PathBuf::from("/fallback/hermes")))
+                    .unwrap();
+            assert_eq!(path, PathBuf::from("/fallback/hermes/skills"));
+        }
+    }
+
+    #[test]
+    fn hermes_target_uses_unix_default_home() {
+        assert_eq!(
+            unix_hermes_home(Some("/home/test")).unwrap(),
+            PathBuf::from("/home/test/.hermes")
+        );
+    }
+
+    #[test]
+    fn hermes_target_uses_native_windows_local_appdata() {
         let home = windows_hermes_home(Some("C:/Users/test/AppData/Local"), None).unwrap();
         assert_eq!(home, PathBuf::from("C:/Users/test/AppData/Local/hermes"));
+    }
+
+    #[test]
+    fn hermes_target_uses_windows_userprofile_fallback() {
+        let expected = PathBuf::from("C:/Users/test")
+            .join("AppData")
+            .join("Local")
+            .join("hermes");
+        for local_appdata in [None, Some(""), Some("  \t  ")] {
+            assert_eq!(
+                windows_hermes_home(local_appdata, Some("C:/Users/test")).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn hermes_defaults_report_missing_required_environment() {
+        for home in [None, Some(""), Some("  \t  ")] {
+            assert_eq!(
+                unix_hermes_home(home).unwrap_err().to_string(),
+                "HOME not set"
+            );
+        }
+        for (local_appdata, userprofile) in [
+            (None, None),
+            (Some(""), None),
+            (None, Some("  \t  ")),
+            (Some("  "), Some("")),
+        ] {
+            assert_eq!(
+                windows_hermes_home(local_appdata, userprofile)
+                    .unwrap_err()
+                    .to_string(),
+                "LOCALAPPDATA and USERPROFILE not set"
+            );
+        }
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
@@ -181,6 +181,10 @@ struct Agent {
 enum AgentParent {
     /// `<HOME or USERPROFILE>/<segment>`.
     Home(&'static str),
+    /// Hermes' effective user skill directory. Unlike the other agents,
+    /// Hermes supports an explicit `HERMES_HOME` and uses a native-Windows
+    /// default outside `USERPROFILE`.
+    Hermes,
     /// `<APPDATA>/<segment>` (Windows roaming app config).
     ///
     /// `#[allow(dead_code)]`: constructed only inside `#[cfg(windows)]`
@@ -227,19 +231,63 @@ const AGENTS: &[Agent] = &[
         label: "Antigravity",
         parent: AgentParent::Home(".gemini/skills"),
     },
-    // Hermes (NousResearch/hermes-agent) resolves user skills from
-    // `~/.hermes/skills/` at agent load time — the same directory its
-    // `/skills install …` slash command and `hermes skills install`
-    // CLI write to. Hermes' bundled `skills/computer-use/SKILL.md`
-    // teaches the Hermes `computer_use` action vocabulary; the
-    // cua-driver pack symlinked here adds the platform-specific deep
-    // dives (MACOS.md / WINDOWS.md / LINUX.md / RECORDING.md /
-    // BROWSER.md) that Hermes deliberately doesn't clone.
+    // Hermes (NousResearch/hermes-agent) resolves user skills from its
+    // effective home at agent load time. `HERMES_HOME` can select a custom
+    // home or profile; otherwise Hermes uses `~/.hermes` on macOS/Linux and
+    // `%LOCALAPPDATA%\hermes` on native Windows. Hermes' bundled
+    // `skills/computer-use/SKILL.md` teaches the wrapper vocabulary; this
+    // pack adds the platform-specific deep dives.
     Agent {
         label: "Hermes",
-        parent: AgentParent::Home(".hermes/skills"),
+        parent: AgentParent::Hermes,
     },
 ];
+
+fn hermes_skills_dir_from_env() -> Result<PathBuf> {
+    resolve_hermes_skills_dir(
+        std::env::var("HERMES_HOME").ok().as_deref(),
+        default_hermes_home,
+    )
+}
+
+fn resolve_hermes_skills_dir(
+    override_home: Option<&str>,
+    default_home: impl FnOnce() -> Result<PathBuf>,
+) -> Result<PathBuf> {
+    let home = match override_home.map(str::trim).filter(|path| !path.is_empty()) {
+        Some(path) => PathBuf::from(path),
+        None => default_home()?,
+    };
+    Ok(home.join("skills"))
+}
+
+#[cfg(not(windows))]
+fn default_hermes_home() -> Result<PathBuf> {
+    Ok(PathBuf::from(std::env::var("HOME").map_err(|_| anyhow!("HOME not set"))?).join(".hermes"))
+}
+
+#[cfg(windows)]
+fn default_hermes_home() -> Result<PathBuf> {
+    windows_hermes_home(
+        std::env::var("LOCALAPPDATA").ok().as_deref(),
+        std::env::var("USERPROFILE").ok().as_deref(),
+    )
+}
+
+#[cfg(any(windows, test))]
+fn windows_hermes_home(local_appdata: Option<&str>, userprofile: Option<&str>) -> Result<PathBuf> {
+    if let Some(path) = local_appdata.map(str::trim).filter(|path| !path.is_empty()) {
+        return Ok(PathBuf::from(path).join("hermes"));
+    }
+    let profile = userprofile
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .ok_or_else(|| anyhow!("LOCALAPPDATA and USERPROFILE not set"))?;
+    Ok(PathBuf::from(profile)
+        .join("AppData")
+        .join("Local")
+        .join("hermes"))
+}
 
 impl Agent {
     fn parent_path(&self) -> Result<PathBuf> {
@@ -252,6 +300,7 @@ impl Agent {
                 let base = std::env::var("HOME").map_err(|_| anyhow!("HOME not set"))?;
                 Ok(PathBuf::from(base).join(seg.replace('/', std::path::MAIN_SEPARATOR_STR)))
             }
+            AgentParent::Hermes => hermes_skills_dir_from_env(),
             AgentParent::AppData(seg) => {
                 #[cfg(windows)]
                 let base = std::env::var("APPDATA").map_err(|_| anyhow!("APPDATA not set"))?;
@@ -808,7 +857,10 @@ fn print_path() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_tar_gz, skill_release_url, AgentParent, AGENTS, SKILL_FILES};
+    use super::{
+        extract_tar_gz, resolve_hermes_skills_dir, skill_release_url, windows_hermes_home,
+        AgentParent, AGENTS, SKILL_FILES,
+    };
     use std::path::PathBuf;
     use tempfile::tempdir;
 
@@ -823,6 +875,21 @@ mod tests {
             target.parent,
             AgentParent::Home(".prime/agent/skills")
         ));
+    }
+
+    #[test]
+    fn hermes_target_prefers_hermes_home() {
+        let path = resolve_hermes_skills_dir(Some("/profiles/work"), || {
+            panic!("the fallback must not be read")
+        })
+        .unwrap();
+        assert_eq!(path, PathBuf::from("/profiles/work/skills"));
+    }
+
+    #[test]
+    fn hermes_target_uses_native_windows_home() {
+        let home = windows_hermes_home(Some("C:/Users/test/AppData/Local"), None).unwrap();
+        assert_eq!(home, PathBuf::from("C:/Users/test/AppData/Local/hermes"));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/tests/hermes_skills_cli_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/hermes_skills_cli_test.rs
@@ -1,0 +1,59 @@
+#[cfg(unix)]
+mod unix {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+    use std::process::Command;
+
+    use tempfile::tempdir;
+
+    #[test]
+    fn status_and_uninstall_use_the_selected_hermes_home() {
+        let root = tempdir().expect("temporary test root");
+        let driver_home = root.path().join("driver");
+        let hermes_home = root.path().join("hermes-profile");
+        let hermes_skills = hermes_home.join("skills");
+        let local_skill = driver_home.join("skills").join("cua-driver");
+        let hermes_link = hermes_skills.join("cua-driver");
+
+        fs::create_dir_all(&hermes_skills).expect("create Hermes skills directory");
+        fs::create_dir_all(&local_skill).expect("create local skill directory");
+        fs::write(local_skill.join("SKILL.md"), "# test\n").expect("write test skill");
+        symlink(&local_skill, &hermes_link).expect("link test skill into Hermes");
+
+        let status = Command::new(env!("CARGO_BIN_EXE_cua-driver"))
+            .args(["skills", "status"])
+            .env("CUA_DRIVER_RS_HOME", &driver_home)
+            .env("HERMES_HOME", &hermes_home)
+            .env("HOME", root.path().join("unused-home"))
+            .output()
+            .expect("run skills status");
+        assert!(status.status.success(), "{status:?}");
+        let stdout = String::from_utf8(status.stdout).expect("UTF-8 status output");
+        assert!(
+            stdout.contains(&hermes_link.display().to_string()),
+            "{stdout}"
+        );
+        assert!(stdout.contains("Hermes"), "{stdout}");
+        assert!(stdout.contains("linked"), "{stdout}");
+
+        let uninstall = Command::new(env!("CARGO_BIN_EXE_cua-driver"))
+            .args(["skills", "uninstall"])
+            .env("CUA_DRIVER_RS_HOME", &driver_home)
+            .env("HERMES_HOME", &hermes_home)
+            .env("HOME", root.path().join("unused-home"))
+            .output()
+            .expect("run skills uninstall");
+        assert!(uninstall.status.success(), "{uninstall:?}");
+        let stdout = String::from_utf8(uninstall.stdout).expect("UTF-8 uninstall output");
+        assert!(
+            stdout.contains(&hermes_link.display().to_string()),
+            "{stdout}"
+        );
+        assert!(!hermes_link.exists());
+        assert!(hermes_link.symlink_metadata().is_err());
+        assert!(
+            local_skill.exists(),
+            "uninstall without --all keeps local skill"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`cua-driver skills` now resolves Hermes links from:

1. non-empty `HERMES_HOME`;
2. `%LOCALAPPDATA%\hermes` on Windows, with `%USERPROFILE%\AppData\Local\hermes` as the fallback when `LOCALAPPDATA` is absent or blank;
3. `$HOME/.hermes` elsewhere.

All skill subcommands use the same resolver. Cua Driver's own skill-pack directory is unchanged.

## Related work

Fixes #3290. The hard-coded Hermes path came from #1963. Open PRs touching `skills.rs` do not address this path resolution.

No RFC is needed; this aligns with Hermes' existing home-directory contract.

## Coverage

- non-empty, empty, and whitespace-only `HERMES_HOME`
- Unix default and missing `HOME` error
- Windows `LOCALAPPDATA` default
- Windows `USERPROFILE` fallback for absent/empty `LOCALAPPDATA`
- Windows missing required environment error
- isolated CLI `status` and `uninstall` lifecycle using a custom Hermes profile

## Validation

Candidate head: `57bac85606a4857b9ac5d8db537c434bd1c5a870` (rebased onto `ee09e869727ce1f80793b0dd830a29139cb6fffa`).

- `cargo test -p cua-driver skills::tests --bin cua-driver` — 22 passed
- `cargo test -p cua-driver --test hermes_skills_cli_test` — 1 passed
- `cargo check -p cua-driver --bin cua-driver`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Local cross-target checks were attempted but the macOS host lacks the Linux cross C compiler and Windows SDK headers required by native dependencies. Hosted Linux and Windows checks are the authoritative cross-platform coverage for this head.

## Checks

- [x] focused production fix and deterministic tests
- [x] contributor authorship preserved after rebase
- [x] conventional release title
- [x] no unrelated files changed

