### PR TITLE
fix(cua-driver): support Bedrock browser prepare schema

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
@@ -2868,21 +2868,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn existing_profile_still_requires_pid() {
+    async fn pid_remains_required_without_a_complete_isolated_launch_request() {
         let tool = BrowserPrepareTool::new(engine());
-        let result = tool
-            .invoke(json!({
+        for request in [
+            json!({
+                "allow_launch": true,
+                "session": "pid-free-without-profile"
+            }),
+            json!({
+                "profile": { "mode": "isolated_new" },
+                "session": "pid-free-without-allow-launch"
+            }),
+            json!({
                 "window_id": 7,
                 "strategy": { "kind": "existing_profile" },
                 "session": "existing-profile-without-pid"
-            }))
-            .await;
-        assert_eq!(result.is_error, Some(true));
-        let body = serde_json::to_string(&result.content).expect("serialize tool error");
-        assert!(
-            body.contains("Missing required integer field: pid"),
-            "{body}"
-        );
+            }),
+        ] {
+            let result = tool.invoke(request).await;
+            assert_eq!(result.is_error, Some(true));
+            let body = serde_json::to_string(&result.content).expect("serialize tool error");
+            assert!(
+                body.contains("Missing required integer field: pid"),
+                "{body}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
@@ -2884,6 +2884,12 @@ mod tests {
                 "strategy": { "kind": "existing_profile" },
                 "session": "existing-profile-without-pid"
             }),
+            json!({
+                "allow_launch": true,
+                "profile": { "mode": "isolated_new" },
+                "strategy": { "kind": "existing_profile" },
+                "session": "conflicting-strategy-without-pid"
+            }),
         ] {
             let result = tool.invoke(request).await;
             assert_eq!(result.is_error, Some(true));

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
@@ -631,22 +631,10 @@ impl BrowserPrepareTool {
                     },
                     "session": schema_session(),
                 },
+                // Keep the top-level input schema a plain object. Bedrock rejects
+                // anyOf/oneOf/allOf at this level, so the conditional pid/profile
+                // contract is described above and enforced by invoke instead.
                 "required": [],
-                "anyOf": [
-                    { "required": ["pid"] },
-                    {
-                        "required": ["allow_launch", "profile"],
-                        "properties": {
-                            "allow_launch": { "const": true },
-                            "profile": {
-                                "required": ["mode"],
-                                "properties": {
-                                    "mode": { "enum": ["isolated_new", "isolated_named"] }
-                                }
-                            }
-                        }
-                    }
-                ],
                 "additionalProperties": true
             }),
             read_only: false,

--- a/libs/cua-driver/rust/crates/cua-driver/tests/protocol_schema_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/protocol_schema_test.rs
@@ -113,15 +113,22 @@ fn tools_list_schema_shape() {
         .iter()
         .find(|tool| tool["name"] == "browser_prepare")
         .expect("browser_prepare not found in tools/list");
+    let prepare_schema = &prepare["inputSchema"];
+    assert_eq!(
+        prepare_schema["type"], "object",
+        "browser_prepare must advertise a plain object input schema"
+    );
+    for unsupported in ["anyOf", "oneOf", "allOf"] {
+        assert!(
+            prepare_schema.get(unsupported).is_none(),
+            "browser_prepare top-level {unsupported} is rejected by Bedrock: {prepare_schema}"
+        );
+    }
     assert!(
-        prepare["inputSchema"]["anyOf"]
+        prepare_schema["required"]
             .as_array()
-            .is_some_and(|alternatives| alternatives.iter().any(|alternative| {
-                alternative["required"]
-                    .as_array()
-                    .is_some_and(|required| required.iter().any(|field| field == "pid"))
-            })),
-        "browser_prepare schema must retain a pid-required alternative"
+            .is_some_and(|required| required.is_empty()),
+        "browser_prepare must leave conditionally required fields to runtime validation"
     );
 
     const DELIVERY_MODE_TOOLS: &[&str] = &[

--- a/libs/cua-driver/rust/crates/cua-driver/tests/protocol_schema_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/protocol_schema_test.rs
@@ -1,7 +1,8 @@
 //! Pure `tools/list` schema-shape assertions.
 //!
 //! These never invoke a tool — they only inspect the advertised inputSchemas:
-//! that `type_text_chars` is hidden, the `list_windows.on_screen_only` knob, the
+//! that every tool keeps its top-level schema provider-compatible, that
+//! `type_text_chars` is hidden, the `list_windows.on_screen_only` knob, the
 //! `set_agent_cursor_motion` Bezier knobs, delivery and scope enums, and the
 //! `set_config.capture_mode` enum and the per-session capture-scope contract.
 
@@ -35,6 +36,20 @@ fn tools_list_schema_shape() {
             .unwrap_or_else(|| panic!("{name} not found in tools/list"))["inputSchema"]
             ["properties"]
     };
+    for tool in tools {
+        let name = tool["name"].as_str().expect("tool name");
+        let schema = &tool["inputSchema"];
+        assert_eq!(
+            schema["type"], "object",
+            "{name} must advertise a plain object input schema"
+        );
+        for unsupported in ["anyOf", "oneOf", "allOf"] {
+            assert!(
+                schema.get(unsupported).is_none(),
+                "{name} top-level {unsupported} is rejected by Bedrock: {schema}"
+            );
+        }
+    }
     let enum_contains = |schema: &serde_json::Value, expected: &str| {
         schema["enum"]
             .as_array()
@@ -109,28 +124,6 @@ fn tools_list_schema_shape() {
             );
         }
     }
-    let prepare = tools
-        .iter()
-        .find(|tool| tool["name"] == "browser_prepare")
-        .expect("browser_prepare not found in tools/list");
-    let prepare_schema = &prepare["inputSchema"];
-    assert_eq!(
-        prepare_schema["type"], "object",
-        "browser_prepare must advertise a plain object input schema"
-    );
-    for unsupported in ["anyOf", "oneOf", "allOf"] {
-        assert!(
-            prepare_schema.get(unsupported).is_none(),
-            "browser_prepare top-level {unsupported} is rejected by Bedrock: {prepare_schema}"
-        );
-    }
-    assert!(
-        prepare_schema["required"]
-            .as_array()
-            .is_some_and(|required| required.is_empty()),
-        "browser_prepare must leave conditionally required fields to runtime validation"
-    );
-
     const DELIVERY_MODE_TOOLS: &[&str] = &[
         "click",
         "double_click",


### PR DESCRIPTION
## summary

- advertise `browser_prepare` as a plain top-level object so Bedrock accepts the MCP tool catalog
- keep the conditional `pid` versus isolated-profile contract in the existing runtime validation
- guard every advertised tool against provider-incompatible top-level schema combinators in the live `tools/list` protocol test
- preserve runtime coverage for valid pid-free isolated launches and invalid incomplete or conflicting requests

closes #3303

## root cause

`browser_prepare.inputSchema` used a top-level `anyOf` to express that callers must provide either `pid` or an isolated launch request. Bedrock rejects top-level `anyOf`, `oneOf`, and `allOf` before the model can call any tool. The Rust invocation path already enforces the same conditional contract, so removing the provider-facing union does not relax runtime behavior.

## validation

candidate: `829711398ca53820bdcdc120af1474e3dfa5f007`

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo test -p cua-driver-core pid_remains_required_without_a_complete_isolated_launch_request`
- the full spawned-driver protocol test remains covered by pull request CI; local compilation stops because this Linux workspace lacks `pkg-config` and X11 development metadata

## known gaps

- no live Bedrock replay was available in this workspace
