### PR TITLE
fix(sandbox): chunk file transfers below Fleet gateway limit

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/interfaces/files.py
+++ b/libs/python/cua-sandbox/cua_sandbox/interfaces/files.py
@@ -19,6 +19,12 @@ from typing import Any, Optional, Union
 from cua_sandbox.transport.base import Transport
 
 
+# Fleet service requests pass through a gateway with a 1 MiB body limit. Binary
+# payloads expand by one third when base64 encoded, so leave room for the JSON
+# command envelope instead of relying on the gateway's exact implementation.
+_TRANSFER_CHUNK_BYTES = 512 * 1024
+
+
 @dataclass
 class FileEntry:
     name: str
@@ -94,18 +100,48 @@ class Files:
 
     # ── binary I/O ───────────────────────────────────────────────────────
     async def read_bytes(self, path: str, offset: int = 0, length: Optional[int] = None) -> bytes:
-        kwargs: dict[str, Any] = {"path": path, "offset": offset}
-        if length is not None:
-            kwargs["length"] = length
-        result = await self._t.send("read_bytes", **kwargs)
-        b64 = _unwrap(result, "content_b64", "") or _unwrap(result, "content", "") or ""
-        if not b64:
-            return b""
-        return base64.b64decode(b64)
+        requested_length = length
+        if requested_length is None:
+            requested_length = max(0, await self.size(path) - max(0, offset))
+
+        if requested_length <= _TRANSFER_CHUNK_BYTES:
+            result = await self._t.send(
+                "read_bytes", path=path, offset=offset, length=requested_length
+            )
+            b64 = _unwrap(result, "content_b64", "") or _unwrap(result, "content", "") or ""
+            return base64.b64decode(b64) if b64 else b""
+
+        chunks: list[bytes] = []
+        current_offset = max(0, offset)
+        remaining = requested_length
+        while remaining > 0:
+            chunk_length = min(remaining, _TRANSFER_CHUNK_BYTES)
+            result = await self._t.send(
+                "read_bytes", path=path, offset=current_offset, length=chunk_length
+            )
+            b64 = _unwrap(result, "content_b64", "") or _unwrap(result, "content", "") or ""
+            chunk = base64.b64decode(b64) if b64 else b""
+            if not chunk:
+                break
+            chunks.append(chunk)
+            current_offset += len(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
 
     async def write_bytes(self, path: str, content: bytes) -> None:
-        b64 = base64.b64encode(content).decode("ascii")
-        await self._t.send("write_bytes", path=path, content_b64=b64)
+        if len(content) <= _TRANSFER_CHUNK_BYTES:
+            b64 = base64.b64encode(content).decode("ascii")
+            await self._t.send("write_bytes", path=path, content_b64=b64)
+            return
+
+        for offset in range(0, len(content), _TRANSFER_CHUNK_BYTES):
+            chunk = content[offset : offset + _TRANSFER_CHUNK_BYTES]
+            await self._t.send(
+                "write_bytes",
+                path=path,
+                content_b64=base64.b64encode(chunk).decode("ascii"),
+                append=offset > 0,
+            )
 
     # ── host ↔ sandbox transfer ──────────────────────────────────────────
     async def upload(self, local_path: Union[str, Path], remote_path: str) -> None:

--- a/libs/python/cua-sandbox/cua_sandbox/interfaces/files.py
+++ b/libs/python/cua-sandbox/cua_sandbox/interfaces/files.py
@@ -18,7 +18,6 @@ from typing import Any, Optional, Union
 
 from cua_sandbox.transport.base import Transport
 
-
 # Fleet service requests pass through a gateway with a 1 MiB body limit. Binary
 # payloads expand by one third when base64 encoded, so leave room for the JSON
 # command envelope instead of relying on the gateway's exact implementation.

--- a/libs/python/cua-sandbox/tests/test_files.py
+++ b/libs/python/cua-sandbox/tests/test_files.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import pytest
+
+from cua_sandbox.interfaces.files import Files, _TRANSFER_CHUNK_BYTES
+
+
+class RecordingTransport:
+    def __init__(self, content: bytes = b"") -> None:
+        self.content = content
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def send(self, action: str, **params: Any) -> dict[str, Any]:
+        self.calls.append((action, params))
+        if action == "get_file_size":
+            return {"success": True, "size": len(self.content)}
+        if action == "write_bytes":
+            chunk = base64.b64decode(params["content_b64"])
+            self.content = self.content + chunk if params.get("append") else chunk
+            return {"success": True}
+        if action == "read_bytes":
+            offset = params["offset"]
+            length = params["length"]
+            chunk = self.content[offset : offset + length]
+            return {"success": True, "content_b64": base64.b64encode(chunk).decode("ascii")}
+        raise AssertionError(f"unexpected action: {action}")
+
+
+@pytest.mark.asyncio
+async def test_write_bytes_chunks_large_payload_below_gateway_limit() -> None:
+    transport = RecordingTransport(b"old content")
+    files = Files(transport)  # type: ignore[arg-type]
+    payload = b"a" * (_TRANSFER_CHUNK_BYTES * 2 + 17)
+
+    await files.write_bytes("/tmp/payload", payload)
+
+    assert transport.content == payload
+    write_calls = [params for action, params in transport.calls if action == "write_bytes"]
+    assert [params.get("append") for params in write_calls] == [False, True, True]
+    assert [len(base64.b64decode(params["content_b64"])) for params in write_calls] == [
+        _TRANSFER_CHUNK_BYTES,
+        _TRANSFER_CHUNK_BYTES,
+        17,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_write_bytes_keeps_small_and_empty_payloads_single_request() -> None:
+    for payload in (b"", b"small"):
+        transport = RecordingTransport(b"old content")
+        files = Files(transport)  # type: ignore[arg-type]
+
+        await files.write_bytes("/tmp/payload", payload)
+
+        assert transport.content == payload
+        assert len(transport.calls) == 1
+        assert "append" not in transport.calls[0][1]
+
+
+@pytest.mark.asyncio
+async def test_read_bytes_chunks_large_file_using_size_and_offsets() -> None:
+    payload = bytes(range(251)) * ((_TRANSFER_CHUNK_BYTES * 2) // 251 + 2)
+    transport = RecordingTransport(payload)
+    files = Files(transport)  # type: ignore[arg-type]
+
+    result = await files.read_bytes("/tmp/payload")
+
+    assert result == payload
+    assert transport.calls[0] == ("get_file_size", {"path": "/tmp/payload"})
+    read_calls = [params for action, params in transport.calls if action == "read_bytes"]
+    assert [params["offset"] for params in read_calls] == [
+        0,
+        _TRANSFER_CHUNK_BYTES,
+        _TRANSFER_CHUNK_BYTES * 2,
+    ]
+    assert all(params["length"] <= _TRANSFER_CHUNK_BYTES for params in read_calls)
+
+
+@pytest.mark.asyncio
+async def test_read_bytes_chunks_explicit_offset_and_length() -> None:
+    payload = bytes(range(256)) * 5000
+    transport = RecordingTransport(payload)
+    files = Files(transport)  # type: ignore[arg-type]
+    offset = 123
+    length = _TRANSFER_CHUNK_BYTES + 19
+
+    result = await files.read_bytes("/tmp/payload", offset=offset, length=length)
+
+    assert result == payload[offset : offset + length]
+    assert all(action == "read_bytes" for action, _ in transport.calls)
+    assert [params["offset"] for _, params in transport.calls] == [
+        offset,
+        offset + _TRANSFER_CHUNK_BYTES,
+    ]

--- a/libs/python/cua-sandbox/tests/test_files.py
+++ b/libs/python/cua-sandbox/tests/test_files.py
@@ -4,8 +4,7 @@ import base64
 from typing import Any
 
 import pytest
-
-from cua_sandbox.interfaces.files import Files, _TRANSFER_CHUNK_BYTES
+from cua_sandbox.interfaces.files import _TRANSFER_CHUNK_BYTES, Files
 
 
 class RecordingTransport:


### PR DESCRIPTION
Fixes #3309.

## scope

- split `cua_sandbox.Files.write_bytes` payloads into 512 KiB chunks, using the existing `append` command field after the first chunk;
- discover file size and split `read_bytes` responses with the existing `offset` and `length` fields;
- preserve single-request behavior for small and empty writes; and
- cover large writes, implicit-size reads, explicit ranges, and small/empty writes with a transport-independent fake.

The 512 KiB raw chunk leaves room for base64 expansion and the JSON command envelope below Fleet's observed 1 MiB request-body limit.

## validation

candidate `c20347b04`:

- `uv run pytest tests/test_files.py -q` — 4 passed
- `uv run pytest tests/test_fleet_transport.py tests/test_files.py -q` — 9 passed
- `uvx ruff check ...` — passed
- `uvx ruff format --check ...` — passed
- `git diff --check` — passed
- pull request CI — passed
- live Fleet Linux round trip: 3 MiB, matching SHA-256
- live Fleet Windows round trip: 3 MiB, matching SHA-256

Before this change, 0.75 MiB writes returned HTTP 413 on both live guests while 0.5 MiB writes passed.

## known gaps

`tests/test_integration_interfaces.py` requires a configured local sandbox in this environment and currently fails during its existing nested asyncio fixture setup. The focused transport suite and both live Fleet platforms cover the changed path.

