### PR TITLE
fix(cua-driver): match canonical Windows executable paths

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/session_manifest.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/session_manifest.rs
@@ -355,7 +355,9 @@ impl SessionManifest {
                         .executable
                         .as_deref()
                         .zip(executable)
-                        .is_some_and(|(allowed, actual)| allowed == actual))
+                        .is_some_and(|(allowed, actual)| {
+                            application_executables_match(allowed, actual)
+                        }))
         })
     }
 
@@ -1040,6 +1042,30 @@ pub fn load_manifest(path: &Path) -> Result<SessionManifest, String> {
     }
 }
 
+fn application_executables_match(allowed: &str, actual: &str) -> bool {
+    comparable_windows_executable_path(allowed) == comparable_windows_executable_path(actual)
+}
+
+fn comparable_windows_executable_path(path: &str) -> std::borrow::Cow<'_, str> {
+    // `canonicalize` uses the verbatim namespace on Windows, while process
+    // fingerprints use Win32 spelling. Keep device namespaces distinct and
+    // normalize only the absolute drive and UNC forms that name the same file.
+    if let Some(unc) = path.strip_prefix(r"\\?\UNC\") {
+        return std::borrow::Cow::Owned(format!(r"\\{unc}"));
+    }
+    if let Some(local) = path.strip_prefix(r"\\?\") {
+        let bytes = local.as_bytes();
+        if bytes.len() >= 3
+            && bytes[0].is_ascii_alphabetic()
+            && bytes[1] == b':'
+            && bytes[2] == b'\\'
+        {
+            return std::borrow::Cow::Borrowed(local);
+        }
+    }
+    std::borrow::Cow::Borrowed(path)
+}
+
 #[cfg(feature = "yaml")]
 fn validate_tools(section: &str, tools: Vec<String>) -> Result<HashSet<String>, String> {
     let mut validated = HashSet::new();
@@ -1358,6 +1384,85 @@ fn now_unix_ms() -> u128 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn windows_executable_paths_match_equivalent_spellings() {
+        assert!(application_executables_match(
+            r"\\?\C:\Program Files\Cua\cua-driver.exe",
+            r"C:\Program Files\Cua\cua-driver.exe"
+        ));
+        assert!(application_executables_match(
+            r"\\?\UNC\server\share\Cua\cua-driver.exe",
+            r"\\server\share\Cua\cua-driver.exe"
+        ));
+        assert!(application_executables_match(
+            r"C:\Program Files\Cua\cua-driver.exe",
+            r"C:\Program Files\Cua\cua-driver.exe"
+        ));
+    }
+
+    #[test]
+    fn windows_executable_paths_keep_distinct_files_separate() {
+        assert!(!application_executables_match(
+            r"\\?\C:\Program Files\Cua\cua-driver.exe",
+            r"C:\Program Files\Other\cua-driver.exe"
+        ));
+        assert!(!application_executables_match(
+            r"\\.\C:\Program Files\Cua\cua-driver.exe",
+            r"C:\Program Files\Cua\cua-driver.exe"
+        ));
+        assert!(!application_executables_match(
+            r"\\?\GLOBALROOT\Device\HarddiskVolume1\cua-driver.exe",
+            r"GLOBALROOT\Device\HarddiskVolume1\cua-driver.exe"
+        ));
+        assert!(!application_executables_match(
+            r"\\?\C:cua-driver.exe",
+            r"C:cua-driver.exe"
+        ));
+        assert!(!application_executables_match(
+            r"\\?\UNC\server\share\Cua\cua-driver.exe",
+            r"\\server\other\Cua\cua-driver.exe"
+        ));
+    }
+
+    #[cfg(feature = "yaml")]
+    #[test]
+    fn application_grants_accept_equivalent_windows_runtime_paths() {
+        let executable = std::fs::canonicalize(std::env::current_exe().unwrap()).unwrap();
+        let executable_yaml = serde_json::to_string(&executable.to_string_lossy()).unwrap();
+        let mut loaded = manifest(&format!(
+            r#"
+version: 2
+mode: bounded
+expires_after: 8h
+idle_timeout: 30m
+resources:
+  apps:
+    - executable: {executable_yaml}
+      windows: all
+allow:
+  tools: [get_window_state]
+"#
+        ))
+        .unwrap();
+        loaded.applications[0].executable =
+            Some(r"\\?\C:\Program Files\Cua\cua-driver.exe".to_owned());
+
+        loaded
+            .authorize_protected_resource(
+                "private_observation",
+                &serde_json::json!({
+                    "kind": "window",
+                    "pid": 42,
+                    "window_id": 7,
+                    "fingerprint": {
+                        "pid": 42,
+                        "executable": r"C:\Program Files\Cua\cua-driver.exe"
+                    }
+                }),
+            )
+            .unwrap();
+    }
 
     #[cfg(feature = "yaml")]
     fn manifest(source: &str) -> Result<SessionManifest, String> {

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/session_manifest.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/session_manifest.rs
@@ -355,9 +355,7 @@ impl SessionManifest {
                         .executable
                         .as_deref()
                         .zip(executable)
-                        .is_some_and(|(allowed, actual)| {
-                            application_executables_match(allowed, actual)
-                        }))
+                        .is_some_and(|(allowed, actual)| allowed == actual))
         })
     }
 
@@ -1042,30 +1040,6 @@ pub fn load_manifest(path: &Path) -> Result<SessionManifest, String> {
     }
 }
 
-fn application_executables_match(allowed: &str, actual: &str) -> bool {
-    comparable_windows_executable_path(allowed) == comparable_windows_executable_path(actual)
-}
-
-fn comparable_windows_executable_path(path: &str) -> std::borrow::Cow<'_, str> {
-    // `canonicalize` uses the verbatim namespace on Windows, while process
-    // fingerprints use Win32 spelling. Keep device namespaces distinct and
-    // normalize only the absolute drive and UNC forms that name the same file.
-    if let Some(unc) = path.strip_prefix(r"\\?\UNC\") {
-        return std::borrow::Cow::Owned(format!(r"\\{unc}"));
-    }
-    if let Some(local) = path.strip_prefix(r"\\?\") {
-        let bytes = local.as_bytes();
-        if bytes.len() >= 3
-            && bytes[0].is_ascii_alphabetic()
-            && bytes[1] == b':'
-            && bytes[2] == b'\\'
-        {
-            return std::borrow::Cow::Borrowed(local);
-        }
-    }
-    std::borrow::Cow::Borrowed(path)
-}
-
 #[cfg(feature = "yaml")]
 fn validate_tools(section: &str, tools: Vec<String>) -> Result<HashSet<String>, String> {
     let mut validated = HashSet::new();
@@ -1384,85 +1358,6 @@ fn now_unix_ms() -> u128 {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn windows_executable_paths_match_equivalent_spellings() {
-        assert!(application_executables_match(
-            r"\\?\C:\Program Files\Cua\cua-driver.exe",
-            r"C:\Program Files\Cua\cua-driver.exe"
-        ));
-        assert!(application_executables_match(
-            r"\\?\UNC\server\share\Cua\cua-driver.exe",
-            r"\\server\share\Cua\cua-driver.exe"
-        ));
-        assert!(application_executables_match(
-            r"C:\Program Files\Cua\cua-driver.exe",
-            r"C:\Program Files\Cua\cua-driver.exe"
-        ));
-    }
-
-    #[test]
-    fn windows_executable_paths_keep_distinct_files_separate() {
-        assert!(!application_executables_match(
-            r"\\?\C:\Program Files\Cua\cua-driver.exe",
-            r"C:\Program Files\Other\cua-driver.exe"
-        ));
-        assert!(!application_executables_match(
-            r"\\.\C:\Program Files\Cua\cua-driver.exe",
-            r"C:\Program Files\Cua\cua-driver.exe"
-        ));
-        assert!(!application_executables_match(
-            r"\\?\GLOBALROOT\Device\HarddiskVolume1\cua-driver.exe",
-            r"GLOBALROOT\Device\HarddiskVolume1\cua-driver.exe"
-        ));
-        assert!(!application_executables_match(
-            r"\\?\C:cua-driver.exe",
-            r"C:cua-driver.exe"
-        ));
-        assert!(!application_executables_match(
-            r"\\?\UNC\server\share\Cua\cua-driver.exe",
-            r"\\server\other\Cua\cua-driver.exe"
-        ));
-    }
-
-    #[cfg(feature = "yaml")]
-    #[test]
-    fn application_grants_accept_equivalent_windows_runtime_paths() {
-        let executable = std::fs::canonicalize(std::env::current_exe().unwrap()).unwrap();
-        let executable_yaml = serde_json::to_string(&executable.to_string_lossy()).unwrap();
-        let mut loaded = manifest(&format!(
-            r#"
-version: 2
-mode: bounded
-expires_after: 8h
-idle_timeout: 30m
-resources:
-  apps:
-    - executable: {executable_yaml}
-      windows: all
-allow:
-  tools: [get_window_state]
-"#
-        ))
-        .unwrap();
-        loaded.applications[0].executable =
-            Some(r"\\?\C:\Program Files\Cua\cua-driver.exe".to_owned());
-
-        loaded
-            .authorize_protected_resource(
-                "private_observation",
-                &serde_json::json!({
-                    "kind": "window",
-                    "pid": 42,
-                    "window_id": 7,
-                    "fingerprint": {
-                        "pid": 42,
-                        "executable": r"C:\Program Files\Cua\cua-driver.exe"
-                    }
-                }),
-            )
-            .unwrap();
-    }
 
     #[cfg(feature = "yaml")]
     fn manifest(source: &str) -> Result<SessionManifest, String> {

--- a/libs/cua-driver/rust/crates/platform-windows/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/browser_platform.rs
@@ -698,7 +698,8 @@ fn process_identity(pid: u32) -> Result<(u64, Option<String>), BrowserRefusal> {
     }
     .ok()
     .filter(|_| path_len > 0)
-    .map(|_| String::from_utf16_lossy(&path_buf[..path_len as usize]));
+    .map(|_| String::from_utf16_lossy(&path_buf[..path_len as usize]))
+    .map(canonical_process_executable);
     let _ = unsafe { CloseHandle(handle) };
     times.map_err(|error| {
         refusal(
@@ -708,6 +709,14 @@ fn process_identity(pid: u32) -> Result<(u64, Option<String>), BrowserRefusal> {
     })?;
     let started = (u64::from(created.dwHighDateTime) << 32) | u64::from(created.dwLowDateTime);
     Ok((started, path))
+}
+
+fn canonical_process_executable(path: String) -> String {
+    // Manifest executable grants use `canonicalize` too. Normalize the Windows
+    // process evidence at collection time so shared authorization stays exact.
+    std::fs::canonicalize(&path)
+        .map(|canonical| canonical.to_string_lossy().into_owned())
+        .unwrap_or(path)
 }
 
 fn cdp_comparable_window_bounds(window_id: u64) -> Result<Rect, BrowserRefusal> {
@@ -1919,6 +1928,18 @@ impl BrowserPlatform for WindowsBrowserPlatform {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn process_fingerprint_uses_manifest_canonical_executable_path() {
+        let (_started, executable) =
+            process_identity(std::process::id()).expect("current process fingerprint");
+        let expected = std::fs::canonicalize(std::env::current_exe().expect("current executable"))
+            .expect("canonical current executable")
+            .to_string_lossy()
+            .into_owned();
+
+        assert_eq!(executable.as_deref(), Some(expected.as_str()));
+    }
 
     #[test]
     fn isolated_browser_candidates_are_vendor_attested_protected_installs() {


### PR DESCRIPTION
## Problem

Windows stores an executable grant from `std::fs::canonicalize` in verbatim `\\?\...` form, while the live process fingerprint uses ordinary Win32 spelling. The bounded-session check compares those strings directly, so it refuses the exact executable named by the manifest.

## Change

- Canonicalize the executable reported by Windows when the process fingerprint is collected, using the same filesystem operation as manifest loading.
- Keep shared authorization on exact identity matching; if canonicalization is unavailable, preserve the original fingerprint instead of inventing an equivalent path.
- Add a Windows-native regression that fingerprints the live test process and compares it with the canonical current executable.

## Tests

- `cargo test -p cua-driver-core --locked` (584 unit, 2 contract-parity, and 3 session-lifecycle tests passed; 1 doctest ignored)
- `cargo test -p platform-windows --locked` on macOS (42 host-safe tests passed)
- `cargo fmt --all -- --check`
- `git diff --check upstream/main...HEAD`

The Windows-native regression is committed, but the fork workflow is still waiting for maintainer approval, so this remains a draft.

Fixes #3196
