### PR TITLE
fix(cua-driver): preserve TCC across release updates

### DIFF
--- a/libs/cua-driver/scripts/_install-rust.sh
+++ b/libs/cua-driver/scripts/_install-rust.sh
@@ -178,6 +178,71 @@ TMP_DIR=$(mktemp -d)
 log() { printf '==> %s\n' "$*"; }
 err() { printf 'error: %s\n' "$*" >&2; }
 
+# Return the source form of an app's designated code-signing requirement.
+# The requirement is emitted on stdout; routine executable details go to stderr.
+macos_designated_requirement() {
+    codesign -d -r- "$1" 2>/dev/null \
+        | sed -n -e 's/^designated => //p' -e 's/^# designated => //p'
+}
+
+# TCC stores the previous app's requirement, not just its bundle identifier.
+# Ask Security.framework (through codesign) whether the replacement satisfies
+# that exact requirement instead of comparing requirement text or cdhashes.
+macos_requirement_compatibility() {
+    local previous_requirement="$1"
+    local candidate_app="$2"
+    local codesign_output
+    local codesign_status
+
+    if [[ -z "$previous_requirement" ]]; then
+        printf '%s' "unknown"
+    elif codesign_output="$(codesign --verify --deep --strict \
+            -R "=$previous_requirement" "$candidate_app" 2>&1)"; then
+        printf '%s' "compatible"
+    else
+        codesign_status=$?
+        if [[ "$codesign_status" == "3" ]]; then
+            printf '%s' "incompatible"
+        else
+            printf 'warning: could not evaluate the previous code-signing requirement (codesign status %s); preserving TCC rows\n' \
+                "$codesign_status" >&2
+            [[ -z "$codesign_output" ]] \
+                || printf 'warning: codesign: %s\n' "$codesign_output" >&2
+            printf '%s' "unknown"
+        fi
+    fi
+}
+
+# Reset only the permissions Cua Driver itself consumes, and only after the
+# newly installed bundle has been verified and registered with LaunchServices.
+macos_reset_tcc_after_requirement_change() {
+    local compatibility="$1"
+    local bundle_id="com.trycua.driver"
+    local failed_services=""
+    local service
+
+    [[ "$compatibility" == "incompatible" ]] || return 0
+    if ! command -v tccutil >/dev/null 2>&1; then
+        err "tccutil is required to clear stale Cua Driver permission rows after its signing requirement changed"
+        return 1
+    fi
+    for service in Accessibility ScreenCapture; do
+        if ! tccutil reset "$service" "$bundle_id" >/dev/null 2>&1; then
+            failed_services="$failed_services $service"
+        fi
+    done
+    if [[ -n "$failed_services" ]]; then
+        err "could not reset these TCC services for $bundle_id:$failed_services"
+        err "the new app is installed, but stale permission rows may remain; run:"
+        err "  tccutil reset Accessibility $bundle_id"
+        err "  tccutil reset ScreenCapture $bundle_id"
+        return 1
+    fi
+
+    log "the app signing requirement changed; cleared stale Accessibility and Screen Recording rows"
+    log "macOS authorization is required again: cua-driver permissions grant"
+}
+
 # --- Concurrent-install lockfile ---------------------------------------
 #
 # A second install kicked off while a first is still running can race
@@ -402,12 +467,9 @@ prune_old_releases() {
 # under the home. Every step is best-effort + idempotent; a machine with no
 # prior local install is a clean no-op.
 #
-# TCC is preserved deliberately: we do NOT `tccutil reset` here. The bundle at
-# /Applications/CuaDriver.app is shared (bundle id com.trycua.driver) and the
-# subsequent release `ditto` re-points the binary in place; grants keyed on the
-# bundle id survive (macOS may re-prompt once on the cdhash change, same as any
-# upgrade). Churning the signing identity would gratuitously invalidate
-# cert-pinned grants, so we leave it alone.
+# The release install below verifies the previous and replacement designated
+# requirements. Compatible releases preserve grants; a proven mismatch resets
+# only the stale Cua Driver rows after the replacement is registered.
 cleanup_prior_local_install() {
     local releases_dir="$HOME_DIR/packages/releases"
     local tcc_marker="$HOME_DIR/.tcc-signing-identity"
@@ -936,11 +998,9 @@ fi
 # `realpath` walk in `is_executable_inside_cuadriver_app()` keys on
 # that resolved path to know whether the auto-relaunch heuristic
 # should fire. Same path and same bundle id as the Swift `cua-driver`
-# install (`/Applications/CuaDriver.app`, `com.trycua.driver`), so an
-# install over an existing Swift bundle is an in-place takeover —
-# TCC grants attributed to the shared bundle id survive the swap and
-# the new binary inherits them (macOS may re-prompt once on first
-# action because the cdhash differs; after that the grants persist).
+# install (`/Applications/CuaDriver.app`, `com.trycua.driver`). The installer
+# also proves whether the replacement satisfies the previous app's designated
+# requirement; the bundle identifier alone is not enough to preserve TCC.
 #
 # The macOS path intentionally does NOT use the
 # $HOME_DIR/packages/releases/<v>/ + current symlink layout used on
@@ -968,22 +1028,30 @@ if [[ "$OS" == "Darwin" ]]; then
         exit 1
     fi
 fi
+DAEMONS_STOPPED_BEFORE_SWAP=0
 if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
     if [[ ! -w "/Applications" ]]; then
         err "/Applications is not writable. Re-run this installer in a shell where it is, or grant write access."
         err "  Without the .app bundle, \`cua-driver-rs mcp\` from an IDE terminal will not auto-relaunch into a TCC-correct daemon."
         exit 1
     fi
-    # The Rust port and the legacy Swift driver both live at
-    # /Applications/CuaDriver.app with bundle id `com.trycua.driver` —
-    # bundle-id-identical so TCC grants survive the upgrade. When we
-    # detect a prior Swift bundle at the install path we log it for
-    # transparency, but no `tccutil reset` is needed; grants transfer
-    # automatically because they're keyed on bundle id. macOS may
-    # surface a one-time re-prompt on first action because the cdhash
-    # of the new binary doesn't match the old one — that's a TCC
-    # cdhash-pairing detail, not a grant loss.
+    if ! command -v codesign >/dev/null 2>&1; then
+        err "codesign is required to verify the macOS release app safely"
+        exit 1
+    fi
+    if ! codesign --verify --deep --strict "$SRC_APP" 2>/dev/null; then
+        err "downloaded CuaDriver.app failed signature verification; the installed app was not changed"
+        exit 1
+    fi
+    STAGED_REQUIREMENT="$(macos_designated_requirement "$SRC_APP")"
+    if [[ -z "$STAGED_REQUIREMENT" ]]; then
+        err "could not read the downloaded app's designated requirement; the installed app was not changed"
+        exit 1
+    fi
+
     REPLACED_SWIFT=0
+    PREVIOUS_REQUIREMENT=""
+    REQUIREMENT_COMPATIBILITY="unknown"
     if [[ -e "$APP_DEST" ]]; then
         PREV_BUNDLE_ID=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP_DEST/Contents/Info.plist" 2>/dev/null || true)
         PREV_BUNDLE_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP_DEST/Contents/Info.plist" 2>/dev/null || true)
@@ -995,16 +1063,96 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
         else
             log "removing existing $APP_DEST"
         fi
-        rm -rf "$APP_DEST"
+        if codesign --verify --deep --strict "$APP_DEST" 2>/dev/null; then
+            PREVIOUS_REQUIREMENT="$(macos_designated_requirement "$APP_DEST")"
+            REQUIREMENT_COMPATIBILITY="$(macos_requirement_compatibility \
+                "$PREVIOUS_REQUIREMENT" "$SRC_APP")"
+        else
+            log "warning: existing CuaDriver.app signature could not be verified; preserving TCC rows because compatibility is unknown"
+        fi
+    fi
+
+    # Stop the old daemon while its verified bundle still exists. This avoids
+    # leaving a running process whose executable path disappears mid-upgrade.
+    stop_cua_driver_daemons
+    show_cua_driver_daemon_survivors
+    DAEMONS_STOPPED_BEFORE_SWAP=1
+
+    APP_BACKUP="${APP_DEST}.install-backup.$$"
+    if [[ -e "$APP_BACKUP" ]]; then
+        err "temporary backup path already exists: $APP_BACKUP"
+        exit 1
+    fi
+    if [[ -e "$APP_DEST" ]]; then
+        mv "$APP_DEST" "$APP_BACKUP"
     fi
     log "installing $APP_DEST"
     # `ditto` preserves the bundle's metadata + nested symlinks the way
     # Apple's installer would. `cp -R` works but doesn't preserve as
     # much, and ditto is always present on macOS.
-    ditto "$SRC_APP" "$APP_DEST"
+    INSTALL_VALID=0
+    if ditto "$SRC_APP" "$APP_DEST" \
+       && codesign --verify --deep --strict "$APP_DEST" 2>/dev/null; then
+        INSTALLED_REQUIREMENT="$(macos_designated_requirement "$APP_DEST")"
+        if [[ -n "$INSTALLED_REQUIREMENT" \
+           && "$INSTALLED_REQUIREMENT" == "$STAGED_REQUIREMENT" ]]; then
+            INSTALL_VALID=1
+        fi
+    fi
+    if [[ "$INSTALL_VALID" != "1" ]]; then
+        rm -rf "$APP_DEST"
+        if [[ -e "$APP_BACKUP" ]]; then
+            mv "$APP_BACKUP" "$APP_DEST"
+        fi
+        err "installed CuaDriver.app did not preserve its verified signing identity; restored the previous app"
+        exit 1
+    fi
     APP_BINARY="$APP_DEST/Contents/MacOS/$BINARY_NAME"
     if [[ ! -x "$APP_BINARY" ]]; then
-        err "binary missing at $APP_BINARY (refusing to create broken symlink)"
+        rm -rf "$APP_DEST"
+        if [[ -e "$APP_BACKUP" ]]; then
+            mv "$APP_BACKUP" "$APP_DEST"
+        fi
+        err "binary missing at $APP_BINARY; restored the previous app"
+        exit 1
+    fi
+
+    # Register synchronously so both `open -a CuaDriver` and `tccutil reset`
+    # resolve the replacement bundle rather than a stale LaunchServices entry.
+    LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister"
+    LSREGISTERED=0
+    if [[ -x "$LSREGISTER" ]] \
+       && "$LSREGISTER" -f "$APP_DEST" >/dev/null 2>&1; then
+        LSREGISTERED=1
+    else
+        log "warning: could not register the replacement app with LaunchServices"
+    fi
+
+    # Re-check the installed copy against the old requirement. A disagreement
+    # with the staged result means the copy did not preserve the expected code
+    # identity and must not trigger a destructive permission reset.
+    if [[ -n "$PREVIOUS_REQUIREMENT" ]]; then
+        INSTALLED_COMPATIBILITY="$(macos_requirement_compatibility \
+            "$PREVIOUS_REQUIREMENT" "$APP_DEST")"
+        if [[ "$INSTALLED_COMPATIBILITY" != "$REQUIREMENT_COMPATIBILITY" ]]; then
+            rm -rf "$APP_DEST"
+            if [[ -e "$APP_BACKUP" ]]; then
+                mv "$APP_BACKUP" "$APP_DEST"
+            fi
+            err "installed app's signing compatibility changed during copy; restored the previous app"
+            exit 1
+        fi
+    fi
+
+    rm -rf "$APP_BACKUP"
+    if [[ "$REQUIREMENT_COMPATIBILITY" == "incompatible" \
+       && "$LSREGISTERED" != "1" ]]; then
+        err "the new app is installed, but its signing requirement changed and LaunchServices registration failed"
+        err "run: $LSREGISTER -f $APP_DEST"
+        err "then reset Accessibility and ScreenCapture for com.trycua.driver and grant them again"
+        exit 1
+    fi
+    if ! macos_reset_tcc_after_requirement_change "$REQUIREMENT_COMPATIBILITY"; then
         exit 1
     fi
     ln -sf "$APP_BINARY" "$BIN_LINK"
@@ -1113,8 +1261,10 @@ fi
 # LaunchAgent / systemd user unit / manual `serve` shell keeps serving
 # pre-upgrade behaviour until logout, which is what surfaces to users
 # as "the bug I just fixed is still there".
-stop_cua_driver_daemons
-show_cua_driver_daemon_survivors
+if [[ "$DAEMONS_STOPPED_BEFORE_SWAP" != "1" ]]; then
+    stop_cua_driver_daemons
+    show_cua_driver_daemon_survivors
+fi
 
 # Agent skill pack: NOT auto-linked. The install script never touches
 # ~/.claude/skills/, ~/.agents/skills/, etc. Run `cua-driver skills
@@ -1166,11 +1316,22 @@ echo ""
 
 if [[ "${REPLACED_SWIFT:-0}" == "1" ]]; then
     echo "Upgraded the cua-driver bundle that was previously at $APP_DEST."
-    echo "TCC grants (Accessibility, Screen Recording) are keyed on the bundle id"
-    echo "(com.trycua.driver) — which is preserved — so they transfer to the new"
-    echo "binary automatically. macOS may surface a one-time re-grant prompt on"
-    echo "first action because the new binary's cdhash doesn't match the old"
-    echo "one's; approve once and the grants persist."
+    case "${REQUIREMENT_COMPATIBILITY:-unknown}" in
+        compatible)
+            echo "Verified that the replacement satisfies the previous code-signing"
+            echo "requirement, so existing Accessibility and Screen Recording grants"
+            echo "were preserved."
+            ;;
+        incompatible)
+            echo "The code-signing requirement changed, so stale Accessibility and"
+            echo "Screen Recording rows were cleared. Re-authorize the new app with:"
+            echo "  cua-driver permissions grant"
+            ;;
+        *)
+            echo "The previous code-signing requirement could not be verified. Existing"
+            echo "TCC rows were left unchanged to avoid destroying valid grants."
+            ;;
+    esac
     echo ""
 fi
 

--- a/libs/cua-driver/scripts/_install-rust.sh
+++ b/libs/cua-driver/scripts/_install-rust.sh
@@ -280,7 +280,14 @@ MACOS_APP_BACKUP=""
 
 restore_macos_app_backup_on_exit() {
     [[ "$MACOS_APP_SWAP_STARTED" == "1" ]] || return 0
-    [[ "$MACOS_APP_INSTALL_COMMITTED" != "1" ]] || return 0
+
+    if [[ "$MACOS_APP_INSTALL_COMMITTED" == "1" ]]; then
+        if [[ -e "$MACOS_APP_BACKUP" ]] && ! rm -rf "$MACOS_APP_BACKUP"; then
+            printf 'warning: could not remove macOS install backup at %s\n' \
+                "$MACOS_APP_BACKUP" >&2
+        fi
+        return 0
+    fi
 
     if [[ "$MACOS_APP_HAD_PREVIOUS" == "1" ]]; then
         # If the backup does not exist, the atomic move never completed or an
@@ -1072,7 +1079,7 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
         err "downloaded app has unexpected bundle id ${STAGED_BUNDLE_ID:-<missing>}; the installed app was not changed"
         exit 1
     fi
-    STAGED_REQUIREMENT="$(macos_designated_requirement "$SRC_APP")"
+    STAGED_REQUIREMENT="$(macos_designated_requirement "$SRC_APP" || true)"
     if [[ -z "$STAGED_REQUIREMENT" ]]; then
         err "could not read the downloaded app's designated requirement; the installed app was not changed"
         exit 1
@@ -1094,9 +1101,13 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
         fi
         if [[ "$PREV_BUNDLE_ID" == "com.trycua.driver" ]] \
            && codesign --verify --deep --strict "$APP_DEST" 2>/dev/null; then
-            PREVIOUS_REQUIREMENT="$(macos_designated_requirement "$APP_DEST")"
-            REQUIREMENT_COMPATIBILITY="$(macos_requirement_compatibility \
-                "$PREVIOUS_REQUIREMENT" "$SRC_APP")"
+            PREVIOUS_REQUIREMENT="$(macos_designated_requirement "$APP_DEST" || true)"
+            if [[ -n "$PREVIOUS_REQUIREMENT" ]]; then
+                REQUIREMENT_COMPATIBILITY="$(macos_requirement_compatibility \
+                    "$PREVIOUS_REQUIREMENT" "$SRC_APP")"
+            else
+                log "warning: could not read the existing app's designated requirement; preserving TCC rows because compatibility is unknown"
+            fi
         elif [[ "$PREV_BUNDLE_ID" == "com.trycua.driver" ]]; then
             log "warning: existing CuaDriver.app signature could not be verified; preserving TCC rows because compatibility is unknown"
         else
@@ -1143,7 +1154,7 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
         if [[ -e "$MACOS_APP_BACKUP" ]]; then
             mv "$MACOS_APP_BACKUP" "$APP_DEST"
         fi
-        err "installed CuaDriver.app did not preserve its verified signing identity; restored the previous app"
+        err "installed CuaDriver.app did not preserve its verified signing identity; the replacement was rolled back"
         exit 1
     fi
     APP_BINARY="$APP_DEST/Contents/MacOS/$BINARY_NAME"
@@ -1152,7 +1163,7 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
         if [[ -e "$MACOS_APP_BACKUP" ]]; then
             mv "$MACOS_APP_BACKUP" "$APP_DEST"
         fi
-        err "binary missing at $APP_BINARY; restored the previous app"
+        err "binary missing at $APP_BINARY; the replacement was rolled back"
         exit 1
     fi
 
@@ -1168,7 +1179,7 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
             mv "$MACOS_APP_BACKUP" "$APP_DEST"
             "$LSREGISTER" -f "$APP_DEST" >/dev/null 2>&1 || true
         fi
-        err "could not register the replacement app with LaunchServices; restored the previous app"
+        err "could not register the replacement app with LaunchServices; the replacement was rolled back"
         exit 1
     fi
 
@@ -1184,16 +1195,16 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
                 mv "$MACOS_APP_BACKUP" "$APP_DEST"
             fi
             if [[ "$INSTALLED_COMPATIBILITY" == "unknown" ]]; then
-                err "could not re-verify the installed app's signing compatibility; restored the previous app"
+                err "could not re-verify the installed app's signing compatibility; the replacement was rolled back"
             else
-                err "installed app's signing compatibility changed during copy; restored the previous app"
+                err "installed app's signing compatibility changed during copy; the replacement was rolled back"
             fi
             exit 1
         fi
     fi
 
     MACOS_APP_INSTALL_COMMITTED=1
-    rm -rf "$MACOS_APP_BACKUP"
+    rm -rf "$MACOS_APP_BACKUP" || true
     ln -sf "$APP_BINARY" "$BIN_LINK"
     log "symlinked $BIN_LINK -> $APP_BINARY"
     if ! macos_reset_tcc_after_requirement_change "$REQUIREMENT_COMPATIBILITY"; then

--- a/libs/cua-driver/scripts/_install-rust.sh
+++ b/libs/cua-driver/scripts/_install-rust.sh
@@ -179,7 +179,6 @@ log() { printf '==> %s\n' "$*"; }
 err() { printf 'error: %s\n' "$*" >&2; }
 
 # Return the source form of an app's designated code-signing requirement.
-# The requirement is emitted on stdout; routine executable details go to stderr.
 macos_designated_requirement() {
     codesign -d -r- "$1" 2>/dev/null \
         | sed -n -e 's/^designated => //p' -e 's/^# designated => //p'
@@ -274,6 +273,29 @@ LOCK_POLL_INTERVAL_SECONDS=1
 LOCK_STALE_AFTER_SECONDS=600
 
 LOCK_HELD=0
+MACOS_APP_SWAP_STARTED=0
+MACOS_APP_HAD_PREVIOUS=0
+MACOS_APP_INSTALL_COMMITTED=0
+MACOS_APP_BACKUP=""
+
+restore_macos_app_backup_on_exit() {
+    [[ "$MACOS_APP_SWAP_STARTED" == "1" ]] || return 0
+    [[ "$MACOS_APP_INSTALL_COMMITTED" != "1" ]] || return 0
+
+    if [[ "$MACOS_APP_HAD_PREVIOUS" == "1" ]]; then
+        # If the backup does not exist, the atomic move never completed or an
+        # explicit rollback already restored it. Leave the live path alone.
+        if [[ -e "$MACOS_APP_BACKUP" ]]; then
+            rm -rf "$APP_DEST"
+            mv "$MACOS_APP_BACKUP" "$APP_DEST"
+            printf 'warning: interrupted macOS install restored the previous CuaDriver.app\n' >&2
+        fi
+    else
+        # A first install has no app to restore; remove only its partial copy.
+        rm -rf "$APP_DEST"
+    fi
+}
+
 release_install_lock() {
     if (( LOCK_HELD == 1 )); then
         rm -rf "$LOCK_DIR" 2>/dev/null || true
@@ -285,6 +307,7 @@ release_install_lock() {
 # clobbers the other. INT/TERM also re-raise via $? so the user-visible
 # exit code reflects the signal.
 cleanup_on_exit() {
+    restore_macos_app_backup_on_exit
     rm -rf "$TMP_DIR" 2>/dev/null || true
     release_install_lock
 }
@@ -1087,13 +1110,17 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
     show_cua_driver_daemon_survivors
     DAEMONS_STOPPED_BEFORE_SWAP=1
 
-    APP_BACKUP="${APP_DEST}.install-backup.$$"
-    if [[ -e "$APP_BACKUP" ]]; then
-        err "temporary backup path already exists: $APP_BACKUP"
+    MACOS_APP_BACKUP="${APP_DEST}.install-backup.$$"
+    if [[ -e "$MACOS_APP_BACKUP" ]]; then
+        err "temporary backup path already exists: $MACOS_APP_BACKUP"
         exit 1
     fi
     if [[ -e "$APP_DEST" ]]; then
-        mv "$APP_DEST" "$APP_BACKUP"
+        MACOS_APP_HAD_PREVIOUS=1
+    fi
+    MACOS_APP_SWAP_STARTED=1
+    if [[ "$MACOS_APP_HAD_PREVIOUS" == "1" ]]; then
+        mv "$APP_DEST" "$MACOS_APP_BACKUP"
     fi
     log "installing $APP_DEST"
     # `ditto` preserves the bundle's metadata + nested symlinks the way
@@ -1104,7 +1131,7 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
        && codesign --verify --deep --strict "$APP_DEST" 2>/dev/null; then
         INSTALLED_BUNDLE_ID=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
             "$APP_DEST/Contents/Info.plist" 2>/dev/null || true)
-        INSTALLED_REQUIREMENT="$(macos_designated_requirement "$APP_DEST")"
+        INSTALLED_REQUIREMENT="$(macos_designated_requirement "$APP_DEST" || true)"
         if [[ "$INSTALLED_BUNDLE_ID" == "$STAGED_BUNDLE_ID" \
            && -n "$INSTALLED_REQUIREMENT" \
            && "$INSTALLED_REQUIREMENT" == "$STAGED_REQUIREMENT" ]]; then
@@ -1113,8 +1140,8 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
     fi
     if [[ "$INSTALL_VALID" != "1" ]]; then
         rm -rf "$APP_DEST"
-        if [[ -e "$APP_BACKUP" ]]; then
-            mv "$APP_BACKUP" "$APP_DEST"
+        if [[ -e "$MACOS_APP_BACKUP" ]]; then
+            mv "$MACOS_APP_BACKUP" "$APP_DEST"
         fi
         err "installed CuaDriver.app did not preserve its verified signing identity; restored the previous app"
         exit 1
@@ -1122,8 +1149,8 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
     APP_BINARY="$APP_DEST/Contents/MacOS/$BINARY_NAME"
     if [[ ! -x "$APP_BINARY" ]]; then
         rm -rf "$APP_DEST"
-        if [[ -e "$APP_BACKUP" ]]; then
-            mv "$APP_BACKUP" "$APP_DEST"
+        if [[ -e "$MACOS_APP_BACKUP" ]]; then
+            mv "$MACOS_APP_BACKUP" "$APP_DEST"
         fi
         err "binary missing at $APP_BINARY; restored the previous app"
         exit 1
@@ -1137,8 +1164,8 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
         :
     else
         rm -rf "$APP_DEST"
-        if [[ -e "$APP_BACKUP" ]]; then
-            mv "$APP_BACKUP" "$APP_DEST"
+        if [[ -e "$MACOS_APP_BACKUP" ]]; then
+            mv "$MACOS_APP_BACKUP" "$APP_DEST"
             "$LSREGISTER" -f "$APP_DEST" >/dev/null 2>&1 || true
         fi
         err "could not register the replacement app with LaunchServices; restored the previous app"
@@ -1153,20 +1180,25 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
             "$PREVIOUS_REQUIREMENT" "$APP_DEST")"
         if [[ "$INSTALLED_COMPATIBILITY" != "$REQUIREMENT_COMPATIBILITY" ]]; then
             rm -rf "$APP_DEST"
-            if [[ -e "$APP_BACKUP" ]]; then
-                mv "$APP_BACKUP" "$APP_DEST"
+            if [[ -e "$MACOS_APP_BACKUP" ]]; then
+                mv "$MACOS_APP_BACKUP" "$APP_DEST"
             fi
-            err "installed app's signing compatibility changed during copy; restored the previous app"
+            if [[ "$INSTALLED_COMPATIBILITY" == "unknown" ]]; then
+                err "could not re-verify the installed app's signing compatibility; restored the previous app"
+            else
+                err "installed app's signing compatibility changed during copy; restored the previous app"
+            fi
             exit 1
         fi
     fi
 
-    rm -rf "$APP_BACKUP"
+    MACOS_APP_INSTALL_COMMITTED=1
+    rm -rf "$MACOS_APP_BACKUP"
+    ln -sf "$APP_BINARY" "$BIN_LINK"
+    log "symlinked $BIN_LINK -> $APP_BINARY"
     if ! macos_reset_tcc_after_requirement_change "$REQUIREMENT_COMPATIBILITY"; then
         exit 1
     fi
-    ln -sf "$APP_BINARY" "$BIN_LINK"
-    log "symlinked $BIN_LINK -> $APP_BINARY"
 else
     # Linux: versioned-dirs + atomic `current` symlink swap.
     #

--- a/libs/cua-driver/scripts/_install-rust.sh
+++ b/libs/cua-driver/scripts/_install-rust.sh
@@ -1043,6 +1043,12 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
         err "downloaded CuaDriver.app failed signature verification; the installed app was not changed"
         exit 1
     fi
+    STAGED_BUNDLE_ID=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
+        "$SRC_APP/Contents/Info.plist" 2>/dev/null || true)
+    if [[ "$STAGED_BUNDLE_ID" != "com.trycua.driver" ]]; then
+        err "downloaded app has unexpected bundle id ${STAGED_BUNDLE_ID:-<missing>}; the installed app was not changed"
+        exit 1
+    fi
     STAGED_REQUIREMENT="$(macos_designated_requirement "$SRC_APP")"
     if [[ -z "$STAGED_REQUIREMENT" ]]; then
         err "could not read the downloaded app's designated requirement; the installed app was not changed"
@@ -1063,12 +1069,15 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
         else
             log "removing existing $APP_DEST"
         fi
-        if codesign --verify --deep --strict "$APP_DEST" 2>/dev/null; then
+        if [[ "$PREV_BUNDLE_ID" == "com.trycua.driver" ]] \
+           && codesign --verify --deep --strict "$APP_DEST" 2>/dev/null; then
             PREVIOUS_REQUIREMENT="$(macos_designated_requirement "$APP_DEST")"
             REQUIREMENT_COMPATIBILITY="$(macos_requirement_compatibility \
                 "$PREVIOUS_REQUIREMENT" "$SRC_APP")"
-        else
+        elif [[ "$PREV_BUNDLE_ID" == "com.trycua.driver" ]]; then
             log "warning: existing CuaDriver.app signature could not be verified; preserving TCC rows because compatibility is unknown"
+        else
+            log "warning: the existing app does not own com.trycua.driver; it will not be used to decide whether Cua Driver TCC rows are stale"
         fi
     fi
 
@@ -1093,8 +1102,11 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
     INSTALL_VALID=0
     if ditto "$SRC_APP" "$APP_DEST" \
        && codesign --verify --deep --strict "$APP_DEST" 2>/dev/null; then
+        INSTALLED_BUNDLE_ID=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
+            "$APP_DEST/Contents/Info.plist" 2>/dev/null || true)
         INSTALLED_REQUIREMENT="$(macos_designated_requirement "$APP_DEST")"
-        if [[ -n "$INSTALLED_REQUIREMENT" \
+        if [[ "$INSTALLED_BUNDLE_ID" == "$STAGED_BUNDLE_ID" \
+           && -n "$INSTALLED_REQUIREMENT" \
            && "$INSTALLED_REQUIREMENT" == "$STAGED_REQUIREMENT" ]]; then
             INSTALL_VALID=1
         fi
@@ -1120,12 +1132,17 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
     # Register synchronously so both `open -a CuaDriver` and `tccutil reset`
     # resolve the replacement bundle rather than a stale LaunchServices entry.
     LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister"
-    LSREGISTERED=0
     if [[ -x "$LSREGISTER" ]] \
        && "$LSREGISTER" -f "$APP_DEST" >/dev/null 2>&1; then
-        LSREGISTERED=1
+        :
     else
-        log "warning: could not register the replacement app with LaunchServices"
+        rm -rf "$APP_DEST"
+        if [[ -e "$APP_BACKUP" ]]; then
+            mv "$APP_BACKUP" "$APP_DEST"
+            "$LSREGISTER" -f "$APP_DEST" >/dev/null 2>&1 || true
+        fi
+        err "could not register the replacement app with LaunchServices; restored the previous app"
+        exit 1
     fi
 
     # Re-check the installed copy against the old requirement. A disagreement
@@ -1145,13 +1162,6 @@ if [[ "$OS" == "Darwin" && -n "$SRC_APP" && -d "$SRC_APP" ]]; then
     fi
 
     rm -rf "$APP_BACKUP"
-    if [[ "$REQUIREMENT_COMPATIBILITY" == "incompatible" \
-       && "$LSREGISTERED" != "1" ]]; then
-        err "the new app is installed, but its signing requirement changed and LaunchServices registration failed"
-        err "run: $LSREGISTER -f $APP_DEST"
-        err "then reset Accessibility and ScreenCapture for com.trycua.driver and grant them again"
-        exit 1
-    fi
     if ! macos_reset_tcc_after_requirement_change "$REQUIREMENT_COMPATIBILITY"; then
         exit 1
     fi

--- a/libs/cua-driver/scripts/tests/test_install_macos_tcc.py
+++ b/libs/cua-driver/scripts/tests/test_install_macos_tcc.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+INSTALLER = Path(__file__).resolve().parents[1] / "_install-rust.sh"
+
+
+def extract_shell_function(name: str) -> str:
+    source = INSTALLER.read_text()
+    match = re.search(
+        rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}\n",
+        source,
+    )
+    assert match, f"could not find shell function {name}"
+    return match.group(0)
+
+
+def run_policy(body: str) -> subprocess.CompletedProcess[str]:
+    functions = "\n".join(
+        extract_shell_function(name)
+        for name in (
+            "macos_requirement_compatibility",
+            "macos_reset_tcc_after_requirement_change",
+        )
+    )
+    return subprocess.run(
+        ["/bin/bash", "-c", f"set -euo pipefail\n{functions}\n{body}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_semantically_compatible_requirement_preserves_tcc_rows() -> None:
+    result = run_policy(
+        r'''
+        err() { printf 'error: %s\n' "$*" >&2; }
+        log() { printf 'log: %s\n' "$*"; }
+        codesign() {
+            [[ "$1" == "--verify" ]]
+            [[ "$4" == '-R' ]]
+            [[ "$5" == '=identifier "com.trycua.driver" and anchor apple generic' ]]
+            [[ "$6" == '/replacement.app' ]]
+        }
+        tccutil() { echo unexpected >&2; return 99; }
+        compatibility="$(macos_requirement_compatibility \
+            'identifier "com.trycua.driver" and anchor apple generic' \
+            /replacement.app)"
+        [[ "$compatibility" == compatible ]]
+        macos_reset_tcc_after_requirement_change "$compatibility"
+        '''
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "unexpected" not in result.stderr
+
+
+def test_incompatible_requirement_resets_only_driver_permissions() -> None:
+    result = run_policy(
+        r'''
+        err() { printf 'error: %s\n' "$*" >&2; }
+        log() { printf 'log: %s\n' "$*"; }
+        codesign() { return 3; }
+        calls=""
+        tccutil() { calls="${calls}${1}:${2}:${3}"$'\n'; }
+        compatibility="$(macos_requirement_compatibility 'old requirement' /replacement.app)"
+        [[ "$compatibility" == incompatible ]]
+        macos_reset_tcc_after_requirement_change "$compatibility"
+        printf '%s' "$calls"
+        '''
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == (
+        "log: the app signing requirement changed; cleared stale Accessibility and Screen Recording rows\n"
+        "log: macOS authorization is required again: cua-driver permissions grant\n"
+        "reset:Accessibility:com.trycua.driver\n"
+        "reset:ScreenCapture:com.trycua.driver\n"
+    )
+
+
+def test_unknown_previous_requirement_does_not_destroy_grants() -> None:
+    result = run_policy(
+        r'''
+        err() { printf 'error: %s\n' "$*" >&2; }
+        log() { printf 'log: %s\n' "$*"; }
+        codesign() { echo unexpected >&2; return 99; }
+        tccutil() { echo unexpected >&2; return 99; }
+        compatibility="$(macos_requirement_compatibility '' /replacement.app)"
+        [[ "$compatibility" == unknown ]]
+        macos_reset_tcc_after_requirement_change "$compatibility"
+        '''
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "unexpected" not in result.stderr
+
+
+def test_requirement_evaluation_error_does_not_destroy_grants() -> None:
+    result = run_policy(
+        r'''
+        err() { printf 'error: %s\n' "$*" >&2; }
+        log() { printf 'log: %s\n' "$*"; }
+        codesign() { echo 'malformed requirement' >&2; return 1; }
+        tccutil() { echo unexpected >&2; return 99; }
+        compatibility="$(macos_requirement_compatibility 'malformed' /replacement.app)"
+        [[ "$compatibility" == unknown ]]
+        macos_reset_tcc_after_requirement_change "$compatibility"
+        '''
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "could not evaluate the previous code-signing requirement" in result.stderr
+    assert "unexpected" not in result.stderr
+
+
+def test_reset_failure_is_actionable_and_returns_failure() -> None:
+    result = run_policy(
+        r'''
+        err() { printf 'error: %s\n' "$*" >&2; }
+        log() { printf 'log: %s\n' "$*"; }
+        tccutil() { [[ "$2" != ScreenCapture ]]; }
+        if macos_reset_tcc_after_requirement_change incompatible; then
+            exit 90
+        fi
+        '''
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "could not reset these TCC services" in result.stderr
+    assert "tccutil reset Accessibility com.trycua.driver" in result.stderr
+    assert "tccutil reset ScreenCapture com.trycua.driver" in result.stderr
+
+
+def test_installer_verifies_then_registers_before_any_tcc_reset() -> None:
+    source = INSTALLER.read_text()
+    install = source.index('if [[ "$OS" == "Darwin" && -n "$SRC_APP"')
+    staged_verify = source.index('codesign --verify --deep --strict "$SRC_APP"', install)
+    stop_daemon = source.index("stop_cua_driver_daemons", staged_verify)
+    backup = source.index('mv "$APP_DEST" "$APP_BACKUP"', staged_verify)
+    copy = source.index('ditto "$SRC_APP" "$APP_DEST"', backup)
+    installed_verify = source.index('codesign --verify --deep --strict "$APP_DEST"', copy)
+    register = source.index('"$LSREGISTER" -f "$APP_DEST"', installed_verify)
+    reset = source.index("macos_reset_tcc_after_requirement_change", register)
+
+    assert staged_verify < stop_daemon < backup < copy < installed_verify < register < reset

--- a/libs/cua-driver/scripts/tests/test_install_macos_tcc.py
+++ b/libs/cua-driver/scripts/tests/test_install_macos_tcc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -31,6 +32,17 @@ def run_policy(body: str) -> subprocess.CompletedProcess[str]:
         check=False,
         capture_output=True,
         text=True,
+    )
+
+
+def run_rollback_policy(body: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    function = extract_shell_function("restore_macos_app_backup_on_exit")
+    return subprocess.run(
+        ["/bin/bash", "-c", f"set -euo pipefail\n{function}\n{body}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **env},
     )
 
 
@@ -140,13 +152,15 @@ def test_installer_verifies_then_registers_before_any_tcc_reset() -> None:
     install = source.index('if [[ "$OS" == "Darwin" && -n "$SRC_APP"')
     staged_verify = source.index('codesign --verify --deep --strict "$SRC_APP"', install)
     stop_daemon = source.index("stop_cua_driver_daemons", staged_verify)
-    backup = source.index('mv "$APP_DEST" "$APP_BACKUP"', staged_verify)
+    backup = source.index('mv "$APP_DEST" "$MACOS_APP_BACKUP"', staged_verify)
     copy = source.index('ditto "$SRC_APP" "$APP_DEST"', backup)
     installed_verify = source.index('codesign --verify --deep --strict "$APP_DEST"', copy)
     register = source.index('"$LSREGISTER" -f "$APP_DEST"', installed_verify)
-    reset = source.index("macos_reset_tcc_after_requirement_change", register)
+    commit = source.index("MACOS_APP_INSTALL_COMMITTED=1", register)
+    link = source.index('ln -sf "$APP_BINARY" "$BIN_LINK"', commit)
+    reset = source.index("macos_reset_tcc_after_requirement_change", link)
 
-    assert staged_verify < stop_daemon < backup < copy < installed_verify < register < reset
+    assert staged_verify < stop_daemon < backup < copy < installed_verify < register < commit < link < reset
 
 
 def test_only_the_release_bundle_identity_can_trigger_a_tcc_reset() -> None:
@@ -156,3 +170,67 @@ def test_only_the_release_bundle_identity_can_trigger_a_tcc_reset() -> None:
     assert 'STAGED_BUNDLE_ID" != "com.trycua.driver"' in source
     assert '[[ "$PREV_BUNDLE_ID" == "com.trycua.driver" ]]' in source
     assert 'INSTALLED_BUNDLE_ID" == "$STAGED_BUNDLE_ID"' in source
+
+
+def test_exit_cleanup_restores_the_previous_app(tmp_path: Path) -> None:
+    app = tmp_path / "CuaDriver.app"
+    backup = tmp_path / "CuaDriver.app.install-backup"
+    app.mkdir()
+    (app / "candidate").write_text("partial")
+    backup.mkdir()
+    (backup / "previous").write_text("valid")
+
+    result = run_rollback_policy(
+        "restore_macos_app_backup_on_exit",
+        {
+            "APP_DEST": str(app),
+            "MACOS_APP_BACKUP": str(backup),
+            "MACOS_APP_SWAP_STARTED": "1",
+            "MACOS_APP_HAD_PREVIOUS": "1",
+            "MACOS_APP_INSTALL_COMMITTED": "0",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (app / "previous").read_text() == "valid"
+    assert not backup.exists()
+
+
+def test_exit_cleanup_removes_a_partial_first_install(tmp_path: Path) -> None:
+    app = tmp_path / "CuaDriver.app"
+    app.mkdir()
+    (app / "candidate").write_text("partial")
+
+    result = run_rollback_policy(
+        "restore_macos_app_backup_on_exit",
+        {
+            "APP_DEST": str(app),
+            "MACOS_APP_BACKUP": str(tmp_path / "missing-backup"),
+            "MACOS_APP_SWAP_STARTED": "1",
+            "MACOS_APP_HAD_PREVIOUS": "0",
+            "MACOS_APP_INSTALL_COMMITTED": "0",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not app.exists()
+
+
+def test_exit_cleanup_leaves_a_committed_install_untouched(tmp_path: Path) -> None:
+    app = tmp_path / "CuaDriver.app"
+    app.mkdir()
+    (app / "candidate").write_text("valid")
+
+    result = run_rollback_policy(
+        "restore_macos_app_backup_on_exit",
+        {
+            "APP_DEST": str(app),
+            "MACOS_APP_BACKUP": str(tmp_path / "missing-backup"),
+            "MACOS_APP_SWAP_STARTED": "1",
+            "MACOS_APP_HAD_PREVIOUS": "0",
+            "MACOS_APP_INSTALL_COMMITTED": "1",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (app / "candidate").read_text() == "valid"

--- a/libs/cua-driver/scripts/tests/test_install_macos_tcc.py
+++ b/libs/cua-driver/scripts/tests/test_install_macos_tcc.py
@@ -147,3 +147,12 @@ def test_installer_verifies_then_registers_before_any_tcc_reset() -> None:
     reset = source.index("macos_reset_tcc_after_requirement_change", register)
 
     assert staged_verify < stop_daemon < backup < copy < installed_verify < register < reset
+
+
+def test_only_the_release_bundle_identity_can_trigger_a_tcc_reset() -> None:
+    source = INSTALLER.read_text()
+
+    assert 'STAGED_BUNDLE_ID' in source
+    assert 'STAGED_BUNDLE_ID" != "com.trycua.driver"' in source
+    assert '[[ "$PREV_BUNDLE_ID" == "com.trycua.driver" ]]' in source
+    assert 'INSTALLED_BUNDLE_ID" == "$STAGED_BUNDLE_ID"' in source

--- a/libs/cua-driver/scripts/tests/test_install_macos_tcc.py
+++ b/libs/cua-driver/scripts/tests/test_install_macos_tcc.py
@@ -218,14 +218,17 @@ def test_exit_cleanup_removes_a_partial_first_install(tmp_path: Path) -> None:
 
 def test_exit_cleanup_leaves_a_committed_install_untouched(tmp_path: Path) -> None:
     app = tmp_path / "CuaDriver.app"
+    backup = tmp_path / "CuaDriver.app.install-backup"
     app.mkdir()
     (app / "candidate").write_text("valid")
+    backup.mkdir()
+    (backup / "previous").write_text("old")
 
     result = run_rollback_policy(
         "restore_macos_app_backup_on_exit",
         {
             "APP_DEST": str(app),
-            "MACOS_APP_BACKUP": str(tmp_path / "missing-backup"),
+            "MACOS_APP_BACKUP": str(backup),
             "MACOS_APP_SWAP_STARTED": "1",
             "MACOS_APP_HAD_PREVIOUS": "0",
             "MACOS_APP_INSTALL_COMMITTED": "1",
@@ -234,3 +237,4 @@ def test_exit_cleanup_leaves_a_committed_install_untouched(tmp_path: Path) -> No
 
     assert result.returncode == 0, result.stderr
     assert (app / "candidate").read_text() == "valid"
+    assert not backup.exists()


### PR DESCRIPTION
## What changed

- verify the downloaded and installed macOS release bundle before replacing the live app
- compare the previous app's designated requirement against the replacement using macOS's own code-signing evaluator
- preserve existing TCC grants when the replacement remains compatible or compatibility cannot be proven safely
- register the replacement with LaunchServices before clearing stale permission rows
- reset only Accessibility and ScreenCapture when a signing-requirement mismatch is proven, then clearly require reauthorization
- stop the old daemon before moving its bundle and restore the previous app if installation fails or is interrupted
- leave the newly installed command usable even if automatic TCC cleanup fails

## Why

A release update can leave Accessibility and Screen Recording enabled in System Settings while macOS rejects the new app against the TCC row stored for the previous signing identity. Bundle-ID equality alone does not prove compatibility.

Fixes #3170

## Validation

Final candidate: `0a9ed3f392048ec2f08c7703d391d4c100bfb3df`

- `bash -n libs/cua-driver/scripts/_install-rust.sh`
- `git diff --check`
- focused TCC and rollback tests: 10 passed
- combined installer suites: 160 passed, 6 platform skips
- exact-head GitHub installer compatibility: macOS 26, Ubuntu, and Windows for v0.20.0 and v0.21.0
- representative macOS validation at `8a9c0a33020894c3d294f47e9061bec286a8d9d9`:
  - released 0.19.3 -> 0.21.0 satisfied the previous designated requirement, preserved TCC rows, and installed with a valid Developer-ID signature
  - an intentionally incompatible old app caused exactly the Accessibility and ScreenCapture rows for `com.trycua.driver` to be reset after the replacement was installed and registered
- the final candidate adds only review-driven failure/interrupt rollback hardening and command-link ordering on top of that representative run; these paths are covered by the exact-head deterministic tests and macOS installer CI
- independent Claude Code Fable review of the complete exact-head diff: no merge-blocking findings; safe to merge

## Scope

This fixes the release-update path that creates stale TCC rows. The issue's separate observation about richer stale-state diagnostics in `permissions status` is not required for the installer to prevent or recover the broken update state.
