### PR TITLE
Add semantic macOS menu-extra automation

### DIFF
--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -12,7 +12,7 @@ description: Reference for every MCP tool Cua Driver exposes
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-`cua-driver` exposes 56 MCP tools through a single stdio server (`cua-driver mcp`). Every tool is also callable from the shell as `cua-driver <name> '<JSON-args>'`.
+`cua-driver` exposes 58 MCP tools through a single stdio server (`cua-driver mcp`). Every tool is also callable from the shell as `cua-driver <name> '<JSON-args>'`.
 
 Tool names are `snake_case`. Responses are MCP `CallTool.Result` envelopes: a text content block prefixed with a `✅` summary (or the error reason on failure), plus optional image or structured-content blocks on tools that produce them. See the [CLI reference](/reference/cua-driver/cli-reference) for CLI-specific options like `--socket` and `--screenshot-out-file`.
 
@@ -844,6 +844,41 @@ accepts it. Omit it to use the authenticated transport's implicit lifecycle sess
 
 ```json
 {"path":["example"],"pid":844,"window_id":10725}
+```
+
+### `get_menu_extra_state`
+
+Read one exact running application's bounded macOS accessibility extras-menu hierarchy without screenshots, action-cache writes, or pixel fallback.
+
+**Arguments:**
+
+- `application` (pid target or bundle_id target, required): Exact running application whose macOS accessibility extras menu bar is
+observed or invoked. Bundle identifiers must resolve to exactly one running
+process; the driver never launches an application while resolving a target.
+- `max_depth` (integer, optional): range: 1–25
+- `max_elements` (integer, optional): range: 1–2000
+- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that
+accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+
+```json
+{"application":{"kind":"pid","pid":844}}
+```
+
+### `invoke_menu_extra`
+
+Resolve an exact macOS accessibility extras-menu path from live native state and invoke it without activating an application window or falling back to pixels.
+
+**Arguments:**
+
+- `application` (pid target or bundle_id target, required): Exact running application whose macOS accessibility extras menu bar is
+observed or invoked. Bundle identifiers must resolve to exactly one running
+process; the driver never launches an application while resolving a target.
+- `path` (array of string, required): items: 1–16
+- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that
+accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+
+```json
+{"application":{"kind":"pid","pid":844},"path":["example"]}
 ```
 
 ### `set_agent_cursor_theme`

--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -866,7 +866,7 @@ accepts it. Omit it to use the authenticated transport's implicit lifecycle sess
 
 ### `invoke_menu_extra`
 
-Resolve an exact macOS accessibility extras-menu path from live native state and invoke it without activating an application window or falling back to pixels.
+Resolve an exact macOS accessibility extras-menu path, including a same-process popup surface opened by the menu extra, and invoke it without activating an application window or falling back to pixels.
 
 **Arguments:**
 

--- a/libs/cua-driver/contract/manifest.json
+++ b/libs/cua-driver/contract/manifest.json
@@ -1163,6 +1163,187 @@
       }
     },
     {
+      "name": "get_menu_extra_state",
+      "description": "Read one exact running application's bounded macOS accessibility extras-menu hierarchy without screenshots, action-cache writes, or pixel fallback.",
+      "platforms": [
+        "macos"
+      ],
+      "capabilities": [
+        "accessibility.menu_extra.observe"
+      ],
+      "annotations": {
+        "read_only": true,
+        "destructive": false,
+        "idempotent": false,
+        "open_world": false
+      },
+      "schema_mode": "canonical_runtime",
+      "cursor_semantics": {
+        "action": "observe"
+      },
+      "input_schema": {
+        "additionalProperties": false,
+        "description": "Read one exact running application's macOS `AXExtrasMenuBar` hierarchy.",
+        "properties": {
+          "application": {
+            "description": "Exact running application whose macOS accessibility extras menu bar is\nobserved or invoked. Bundle identifiers must resolve to exactly one running\nprocess; the driver never launches an application while resolving a target.",
+            "oneOf": [
+              {
+                "additionalProperties": true,
+                "properties": {
+                  "kind": {
+                    "const": "pid",
+                    "type": "string"
+                  },
+                  "pid": {
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "pid"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": true,
+                "properties": {
+                  "bundle_id": {
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "kind": {
+                    "const": "bundle_id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "bundle_id"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "max_depth": {
+            "maximum": 25,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "max_elements": {
+            "maximum": 2000,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "session": {
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "application"
+        ],
+        "type": "object"
+      },
+      "success_output_schema": {
+        "additionalProperties": true,
+        "properties": {
+          "bundle_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "content_redacted_from_telemetry": {
+            "type": "boolean"
+          },
+          "node_count": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "nodes": {
+            "items": {
+              "properties": {
+                "actions": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "depth": {
+                  "format": "uint32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "enabled": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "label": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "role": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "depth",
+                "role",
+                "label",
+                "title",
+                "description",
+                "enabled",
+                "actions"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "pid": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "privacy_sensitive": {
+            "type": "boolean"
+          },
+          "truncated": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "pid",
+          "bundle_id",
+          "nodes",
+          "node_count",
+          "truncated",
+          "privacy_sensitive",
+          "content_redacted_from_telemetry"
+        ],
+        "type": "object"
+      }
+    },
+    {
       "name": "get_screen_size",
       "description": "Return the primary display dimensions and scale factor in the platform's desktop coordinate space.",
       "platforms": [
@@ -1681,6 +1862,207 @@
         "required": [
           "pid",
           "window_id",
+          "path"
+        ],
+        "type": "object"
+      },
+      "success_output_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "delivery": {
+            "additionalProperties": false,
+            "properties": {
+              "delivered_count": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "mode": {
+                "enum": [
+                  "background",
+                  "foreground",
+                  "not_applicable",
+                  "unknown"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "mode"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "effect": {
+            "enum": [
+              "confirmed",
+              "partial",
+              "unverifiable",
+              "suspected_noop",
+              "refused"
+            ],
+            "type": "string"
+          },
+          "escalation": {
+            "additionalProperties": false,
+            "properties": {
+              "reason": {
+                "enum": [
+                  "route_unavailable",
+                  "delivery_failed",
+                  "effect_unconfirmed",
+                  "suspected_noop",
+                  "permission_required"
+                ],
+                "type": "string"
+              },
+              "target": {
+                "enum": [
+                  "pixel",
+                  "foreground",
+                  "page",
+                  "session"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "target",
+              "reason"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "evidence": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "value_readback",
+                    "window_change"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "route": {
+            "enum": [
+              "accessibility",
+              "synthetic_events",
+              "global_input",
+              "system_api",
+              "dom",
+              "trusted_input"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "effect",
+          "route"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "invoke_menu_extra",
+      "description": "Resolve an exact macOS accessibility extras-menu path from live native state and invoke it without activating an application window or falling back to pixels.",
+      "platforms": [
+        "macos"
+      ],
+      "capabilities": [
+        "accessibility.menu_extra.invoke"
+      ],
+      "annotations": {
+        "read_only": false,
+        "destructive": true,
+        "idempotent": false,
+        "open_world": true
+      },
+      "schema_mode": "canonical_runtime",
+      "cursor_semantics": {
+        "action": "system"
+      },
+      "input_schema": {
+        "additionalProperties": false,
+        "description": "Invoke an exact, immediate-child path under one running application's\nmacOS `AXExtrasMenuBar` hierarchy.",
+        "properties": {
+          "application": {
+            "description": "Exact running application whose macOS accessibility extras menu bar is\nobserved or invoked. Bundle identifiers must resolve to exactly one running\nprocess; the driver never launches an application while resolving a target.",
+            "oneOf": [
+              {
+                "additionalProperties": true,
+                "properties": {
+                  "kind": {
+                    "const": "pid",
+                    "type": "string"
+                  },
+                  "pid": {
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "pid"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": true,
+                "properties": {
+                  "bundle_id": {
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "kind": {
+                    "const": "bundle_id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "bundle_id"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "path": {
+            "items": {
+              "maxLength": 200,
+              "minLength": 1,
+              "type": "string"
+            },
+            "maxItems": 16,
+            "minItems": 1,
+            "type": "array"
+          },
+          "session": {
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "application",
           "path"
         ],
         "type": "object"

--- a/libs/cua-driver/contract/manifest.json
+++ b/libs/cua-driver/contract/manifest.json
@@ -1983,7 +1983,7 @@
     },
     {
       "name": "invoke_menu_extra",
-      "description": "Resolve an exact macOS accessibility extras-menu path from live native state and invoke it without activating an application window or falling back to pixels.",
+      "description": "Resolve an exact macOS accessibility extras-menu path, including a same-process popup surface opened by the menu extra, and invoke it without activating an application window or falling back to pixels.",
       "platforms": [
         "macos"
       ],
@@ -2002,7 +2002,7 @@
       },
       "input_schema": {
         "additionalProperties": false,
-        "description": "Invoke an exact, immediate-child path under one running application's\nmacOS `AXExtrasMenuBar` hierarchy.",
+        "description": "Invoke an exact path through one running application's macOS\n`AXExtrasMenuBar` and any same-process popup surface it opens.",
         "properties": {
           "application": {
             "description": "Exact running application whose macOS accessibility extras menu bar is\nobserved or invoked. Bundle identifiers must resolve to exactly one running\nprocess; the driver never launches an application while resolving a target.",

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/cursor.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/cursor.rs
@@ -205,6 +205,7 @@ pub fn classify_cursor_semantics(name: &str, args: &Value) -> Option<CursorSeman
     let action = match name {
         "get_desktop_state"
         | "get_window_state"
+        | "get_menu_extra_state"
         | "get_accessibility_tree"
         | "get_ax_tree"
         | "get_screen_size"
@@ -244,9 +245,9 @@ pub fn classify_cursor_semantics(name: &str, args: &Value) -> Option<CursorSeman
         }
 
         "start_session" | "escalate_session" | "get_session_state" | "end_session"
-        | "check_permissions" | "get_config" | "set_config" | "health_report"
-        | "browser_prepare" | "browser_close" | "browser_release" | "browser_activate"
-        | "install_ffmpeg" | "check_update" | "update" => CursorAction::System,
+        | "invoke_menu_extra" | "check_permissions" | "get_config" | "set_config"
+        | "health_report" | "browser_prepare" | "browser_close" | "browser_release"
+        | "browser_activate" | "install_ffmpeg" | "check_update" | "update" => CursorAction::System,
 
         "set_agent_cursor_enabled"
         | "set_agent_cursor_motion"
@@ -257,7 +258,10 @@ pub fn classify_cursor_semantics(name: &str, args: &Value) -> Option<CursorSeman
 
     let target = if name.starts_with("browser_") {
         Some(CursorTarget::Browser)
-    } else if matches!(name, "set_window_frame" | "invoke_menu") {
+    } else if matches!(
+        name,
+        "set_window_frame" | "invoke_menu" | "invoke_menu_extra"
+    ) {
         Some(CursorTarget::Desktop)
     } else if args
         .get("element_index")

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/desktop.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/desktop.rs
@@ -10,10 +10,10 @@
 use crate::{
     ActionResult, ClickInput, ClipboardReadInput, ClipboardReadOutput, ClipboardWriteInput,
     ClipboardWriteOutput, CursorAction, CursorPositionOutput, CursorSemantics, DesktopStateOutput,
-    DragInput, GetCursorPositionInput, GetDesktopStateInput, GetScreenSizeInput, HotkeyInput,
-    InvokeMenuInput, MoveCursorInput, Platform, PressKeyInput, SchemaMode, ScreenSizeOutput,
-    ScrollInput, SetWindowFrameInput, ToolAnnotations, ToolContract, ToolInput, ToolOutput,
-    TypeTextInput,
+    DragInput, GetCursorPositionInput, GetDesktopStateInput, GetMenuExtraStateInput,
+    GetScreenSizeInput, HotkeyInput, InvokeMenuExtraInput, InvokeMenuInput, MenuExtraStateOutput,
+    MoveCursorInput, Platform, PressKeyInput, SchemaMode, ScreenSizeOutput, ScrollInput,
+    SetWindowFrameInput, ToolAnnotations, ToolContract, ToolInput, ToolOutput, TypeTextInput,
 };
 
 const ALL_PLATFORMS: [Platform; 3] = [Platform::Macos, Platform::Windows, Platform::Linux];
@@ -26,6 +26,8 @@ pub fn contracts() -> Vec<ToolContract> {
         move_cursor(),
         set_window_frame(),
         invoke_menu(),
+        get_menu_extra_state(),
+        invoke_menu_extra(),
         click(),
         drag(),
         scroll(),
@@ -142,6 +144,20 @@ fn contract<I: ToolInput, O: ToolOutput>(
     }
 }
 
+fn macos_contract<I: ToolInput, O: ToolOutput>(
+    name: &str,
+    description: &str,
+    capabilities: &[&str],
+    annotations: ToolAnnotations,
+    cursor_action: CursorAction,
+) -> ToolContract {
+    let mut contract =
+        contract::<I, O>(name, description, capabilities, annotations, cursor_action);
+    contract.platforms = vec![Platform::Macos];
+    contract.schema_mode = SchemaMode::CanonicalRuntime;
+    contract
+}
+
 fn get_desktop_state() -> ToolContract {
     contract::<GetDesktopStateInput, DesktopStateOutput>(
         "get_desktop_state",
@@ -229,6 +245,36 @@ fn invoke_menu() -> ToolContract {
             open_world: true,
         },
         CursorAction::App,
+    )
+}
+
+fn get_menu_extra_state() -> ToolContract {
+    macos_contract::<GetMenuExtraStateInput, MenuExtraStateOutput>(
+        "get_menu_extra_state",
+        "Read one exact running application's bounded macOS accessibility extras-menu hierarchy without screenshots, action-cache writes, or pixel fallback.",
+        &["accessibility.menu_extra.observe"],
+        ToolAnnotations {
+            read_only: true,
+            destructive: false,
+            idempotent: false,
+            open_world: false,
+        },
+        CursorAction::Observe,
+    )
+}
+
+fn invoke_menu_extra() -> ToolContract {
+    macos_contract::<InvokeMenuExtraInput, ActionResult>(
+        "invoke_menu_extra",
+        "Resolve an exact macOS accessibility extras-menu path from live native state and invoke it without activating an application window or falling back to pixels.",
+        &["accessibility.menu_extra.invoke"],
+        ToolAnnotations {
+            read_only: false,
+            destructive: true,
+            idempotent: false,
+            open_world: true,
+        },
+        CursorAction::System,
     )
 }
 

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/desktop.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/desktop.rs
@@ -266,7 +266,7 @@ fn get_menu_extra_state() -> ToolContract {
 fn invoke_menu_extra() -> ToolContract {
     macos_contract::<InvokeMenuExtraInput, ActionResult>(
         "invoke_menu_extra",
-        "Resolve an exact macOS accessibility extras-menu path from live native state and invoke it without activating an application window or falling back to pixels.",
+        "Resolve an exact macOS accessibility extras-menu path, including a same-process popup surface opened by the menu extra, and invoke it without activating an application window or falling back to pixels.",
         &["accessibility.menu_extra.invoke"],
         ToolAnnotations {
             read_only: false,

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/inputs.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/inputs.rs
@@ -606,8 +606,8 @@ impl ToolInput for GetMenuExtraStateInput {
     const TOOL_NAME: &'static str = "get_menu_extra_state";
 }
 
-/// Invoke an exact, immediate-child path under one running application's
-/// macOS `AXExtrasMenuBar` hierarchy.
+/// Invoke an exact path through one running application's macOS
+/// `AXExtrasMenuBar` and any same-process popup surface it opens.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, uniffi::Record)]
 #[serde(deny_unknown_fields)]
 pub struct InvokeMenuExtraInput {

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/inputs.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/inputs.rs
@@ -75,6 +75,18 @@ fn menu_path_schema(_: &mut SchemaGenerator) -> Schema {
     })
 }
 
+fn bundle_identifier_schema(_: &mut SchemaGenerator) -> Schema {
+    json_schema!({ "type": "string", "minLength": 1, "maxLength": 255 })
+}
+
+fn menu_extra_max_depth_schema(_: &mut SchemaGenerator) -> Schema {
+    json_schema!({ "type": "integer", "minimum": 1, "maximum": 25 })
+}
+
+fn menu_extra_max_elements_schema(_: &mut SchemaGenerator) -> Schema {
+    json_schema!({ "type": "integer", "minimum": 1, "maximum": 2000 })
+}
+
 fn number_schema(_: &mut SchemaGenerator) -> Schema {
     json_schema!({ "type": "number" })
 }
@@ -554,6 +566,63 @@ pub struct InvokeMenuInput {
 
 impl ToolInput for InvokeMenuInput {
     const TOOL_NAME: &'static str = "invoke_menu";
+}
+
+/// Exact running application whose macOS accessibility extras menu bar is
+/// observed or invoked. Bundle identifiers must resolve to exactly one running
+/// process; the driver never launches an application while resolving a target.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, uniffi::Enum)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MenuExtraTarget {
+    Pid {
+        #[schemars(schema_with = "positive_integer_schema")]
+        pid: u32,
+    },
+    BundleId {
+        #[schemars(schema_with = "bundle_identifier_schema")]
+        bundle_id: String,
+    },
+}
+
+/// Read one exact running application's macOS `AXExtrasMenuBar` hierarchy.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, uniffi::Record)]
+#[serde(deny_unknown_fields)]
+pub struct GetMenuExtraStateInput {
+    pub application: MenuExtraTarget,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "menu_extra_max_depth_schema")]
+    pub max_depth: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "menu_extra_max_elements_schema")]
+    pub max_elements: Option<u32>,
+    /// For multi-call work, prefer a short public session label and repeat it on every call that
+    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "string_schema")]
+    pub session: Option<String>,
+}
+
+impl ToolInput for GetMenuExtraStateInput {
+    const TOOL_NAME: &'static str = "get_menu_extra_state";
+}
+
+/// Invoke an exact, immediate-child path under one running application's
+/// macOS `AXExtrasMenuBar` hierarchy.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, uniffi::Record)]
+#[serde(deny_unknown_fields)]
+pub struct InvokeMenuExtraInput {
+    pub application: MenuExtraTarget,
+    #[schemars(schema_with = "menu_path_schema")]
+    pub path: Vec<String>,
+    /// For multi-call work, prefer a short public session label and repeat it on every call that
+    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "string_schema")]
+    pub session: Option<String>,
+}
+
+impl ToolInput for InvokeMenuExtraInput {
+    const TOOL_NAME: &'static str = "invoke_menu_extra";
 }
 
 impl ToolInput for MoveCursorInput {

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/lib.rs
@@ -30,11 +30,11 @@ pub use inputs::{
     action_target_schema, ActionTarget, CaptureScope, ClickButton, ClickInput, ClipboardReadInput,
     ClipboardWriteInput, DesktopScope, DragInput, EndSessionInput, EscalateSessionInput,
     EscalationReason, GetAgentCursorStateInput, GetCursorPositionInput, GetDesktopStateInput,
-    GetScreenSizeInput, GetSessionInput, GetSessionStateInput, HotkeyInput, InvokeMenuInput,
-    ListSessionsInput, MoveCursorInput, PressKeyInput, ScrollBy, ScrollDirection, ScrollInput,
-    SetAgentCursorEnabledInput, SetAgentCursorMotionInput, SetAgentCursorThemeInput,
-    SetWindowFrameInput, StartSessionInput, ToolInput, TypeTextInput,
-    MULTI_CALL_SESSION_DESCRIPTION,
+    GetMenuExtraStateInput, GetScreenSizeInput, GetSessionInput, GetSessionStateInput, HotkeyInput,
+    InvokeMenuExtraInput, InvokeMenuInput, ListSessionsInput, MenuExtraTarget, MoveCursorInput,
+    PressKeyInput, ScrollBy, ScrollDirection, ScrollInput, SetAgentCursorEnabledInput,
+    SetAgentCursorMotionInput, SetAgentCursorThemeInput, SetWindowFrameInput, StartSessionInput,
+    ToolInput, TypeTextInput, MULTI_CALL_SESSION_DESCRIPTION,
 };
 pub use outputs::{
     advertised_output_schema, refusal_envelope_schema, ActionDelivery, ActionDeliveryMode,
@@ -43,9 +43,10 @@ pub use outputs::{
     ClipboardReadOutput, ClipboardWriteOutput, CursorMotionOutput, CursorPointOutput,
     CursorPositionOutput, CursorThemeOutput, CursorVisualOutput, DesktopStateOutput,
     EffectiveScope, EndSessionOutput, GetAgentCursorStateOutput, ListSessionsOutput,
-    ScreenSizeOutput, SessionClientKindOutput, SessionLifecycleState, SessionOutput,
-    SessionStateOutput, SessionTransportOutput, SetAgentCursorEnabledOutput,
-    SetAgentCursorMotionOutput, SetAgentCursorThemeOutput, StartSessionOutput, ToolOutput,
+    MenuExtraNodeOutput, MenuExtraStateOutput, ScreenSizeOutput, SessionClientKindOutput,
+    SessionLifecycleState, SessionOutput, SessionStateOutput, SessionTransportOutput,
+    SetAgentCursorEnabledOutput, SetAgentCursorMotionOutput, SetAgentCursorThemeOutput,
+    StartSessionOutput, ToolOutput,
 };
 pub use verification::{
     BoundsExpectation, ElementPredicate, ElementSelector, PredicateOutcome, StatePredicate,
@@ -87,6 +88,7 @@ pub const ACTION_RESULT_TOOLS: &[&str] = &[
     "set_value",
     "set_window_frame",
     "invoke_menu",
+    "invoke_menu_extra",
     "browser_click",
     "browser_pointer",
     "browser_type",
@@ -357,7 +359,9 @@ mod tests {
             "get_desktop_state",
             "get_screen_size",
             "hotkey",
+            "get_menu_extra_state",
             "invoke_menu",
+            "invoke_menu_extra",
             "move_cursor",
             "press_key",
             "scroll",
@@ -469,6 +473,48 @@ mod tests {
             contract.capabilities,
             vec!["menu.path.invoke", "accessibility.menu.native"]
         );
+    }
+
+    #[test]
+    fn menu_extra_tools_are_macos_only_bounded_and_separately_capable() {
+        let observe = tool_contract("get_menu_extra_state").expect("menu extra state contract");
+        assert_eq!(observe.platforms, vec![Platform::Macos]);
+        assert_eq!(observe.schema_mode, SchemaMode::CanonicalRuntime);
+        assert!(observe.annotations.read_only);
+        assert_eq!(
+            observe.input_schema["required"],
+            serde_json::json!(["application"])
+        );
+        assert!(observe.input_schema["properties"].get("target").is_none());
+        assert!(observe.input_schema["properties"]["application"]["oneOf"].is_array());
+        assert_eq!(
+            observe.capabilities,
+            vec!["accessibility.menu_extra.observe"]
+        );
+        assert_eq!(
+            observe.input_schema["properties"]["max_depth"]["maximum"],
+            serde_json::json!(25)
+        );
+        assert_eq!(
+            observe.input_schema["properties"]["max_elements"]["maximum"],
+            serde_json::json!(2000)
+        );
+
+        let invoke = tool_contract("invoke_menu_extra").expect("menu extra action contract");
+        assert_eq!(invoke.platforms, vec![Platform::Macos]);
+        assert_eq!(invoke.schema_mode, SchemaMode::CanonicalRuntime);
+        assert!(!invoke.annotations.read_only);
+        assert!(invoke.annotations.destructive);
+        assert_eq!(
+            invoke.input_schema["required"],
+            serde_json::json!(["application", "path"])
+        );
+        assert!(invoke.input_schema["properties"].get("target").is_none());
+        assert_eq!(invoke.capabilities, vec!["accessibility.menu_extra.invoke"]);
+        let path = &invoke.input_schema["properties"]["path"];
+        assert_eq!(path["minItems"], serde_json::json!(1));
+        assert_eq!(path["maxItems"], serde_json::json!(16));
+        assert!(is_action_result_tool("invoke_menu_extra"));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/outputs.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/outputs.rs
@@ -384,6 +384,50 @@ pub struct ClipboardWriteOutput {
     pub content_redacted_from_telemetry: bool,
 }
 
+/// One accessibility node in a bounded, depth-first menu-extra snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, uniffi::Record)]
+pub struct MenuExtraNodeOutput {
+    pub depth: u32,
+    pub role: String,
+    #[schemars(required, schema_with = "nullable_string_schema")]
+    pub label: Option<String>,
+    #[schemars(required, schema_with = "nullable_string_schema")]
+    pub title: Option<String>,
+    #[schemars(required, schema_with = "nullable_string_schema")]
+    pub description: Option<String>,
+    #[schemars(required, schema_with = "nullable_boolean_schema")]
+    pub enabled: Option<bool>,
+    pub actions: Vec<String>,
+}
+
+/// Successful bounded observation of a macOS accessibility extras menu bar.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, uniffi::Record)]
+pub struct MenuExtraStateOutput {
+    pub pid: u32,
+    #[schemars(required, schema_with = "nullable_string_schema")]
+    pub bundle_id: Option<String>,
+    pub nodes: Vec<MenuExtraNodeOutput>,
+    pub node_count: u32,
+    pub truncated: bool,
+    pub privacy_sensitive: bool,
+    pub content_redacted_from_telemetry: bool,
+}
+
+impl ToolOutput for MenuExtraStateOutput {
+    fn validate(&self) -> Result<(), String> {
+        if self.pid == 0 {
+            return Err("pid must be positive".into());
+        }
+        if usize::try_from(self.node_count).ok() != Some(self.nodes.len()) {
+            return Err("node_count must equal nodes.len()".into());
+        }
+        if !self.privacy_sensitive || !self.content_redacted_from_telemetry {
+            return Err("menu-extra privacy metadata must remain enabled".into());
+        }
+        Ok(())
+    }
+}
+
 impl ToolOutput for ClipboardWriteOutput {
     fn validate(&self) -> Result<(), String> {
         if !self.supported {
@@ -577,6 +621,10 @@ fn platform_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
 
 fn nullable_string_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
     schemars::json_schema!({ "anyOf": [{ "type": "string" }, { "type": "null" }] })
+}
+
+fn nullable_boolean_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({ "anyOf": [{ "type": "boolean" }, { "type": "null" }] })
 }
 
 fn nullable_escalation_reason_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/authorization.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/authorization.rs
@@ -911,6 +911,8 @@ pub fn advertised_risk_for(tool: &str) -> RiskAssessment {
         | "debug_window_info"
         | "check_permissions"
         | "get_accessibility_tree"
+        | "get_menu_extra_state"
+        | "invoke_menu_extra"
         | "verify_state"
         | "set_config"
         | "escalate_session"
@@ -1557,6 +1559,24 @@ mod tests {
         assert_eq!(risk.class, RiskClass::R1);
         assert_eq!(risk.enforcement, RiskEnforcement::MetadataOnly);
         assert!(!risk.operation_sensitive);
+    }
+
+    #[test]
+    fn menu_extra_access_is_explicit_sensitive_system_ui_risk() {
+        for tool in ["get_menu_extra_state", "invoke_menu_extra"] {
+            let risk = advertised_risk_for(tool);
+            assert_eq!(risk.class, RiskClass::R2);
+            assert_eq!(risk.enforcement, RiskEnforcement::MetadataOnly);
+            assert!(risk.operation_sensitive);
+        }
+        assert_eq!(
+            crate::tool::default_capabilities_for("get_menu_extra_state"),
+            ["accessibility.menu_extra.observe"]
+        );
+        assert_eq!(
+            crate::tool::default_capabilities_for("invoke_menu_extra"),
+            ["accessibility.menu_extra.invoke"]
+        );
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -4700,6 +4700,15 @@ fn recording_args_for(tool_name: &str, args: &Value) -> Value {
                     }
                 }
             }
+            "invoke_menu_extra" => {
+                if let Some(count) = arguments
+                    .get("path")
+                    .and_then(Value::as_array)
+                    .map(Vec::len)
+                {
+                    arguments.insert("path".to_owned(), serde_json::json!({ "count": count }));
+                }
+            }
             "browser_set_input_files" => {
                 if let Some(count) = arguments
                     .get("files")
@@ -4867,6 +4876,25 @@ mod capability_tests {
         ] {
             assert!(!serialized.contains(forbidden));
         }
+    }
+
+    #[test]
+    fn menu_extra_recording_args_are_account_label_free() {
+        let recorded = recording_args_for(
+            "invoke_menu_extra",
+            &serde_json::json!({
+                "application": {"kind": "bundle_id", "bundle_id": "com.apple.controlcenter"},
+                "path": ["User Switcher", "Private Account Name"],
+                "session": "public-session",
+            }),
+        );
+        assert_eq!(recorded["path"], serde_json::json!({"count": 2}));
+        assert_eq!(
+            recorded["application"]["bundle_id"],
+            "com.apple.controlcenter"
+        );
+        assert_eq!(recorded["session"], "public-session");
+        assert!(!recorded.to_string().contains("Private Account Name"));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/lib.rs
@@ -8,11 +8,12 @@
 use cua_driver_contract::{
     ActionResult, ClickInput, ClipboardReadInput, ClipboardWriteInput, DragInput, EndSessionInput,
     EndSessionOutput, EscalateSessionInput, GetAgentCursorStateInput, GetCursorPositionInput,
-    GetDesktopStateInput, GetScreenSizeInput, GetSessionInput, GetSessionStateInput, HotkeyInput,
-    InvokeMenuInput, ListSessionsInput, ListSessionsOutput, MoveCursorInput, PressKeyInput,
-    ScrollInput, SessionOutput, SessionStateOutput, SetAgentCursorEnabledInput,
-    SetAgentCursorMotionInput, SetAgentCursorThemeInput, SetWindowFrameInput, StartSessionInput,
-    StartSessionOutput, ToolInput, TypeTextInput, VerifyStateInput, VerifyStateOutput,
+    GetDesktopStateInput, GetMenuExtraStateInput, GetScreenSizeInput, GetSessionInput,
+    GetSessionStateInput, HotkeyInput, InvokeMenuExtraInput, InvokeMenuInput, ListSessionsInput,
+    ListSessionsOutput, MoveCursorInput, PressKeyInput, ScrollInput, SessionOutput,
+    SessionStateOutput, SetAgentCursorEnabledInput, SetAgentCursorMotionInput,
+    SetAgentCursorThemeInput, SetWindowFrameInput, StartSessionInput, StartSessionOutput,
+    ToolInput, TypeTextInput, VerifyStateInput, VerifyStateOutput,
 };
 use cua_driver_core::daemon::{
     is_daemon_listening, request_daemon_metadata, send_request, socket_path_for_namespace,
@@ -635,6 +636,8 @@ macro_rules! desktop_tool_methods {
             move_cursor: MoveCursorInput,
             set_window_frame: SetWindowFrameInput,
             invoke_menu: InvokeMenuInput,
+            get_menu_extra_state: GetMenuExtraStateInput,
+            invoke_menu_extra: InvokeMenuExtraInput,
             click: ClickInput,
             drag: DragInput,
             scroll: ScrollInput,

--- a/libs/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
@@ -44,6 +44,31 @@ pub fn list_running_apps() -> Vec<AppInfo> {
     list_running_apps_native()
 }
 
+/// Return every live process with exactly this bundle identifier, including
+/// accessory and background-only applications omitted from `list_running_apps`.
+pub fn running_pids_for_bundle(bundle_id: &str) -> Vec<i32> {
+    use objc2::rc::Retained;
+    use objc2_app_kit::NSRunningApplication;
+    use objc2_foundation::NSString;
+
+    let bundle_id = NSString::from_str(bundle_id);
+    let running: Retained<objc2_foundation::NSArray<NSRunningApplication>> =
+        unsafe { NSRunningApplication::runningApplicationsWithBundleIdentifier(&bundle_id) };
+    let mut pids = Vec::new();
+    unsafe {
+        for index in 0..running.count() {
+            let app = running.objectAtIndex(index);
+            let pid = app.processIdentifier();
+            if pid > 0 && !app.isTerminated() {
+                pids.push(pid);
+            }
+        }
+    }
+    pids.sort_unstable();
+    pids.dedup();
+    pids
+}
+
 fn list_running_apps_native() -> Vec<AppInfo> {
     use objc2_app_kit::{NSApplicationActivationPolicy, NSWorkspace};
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
@@ -55,6 +55,18 @@ extern "C" {
         attribute: CFStringRef,
         value: *mut CFTypeRef,
     ) -> AXError;
+    pub fn AXUIElementGetAttributeValueCount(
+        element: AXUIElementRef,
+        attribute: CFStringRef,
+        count: *mut isize,
+    ) -> AXError;
+    pub fn AXUIElementCopyAttributeValues(
+        element: AXUIElementRef,
+        attribute: CFStringRef,
+        index: isize,
+        max_values: isize,
+        values: *mut CFArrayRef,
+    ) -> AXError;
     pub fn AXUIElementCopyAttributeNames(
         element: AXUIElementRef,
         names: *mut CFArrayRef,
@@ -82,6 +94,7 @@ extern "C" {
         timeout_in_seconds: f32,
     ) -> AXError;
     pub fn AXUIElementGetTypeID() -> CFTypeID;
+    pub fn AXUIElementGetPid(element: AXUIElementRef, pid: *mut i32) -> AXError;
     pub fn AXIsProcessTrusted() -> bool;
     /// `AXIsProcessTrustedWithOptions(options)` — when called with
     /// `{kAXTrustedCheckOptionPrompt: true}` raises the system Accessibility
@@ -111,6 +124,21 @@ pub unsafe fn element_at_screen_position(pid: i32, x: f64, y: f64) -> Option<AXU
     let error = AXUIElementCopyElementAtPosition(application, x as f32, y as f32, &mut element);
     CFRelease(application as CFTypeRef);
     (error == kAXErrorSuccess && !element.is_null()).then_some(element)
+}
+
+/// Return the owning process reported by the accessibility object.
+///
+/// # Safety
+///
+/// `element` must be a valid Accessibility object reference.
+pub unsafe fn pid_of_element(element: AXUIElementRef) -> Result<i32, AXError> {
+    let mut pid = 0_i32;
+    let error = AXUIElementGetPid(element, &mut pid);
+    if error == kAXErrorSuccess {
+        Ok(pid)
+    } else {
+        Err(error)
+    }
 }
 
 // ── AXValue functions ────────────────────────────────────────────────────────
@@ -519,6 +547,64 @@ pub unsafe fn copy_children(element: AXUIElementRef) -> Vec<AXUIElementRef> {
         .collect()
 }
 
+/// Copy at most `max_values` children while also returning the total native
+/// child count. Unlike `copy_children`, this bounds the AX request itself.
+///
+/// # Safety
+///
+/// `element` must be valid, and the caller must release every returned element.
+pub unsafe fn copy_children_bounded(
+    element: AXUIElementRef,
+    max_values: usize,
+) -> Result<(Vec<AXUIElementRef>, usize), AXError> {
+    let attr = CFStr::new("AXChildren");
+    let mut native_count = 0_isize;
+    let count_error =
+        AXUIElementGetAttributeValueCount(element, attr.as_concrete_TypeRef(), &mut native_count);
+    if matches!(count_error, kAXErrorAttributeUnsupported | kAXErrorNoValue) {
+        return Ok((Vec::new(), 0));
+    }
+    if count_error != kAXErrorSuccess {
+        return Err(count_error);
+    }
+
+    let total_count = usize::try_from(native_count.max(0)).unwrap_or(usize::MAX);
+    let requested_count = total_count.min(max_values);
+    if requested_count == 0 {
+        return Ok((Vec::new(), total_count));
+    }
+
+    let mut values: CFArrayRef = std::ptr::null();
+    let copy_error = AXUIElementCopyAttributeValues(
+        element,
+        attr.as_concrete_TypeRef(),
+        0,
+        isize::try_from(requested_count).unwrap_or(isize::MAX),
+        &mut values,
+    );
+    if copy_error != kAXErrorSuccess {
+        return Err(copy_error);
+    }
+    if values.is_null() {
+        return Ok((Vec::new(), total_count));
+    }
+
+    let array = CFArray::<CFTypeRef>::wrap_under_create_rule(values);
+    let ax_type_id = AXUIElementGetTypeID();
+    let children = (0..array.len())
+        .filter_map(|index| {
+            let item = *array.get(index)?;
+            if core_foundation::base::CFGetTypeID(item) == ax_type_id {
+                CFRetain(item);
+                Some(item as AXUIElementRef)
+            } else {
+                None
+            }
+        })
+        .collect();
+    Ok((children, total_count))
+}
+
 /// Copy an AX element-valued attribute. The returned element is retained and
 /// must be released by the caller.
 ///
@@ -540,6 +626,35 @@ pub unsafe fn copy_element_attr(
         return None;
     }
     Some(value as AXUIElementRef)
+}
+
+/// Copy an AX element-valued attribute without collapsing native AX failures
+/// into an absent value.
+///
+/// # Safety
+///
+/// `element` must be valid, and the caller must release any returned element.
+pub unsafe fn copy_element_attr_result(
+    element: AXUIElementRef,
+    attr_name: &str,
+) -> Result<Option<AXUIElementRef>, AXError> {
+    let attr = CFStr::new(attr_name);
+    let mut value: CFTypeRef = std::ptr::null();
+    let error = AXUIElementCopyAttributeValue(element, attr.as_concrete_TypeRef(), &mut value);
+    if matches!(error, kAXErrorAttributeUnsupported | kAXErrorNoValue) {
+        return Ok(None);
+    }
+    if error != kAXErrorSuccess {
+        return Err(error);
+    }
+    if value.is_null() {
+        return Ok(None);
+    }
+    if core_foundation::base::CFGetTypeID(value) != AXUIElementGetTypeID() {
+        CFRelease(value);
+        return Err(kAXErrorFailure);
+    }
+    Ok(Some(value as AXUIElementRef))
 }
 
 /// Perform an AX action using a string attribute name.

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/menu_extra.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/menu_extra.rs
@@ -13,7 +13,7 @@ use cua_driver_core::{
     tool::{Tool, ToolDef},
 };
 use serde_json::Value;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::ax::bindings::{
     copy_action_names, copy_bool_attr, copy_children_bounded, copy_element_attr_result,
@@ -503,6 +503,111 @@ unsafe fn resolve_exact_prefix(
     current.ok_or_else(|| MenuExtraError::new("invalid_path", "path is empty"))
 }
 
+unsafe fn resolve_exact_popup_descendant(
+    app: AXUIElementRef,
+    expected_pid: i32,
+    segment: &str,
+    depth: usize,
+) -> Result<OwnedAxElement, MenuExtraError> {
+    let (children, total_count) =
+        copy_children_bounded(app, MAX_SEMANTIC_CHILDREN + 1).map_err(|error| {
+            MenuExtraError::new(
+                "menu_extra_query_failed",
+                format!("reading application popup children failed with AX error {error}"),
+            )
+        })?;
+    if total_count > MAX_SEMANTIC_CHILDREN {
+        for child in children {
+            drop(OwnedAxElement::new(child));
+        }
+        return Err(MenuExtraError::new(
+            "menu_extra_query_limit",
+            format!("popup hierarchy exceeds {MAX_SEMANTIC_CHILDREN} native elements"),
+        ));
+    }
+
+    let mut discovered = children.len();
+    let mut pending = children
+        .into_iter()
+        .map(|child| OwnedAxElement::new(child))
+        .collect::<Vec<_>>();
+    let mut matches = Vec::new();
+
+    while let Some(element) = pending.pop() {
+        let owner_pid = pid_of_element(element.as_ptr()).map_err(|error| {
+            MenuExtraError::new(
+                "menu_extra_query_failed",
+                format!("reading popup element owner failed with AX error {error}"),
+            )
+        })?;
+        if owner_pid != expected_pid {
+            return Err(MenuExtraError::new(
+                "menu_extra_foreign_owner",
+                format!("popup element belongs to pid {owner_pid}, expected {expected_pid}"),
+            ));
+        }
+
+        let remaining = MAX_SEMANTIC_CHILDREN.saturating_sub(discovered);
+        let query_limit = remaining.saturating_add(1);
+        let (descendants, descendant_count) = copy_children_bounded(element.as_ptr(), query_limit)
+            .map_err(|error| {
+                MenuExtraError::new(
+                    "menu_extra_query_failed",
+                    format!("reading popup descendants failed with AX error {error}"),
+                )
+            })?;
+        if descendant_count > remaining {
+            for descendant in descendants {
+                drop(OwnedAxElement::new(descendant));
+            }
+            return Err(MenuExtraError::new(
+                "menu_extra_query_limit",
+                format!("popup hierarchy exceeds {MAX_SEMANTIC_CHILDREN} native elements"),
+            ));
+        }
+        discovered += descendant_count;
+        pending.extend(
+            descendants
+                .into_iter()
+                .map(|descendant| OwnedAxElement::new(descendant)),
+        );
+
+        if semantic_label(element.as_ptr()).as_deref() == Some(segment) {
+            matches.push(element);
+        }
+    }
+
+    match matches.len() {
+        1 => Ok(matches.pop().expect("one exact popup match")),
+        0 => Err(MenuExtraError::new(
+            "menu_path_not_found",
+            format!("path segment {depth} was not found"),
+        )),
+        count => Err(MenuExtraError::new(
+            "menu_path_ambiguous",
+            format!("path segment {depth} matched {count} elements"),
+        )),
+    }
+}
+
+unsafe fn resolve_exact_popup_descendant_with_retry(
+    app: AXUIElementRef,
+    expected_pid: i32,
+    segment: &str,
+    depth: usize,
+) -> Result<OwnedAxElement, MenuExtraError> {
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        match resolve_exact_popup_descendant(app, expected_pid, segment, depth) {
+            Ok(element) => return Ok(element),
+            Err(error) if error.code == "menu_path_not_found" && Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
 fn choose_action(actions: &[String], final_segment: bool) -> Option<&'static str> {
     let supports = |name: &str| actions.iter().any(|action| action == name);
     let order: &[&str] = if final_segment {
@@ -519,8 +624,20 @@ fn invoke_path(target: ResolvedTarget, path: &[String]) -> Result<bool, MenuExtr
         prior_frontmost.and_then(crate::ax::bindings::focused_window_id_of_pid);
     unsafe {
         for depth in 0..path.len() {
-            let (_app, menu_bar) = extras_menu_bar(target.pid)?;
-            let element = resolve_exact_prefix(menu_bar.as_ptr(), target.pid, &path[..=depth])?;
+            let (app, menu_bar) = extras_menu_bar(target.pid)?;
+            let element = match resolve_exact_prefix(menu_bar.as_ptr(), target.pid, &path[..=depth])
+            {
+                Ok(element) => element,
+                Err(error) if depth > 0 && error.code == "menu_path_not_found" => {
+                    resolve_exact_popup_descendant_with_retry(
+                        app.as_ptr(),
+                        target.pid,
+                        &path[depth],
+                        depth,
+                    )?
+                }
+                Err(error) => return Err(error),
+            };
             if copy_bool_attr(element.as_ptr(), "AXEnabled") == Some(false) {
                 return Err(MenuExtraError::new(
                     "menu_path_disabled",

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/menu_extra.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/menu_extra.rs
@@ -1,0 +1,703 @@
+use async_trait::async_trait;
+use core_foundation::base::{CFRelease, CFTypeRef};
+use cua_driver_contract::{
+    GetMenuExtraStateInput, InvokeMenuExtraInput, MenuExtraNodeOutput, MenuExtraStateOutput,
+    MenuExtraTarget, ToolOutput,
+};
+use cua_driver_core::{
+    action_record::{
+        ActionEffect, ActionEvidence, ActionExecutionRecord, ActionTransport, ActualDelivery,
+        EvidenceKind, RequestedDelivery,
+    },
+    protocol::ToolResult,
+    tool::{Tool, ToolDef},
+};
+use serde_json::Value;
+use std::time::Duration;
+
+use crate::ax::bindings::{
+    copy_action_names, copy_bool_attr, copy_children_bounded, copy_element_attr_result,
+    copy_string_attr, kAXErrorSuccess, perform_action, pid_of_element, AXIsProcessTrusted,
+    AXUIElementCreateApplication, AXUIElementRef, AXUIElementSetMessagingTimeout,
+};
+
+const AX_MESSAGING_TIMEOUT_SECONDS: f32 = 2.0;
+const DEFAULT_MAX_DEPTH: usize = 12;
+const DEFAULT_MAX_ELEMENTS: usize = 500;
+const MAX_DEPTH: u32 = 25;
+const MAX_ELEMENTS: u32 = 2_000;
+const MAX_SEMANTIC_CHILDREN: usize = 512;
+
+pub struct GetMenuExtraStateTool;
+pub struct InvokeMenuExtraTool;
+
+#[derive(Debug)]
+struct MenuExtraError {
+    code: &'static str,
+    message: String,
+}
+
+impl MenuExtraError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+struct OwnedAxElement(AXUIElementRef);
+
+impl OwnedAxElement {
+    unsafe fn new(element: AXUIElementRef) -> Self {
+        Self(element)
+    }
+
+    fn as_ptr(&self) -> AXUIElementRef {
+        self.0
+    }
+}
+
+impl Drop for OwnedAxElement {
+    fn drop(&mut self) {
+        unsafe { CFRelease(self.0 as CFTypeRef) };
+    }
+}
+
+#[derive(Debug)]
+struct ResolvedTarget {
+    pid: i32,
+    bundle_id: Option<String>,
+}
+
+#[derive(Debug)]
+struct MenuExtraSnapshot {
+    nodes: Vec<MenuExtraNodeOutput>,
+    visited: usize,
+    truncated: bool,
+}
+
+fn contract_def(name: &str) -> ToolDef {
+    let contract = cua_driver_contract::tool_contract(name).expect("menu-extra contract exists");
+    ToolDef::from_contract(&contract)
+}
+
+fn get_state_def() -> &'static ToolDef {
+    static DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();
+    DEF.get_or_init(|| contract_def("get_menu_extra_state"))
+}
+
+fn invoke_def() -> &'static ToolDef {
+    static DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();
+    DEF.get_or_init(|| contract_def("invoke_menu_extra"))
+}
+
+fn resolve_target(target: MenuExtraTarget) -> Result<ResolvedTarget, MenuExtraError> {
+    match target {
+        MenuExtraTarget::Pid { pid } => {
+            let pid = i32::try_from(pid).map_err(|_| {
+                MenuExtraError::new("target_unavailable", "pid is outside the macOS range")
+            })?;
+            let bundle_id = crate::apps::bundle_id_for_pid(pid).ok_or_else(|| {
+                MenuExtraError::new(
+                    "target_unavailable",
+                    format!("pid {pid} is not a running bundled application"),
+                )
+            })?;
+            Ok(ResolvedTarget {
+                pid,
+                bundle_id: Some(bundle_id),
+            })
+        }
+        MenuExtraTarget::BundleId { bundle_id } => {
+            let normalized = bundle_id.trim();
+            if normalized.is_empty()
+                || normalized != bundle_id
+                || normalized.chars().count() > 255
+                || normalized.chars().any(char::is_control)
+            {
+                return Err(MenuExtraError::new(
+                    "invalid_target",
+                    "bundle_id must be 1–255 non-control characters with no surrounding whitespace",
+                ));
+            }
+            let pids = crate::apps::running_pids_for_bundle(normalized);
+            match pids.as_slice() {
+                [pid] => Ok(ResolvedTarget {
+                    pid: *pid,
+                    bundle_id: Some(bundle_id),
+                }),
+                [] => Err(MenuExtraError::new(
+                    "target_unavailable",
+                    format!("no running process has bundle_id {normalized}"),
+                )),
+                _ => Err(MenuExtraError::new(
+                    "target_ambiguous",
+                    format!(
+                        "bundle_id {normalized} resolves to {} running processes",
+                        pids.len()
+                    ),
+                )),
+            }
+        }
+    }
+}
+
+fn normalize_path(path: Vec<String>) -> Result<Vec<String>, MenuExtraError> {
+    if path.is_empty() || path.len() > 16 {
+        return Err(MenuExtraError::new(
+            "invalid_path",
+            "path must contain between 1 and 16 segments",
+        ));
+    }
+    path.into_iter()
+        .enumerate()
+        .map(|(index, segment)| {
+            let segment = segment.trim();
+            if segment.is_empty()
+                || segment.chars().count() > 200
+                || segment.chars().any(char::is_control)
+            {
+                Err(MenuExtraError::new(
+                    "invalid_path",
+                    format!(
+                        "path segment {index} must be 1–200 non-control characters after trimming"
+                    ),
+                ))
+            } else {
+                Ok(segment.to_owned())
+            }
+        })
+        .collect()
+}
+
+fn bounded_limit(
+    value: Option<u32>,
+    default: usize,
+    maximum: u32,
+    name: &str,
+) -> Result<usize, MenuExtraError> {
+    match value {
+        Some(value) if (1..=maximum).contains(&value) => Ok(value as usize),
+        Some(_) => Err(MenuExtraError::new(
+            "invalid_limits",
+            format!("{name} must be between 1 and {maximum}"),
+        )),
+        None => Ok(default),
+    }
+}
+
+fn refusal(error: MenuExtraError) -> ToolResult {
+    ToolResult::error(error.message.clone()).with_structured(serde_json::json!({
+        "status": "refused",
+        "refusal": { "code": error.code, "message": error.message }
+    }))
+}
+
+fn blocking_failure(name: &str, error: tokio::task::JoinError) -> ToolResult {
+    refusal(MenuExtraError::new(
+        "internal_error",
+        format!("{name}: blocking task failed: {error}"),
+    ))
+}
+
+unsafe fn set_messaging_timeout(element: AXUIElementRef) {
+    let _ = AXUIElementSetMessagingTimeout(element, AX_MESSAGING_TIMEOUT_SECONDS);
+}
+
+unsafe fn extras_menu_bar(pid: i32) -> Result<(OwnedAxElement, OwnedAxElement), MenuExtraError> {
+    if !AXIsProcessTrusted() {
+        return Err(MenuExtraError::new(
+            "accessibility_permission_denied",
+            "macOS Accessibility permission is required",
+        ));
+    }
+    let app = AXUIElementCreateApplication(pid);
+    if app.is_null() {
+        return Err(MenuExtraError::new(
+            "target_unavailable",
+            "target application accessibility object is unavailable",
+        ));
+    }
+    let app = OwnedAxElement::new(app);
+    set_messaging_timeout(app.as_ptr());
+    let menu_bar = copy_element_attr_result(app.as_ptr(), "AXExtrasMenuBar")
+        .map_err(|error| {
+            MenuExtraError::new(
+                "menu_extra_query_failed",
+                format!("reading AXExtrasMenuBar failed with AX error {error}"),
+            )
+        })?
+        .ok_or_else(|| {
+            MenuExtraError::new(
+                "menu_extra_unavailable",
+                "target application exposes no AXExtrasMenuBar",
+            )
+        })?;
+    let menu_bar = OwnedAxElement::new(menu_bar);
+    set_messaging_timeout(menu_bar.as_ptr());
+    let owner_pid = pid_of_element(menu_bar.as_ptr()).map_err(|error| {
+        MenuExtraError::new(
+            "menu_extra_query_failed",
+            format!("reading AXExtrasMenuBar owner failed with AX error {error}"),
+        )
+    })?;
+    if owner_pid != pid {
+        return Err(MenuExtraError::new(
+            "menu_extra_foreign_owner",
+            format!("AXExtrasMenuBar belongs to pid {owner_pid}, expected {pid}"),
+        ));
+    }
+    Ok((app, menu_bar))
+}
+
+fn nonempty_attr(element: AXUIElementRef, attribute: &str) -> Option<String> {
+    unsafe { copy_string_attr(element, attribute) }
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+fn semantic_label(element: AXUIElementRef) -> Option<String> {
+    nonempty_attr(element, "AXTitle").or_else(|| nonempty_attr(element, "AXDescription"))
+}
+
+unsafe fn walk_element(
+    element: AXUIElementRef,
+    expected_pid: i32,
+    depth: usize,
+    max_depth: usize,
+    max_elements: usize,
+    snapshot: &mut MenuExtraSnapshot,
+) -> Result<(), MenuExtraError> {
+    if snapshot.visited >= max_elements {
+        snapshot.truncated = true;
+        return Ok(());
+    }
+    snapshot.visited += 1;
+
+    set_messaging_timeout(element);
+    let owner_pid = pid_of_element(element).map_err(|error| {
+        MenuExtraError::new(
+            "menu_extra_query_failed",
+            format!("reading element owner failed with AX error {error}"),
+        )
+    })?;
+    if owner_pid != expected_pid {
+        return Err(MenuExtraError::new(
+            "menu_extra_foreign_owner",
+            format!("menu-extra element belongs to pid {owner_pid}, expected {expected_pid}"),
+        ));
+    }
+    let role = copy_string_attr(element, "AXRole").unwrap_or_else(|| "AXUnknown".into());
+    let transparent_menu = role == "AXMenu";
+    let title = nonempty_attr(element, "AXTitle");
+    let description = nonempty_attr(element, "AXDescription");
+    let label = title.clone().or_else(|| description.clone());
+
+    if !transparent_menu {
+        snapshot.nodes.push(MenuExtraNodeOutput {
+            depth: u32::try_from(depth).unwrap_or(u32::MAX),
+            role,
+            label,
+            title,
+            description,
+            enabled: copy_bool_attr(element, "AXEnabled"),
+            actions: copy_action_names(element),
+        });
+    }
+
+    let child_depth = if transparent_menu { depth } else { depth + 1 };
+    let can_descend = child_depth <= max_depth && snapshot.visited < max_elements;
+    let remaining = max_elements.saturating_sub(snapshot.visited);
+    let query_limit = if can_descend { remaining.max(1) } else { 1 };
+    let (children, total_count) = copy_children_bounded(element, query_limit).map_err(|error| {
+        MenuExtraError::new(
+            "menu_extra_query_failed",
+            format!("reading AXChildren failed with AX error {error}"),
+        )
+    })?;
+
+    if total_count > children.len() || (!can_descend && total_count > 0) {
+        snapshot.truncated = true;
+    }
+    if !can_descend {
+        for child in children {
+            drop(OwnedAxElement::new(child));
+        }
+        return Ok(());
+    }
+
+    for child in children {
+        let child = OwnedAxElement::new(child);
+        walk_element(
+            child.as_ptr(),
+            expected_pid,
+            child_depth,
+            max_depth,
+            max_elements,
+            snapshot,
+        )?;
+    }
+    Ok(())
+}
+
+fn snapshot_menu_extra(
+    target: ResolvedTarget,
+    max_depth: usize,
+    max_elements: usize,
+) -> Result<MenuExtraStateOutput, MenuExtraError> {
+    unsafe {
+        let (_app, menu_bar) = extras_menu_bar(target.pid)?;
+        let mut snapshot = MenuExtraSnapshot {
+            nodes: Vec::new(),
+            visited: 0,
+            truncated: false,
+        };
+        let (children, total_count) = copy_children_bounded(menu_bar.as_ptr(), max_elements)
+            .map_err(|error| {
+                MenuExtraError::new(
+                    "menu_extra_query_failed",
+                    format!("reading AXExtrasMenuBar children failed with AX error {error}"),
+                )
+            })?;
+        if total_count > children.len() {
+            snapshot.truncated = true;
+        }
+        for child in children {
+            let child = OwnedAxElement::new(child);
+            walk_element(
+                child.as_ptr(),
+                target.pid,
+                0,
+                max_depth,
+                max_elements,
+                &mut snapshot,
+            )?;
+        }
+        let node_count = u32::try_from(snapshot.nodes.len()).unwrap_or(u32::MAX);
+        Ok(MenuExtraStateOutput {
+            pid: u32::try_from(target.pid).unwrap_or_default(),
+            bundle_id: target.bundle_id,
+            nodes: snapshot.nodes,
+            node_count,
+            truncated: snapshot.truncated,
+            privacy_sensitive: true,
+            content_redacted_from_telemetry: true,
+        })
+    }
+}
+
+unsafe fn semantic_children(
+    parent: AXUIElementRef,
+    expected_pid: i32,
+) -> Result<Vec<OwnedAxElement>, MenuExtraError> {
+    let (children, total_count) = copy_children_bounded(parent, MAX_SEMANTIC_CHILDREN + 1)
+        .map_err(|error| {
+            MenuExtraError::new(
+                "menu_extra_query_failed",
+                format!("reading menu children failed with AX error {error}"),
+            )
+        })?;
+    if total_count > MAX_SEMANTIC_CHILDREN {
+        for child in children {
+            drop(OwnedAxElement::new(child));
+        }
+        return Err(MenuExtraError::new(
+            "menu_extra_query_limit",
+            format!("menu level exceeds {MAX_SEMANTIC_CHILDREN} native children"),
+        ));
+    }
+
+    let mut semantic = Vec::new();
+    for child in children {
+        let child = OwnedAxElement::new(child);
+        let owner_pid = pid_of_element(child.as_ptr()).map_err(|error| {
+            MenuExtraError::new(
+                "menu_extra_query_failed",
+                format!("reading menu child owner failed with AX error {error}"),
+            )
+        })?;
+        if owner_pid != expected_pid {
+            return Err(MenuExtraError::new(
+                "menu_extra_foreign_owner",
+                format!("menu child belongs to pid {owner_pid}, expected {expected_pid}"),
+            ));
+        }
+        if copy_string_attr(child.as_ptr(), "AXRole").as_deref() == Some("AXMenu") {
+            let (menu_children, menu_total) =
+                copy_children_bounded(child.as_ptr(), MAX_SEMANTIC_CHILDREN + 1).map_err(
+                    |error| {
+                        MenuExtraError::new(
+                            "menu_extra_query_failed",
+                            format!("reading menu container failed with AX error {error}"),
+                        )
+                    },
+                )?;
+            if semantic.len() + menu_total > MAX_SEMANTIC_CHILDREN {
+                for menu_child in menu_children {
+                    drop(OwnedAxElement::new(menu_child));
+                }
+                return Err(MenuExtraError::new(
+                    "menu_extra_query_limit",
+                    format!("semantic menu level exceeds {MAX_SEMANTIC_CHILDREN} children"),
+                ));
+            }
+            for menu_child in menu_children {
+                let menu_child = OwnedAxElement::new(menu_child);
+                let owner_pid = pid_of_element(menu_child.as_ptr()).map_err(|error| {
+                    MenuExtraError::new(
+                        "menu_extra_query_failed",
+                        format!("reading semantic child owner failed with AX error {error}"),
+                    )
+                })?;
+                if owner_pid != expected_pid {
+                    return Err(MenuExtraError::new(
+                        "menu_extra_foreign_owner",
+                        format!(
+                            "semantic menu child belongs to pid {owner_pid}, expected {expected_pid}"
+                        ),
+                    ));
+                }
+                semantic.push(menu_child);
+            }
+        } else {
+            semantic.push(child);
+        }
+    }
+    Ok(semantic)
+}
+
+unsafe fn resolve_exact_prefix(
+    menu_bar: AXUIElementRef,
+    expected_pid: i32,
+    prefix: &[String],
+) -> Result<OwnedAxElement, MenuExtraError> {
+    let mut current = None;
+    let mut parent = menu_bar;
+
+    for (depth, segment) in prefix.iter().enumerate() {
+        let children = semantic_children(parent, expected_pid)?;
+        let mut matches = children
+            .into_iter()
+            .filter(|child| semantic_label(child.as_ptr()).as_deref() == Some(segment.as_str()))
+            .collect::<Vec<_>>();
+        if matches.len() != 1 {
+            let match_count = matches.len();
+            return Err(MenuExtraError::new(
+                if match_count == 0 {
+                    "menu_path_not_found"
+                } else {
+                    "menu_path_ambiguous"
+                },
+                if match_count == 0 {
+                    format!("path segment {depth} was not found")
+                } else {
+                    format!("path segment {depth} matched {match_count} elements")
+                },
+            ));
+        }
+        current = matches.pop();
+        parent = current.as_ref().expect("one exact match").as_ptr();
+    }
+
+    current.ok_or_else(|| MenuExtraError::new("invalid_path", "path is empty"))
+}
+
+fn choose_action(actions: &[String], final_segment: bool) -> Option<&'static str> {
+    let supports = |name: &str| actions.iter().any(|action| action == name);
+    let order: &[&str] = if final_segment {
+        &["AXPress", "AXPick", "AXConfirm"]
+    } else {
+        &["AXPress", "AXPick", "AXShowMenu", "AXOpen"]
+    };
+    order.iter().copied().find(|action| supports(action))
+}
+
+fn invoke_path(target: ResolvedTarget, path: &[String]) -> Result<bool, MenuExtraError> {
+    let prior_frontmost = crate::apps::frontmost_pid();
+    let prior_focused_window =
+        prior_frontmost.and_then(crate::ax::bindings::focused_window_id_of_pid);
+    unsafe {
+        for depth in 0..path.len() {
+            let (_app, menu_bar) = extras_menu_bar(target.pid)?;
+            let element = resolve_exact_prefix(menu_bar.as_ptr(), target.pid, &path[..=depth])?;
+            if copy_bool_attr(element.as_ptr(), "AXEnabled") == Some(false) {
+                return Err(MenuExtraError::new(
+                    "menu_path_disabled",
+                    format!("path segment {depth} is disabled"),
+                ));
+            }
+            let actions = copy_action_names(element.as_ptr());
+            let action = choose_action(&actions, depth + 1 == path.len()).ok_or_else(|| {
+                MenuExtraError::new(
+                    "menu_action_unavailable",
+                    format!("path segment {depth} has no usable native accessibility action"),
+                )
+            })?;
+            let error = perform_action(element.as_ptr(), action);
+            if error != kAXErrorSuccess {
+                return Err(MenuExtraError::new(
+                    "menu_action_failed",
+                    format!("path segment {depth} action failed with AX error {error}"),
+                ));
+            }
+            if depth + 1 != path.len() {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+        }
+    }
+    let current_frontmost = crate::apps::frontmost_pid();
+    let current_focused_window =
+        current_frontmost.and_then(crate::ax::bindings::focused_window_id_of_pid);
+    Ok(current_frontmost == prior_frontmost && current_focused_window == prior_focused_window)
+}
+
+#[async_trait]
+impl Tool for GetMenuExtraStateTool {
+    fn def(&self) -> &ToolDef {
+        get_state_def()
+    }
+
+    async fn invoke(&self, args: Value) -> ToolResult {
+        let input: GetMenuExtraStateInput =
+            match cua_driver_core::tool_args::parse_typed_input("get_menu_extra_state", args) {
+                Ok(input) => input,
+                Err(result) => return result,
+            };
+        let max_depth =
+            match bounded_limit(input.max_depth, DEFAULT_MAX_DEPTH, MAX_DEPTH, "max_depth") {
+                Ok(value) => value,
+                Err(error) => return refusal(error),
+            };
+        let max_elements = match bounded_limit(
+            input.max_elements,
+            DEFAULT_MAX_ELEMENTS,
+            MAX_ELEMENTS,
+            "max_elements",
+        ) {
+            Ok(value) => value,
+            Err(error) => return refusal(error),
+        };
+        let outcome = tokio::task::spawn_blocking(move || {
+            let target = resolve_target(input.application)?;
+            snapshot_menu_extra(target, max_depth, max_elements)
+        })
+        .await;
+
+        match outcome {
+            Ok(Ok(output)) => {
+                let node_count = output.node_count;
+                let truncated = output.truncated;
+                let structured =
+                    serde_json::to_value(&output).expect("MenuExtraStateOutput always serializes");
+                debug_assert!(output.validate().is_ok());
+                ToolResult::text(format!(
+                    "Observed {node_count} menu-extra accessibility node(s){}.",
+                    if truncated { " (truncated)" } else { "" }
+                ))
+                .with_structured(structured)
+            }
+            Ok(Err(error)) => refusal(error),
+            Err(error) => blocking_failure("get_menu_extra_state", error),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for InvokeMenuExtraTool {
+    fn def(&self) -> &ToolDef {
+        invoke_def()
+    }
+
+    async fn invoke(&self, args: Value) -> ToolResult {
+        let input: InvokeMenuExtraInput =
+            match cua_driver_core::tool_args::parse_typed_input("invoke_menu_extra", args) {
+                Ok(input) => input,
+                Err(result) => return result,
+            };
+        let path = match normalize_path(input.path) {
+            Ok(path) => path,
+            Err(error) => return refusal(error),
+        };
+        let outcome = tokio::task::spawn_blocking(move || {
+            let target = resolve_target(input.application)?;
+            invoke_path(target, &path)
+        })
+        .await;
+
+        match outcome {
+            Ok(Ok(focus_preserved)) => {
+                let (effect, actual_delivery, detail) = if focus_preserved {
+                    (
+                        ActionEffect::Unverifiable,
+                        ActualDelivery::NotApplicable,
+                        "Every path hop resolved uniquely, AX accepted the final action, and the frontmost application and focused window were preserved",
+                    )
+                } else {
+                    (
+                        ActionEffect::Partial,
+                        ActualDelivery::Unknown,
+                        "AX accepted the final action, but the frontmost application or focused window changed",
+                    )
+                };
+                ToolResult::text(
+                    "Invoked the exact live menu-extra path through macOS Accessibility; verify its semantic effect from fresh state.",
+                )
+                .with_action_record(
+                    ActionExecutionRecord::builder(
+                        effect,
+                        ActionTransport::MacosAxAction,
+                        RequestedDelivery::NotApplicable,
+                    )
+                    .actual_delivery(actual_delivery)
+                    .evidence(ActionEvidence {
+                        kind: EvidenceKind::NativeApiResult,
+                        detail: detail.into(),
+                    })
+                    .build()
+                    .expect("invoke_menu_extra record is valid"),
+                )
+            }
+            Ok(Err(error)) => refusal(error),
+            Err(error) => blocking_failure("invoke_menu_extra", error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_normalization_is_exact_and_bounded() {
+        assert_eq!(
+            normalize_path(vec![" User ".into(), " Switch Test ".into()])
+                .unwrap()
+                .as_slice(),
+            ["User", "Switch Test"]
+        );
+        assert!(normalize_path(Vec::new()).is_err());
+        assert!(normalize_path(vec![" ".into()]).is_err());
+        assert!(normalize_path(vec!["x".into(); 17]).is_err());
+    }
+
+    #[test]
+    fn action_priority_distinguishes_intermediate_and_final_segments() {
+        let actions = vec!["AXOpen".into(), "AXPress".into(), "AXPick".into()];
+        assert_eq!(choose_action(&actions, false), Some("AXPress"));
+        assert_eq!(choose_action(&actions, true), Some("AXPress"));
+        assert_eq!(
+            choose_action(&["AXShowMenu".into()], false),
+            Some("AXShowMenu")
+        );
+        assert_eq!(choose_action(&["AXShowMenu".into()], true), None);
+    }
+
+    #[test]
+    fn native_walk_limits_are_enforced_after_deserialization() {
+        assert_eq!(bounded_limit(None, 12, 25, "max_depth").unwrap(), 12);
+        assert_eq!(bounded_limit(Some(25), 12, 25, "max_depth").unwrap(), 25);
+        assert!(bounded_limit(Some(0), 12, 25, "max_depth").is_err());
+        assert!(bounded_limit(Some(26), 12, 25, "max_depth").is_err());
+    }
+}

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
@@ -12,6 +12,7 @@ mod kill_app;
 mod launch_app;
 mod list_apps;
 mod list_windows;
+mod menu_extra;
 mod press_key;
 mod right_click;
 mod scroll;
@@ -908,6 +909,8 @@ pub fn register_all(
     ));
     registry.register(Box::new(set_window_frame::SetWindowFrameTool));
     registry.register(Box::new(invoke_menu::InvokeMenuTool));
+    registry.register(Box::new(menu_extra::GetMenuExtraStateTool));
+    registry.register(Box::new(menu_extra::InvokeMenuExtraTool));
     registry.register(pid_window_guarded(
         click::ClickTool::new(state.clone()),
         &pid_window_candidates,

--- a/scripts/docs-generators/cua-driver.test.ts
+++ b/scripts/docs-generators/cua-driver.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { getLatestReleasedVersion, selectLatestReleasedVersion } from './cua-driver';
+import {
+  generateMCPToolDoc,
+  getLatestReleasedVersion,
+  selectLatestReleasedVersion,
+} from './cua-driver';
 
 test('lists matching tags through git argv without invoking a shell', () => {
   const calls: Array<{ command: string; args: readonly string[] }> = [];
@@ -55,4 +59,40 @@ test('reports when git returns no valid stable release tags', () => {
     () => getLatestReleasedVersion(() => 'nightly-cua-driver-rs-v0.21.0-nightly.20260816.1\n'),
     /No stable Cua Driver release tag matching cua-driver-rs-v<major>\.<minor>\.<patch> was found/
   );
+});
+
+test('generates a valid tagged-object example for required union inputs', () => {
+  const lines = generateMCPToolDoc({
+    name: 'get_menu_extra_state',
+    description: 'Observe a menu extra.',
+    input_schema: {
+      type: 'object',
+      required: ['application'],
+      properties: {
+        application: {
+          oneOf: [
+            {
+              type: 'object',
+              required: ['kind', 'pid'],
+              properties: {
+                kind: { type: 'string', const: 'pid' },
+                pid: { type: 'integer', minimum: 1 },
+              },
+            },
+            {
+              type: 'object',
+              required: ['kind', 'bundle_id'],
+              properties: {
+                kind: { type: 'string', const: 'bundle_id' },
+                bundle_id: { type: 'string' },
+              },
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  assert.ok(lines.includes('{"application":{"kind":"pid","pid":844}}'));
+  assert.ok(!lines.includes('{"application":"value"}'));
 });

--- a/scripts/docs-generators/cua-driver.ts
+++ b/scripts/docs-generators/cua-driver.ts
@@ -76,6 +76,7 @@ export interface MCPPropertyDoc {
   type?: string | string[];
   description?: string;
   items?: { type: string };
+  required?: string[];
   enum?: string[];
   const?: unknown;
   anyOf?: MCPPropertyDoc[];
@@ -855,8 +856,24 @@ function propertyDescription(prop: MCPPropertyDoc): string {
 }
 
 function syntheticExampleValue(name: string, prop: MCPPropertyDoc): unknown {
+  if (prop.const !== undefined) {
+    return prop.const;
+  }
   if (prop.enum?.length) {
     return prop.enum[0];
+  }
+  const objectAlternative = (prop.oneOf ?? prop.anyOf)?.find(
+    (alternative) => alternative.type === 'object' && alternative.properties
+  );
+  if (objectAlternative?.properties) {
+    const example: Record<string, unknown> = {};
+    for (const propertyName of objectAlternative.required ?? []) {
+      const property = objectAlternative.properties[propertyName];
+      if (property) {
+        example[propertyName] = syntheticExampleValue(propertyName, property);
+      }
+    }
+    return example;
   }
   switch (prop.type) {
     case 'integer':


### PR DESCRIPTION
## Summary
- add typed `get_menu_extra_state` and `invoke_menu_extra` tools for macOS `AXExtrasMenuBar`
- resolve targets by exact PID or bundle ID with bounded traversal, same-process ownership checks, and exact-label ambiguity refusal
- support detached same-process popup surfaces opened by modern menu extras without activating windows or falling back to pixels
- add separate observe/invoke capabilities, action-risk classification, telemetry redaction, generated contracts, and MCP reference docs

## Live validation
- installed a separately identified local app build in a Lume macOS VM and granted only Accessibility
- observed Control Center menu extras semantically
- opened Fast User Switching through `AXPress`
- invoked an exact two-hop user-switch path through the detached Control Center popup in 1.67 seconds
- authenticated the selected local account and confirmed the prior GUI user remained logged in in the background

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p cua-driver-contract` (33 passed)
- `cargo test -p platform-macos menu_extra --lib` (3 passed)
- `cargo test -p cua-driver --test protocol_schema_test` (2 passed)
- `cargo test -p cua-driver --test schema_consistency_test` (4 passed)
- `cargo run -p cua-driver-contract --bin cua-contract-gen -- all --check`
- `CUA_DRIVER_BINARY=/Users/mh/.cache/cargo-target/release/cua-driver pnpm --dir docs docs:check:cua-driver`

The macOS linker continues to emit the repository-known duplicate Swift bridge symbol warnings; all builds and tests pass.