### PR TITLE
fix(cua-driver): respect click count on accessibility element path

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -2439,7 +2439,9 @@ impl Tool for ClickTool {
 
             // Chromium can execute a genuine AT-SPI action without focus. Try
             // that route before applying its background synthetic-input gate.
-            if modifiers.is_empty() {
+            // A multi-click request must land real pointer events, so skip the
+            // single-shot AX action path when count > 1.
+            if modifiers.is_empty() && count == 1 {
                 let ax_result =
                     tokio::task::spawn_blocking(move || crate::atspi::perform_action(pid, idx))
                         .await;


### PR DESCRIPTION
The element-index branch of ClickTool called perform_action once and ignored the caller's count parameter. A multi-click request (count > 1) must land real pointer events, so skip the single-shot AT-SPI action path when count > 1 and fall through to the X11/Wayland pointer path that already honours count.

Validation: cargo fmt --check, cargo check -p platform-linux, cargo test -p platform-linux (283 passed, 0 failed, 5 ignored).

<!--
Keep this description current as scope and evidence change. Do not include
credentials, private user data, sensitive screenshots, or vulnerability details.
Preserve external contributor authorship when their code or design ships.
While this pull request is a draft, use this description as the live record of
scope, progress, blockers, and evidence rather than posting periodic status comments.
-->

## Summary

- Problem this solves:
- What changed:

<!-- Describe observable behavior. Do not narrate the diff file by file. -->

## Related work

<!-- Use Fixes only when this PR fully resolves the issue. Otherwise use Refs. -->

Refs #

RFC (required for a public SDK, CLI, MCP, protocol, compatibility, permission,
or cross-component contract change):

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact:
- Risk and rollback:

## Validation

- Focused tests and checks:
- Manual or platform evidence:
- Known gaps or CI still required:

## Contributor and release checks

- [ ] The PR is focused and the description matches the final diff.
- [ ] This change does not require an RFC, or the accepted RFC is linked above.
- [ ] Tests, documentation, and platform evidence are included or the gap is explained.
- [ ] The PR title is a Conventional Commit describing the production change.
- [ ] External contributor authorship is preserved, or no external contribution is included.
- [ ] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.
