### PR TITLE
fix(cua-driver): bind rootless XWayland browser windows

### DIFF
--- a/.github/workflows/ci-rust-linux.yml
+++ b/.github/workflows/ci-rust-linux.yml
@@ -79,6 +79,13 @@ jobs:
             cargo test -p platform-linux \
             x11_overlay_owner_stays_click_through_across_cursor_lifecycle_and_randr \
             --locked -- --ignored --nocapture
+      - name: Run X11 nested-client enumeration regression
+        working-directory: libs/cua-driver/rust
+        run: |
+          xvfb-run -a --server-args="-screen 0 1920x1080x24" \
+            cargo test -p platform-linux \
+            x11::tests::live_nested_client_fallback_lists_reparented_client \
+            --locked -- --ignored --exact --nocapture --test-threads=1
       - name: Run X11 MIT-SHM capture correctness and performance regression
         working-directory: libs/cua-driver/rust
         run: |

--- a/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
@@ -23,6 +23,12 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 #[derive(Debug, Default)]
 pub struct LinuxBrowserPlatform;
 
+fn exact_x11_singleton(owned_window_ids: &[u64], target_window_id: u64) -> Option<bool> {
+    owned_window_ids
+        .contains(&target_window_id)
+        .then_some(owned_window_ids.len() == 1)
+}
+
 fn refusal(code: BrowserRefusalCode, message: impl Into<String>) -> BrowserRefusal {
     BrowserRefusal::new(code, message)
 }
@@ -531,6 +537,42 @@ impl BrowserPlatform for LinuxBrowserPlatform {
                 format!("pid {pid} is outside the Linux process-id range"),
             )
         })?;
+        // A mixed Wayland+XWayland session still gives X11 clients an exact,
+        // PID-owned XID and geometry. Resolve that identity before consulting
+        // native-Wayland adapters; treating the mere presence of
+        // WAYLAND_DISPLAY as proof that every target is native Wayland turns a
+        // uniquely bound embedded Chromium window into a read-only heuristic.
+        if let Some(window) = tokio::task::spawn_blocking(move || {
+            crate::x11::list_windows(Some(pid_u32))
+                .into_iter()
+                .find(|window| window.xid == window_id)
+        })
+        .await
+        .ok()
+        .flatten()
+        {
+            return Ok(NativeWindowInfo {
+                pid,
+                window_id,
+                title: window.title,
+                bounds: Rect::new(
+                    f64::from(window.x),
+                    f64::from(window.y),
+                    f64::from(window.width),
+                    f64::from(window.height),
+                ),
+                geometry_exact: true,
+                ownership: NativeOwnershipProof {
+                    method: NativeOwnershipMethod::PlatformAttested,
+                    owner_pid: pid,
+                    detail: Some(
+                        "X11 _NET_WM_PID corroborated independently by the owned endpoint pid"
+                            .to_owned(),
+                    ),
+                },
+            });
+        }
+
         if std::env::var_os("WAYLAND_DISPLAY").is_some() {
             if let Some(window) = crate::wayland::sway_ipc::window_for_id(window_id) {
                 if window.pid != pid_u32 {
@@ -617,40 +659,10 @@ impl BrowserPlatform for LinuxBrowserPlatform {
             });
         }
 
-        let window = tokio::task::spawn_blocking(move || {
-            crate::x11::list_windows(Some(pid_u32))
-                .into_iter()
-                .find(|window| window.xid == window_id)
-        })
-        .await
-        .ok()
-        .flatten()
-        .ok_or_else(|| {
-            refusal(
-                BrowserRefusalCode::BrowserBindingStale,
-                format!("X11 window {window_id} is not owned by pid {pid}"),
-            )
-        })?;
-        Ok(NativeWindowInfo {
-            pid,
-            window_id,
-            title: window.title,
-            bounds: Rect::new(
-                f64::from(window.x),
-                f64::from(window.y),
-                f64::from(window.width),
-                f64::from(window.height),
-            ),
-            geometry_exact: true,
-            ownership: NativeOwnershipProof {
-                method: NativeOwnershipMethod::PlatformAttested,
-                owner_pid: pid,
-                detail: Some(
-                    "X11 _NET_WM_PID corroborated independently by the owned endpoint pid"
-                        .to_owned(),
-                ),
-            },
-        })
+        Err(refusal(
+            BrowserRefusalCode::BrowserBindingStale,
+            format!("X11 window {window_id} is not owned by pid {pid}"),
+        ))
     }
 
     async fn is_only_exact_native_window(
@@ -664,6 +676,23 @@ impl BrowserPlatform for LinuxBrowserPlatform {
                 format!("pid {pid} is outside the Linux process-id range"),
             )
         })?;
+        let x11_owned = tokio::task::spawn_blocking(move || {
+            crate::x11::list_windows(Some(pid_u32))
+                .into_iter()
+                .map(|window| window.xid)
+                .collect::<Vec<_>>()
+        })
+        .await
+        .map_err(|error| {
+            refusal(
+                BrowserRefusalCode::BrowserRouteUnavailable,
+                format!("could not enumerate X11 browser windows: {error}"),
+            )
+        })?;
+        if let Some(singleton) = exact_x11_singleton(&x11_owned, window_id) {
+            return Ok(Some(singleton));
+        }
+
         if std::env::var_os("WAYLAND_DISPLAY").is_some() {
             let Some(windows) = crate::wayland::sway_ipc::list_windows() else {
                 if let Some(owned) =
@@ -702,20 +731,7 @@ impl BrowserPlatform for LinuxBrowserPlatform {
                 .collect::<Vec<_>>();
             return Ok(Some(owned.len() == 1 && owned[0] == window_id));
         }
-        let owned = tokio::task::spawn_blocking(move || {
-            crate::x11::list_windows(Some(pid_u32))
-                .into_iter()
-                .map(|window| u64::from(window.xid))
-                .collect::<Vec<_>>()
-        })
-        .await
-        .map_err(|error| {
-            refusal(
-                BrowserRefusalCode::BrowserRouteUnavailable,
-                format!("could not enumerate X11 browser windows: {error}"),
-            )
-        })?;
-        Ok(Some(owned.len() == 1 && owned[0] == window_id))
+        Ok(Some(false))
     }
 
     async fn discover_owned_endpoint(
@@ -1152,6 +1168,16 @@ impl BrowserPlatform for LinuxBrowserPlatform {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn exact_x11_identity_wins_in_mixed_display_sessions() {
+        assert_eq!(exact_x11_singleton(&[0x400004], 0x400004), Some(true));
+        assert_eq!(
+            exact_x11_singleton(&[0x400004, 0x600007], 0x400004),
+            Some(false)
+        );
+        assert_eq!(exact_x11_singleton(&[0x400004], 0x700001), None);
+    }
 
     #[test]
     fn isolated_browser_candidates_use_only_root_managed_payloads() {

--- a/libs/cua-driver/rust/crates/platform-linux/src/x11/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/x11/mod.rs
@@ -125,32 +125,102 @@ fn get_window_list(conn: &RustConnection, root: Window) -> Result<Vec<Window>> {
                     .value32()
                     .map(|iter| iter.collect())
                     .unwrap_or_default();
-                if client_list_property(reply.type_, windows.as_slice()).is_some() {
+                if ewmh_client_list_is_usable(reply.type_, &windows) {
                     return Ok(windows);
                 }
             }
         }
     }
 
-    // No EWMH client-list property means there may be no window manager. In
-    // that case only expose mapped root children; unmapped Electron children
-    // can otherwise be reported before a late-starting WM reparents them.
-    let tree = conn.query_tree(root)?.reply()?;
-    Ok(tree
-        .children
-        .into_iter()
-        .filter(|window| {
-            conn.get_window_attributes(*window)
-                .ok()
-                .and_then(|cookie| cookie.reply().ok())
-                .map(|attributes| fallback_window_is_listable(attributes.map_state))
-                .unwrap_or(false)
-        })
-        .collect())
+    // Rootless XWayland WMs can omit the EWMH client lists, or publish them
+    // while leaving them empty, then reparent each real client beneath a
+    // compositor-owned frame. The same fallback covers bare X. Walk only
+    // bounded, viewable descendants and admit ICCCM client windows with an
+    // exact PID, title, and WM_STATE. This excludes compositor frames, support
+    // windows, and our overlay while avoiding unmapped Electron startup rows.
+    nested_client_windows(conn, root)
 }
 
-fn client_list_property(property_type: Atom, windows: &[Window]) -> Option<&[Window]> {
-    (property_type != x11rb::NONE).then_some(windows)
+fn ewmh_client_list_is_usable(property_type: Atom, windows: &[Window]) -> bool {
+    property_type != x11rb::NONE && !windows.is_empty()
+}
+
+const MAX_FALLBACK_TREE_DEPTH: usize = 8;
+const MAX_FALLBACK_TREE_WINDOWS: usize = 4096;
+
+fn nested_client_windows(conn: &RustConnection, root: Window) -> Result<Vec<Window>> {
+    let root_children = conn.query_tree(root)?.reply()?.children;
+    if !fallback_tree_within_budget(0, 0, root_children.len()) {
+        anyhow::bail!(
+            "X11 fallback tree exceeds the {MAX_FALLBACK_TREE_WINDOWS}-window discovery limit"
+        );
+    }
+    let wm_state = get_atom(conn, "WM_STATE")?;
+    let mut pending = root_children
+        .into_iter()
+        .rev()
+        .map(|window| (window, 1_usize))
+        .collect::<Vec<_>>();
+    let mut visited = 0_usize;
+    let mut clients = Vec::new();
+
+    while let Some((window, depth)) = pending.pop() {
+        visited += 1;
+        if !window_is_viewable(conn, window) {
+            continue;
+        }
+        if fallback_window_is_client(conn, window, wm_state) {
+            clients.push(window);
+            continue;
+        }
+        if depth >= MAX_FALLBACK_TREE_DEPTH {
+            continue;
+        }
+        if let Ok(tree) = conn.query_tree(window)?.reply() {
+            if !fallback_tree_within_budget(visited, pending.len(), tree.children.len()) {
+                anyhow::bail!(
+                    "X11 fallback tree exceeds the {MAX_FALLBACK_TREE_WINDOWS}-window discovery limit"
+                );
+            }
+            pending.extend(
+                tree.children
+                    .into_iter()
+                    .rev()
+                    .map(|child| (child, depth + 1)),
+            );
+        }
+    }
+
+    Ok(clients)
+}
+
+fn fallback_tree_within_budget(visited: usize, pending: usize, additional: usize) -> bool {
+    visited
+        .checked_add(pending)
+        .and_then(|known| known.checked_add(additional))
+        .is_some_and(|known| known <= MAX_FALLBACK_TREE_WINDOWS)
+}
+
+fn window_is_viewable(conn: &RustConnection, window: Window) -> bool {
+    conn.get_window_attributes(window)
+        .ok()
+        .and_then(|cookie| cookie.reply().ok())
+        .is_some_and(|attributes| fallback_window_is_listable(attributes.map_state))
+}
+
+fn fallback_window_is_client(conn: &RustConnection, window: Window, wm_state: Atom) -> bool {
+    let has_pid = get_window_pid(conn, window).ok().flatten().is_some();
+    let has_title = get_window_title(conn, window).is_ok_and(|title| !title.trim().is_empty());
+    let has_wm_state = conn
+        .get_property(false, window, wm_state, AtomEnum::ANY, 0, 2)
+        .ok()
+        .and_then(|cookie| cookie.reply().ok())
+        .is_some_and(|reply| reply.type_ != x11rb::NONE);
+    fallback_client_is_eligible(has_pid, has_title, has_wm_state)
+}
+
+fn fallback_client_is_eligible(has_pid: bool, has_title: bool, has_wm_state: bool) -> bool {
+    has_pid && has_title && has_wm_state
 }
 
 fn fallback_window_is_listable(map_state: MapState) -> bool {
@@ -319,13 +389,127 @@ mod tests {
     use super::*;
 
     #[test]
-    fn empty_present_client_list_does_not_fall_back_to_query_tree() {
-        assert_eq!(client_list_property(1, &[]), Some([].as_slice()));
+    #[ignore = "requires a live X11 server"]
+    fn live_nested_client_fallback_lists_reparented_client() {
+        use x11rb::protocol::xproto::ConnectionExt as _;
+        use x11rb::wrapper::ConnectionExt as _;
+
+        let (conn, screen_num) = RustConnection::connect(None).expect("connect to X11 fixture");
+        let screen = &conn.setup().roots[screen_num];
+        let frame = conn.generate_id().expect("generate frame window id");
+        let client = conn.generate_id().expect("generate client window id");
+
+        conn.create_window(
+            screen.root_depth,
+            frame,
+            screen.root,
+            20,
+            20,
+            360,
+            240,
+            0,
+            WindowClass::INPUT_OUTPUT,
+            screen.root_visual,
+            &CreateWindowAux::new().background_pixel(screen.black_pixel),
+        )
+        .expect("create frame request")
+        .check()
+        .expect("create frame");
+        conn.create_window(
+            screen.root_depth,
+            client,
+            frame,
+            4,
+            4,
+            320,
+            200,
+            0,
+            WindowClass::INPUT_OUTPUT,
+            screen.root_visual,
+            &CreateWindowAux::new().background_pixel(screen.white_pixel),
+        )
+        .expect("create client request")
+        .check()
+        .expect("create client");
+
+        let pid_atom = get_atom(&conn, "_NET_WM_PID").expect("intern pid atom");
+        let name_atom = get_atom(&conn, "_NET_WM_NAME").expect("intern name atom");
+        let utf8_atom = get_atom(&conn, "UTF8_STRING").expect("intern UTF8 atom");
+        let wm_state = get_atom(&conn, "WM_STATE").expect("intern WM_STATE atom");
+        conn.change_property32(
+            PropMode::REPLACE,
+            client,
+            pid_atom,
+            AtomEnum::CARDINAL,
+            &[std::process::id()],
+        )
+        .expect("set client pid");
+        conn.change_property8(
+            PropMode::REPLACE,
+            client,
+            name_atom,
+            utf8_atom,
+            b"nested-client-fixture",
+        )
+        .expect("set client title");
+        conn.change_property32(
+            PropMode::REPLACE,
+            client,
+            wm_state,
+            wm_state,
+            &[1, x11rb::NONE],
+        )
+        .expect("set client WM_STATE");
+
+        let stacking = get_atom(&conn, "_NET_CLIENT_LIST_STACKING").expect("intern stacking atom");
+        let client_list = get_atom(&conn, "_NET_CLIENT_LIST").expect("intern client-list atom");
+        conn.change_property32(
+            PropMode::REPLACE,
+            screen.root,
+            stacking,
+            AtomEnum::WINDOW,
+            &[],
+        )
+        .expect("publish empty stacking list");
+        conn.delete_property(screen.root, client_list)
+            .expect("remove client list");
+        conn.map_window(client).expect("map client");
+        conn.map_window(frame).expect("map frame");
+        conn.flush().expect("flush fixture");
+        conn.get_input_focus()
+            .expect("fixture sync request")
+            .reply()
+            .expect("fixture sync reply");
+
+        let windows = list_windows(Some(std::process::id()));
+        assert_eq!(windows.len(), 1, "only the nested ICCCM client is listable");
+        assert_eq!(windows[0].xid, u64::from(client));
+        assert_eq!(windows[0].title, "nested-client-fixture");
+        assert!(windows[0].is_on_screen);
     }
 
     #[test]
-    fn absent_client_list_allows_query_tree_fallback() {
-        assert_eq!(client_list_property(x11rb::NONE, &[]), None);
+    fn nested_client_fallback_is_strictly_bounded() {
+        assert_eq!(MAX_FALLBACK_TREE_DEPTH, 8);
+        assert_eq!(MAX_FALLBACK_TREE_WINDOWS, 4096);
+        assert!(fallback_tree_within_budget(1, 4094, 1));
+        assert!(!fallback_tree_within_budget(1, 4094, 2));
+        assert!(!fallback_tree_within_budget(usize::MAX, 0, 1));
+    }
+
+    #[test]
+    fn empty_or_absent_ewmh_client_lists_require_fallback_discovery() {
+        assert!(!ewmh_client_list_is_usable(1, &[]));
+        assert!(!ewmh_client_list_is_usable(x11rb::NONE, &[0x400004]));
+        assert!(ewmh_client_list_is_usable(1, &[0x400004]));
+    }
+
+    #[test]
+    fn nested_client_fallback_requires_exact_client_metadata() {
+        assert!(fallback_client_is_eligible(true, true, true));
+        assert!(!fallback_client_is_eligible(false, true, true));
+        assert!(!fallback_client_is_eligible(true, false, true));
+        assert!(!fallback_client_is_eligible(true, true, false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Problem this solves: rootless XWayland compositors can omit or leave EWMH client lists empty while nesting real application clients below compositor-owned frames. Cua then reports no X11 window and treats embedded Chromium as a read-only heuristic in mixed Wayland and XWayland sessions.
- What changed: Cua now performs a bounded fallback traversal for viewable ICCCM clients with `_NET_WM_PID`, a title, and `WM_STATE`. Browser binding checks PID-owned X11 identities before native-Wayland adapters, which restores exact embedded Chromium binding and trusted CDP input.

## Related work

Refs #2206

#1991 addresses the distinct Xauthority connection failure reported in #1978. This PR neither supersedes nor reimplements that contribution; it handles missing EWMH client lists after the X11 connection succeeds.

RFC: not required. This is a Linux implementation correction and does not change a public SDK, CLI, MCP, protocol, compatibility, permission, or cross-component contract.

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: Linux rootless-XWayland applications can now be discovered and bound through their exact X11 identity. Nonempty EWMH client-list handling and native-Wayland fallback behavior remain unchanged. There is no API, schema, migration, or permission change.
- Risk and rollback: fallback enumeration could admit an unrelated nested X11 window, so candidates must be viewable and provide PID, title, and `WM_STATE` evidence. Traversal is limited to eight levels and 4,096 discovered windows. Exceeding that budget fails closed instead of returning a partial list that could be mistaken for singleton ownership. Reverting this PR restores the previous EWMH-only behavior.

## Validation

- Exact candidate: `019a594b0bb4369eb51e12e3d3bfc218c8311a38`, rebased onto `origin/main` at `9a61050e3474fc9488d7adc85184299f02514d0e`.
- Focused checks: `cargo fmt --all -- --check`; Linux container `cargo test -p platform-linux --lib --locked x11::tests -- --nocapture` (7 passed); Linux container `cargo test -p platform-linux --lib --locked browser_platform::tests::exact_x11_identity_wins_in_mixed_display_sessions -- --exact --nocapture` (1 passed); live Xvfb `cargo test -p platform-linux x11::tests::live_nested_client_fallback_lists_reparented_client --locked -- --ignored --exact --nocapture --test-threads=1` (1 passed).
- Manual platform evidence from the original candidate: Weston 13 with rootless XWayland 23.2.6 and Electron 39.8.5 returned the PID-owned 1280x800 client, produced an exact mutation-enabled embedded binding, delivered `event.isTrusted=true` to an accessibility-hidden custom control, and opened the native GTK picker. An Xvfb and Openbox comparison retained exact 900x650 Electron discovery and mutation-enabled binding.
- Known gaps or CI still required: generic raw XTEST foreground input still fails closed when a rootless compositor exposes neither EWMH activation nor a compositor control protocol. Exact-head Linux CI passed, including the automated Xvfb nested-client regression. The Ubuntu contract lane passed on rerun after an unrelated temporary-fixture spawn transiently returned `ETXTBSY` (`Text file busy`); the full representative desktop matrix remains deferred for final pre-merge certification.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [x] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied. This is a releasing bug fix, so the label does not apply.



