### PR TITLE
refactor(cua-driver): share cursor movement spec with playground

### DIFF
--- a/libs/cua-driver/rust/crates/cursor-overlay/assets/motion.default.json
+++ b/libs/cua-driver/rust/crates/cursor-overlay/assets/motion.default.json
@@ -1,0 +1,33 @@
+{
+  "schema": "cua.cursor-motion/1",
+  "shared": {
+    "start_handle": 0.3,
+    "end_handle": 0.3,
+    "arc_size": 0.25,
+    "arc_flow": 0.0,
+    "spring": 0.72,
+    "glide_duration_ms": 0.0,
+    "dwell_after_click_ms": 80.0,
+    "idle_hide_ms": 20000.0,
+    "press_duration_ms": 120.0,
+    "peak_speed": 900.0,
+    "min_start_speed": 300.0,
+    "min_end_speed": 200.0,
+    "turn_radius": 80.0,
+    "click_offset": 16.0
+  },
+  "spring_settle": {
+    "macos": {
+      "mode": "fixed",
+      "k": 400.0,
+      "c": 17.0,
+      "overshoot": 0.8
+    },
+    "windows_linux": {
+      "mode": "derived",
+      "k_per_spring": 400.0,
+      "c_per_spring": 20.0,
+      "overshoot": 0.5
+    }
+  }
+}

--- a/libs/cua-driver/rust/crates/cursor-overlay/examples/export_gallery_frames.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/examples/export_gallery_frames.rs
@@ -1,8 +1,8 @@
 use cursor_overlay::{
-    inspect_artifact, render_frame, CompiledTheme, CursorAction, CursorConfig, DeliveryModifier,
-    OverlayCommand, ReducedMotion, RenderStateCore, TargetModifier,
+    inspect_artifact, motion_spec, render_frame, CompiledTheme, CursorAction, CursorConfig,
+    DeliveryModifier, MotionConfig, OverlayCommand, ReducedMotion, RenderStateCore, TargetModifier,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -32,6 +32,7 @@ struct Args {
     output: PathBuf,
     theme: Option<PathBuf>,
     dev: bool,
+    motion_overrides: Option<PathBuf>,
 }
 
 #[derive(Serialize)]
@@ -45,7 +46,157 @@ struct GalleryManifest<'a> {
     movement_fps: f64,
     movement_tick_ms: u32,
     duration_secs: u32,
+    motion: MotionManifest,
     actions: Vec<ActionManifest>,
+}
+
+/// Movement-contract echo in the gallery manifest. The values are what the
+/// renderer actually used, so a recording can never be mistaken for the
+/// production defaults when overrides were active.
+#[derive(Serialize)]
+struct MotionManifest {
+    /// Repository spec revision the render was based on.
+    spec_schema: String,
+    /// Platform tick path that produced the movement frames:
+    /// `swift_constants` (macOS) or `motion` (Windows/Linux).
+    tick_path: &'static str,
+    /// Effective `MotionConfig` used by the movement scenes.
+    effective: MotionConfigEcho,
+    /// Spring-settle constants the tick path used.
+    spring_settle: SpringSettleEcho,
+    /// Movement fields overridden for this render (empty for defaults).
+    overridden_fields: Vec<&'static str>,
+}
+
+#[derive(Serialize)]
+struct MotionConfigEcho {
+    peak_speed: f64,
+    min_start_speed: f64,
+    min_end_speed: f64,
+    turn_radius: f64,
+    spring: f64,
+    glide_duration_ms: f64,
+}
+
+#[derive(Serialize)]
+struct SpringSettleEcho {
+    mode: &'static str,
+    k: f64,
+    c: f64,
+    overshoot: f64,
+}
+
+/// Playground override file (`cua.cursor-gallery-motion-override/1`).
+///
+/// Only fields that affect the current production movement path are
+/// accepted; every value is re-clamped in Rust before use, so the file is
+/// advisory input, never authority.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MotionOverrideFile {
+    schema: String,
+    #[serde(default)]
+    peak_speed: Option<f64>,
+    #[serde(default)]
+    min_start_speed: Option<f64>,
+    #[serde(default)]
+    min_end_speed: Option<f64>,
+    #[serde(default)]
+    turn_radius: Option<f64>,
+    #[serde(default)]
+    spring: Option<f64>,
+    #[serde(default)]
+    glide_duration_ms: Option<f64>,
+}
+
+const MOTION_OVERRIDE_SCHEMA: &str = "cua.cursor-gallery-motion-override/1";
+
+impl MotionOverrideFile {
+    /// Parse and validate an override file. Unknown fields are rejected by
+    /// `deny_unknown_fields`; values are clamped to the same production
+    /// bounds the runtime uses.
+    fn load(path: &Path) -> Self {
+        let raw = fs::read_to_string(path)
+            .unwrap_or_else(|error| panic!("read motion overrides {path:?}: {error}"));
+        let file: MotionOverrideFile = serde_json::from_str(&raw)
+            .unwrap_or_else(|error| panic!("parse motion overrides {path:?}: {error}"));
+        if file.schema != MOTION_OVERRIDE_SCHEMA {
+            panic!(
+                "motion overrides {path:?}: expected schema {MOTION_OVERRIDE_SCHEMA}, found {}",
+                file.schema
+            );
+        }
+        file.clamped()
+    }
+
+    fn clamped(&self) -> Self {
+        fn finite(v: f64) -> f64 {
+            if v.is_finite() {
+                v
+            } else {
+                panic!("motion override values must be finite numbers")
+            }
+        }
+        let peak_speed = self.peak_speed.map(|v| finite(v).clamp(50.0, 5000.0));
+        let effective_peak = peak_speed.unwrap_or_else(|| motion_spec().shared.peak_speed);
+        // The end floor keeps the arrival impulse positive: a 0 floor would
+        // stall the glide exactly at u = 1 (speed → 0 before arrival).
+        Self {
+            schema: self.schema.clone(),
+            peak_speed,
+            min_start_speed: self
+                .min_start_speed
+                .map(|v| finite(v).clamp(1.0, effective_peak)),
+            min_end_speed: self
+                .min_end_speed
+                .map(|v| finite(v).clamp(1.0, effective_peak)),
+            turn_radius: self.turn_radius.map(|v| finite(v).clamp(1.0, 1000.0)),
+            spring: self.spring.map(|v| finite(v).clamp(0.3, 1.0)),
+            glide_duration_ms: self.glide_duration_ms.map(|v| finite(v).clamp(0.0, 5000.0)),
+        }
+    }
+
+    fn apply(&self, mut config: MotionConfig) -> (MotionConfig, Vec<&'static str>) {
+        let mut overridden = Vec::new();
+        if let Some(v) = self.peak_speed {
+            config.peak_speed = v;
+            overridden.push("peak_speed");
+        }
+        if let Some(v) = self.min_start_speed {
+            config.min_start_speed = v;
+            overridden.push("min_start_speed");
+        }
+        if let Some(v) = self.min_end_speed {
+            config.min_end_speed = v;
+            overridden.push("min_end_speed");
+        }
+        if let Some(v) = self.turn_radius {
+            config.turn_radius = v;
+            overridden.push("turn_radius");
+        }
+        if let Some(v) = self.spring {
+            config.spring = v;
+            overridden.push("spring");
+        }
+        if let Some(v) = self.glide_duration_ms {
+            config.glide_duration_ms = v;
+            overridden.push("glide_duration_ms");
+        }
+        (config, overridden)
+    }
+}
+
+/// The movement override applied to this render, if any. Held in an Option so
+/// the static (non-dev) export path provably never renders overridden physics.
+static MOTION_OVERRIDES: std::sync::OnceLock<Option<MotionOverrideFile>> =
+    std::sync::OnceLock::new();
+
+fn movement_motion_config() -> (MotionConfig, Vec<&'static str>) {
+    let defaults = MotionConfig::default();
+    match MOTION_OVERRIDES.get().and_then(|o| o.as_ref()) {
+        Some(file) => file.apply(defaults),
+        None => (defaults, Vec::new()),
+    }
 }
 
 #[derive(Serialize)]
@@ -138,9 +289,10 @@ fn parse_args() -> Args {
     let output = values
         .next()
         .map(PathBuf::from)
-        .expect("usage: export_gallery_frames <output-directory> [--theme <artifact>] [--dev]");
+        .expect("usage: export_gallery_frames <output-directory> [--theme <artifact>] [--dev] [--motion-overrides <file>]");
     let mut theme = None;
     let mut dev = false;
+    let mut motion_overrides = None;
     while let Some(value) = values.next() {
         match value.as_str() {
             "--theme" => {
@@ -152,15 +304,40 @@ fn parse_args() -> Args {
                 );
             }
             "--dev" => dev = true,
+            "--motion-overrides" => {
+                motion_overrides = Some(
+                    values
+                        .next()
+                        .map(PathBuf::from)
+                        .expect("--motion-overrides requires a JSON override file path"),
+                );
+            }
             other => panic!("unknown argument `{other}`"),
         }
     }
-    Args { output, theme, dev }
+    if !dev && motion_overrides.is_some() {
+        panic!(
+            "--motion-overrides requires --dev: overrides exist only in the repository playground"
+        );
+    }
+    Args {
+        output,
+        theme,
+        dev,
+        motion_overrides,
+    }
 }
 
 fn main() {
     let args = parse_args();
     let output = args.output.as_path();
+    MOTION_OVERRIDES
+        .set(
+            args.motion_overrides
+                .as_deref()
+                .map(MotionOverrideFile::load),
+        )
+        .expect("motion overrides are initialised exactly once");
     let theme = args
         .theme
         .as_deref()
@@ -277,6 +454,10 @@ fn export_state(output: &Path, state: GalleryState, theme: &Arc<CompiledTheme>) 
 
 fn movement_core(theme: &Arc<CompiledTheme>, action: CursorAction) -> RenderStateCore {
     let mut core = configured_core(theme);
+    let (motion, _) = movement_motion_config();
+    core.motion = motion;
+    // Previews never hide the cursor mid-glide (configured_core contract).
+    core.motion.idle_hide_ms = 0.0;
     core.pos = (
         MOVEMENT_TARGETS[0].0 - FIRST_ACTION_SEED_OFFSET,
         MOVEMENT_TARGETS[0].1 - FIRST_ACTION_SEED_OFFSET,
@@ -455,8 +636,10 @@ fn write_manifest(output: &Path, theme: &CompiledTheme) {
             }
         })
         .collect();
+    let spec = motion_spec();
+    let (effective, overridden_fields) = movement_motion_config();
     let manifest = GalleryManifest {
-        schema: "cua.cursor-gallery/1",
+        schema: "cua.cursor-gallery/2",
         theme_id: &theme.id,
         theme_name: &theme.name,
         theme_version: &theme.version,
@@ -465,6 +648,7 @@ fn write_manifest(output: &Path, theme: &CompiledTheme) {
         movement_fps: 1000.0 / f64::from(MOVEMENT_TICK_MS),
         movement_tick_ms: MOVEMENT_TICK_MS,
         duration_secs: DURATION_SECS,
+        motion: motion_manifest(spec, &effective, overridden_fields),
         actions,
     };
     fs::write(
@@ -472,6 +656,56 @@ fn write_manifest(output: &Path, theme: &CompiledTheme) {
         serde_json::to_vec_pretty(&manifest).expect("serialize gallery manifest"),
     )
     .expect("write gallery manifest");
+}
+
+/// Build the movement echo for the manifest. `swift_constants` keeps its
+/// fixed spec constants regardless of the runtime `spring` value — the
+/// documented macOS limitation — while `motion` derives them.
+fn motion_manifest(
+    spec: &cursor_overlay::MotionSpec,
+    effective: &MotionConfig,
+    overridden_fields: Vec<&'static str>,
+) -> MotionManifest {
+    #[cfg(target_os = "macos")]
+    let (tick_path, spring_settle): (&'static str, SpringSettleEcho) = {
+        let settle = &spec.spring_settle.macos;
+        (
+            "swift_constants",
+            SpringSettleEcho {
+                mode: "fixed",
+                k: settle.k,
+                c: settle.c,
+                overshoot: settle.overshoot,
+            },
+        )
+    };
+    #[cfg(not(target_os = "macos"))]
+    let (tick_path, spring_settle): (&'static str, SpringSettleEcho) = {
+        let settle = &spec.spring_settle.windows_linux;
+        (
+            "motion",
+            SpringSettleEcho {
+                mode: "derived",
+                k: settle.k_per_spring * effective.spring,
+                c: settle.c_per_spring * effective.spring,
+                overshoot: settle.overshoot,
+            },
+        )
+    };
+    MotionManifest {
+        spec_schema: spec.schema.clone(),
+        tick_path,
+        effective: MotionConfigEcho {
+            peak_speed: effective.peak_speed,
+            min_start_speed: effective.min_start_speed,
+            min_end_speed: effective.min_end_speed,
+            turn_radius: effective.turn_radius,
+            spring: effective.spring,
+            glide_duration_ms: effective.glide_duration_ms,
+        },
+        spring_settle,
+        overridden_fields,
+    }
 }
 
 #[cfg(test)]
@@ -529,6 +763,108 @@ mod tests {
         tick_production_motion(&mut core, f64::from(MOVEMENT_TICK_MS) / 1000.0);
         assert_ne!(core.pos, start);
         assert_eq!(core.visual.resolved_action, CursorAction::Navigate);
+    }
+
+    #[test]
+    fn movement_core_uses_spec_defaults_without_overrides() {
+        let theme = cursor_overlay::embedded_default_theme();
+        let core = movement_core(&theme, CursorAction::Observe);
+        let mut expected = MotionConfig::default();
+        // The exporter never hides the cursor mid-preview.
+        expected.idle_hide_ms = 0.0;
+        assert_eq!(core.motion, expected);
+    }
+
+    #[test]
+    fn motion_overrides_apply_clamp_and_stay_scoped_to_dev() {
+        let file = MotionOverrideFile {
+            schema: MOTION_OVERRIDE_SCHEMA.into(),
+            peak_speed: Some(99_999.0),
+            min_start_speed: Some(-5.0),
+            min_end_speed: Some(0.0),
+            turn_radius: Some(2_000.0),
+            spring: Some(0.05),
+            glide_duration_ms: Some(9_000.0),
+        };
+        let clamped = file.clamped();
+        assert_eq!(clamped.peak_speed, Some(5000.0));
+        assert_eq!(clamped.min_start_speed, Some(1.0));
+        assert_eq!(clamped.min_end_speed, Some(1.0));
+        assert_eq!(clamped.turn_radius, Some(1000.0));
+        assert_eq!(clamped.spring, Some(0.3));
+        assert_eq!(clamped.glide_duration_ms, Some(5000.0));
+
+        let (effective, overridden) = clamped.apply(MotionConfig::default());
+        assert_eq!(effective.peak_speed, 5000.0);
+        assert_eq!(effective.min_end_speed, 1.0);
+        assert_eq!(
+            overridden,
+            vec![
+                "peak_speed",
+                "min_start_speed",
+                "min_end_speed",
+                "turn_radius",
+                "spring",
+                "glide_duration_ms"
+            ]
+        );
+    }
+
+    #[test]
+    fn floors_cannot_exceed_the_effective_peak_speed() {
+        let file = MotionOverrideFile {
+            schema: MOTION_OVERRIDE_SCHEMA.into(),
+            peak_speed: Some(120.0),
+            min_start_speed: Some(400.0),
+            min_end_speed: Some(350.0),
+            turn_radius: None,
+            spring: None,
+            glide_duration_ms: None,
+        };
+        let clamped = file.clamped();
+        assert_eq!(clamped.min_start_speed, Some(120.0));
+        assert_eq!(clamped.min_end_speed, Some(120.0));
+    }
+
+    #[test]
+    fn motion_overrides_reject_unknown_fields() {
+        // Unknown fields are denied by the schema, so a stale or hostile
+        // override file cannot smuggle non-movement knobs into a render.
+        assert!(serde_json::from_str::<MotionOverrideFile>(
+            r#"{"schema": "cua.cursor-gallery-motion-override/1", "idle_hide_ms": 5.0}"#
+        )
+        .is_err());
+        // The schema string is a namespaced constant, never free-form.
+        assert_ne!(MOTION_OVERRIDE_SCHEMA, "cua.other/9");
+    }
+
+    #[test]
+    fn empty_overrides_render_exact_production_defaults() {
+        let file = MotionOverrideFile {
+            schema: MOTION_OVERRIDE_SCHEMA.into(),
+            peak_speed: None,
+            min_start_speed: None,
+            min_end_speed: None,
+            turn_radius: None,
+            spring: None,
+            glide_duration_ms: None,
+        };
+        let (effective, overridden) = file.apply(MotionConfig::default());
+        assert_eq!(effective, MotionConfig::default());
+        assert!(overridden.is_empty());
+    }
+
+    #[test]
+    fn manifest_motion_block_reports_the_spec_contract() {
+        let spec = motion_spec();
+        let (effective, overridden) = movement_motion_config();
+        let block = motion_manifest(spec, &effective, overridden);
+        assert_eq!(block.spec_schema, spec.schema);
+        assert!(matches!(block.tick_path, "swift_constants" | "motion"));
+        assert_eq!(block.effective.peak_speed, spec.shared.peak_speed);
+        assert_eq!(block.effective.turn_radius, spec.shared.turn_radius);
+        assert_eq!(block.effective.spring, spec.shared.spring);
+        assert!(block.overridden_fields.is_empty());
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cursor-overlay/examples/export_gallery_frames.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/examples/export_gallery_frames.rs
@@ -1,17 +1,60 @@
 use cursor_overlay::{
-    render_frame, CursorAction, CursorConfig, DeliveryModifier, OverlayCommand, RenderStateCore,
-    TargetModifier,
+    inspect_artifact, render_frame, CompiledTheme, CursorAction, CursorConfig, DeliveryModifier,
+    OverlayCommand, ReducedMotion, RenderStateCore, TargetModifier,
 };
+use serde::Serialize;
 use std::{
     fs,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 const SIZE: u32 = 256;
-const FPS: u32 = 30;
+const MOVEMENT_WIDTH: u32 = 1024;
+const MOVEMENT_HEIGHT: u32 = 576;
+const ACTION_FPS: u32 = 30;
+const MOVEMENT_TICK_MS: u32 = 16;
+const MOVEMENT_FRAME_COUNT: u32 = DURATION_SECS * 1000 / MOVEMENT_TICK_MS;
 const DURATION_SECS: u32 = 4;
 const PREVIEW_BACKING_SCALE: f32 = 1.5;
+const MOVEMENT_BACKING_SCALE: f32 = 1.0;
 const RUNTIME_SESSION_LABEL: &str = "Research";
+const MOVEMENT_TARGETS: [(f64, f64); 4] = [
+    (400.0, 350.0),
+    (650.0, 200.0),
+    (550.0, 390.0),
+    (280.0, 350.0),
+];
+const PRODUCTION_END_HEADING: f64 = std::f64::consts::FRAC_PI_4;
+const FIRST_ACTION_SEED_OFFSET: f64 = 140.0;
+
+struct Args {
+    output: PathBuf,
+    theme: Option<PathBuf>,
+    dev: bool,
+}
+
+#[derive(Serialize)]
+struct GalleryManifest<'a> {
+    schema: &'static str,
+    theme_id: &'a str,
+    theme_name: &'a str,
+    theme_version: &'a str,
+    content_hash: String,
+    fps: u32,
+    movement_fps: f64,
+    movement_tick_ms: u32,
+    duration_secs: u32,
+    actions: Vec<ActionManifest>,
+}
+
+#[derive(Serialize)]
+struct ActionManifest {
+    id: &'static str,
+    authored_frames: usize,
+    still_frame: u16,
+    playback: &'static str,
+}
 
 #[derive(Clone, Copy)]
 struct GalleryState {
@@ -90,29 +133,42 @@ fn preview_states(output: &Path) -> Vec<(PathBuf, GalleryState)> {
     states
 }
 
-fn export_states(states: Vec<(PathBuf, GalleryState)>) {
-    let worker_count = std::thread::available_parallelism()
-        .map(usize::from)
-        .unwrap_or(4)
-        .min(12)
-        .min(states.len().max(1));
-    let chunk_size = states.len().div_ceil(worker_count);
-    std::thread::scope(|scope| {
-        for chunk in states.chunks(chunk_size) {
-            scope.spawn(move || {
-                for (path, state) in chunk {
-                    export_state(path, *state);
-                }
-            });
+fn parse_args() -> Args {
+    let mut values = std::env::args().skip(1);
+    let output = values
+        .next()
+        .map(PathBuf::from)
+        .expect("usage: export_gallery_frames <output-directory> [--theme <artifact>] [--dev]");
+    let mut theme = None;
+    let mut dev = false;
+    while let Some(value) = values.next() {
+        match value.as_str() {
+            "--theme" => {
+                theme = Some(
+                    values
+                        .next()
+                        .map(PathBuf::from)
+                        .expect("--theme requires a compiled .cua-theme path"),
+                );
+            }
+            "--dev" => dev = true,
+            other => panic!("unknown argument `{other}`"),
         }
-    });
+    }
+    Args { output, theme, dev }
 }
 
 fn main() {
-    let output = std::env::args()
-        .nth(1)
-        .expect("usage: export_gallery_frames <output-directory>");
-    let output = Path::new(&output);
+    let args = parse_args();
+    let output = args.output.as_path();
+    let theme = args
+        .theme
+        .as_deref()
+        .map(inspect_artifact)
+        .transpose()
+        .expect("load compiled cursor theme")
+        .unwrap_or_else(|| (*cursor_overlay::embedded_default_theme()).clone());
+    let theme = Arc::new(theme);
 
     let mut states = Vec::new();
     for action in CursorAction::ALL {
@@ -126,51 +182,296 @@ fn main() {
             },
         ));
     }
-    export_states(states);
-    export_states(preview_states(output));
+    export_states(states, &theme);
+    export_reduced_states(output, &theme);
+    if args.dev {
+        export_states(runtime_preview_states(output), &theme);
+        export_movement_states(output, &theme);
+    } else {
+        export_states(preview_states(output), &theme);
+    }
+    write_manifest(output, &theme);
 }
 
-fn export_state(output: &Path, state: GalleryState) {
-    fs::create_dir_all(output).expect("create frame output");
-    for frame in 0..FPS * DURATION_SECS {
-        let mut config = CursorConfig::default();
-        config.cursor_id = "gallery-session".into();
-        let mut core = RenderStateCore::new(config);
-        core.motion.idle_hide_ms = 0.0;
-        core.pos = (
-            f64::from(SIZE) / (2.0 * f64::from(PREVIEW_BACKING_SCALE)),
-            f64::from(SIZE) / (2.0 * f64::from(PREVIEW_BACKING_SCALE)),
-        );
-        core.heading = f64::from(std::f32::consts::FRAC_PI_4);
-        if let Some(session_label) = state.session_label {
-            core.apply_command_base(
-                OverlayCommand::SetSessionLabel(session_label.into()),
-                false,
-                false,
-            );
+fn runtime_preview_states(output: &Path) -> Vec<(PathBuf, GalleryState)> {
+    CursorAction::ALL
+        .into_iter()
+        .map(|action| {
+            (
+                output.join("runtime").join(action.as_str()),
+                GalleryState {
+                    action,
+                    delivery: Some(DeliveryModifier::Background),
+                    target: Some(TargetModifier::Browser),
+                    session_label: Some(RUNTIME_SESSION_LABEL),
+                },
+            )
+        })
+        .collect()
+}
+
+fn export_states(states: Vec<(PathBuf, GalleryState)>, theme: &Arc<CompiledTheme>) {
+    let worker_count = std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(4)
+        .min(12)
+        .min(states.len().max(1));
+    let chunk_size = states.len().div_ceil(worker_count);
+    std::thread::scope(|scope| {
+        for chunk in states.chunks(chunk_size) {
+            let theme = theme.clone();
+            scope.spawn(move || {
+                for (path, state) in chunk {
+                    export_state(path, *state, &theme);
+                }
+            });
         }
-        core.apply_command_base(
-            OverlayCommand::BeginAction {
-                action: state.action,
-                delivery: state.delivery,
-                target: state.target,
-            },
-            false,
-            false,
-        );
-        core.visual.elapsed_secs = f64::from(frame) / f64::from(FPS);
-        let pixmap = render_frame(&core, SIZE, SIZE, 0.0, 0.0, None, PREVIEW_BACKING_SCALE);
-        let pixels = unpremultiply_rgba(pixmap.data().to_vec());
-        image::save_buffer_with_format(
-            output.join(format!("{frame:04}.png")),
-            &pixels,
-            SIZE,
-            SIZE,
-            image::ColorType::Rgba8,
-            image::ImageFormat::Png,
-        )
-        .expect("write frame");
+    });
+}
+
+fn configured_core(theme: &Arc<CompiledTheme>) -> RenderStateCore {
+    let mut config = CursorConfig::default();
+    config.cursor_id = "gallery-session".into();
+    let mut core = RenderStateCore::new(config);
+    core.theme = Some(theme.clone());
+    core.motion.idle_hide_ms = 0.0;
+    core.pos = (
+        f64::from(SIZE) / (2.0 * f64::from(PREVIEW_BACKING_SCALE)),
+        f64::from(SIZE) / (2.0 * f64::from(PREVIEW_BACKING_SCALE)),
+    );
+    core.heading = f64::from(std::f32::consts::FRAC_PI_4);
+    core
+}
+
+fn apply_production_command(core: &mut RenderStateCore, command: OverlayCommand) {
+    #[cfg(target_os = "macos")]
+    core.apply_command_base(command, true, true);
+
+    #[cfg(not(target_os = "macos"))]
+    core.apply_command_base(command, false, false);
+}
+
+fn apply_gallery_state(core: &mut RenderStateCore, state: GalleryState) {
+    if let Some(session_label) = state.session_label {
+        apply_production_command(core, OverlayCommand::SetSessionLabel(session_label.into()));
     }
+    apply_production_command(
+        core,
+        OverlayCommand::BeginAction {
+            action: state.action,
+            delivery: state.delivery,
+            target: state.target,
+        },
+    );
+}
+
+fn export_state(output: &Path, state: GalleryState, theme: &Arc<CompiledTheme>) {
+    fs::create_dir_all(output).expect("create frame output");
+    for frame in 0..ACTION_FPS * DURATION_SECS {
+        let mut core = configured_core(theme);
+        apply_gallery_state(&mut core, state);
+        core.visual.elapsed_secs = f64::from(frame) / f64::from(ACTION_FPS);
+        save_frame(&core, output.join(format!("{frame:04}.png")), SIZE, SIZE);
+    }
+}
+
+fn movement_core(theme: &Arc<CompiledTheme>, action: CursorAction) -> RenderStateCore {
+    let mut core = configured_core(theme);
+    core.pos = (
+        MOVEMENT_TARGETS[0].0 - FIRST_ACTION_SEED_OFFSET,
+        MOVEMENT_TARGETS[0].1 - FIRST_ACTION_SEED_OFFSET,
+    );
+    core.heading = PRODUCTION_END_HEADING;
+    apply_gallery_state(
+        &mut core,
+        GalleryState {
+            action,
+            delivery: None,
+            target: None,
+            session_label: None,
+        },
+    );
+    core
+}
+
+fn tick_production_motion(core: &mut RenderStateCore, dt: f64) -> bool {
+    #[cfg(target_os = "macos")]
+    return core.tick_swift_constants(dt);
+
+    #[cfg(not(target_os = "macos"))]
+    return core.tick_motion(dt);
+}
+
+fn movement_target(core: &mut RenderStateCore, position: (f64, f64)) {
+    apply_production_command(
+        core,
+        OverlayCommand::MoveTo {
+            x: position.0,
+            y: position.1,
+            end_heading_radians: PRODUCTION_END_HEADING,
+        },
+    );
+}
+
+fn export_movement_states(output: &Path, theme: &Arc<CompiledTheme>) {
+    let worker_count = std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(4)
+        .min(CursorAction::ALL.len());
+    let chunk_size = CursorAction::ALL.len().div_ceil(worker_count);
+    std::thread::scope(|scope| {
+        for actions in CursorAction::ALL.chunks(chunk_size) {
+            let theme = theme.clone();
+            scope.spawn(move || {
+                for action in actions {
+                    let path = output.join("movement").join(action.as_str());
+                    fs::create_dir_all(&path).expect("create movement frame output");
+                    let mut core = movement_core(&theme, *action);
+                    let mut active_target = 0;
+                    movement_target(&mut core, MOVEMENT_TARGETS[active_target]);
+                    for frame in 0..MOVEMENT_FRAME_COUNT {
+                        let dt = if frame == 0 {
+                            0.0
+                        } else {
+                            f64::from(MOVEMENT_TICK_MS) / 1000.0
+                        };
+                        let arrived = tick_production_motion(&mut core, dt);
+                        save_frame_at_scale(
+                            &core,
+                            path.join(format!("{frame:04}.png")),
+                            MOVEMENT_WIDTH,
+                            MOVEMENT_HEIGHT,
+                            MOVEMENT_BACKING_SCALE,
+                        );
+                        if arrived && active_target + 1 < MOVEMENT_TARGETS.len() {
+                            active_target += 1;
+                            movement_target(&mut core, MOVEMENT_TARGETS[active_target]);
+                        }
+                    }
+                }
+            });
+        }
+    });
+}
+
+fn export_reduced_states(output: &Path, theme: &Arc<CompiledTheme>) {
+    let reduced = output.join("reduced");
+    let actions_output = reduced.join("actions");
+    let runtime_output = reduced.join("runtime");
+    let movement_output = reduced.join("movement");
+    fs::create_dir_all(&actions_output).expect("create reduced-motion action output");
+    fs::create_dir_all(&runtime_output).expect("create reduced-motion runtime output");
+    fs::create_dir_all(&movement_output).expect("create reduced-motion movement output");
+    for action in CursorAction::ALL {
+        let mut core = configured_core(theme);
+        core.visual.reduced_motion = ReducedMotion::On;
+        apply_gallery_state(
+            &mut core,
+            GalleryState {
+                action,
+                delivery: None,
+                target: None,
+                session_label: None,
+            },
+        );
+        save_frame(
+            &core,
+            actions_output.join(format!("{}.png", action.as_str())),
+            SIZE,
+            SIZE,
+        );
+
+        let mut runtime = configured_core(theme);
+        runtime.visual.reduced_motion = ReducedMotion::On;
+        apply_gallery_state(
+            &mut runtime,
+            GalleryState {
+                action,
+                delivery: Some(DeliveryModifier::Background),
+                target: Some(TargetModifier::Browser),
+                session_label: Some(RUNTIME_SESSION_LABEL),
+            },
+        );
+        save_frame(
+            &runtime,
+            runtime_output.join(format!("{}.png", action.as_str())),
+            SIZE,
+            SIZE,
+        );
+
+        let mut movement = movement_core(theme, action);
+        movement.visual.reduced_motion = ReducedMotion::On;
+        save_frame_at_scale(
+            &movement,
+            movement_output.join(format!("{}.png", action.as_str())),
+            MOVEMENT_WIDTH,
+            MOVEMENT_HEIGHT,
+            MOVEMENT_BACKING_SCALE,
+        );
+    }
+}
+
+fn save_frame(core: &RenderStateCore, path: PathBuf, width: u32, height: u32) {
+    save_frame_at_scale(core, path, width, height, PREVIEW_BACKING_SCALE);
+}
+
+fn save_frame_at_scale(
+    core: &RenderStateCore,
+    path: PathBuf,
+    width: u32,
+    height: u32,
+    backing_scale: f32,
+) {
+    let pixmap = render_frame(core, width, height, 0.0, 0.0, None, backing_scale);
+    let pixels = unpremultiply_rgba(pixmap.data().to_vec());
+    image::save_buffer_with_format(
+        path,
+        &pixels,
+        width,
+        height,
+        image::ColorType::Rgba8,
+        image::ImageFormat::Png,
+    )
+    .expect("write frame");
+}
+
+fn write_manifest(output: &Path, theme: &CompiledTheme) {
+    let actions = CursorAction::ALL
+        .into_iter()
+        .map(|action| {
+            let animation = theme
+                .animation_for_action(action)
+                .expect("compiled theme contains every cursor action");
+            ActionManifest {
+                id: action.as_str(),
+                authored_frames: animation.frames.len(),
+                still_frame: animation.still_frame,
+                playback: match action.playback() {
+                    cursor_overlay::PlaybackKind::Resting => "resting",
+                    cursor_overlay::PlaybackKind::OneShot => "one_shot",
+                    cursor_overlay::PlaybackKind::Held => "held",
+                    cursor_overlay::PlaybackKind::Loop => "loop",
+                },
+            }
+        })
+        .collect();
+    let manifest = GalleryManifest {
+        schema: "cua.cursor-gallery/1",
+        theme_id: &theme.id,
+        theme_name: &theme.name,
+        theme_version: &theme.version,
+        content_hash: theme.content_hash(),
+        fps: ACTION_FPS,
+        movement_fps: 1000.0 / f64::from(MOVEMENT_TICK_MS),
+        movement_tick_ms: MOVEMENT_TICK_MS,
+        duration_secs: DURATION_SECS,
+        actions,
+    };
+    fs::write(
+        output.join("manifest.json"),
+        serde_json::to_vec_pretty(&manifest).expect("serialize gallery manifest"),
+    )
+    .expect("write gallery manifest");
 }
 
 #[cfg(test)]
@@ -200,6 +501,90 @@ mod tests {
         assert!(slugs.contains("observe--background--browser"));
         assert!(slugs.contains("idle--none--none"));
         assert!(slugs.contains("system--foreground--desktop"));
+    }
+
+    #[test]
+    fn development_inventory_keeps_one_exact_runtime_composition_per_action() {
+        let root = Path::new("gallery");
+        let states = runtime_preview_states(root);
+        assert_eq!(states.len(), CursorAction::ALL.len());
+        for (path, state) in states {
+            assert_eq!(path, root.join("runtime").join(state.action.as_str()));
+            assert_eq!(state.delivery, Some(DeliveryModifier::Background));
+            assert_eq!(state.target, Some(TargetModifier::Browser));
+            assert_eq!(state.session_label, Some(RUNTIME_SESSION_LABEL));
+        }
+    }
+
+    #[test]
+    fn movement_preview_drives_the_production_motion_path() {
+        let theme = cursor_overlay::embedded_default_theme();
+        let mut core = movement_core(&theme, CursorAction::Navigate);
+        let start = core.pos;
+        assert_eq!(core.motion.glide_duration_ms, 0.0);
+
+        movement_target(&mut core, MOVEMENT_TARGETS[0]);
+        assert!(core.path.is_some());
+
+        tick_production_motion(&mut core, f64::from(MOVEMENT_TICK_MS) / 1000.0);
+        assert_ne!(core.pos, start);
+        assert_eq!(core.visual.resolved_action, CursorAction::Navigate);
+    }
+
+    #[test]
+    fn movement_preview_stays_inside_the_canvas() {
+        const EDGE_GUARD: u32 = 12;
+        let theme = cursor_overlay::embedded_default_theme();
+        let mut core = movement_core(&theme, CursorAction::Observe);
+
+        let mut active_target = 0;
+        movement_target(&mut core, MOVEMENT_TARGETS[active_target]);
+        for frame in 0..MOVEMENT_FRAME_COUNT {
+            let dt = if frame == 0 {
+                0.0
+            } else {
+                f64::from(MOVEMENT_TICK_MS) / 1000.0
+            };
+            let arrived = tick_production_motion(&mut core, dt);
+
+            let pixmap = render_frame(
+                &core,
+                MOVEMENT_WIDTH,
+                MOVEMENT_HEIGHT,
+                0.0,
+                0.0,
+                None,
+                MOVEMENT_BACKING_SCALE,
+            );
+            let mut bounds = None;
+            for y in 0..MOVEMENT_HEIGHT {
+                for x in 0..MOVEMENT_WIDTH {
+                    let alpha = pixmap.data()[((y * MOVEMENT_WIDTH + x) * 4 + 3) as usize];
+                    if alpha == 0 {
+                        continue;
+                    }
+                    let (min_x, min_y, max_x, max_y) = bounds.get_or_insert((x, y, x, y));
+                    *min_x = (*min_x).min(x);
+                    *min_y = (*min_y).min(y);
+                    *max_x = (*max_x).max(x);
+                    *max_y = (*max_y).max(y);
+                }
+            }
+            if let Some((min_x, min_y, max_x, max_y)) = bounds {
+                assert!(
+                    min_x >= EDGE_GUARD
+                        && min_y >= EDGE_GUARD
+                        && max_x < MOVEMENT_WIDTH - EDGE_GUARD
+                        && max_y < MOVEMENT_HEIGHT - EDGE_GUARD,
+                    "movement frame {frame} at {:?} entered the canvas edge guard: ({min_x}, {min_y})..({max_x}, {max_y})",
+                    core.pos
+                );
+            }
+            if arrived && active_target + 1 < MOVEMENT_TARGETS.len() {
+                active_target += 1;
+                movement_target(&mut core, MOVEMENT_TARGETS[active_target]);
+            }
+        }
     }
 }
 

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/lib.rs
@@ -20,7 +20,7 @@ pub mod z_order;
 
 pub use badge_glyphs::{BadgeChip, BadgeGlyph};
 pub use bezier::CubicBezier;
-pub use motion::{MotionConfig, Spring};
+pub use motion::{motion_spec, parse_motion_spec, MotionConfig, MotionSpec, Spring};
 pub use path_planner::{PathPlanner, PathState, PlannedPath};
 pub use render_state::{
     paint_cursor, render_frame, FocusRect, RenderStateCore, SESSION_BADGE_FADE_SECS,
@@ -381,11 +381,11 @@ pub enum OverlayCommand {
 /// coordinate. Keeping this transform here prevents platform-specific drag
 /// loops from drifting apart.
 pub fn track_pointer_command(x: f64, y: f64) -> OverlayCommand {
-    const CLICK_OFFSET: f64 = 16.0;
+    let offset = motion::click_offset();
     let heading = std::f64::consts::FRAC_PI_4;
     OverlayCommand::SnapTo {
-        x: x + heading.cos() * CLICK_OFFSET,
-        y: y + heading.sin() * CLICK_OFFSET,
+        x: x + heading.cos() * offset,
+        y: y + heading.sin() * offset,
         heading_radians: Some(heading),
     }
 }

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/motion.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/motion.rs
@@ -6,9 +6,16 @@
 //! and the cursor-gallery exporter cannot drift apart. Changing a default is a
 //! two-file review: edit the JSON, then update the independent Rust literal in
 //! [`self::spec_tests`] until the parity test passes again.
+//!
+//! The embedded asset is trusted repository input, not runtime configuration.
+//! Invalid JSON or values therefore fail fast on first access; there is
+//! deliberately no silent fallback to a second set of defaults.
 
+use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
+
+const MOTION_SPEC_SCHEMA: &str = "cua.cursor-motion/1";
 
 /// Click-point offset in points: the arrow artwork is centred this far
 /// down-right of the reported click coordinate so its tip lands on it.
@@ -49,7 +56,7 @@ pub struct MotionSpecShared {
     /// Post-arrival spring damping: 1.0 = critical, 0.3 = bouncy. [0.3, 1.0]
     pub spring: f64,
     /// Main glide duration in milliseconds — used only as a legacy override.
-    /// When <= 0 the render engine uses speed-based timing instead. [50, 5000]
+    /// When <= 0 the render engine uses speed-based timing instead. [0, 5000]
     pub glide_duration_ms: f64,
     /// Post-click dwell in milliseconds. [0, 5000]
     pub dwell_after_click_ms: f64,
@@ -83,11 +90,19 @@ pub struct MotionSpecSpringSettle {
     pub windows_linux: SpringSettleWindowsLinux,
 }
 
+/// How a platform obtains its post-arrival spring constants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpringSettleMode {
+    Fixed,
+    Derived,
+}
+
 /// macOS `tick_swift_constants` settle: fixed constants.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SpringSettleMacos {
-    pub mode: String,
+    pub mode: SpringSettleMode,
     pub k: f64,
     pub c: f64,
     pub overshoot: f64,
@@ -97,7 +112,7 @@ pub struct SpringSettleMacos {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SpringSettleWindowsLinux {
-    pub mode: String,
+    pub mode: SpringSettleMode,
     pub k_per_spring: f64,
     pub c_per_spring: f64,
     pub overshoot: f64,
@@ -105,9 +120,16 @@ pub struct SpringSettleWindowsLinux {
 
 fn embedded_motion_spec() -> &'static MotionSpec {
     static SPEC: OnceLock<MotionSpec> = OnceLock::new();
-    SPEC.get_or_init(|| {
-        serde_json::from_str(MOTION_SPEC_JSON)
-            .expect("embedded assets/motion.default.json is valid at compile time")
+    SPEC.get_or_init(|| parse_embedded_motion_spec(MOTION_SPEC_JSON))
+}
+
+fn parse_embedded_motion_spec(raw: &str) -> MotionSpec {
+    parse_motion_spec(raw).unwrap_or_else(|error| {
+        panic!(
+            "embedded assets/motion.default.json failed validation: {error}; \
+             there is deliberately no fallback because the checked-in spec is the \
+             single source of movement defaults"
+        )
     })
 }
 
@@ -115,12 +137,124 @@ fn embedded_motion_spec() -> &'static MotionSpec {
 /// as the embedded default. Exporters and tests use this for override files;
 /// production always uses the embedded copy.
 pub fn parse_motion_spec(raw: &str) -> Result<MotionSpec, serde_json::Error> {
-    serde_json::from_str(raw)
+    let spec: MotionSpec = serde_json::from_str(raw)?;
+    spec.validate().map_err(serde_json::Error::custom)?;
+    Ok(spec)
 }
 
 /// The embedded repository-owned movement specification.
 pub fn motion_spec() -> &'static MotionSpec {
     embedded_motion_spec()
+}
+
+impl MotionSpec {
+    fn validate(&self) -> Result<(), String> {
+        if self.schema != MOTION_SPEC_SCHEMA {
+            return Err(format!(
+                "schema must be {MOTION_SPEC_SCHEMA:?}, got {:?}",
+                self.schema
+            ));
+        }
+
+        let shared = &self.shared;
+        validate_range("shared.start_handle", shared.start_handle, 0.0, 1.0)?;
+        validate_range("shared.end_handle", shared.end_handle, 0.0, 1.0)?;
+        validate_range("shared.arc_size", shared.arc_size, 0.0, 1.0)?;
+        validate_range("shared.arc_flow", shared.arc_flow, -1.0, 1.0)?;
+        validate_range("shared.spring", shared.spring, 0.3, 1.0)?;
+        validate_range(
+            "shared.glide_duration_ms",
+            shared.glide_duration_ms,
+            0.0,
+            5000.0,
+        )?;
+        validate_range(
+            "shared.dwell_after_click_ms",
+            shared.dwell_after_click_ms,
+            0.0,
+            5000.0,
+        )?;
+        validate_range("shared.idle_hide_ms", shared.idle_hide_ms, 0.0, 60_000.0)?;
+        validate_range(
+            "shared.press_duration_ms",
+            shared.press_duration_ms,
+            0.0,
+            5000.0,
+        )?;
+        validate_range("shared.peak_speed", shared.peak_speed, 50.0, 5000.0)?;
+        validate_range(
+            "shared.min_start_speed",
+            shared.min_start_speed,
+            1.0,
+            shared.peak_speed,
+        )?;
+        validate_range(
+            "shared.min_end_speed",
+            shared.min_end_speed,
+            1.0,
+            shared.peak_speed,
+        )?;
+        validate_range("shared.turn_radius", shared.turn_radius, 1.0, 1000.0)?;
+        validate_range(
+            "shared.click_offset",
+            shared.click_offset,
+            f64::EPSILON,
+            1000.0,
+        )?;
+
+        let macos = &self.spring_settle.macos;
+        if macos.mode != SpringSettleMode::Fixed {
+            return Err("spring_settle.macos.mode must be `fixed`".into());
+        }
+        validate_positive("spring_settle.macos.k", macos.k)?;
+        validate_non_negative("spring_settle.macos.c", macos.c)?;
+        validate_range("spring_settle.macos.overshoot", macos.overshoot, 0.0, 1.0)?;
+
+        let windows_linux = &self.spring_settle.windows_linux;
+        if windows_linux.mode != SpringSettleMode::Derived {
+            return Err("spring_settle.windows_linux.mode must be `derived`".into());
+        }
+        validate_positive(
+            "spring_settle.windows_linux.k_per_spring",
+            windows_linux.k_per_spring,
+        )?;
+        validate_non_negative(
+            "spring_settle.windows_linux.c_per_spring",
+            windows_linux.c_per_spring,
+        )?;
+        validate_range(
+            "spring_settle.windows_linux.overshoot",
+            windows_linux.overshoot,
+            0.0,
+            1.0,
+        )?;
+
+        Ok(())
+    }
+}
+
+fn validate_range(name: &str, value: f64, min: f64, max: f64) -> Result<(), String> {
+    if !value.is_finite() {
+        return Err(format!("{name} must be finite"));
+    }
+    if !(min..=max).contains(&value) {
+        return Err(format!("{name} must be in [{min}, {max}], got {value}"));
+    }
+    Ok(())
+}
+
+fn validate_positive(name: &str, value: f64) -> Result<(), String> {
+    if !value.is_finite() || value <= 0.0 {
+        return Err(format!("{name} must be finite and positive"));
+    }
+    Ok(())
+}
+
+fn validate_non_negative(name: &str, value: f64) -> Result<(), String> {
+    if !value.is_finite() || value < 0.0 {
+        return Err(format!("{name} must be finite and non-negative"));
+    }
+    Ok(())
 }
 
 impl MotionSpecShared {
@@ -160,7 +294,7 @@ pub struct MotionConfig {
     /// Post-arrival spring damping: 1.0 = critical, 0.3 = bouncy. [0.3, 1.0]
     pub spring: f64,
     /// Main glide duration in milliseconds — used only as a legacy override.
-    /// When <= 0 the render engine uses speed-based timing instead. [50, 5000]
+    /// When <= 0 the render engine uses speed-based timing instead. [0, 5000]
     pub glide_duration_ms: f64,
     /// Post-click dwell in milliseconds. [0, 5000]
     pub dwell_after_click_ms: f64,
@@ -301,15 +435,59 @@ mod spec_tests {
     }
 
     #[test]
+    fn spec_rejects_foreign_schema_and_invalid_modes() {
+        let foreign_schema = MOTION_SPEC_JSON.replace(
+            "\"schema\": \"cua.cursor-motion/1\"",
+            "\"schema\": \"cua.cursor-motion/2\"",
+        );
+        let error = parse_motion_spec(&foreign_schema).unwrap_err();
+        assert!(error.to_string().contains("schema must be"), "{error}");
+
+        let wrong_platform_mode =
+            MOTION_SPEC_JSON.replacen("\"mode\": \"fixed\"", "\"mode\": \"derived\"", 1);
+        let error = parse_motion_spec(&wrong_platform_mode).unwrap_err();
+        assert!(error.to_string().contains("macos.mode"), "{error}");
+
+        let unknown_mode =
+            MOTION_SPEC_JSON.replacen("\"mode\": \"fixed\"", "\"mode\": \"wobbly\"", 1);
+        let error = parse_motion_spec(&unknown_mode).unwrap_err();
+        assert!(error.to_string().contains("unknown variant"), "{error}");
+    }
+
+    #[test]
+    fn spec_rejects_non_finite_out_of_range_and_inverted_speeds() {
+        let mut non_finite = motion_spec().clone();
+        non_finite.shared.peak_speed = f64::INFINITY;
+        let error = non_finite.validate().unwrap_err();
+        assert!(error.contains("finite"), "{error}");
+
+        let too_slow =
+            MOTION_SPEC_JSON.replacen("\"peak_speed\": 900.0", "\"peak_speed\": 10.0", 1);
+        let error = parse_motion_spec(&too_slow).unwrap_err();
+        assert!(error.to_string().contains("peak_speed"), "{error}");
+
+        let floor_above_peak =
+            MOTION_SPEC_JSON.replacen("\"min_end_speed\": 200.0", "\"min_end_speed\": 2000.0", 1);
+        let error = parse_motion_spec(&floor_above_peak).unwrap_err();
+        assert!(error.to_string().contains("min_end_speed"), "{error}");
+    }
+
+    #[test]
+    #[should_panic(expected = "there is deliberately no fallback")]
+    fn invalid_embedded_spec_fails_fast_instead_of_using_shadow_defaults() {
+        parse_embedded_motion_spec("{}");
+    }
+
+    #[test]
     fn spring_settle_platform_divergence_is_recorded_deliberately() {
         let settle = &motion_spec().spring_settle;
         // macOS runs the fixed Swift reference constants.
-        assert_eq!(settle.macos.mode, "fixed");
+        assert_eq!(settle.macos.mode, SpringSettleMode::Fixed);
         assert_eq!(settle.macos.k, 400.0);
         assert_eq!(settle.macos.c, 17.0);
         assert_eq!(settle.macos.overshoot, 0.8);
         // Windows/Linux derive from the runtime spring scalar.
-        assert_eq!(settle.windows_linux.mode, "derived");
+        assert_eq!(settle.windows_linux.mode, SpringSettleMode::Derived);
         assert_eq!(settle.windows_linux.k_per_spring, 400.0);
         assert_eq!(settle.windows_linux.c_per_spring, 20.0);
         assert_eq!(settle.windows_linux.overshoot, 0.5);

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/motion.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/motion.rs
@@ -1,6 +1,149 @@
 //! Motion / timing configuration — 1:1 port of `AgentCursorMotion.cs`.
+//!
+//! The canonical default values live in [`assets/motion.default.json`] and are
+//! embedded here at compile time. `MotionConfig::default()` is derived from
+//! that single shared source, so the checked-in spec, the production runtime,
+//! and the cursor-gallery exporter cannot drift apart. Changing a default is a
+//! two-file review: edit the JSON, then update the independent Rust literal in
+//! [`self::spec_tests`] until the parity test passes again.
 
 use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
+
+/// Click-point offset in points: the arrow artwork is centred this far
+/// down-right of the reported click coordinate so its tip lands on it.
+/// The authoritative value is `shared.click_offset` in the embedded
+/// repository-owned movement spec; callers use [`click_offset`] instead of
+/// re-declaring a local constant.
+pub fn click_offset() -> f64 {
+    motion_spec().shared.click_offset
+}
+
+const MOTION_SPEC_JSON: &str = include_str!("../assets/motion.default.json");
+
+/// Repository-owned movement specification (`assets/motion.default.json`).
+///
+/// Only the `shared` section maps onto [`MotionConfig`]; the `spring_settle`
+/// section records the deliberate macOS vs Windows/Linux settle divergence
+/// consumed by `render_state`'s tick paths.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MotionSpec {
+    pub schema: String,
+    pub shared: MotionSpecShared,
+    pub spring_settle: MotionSpecSpringSettle,
+}
+
+/// Bounded movement tunables shared by every platform.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MotionSpecShared {
+    /// Control-point offset from start, as fraction of distance. [0, 1]
+    pub start_handle: f64,
+    /// Control-point offset from end.  [0, 1]
+    pub end_handle: f64,
+    /// Perpendicular deflection magnitude as fraction of distance. [0, 1]
+    pub arc_size: f64,
+    /// Deflection asymmetry: positive = apex near destination. [-1, 1]
+    pub arc_flow: f64,
+    /// Post-arrival spring damping: 1.0 = critical, 0.3 = bouncy. [0.3, 1.0]
+    pub spring: f64,
+    /// Main glide duration in milliseconds — used only as a legacy override.
+    /// When <= 0 the render engine uses speed-based timing instead. [50, 5000]
+    pub glide_duration_ms: f64,
+    /// Post-click dwell in milliseconds. [0, 5000]
+    pub dwell_after_click_ms: f64,
+    /// Auto-hide delay in milliseconds. 0 = never hide. [0, 60000]
+    pub idle_hide_ms: f64,
+    /// Click-press visual duration. [0, 5000]
+    pub press_duration_ms: f64,
+    /// Peak cursor speed in pts/sec (speed-based mode). Matches Swift peakSpeed=900.
+    pub peak_speed: f64,
+    /// Minimum cursor speed at start of glide, pts/sec.
+    pub min_start_speed: f64,
+    /// Minimum cursor speed at end of glide (deceleration floor), pts/sec.
+    pub min_end_speed: f64,
+    /// Minimum turning radius of the Dubins glide path, in points. Smaller =
+    /// tighter curves. Matches the Swift reference default of 80.
+    pub turn_radius: f64,
+    /// Distance from the click point to the artwork centre, in points.
+    pub click_offset: f64,
+}
+
+/// Per-platform post-arrival spring settle constants.
+///
+/// macOS runs the Swift reference constants directly (`fixed` mode) and does
+/// not scale them with the runtime `spring` override — a documented platform
+/// limitation, not an accident. Windows/Linux derive both constants from the
+/// runtime `spring` scalar (`derived` mode).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MotionSpecSpringSettle {
+    pub macos: SpringSettleMacos,
+    pub windows_linux: SpringSettleWindowsLinux,
+}
+
+/// macOS `tick_swift_constants` settle: fixed constants.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpringSettleMacos {
+    pub mode: String,
+    pub k: f64,
+    pub c: f64,
+    pub overshoot: f64,
+}
+
+/// Windows/Linux `tick_motion` settle: derived from the runtime spring scalar.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpringSettleWindowsLinux {
+    pub mode: String,
+    pub k_per_spring: f64,
+    pub c_per_spring: f64,
+    pub overshoot: f64,
+}
+
+fn embedded_motion_spec() -> &'static MotionSpec {
+    static SPEC: OnceLock<MotionSpec> = OnceLock::new();
+    SPEC.get_or_init(|| {
+        serde_json::from_str(MOTION_SPEC_JSON)
+            .expect("embedded assets/motion.default.json is valid at compile time")
+    })
+}
+
+/// Parse a movement specification from raw JSON using the same strict schema
+/// as the embedded default. Exporters and tests use this for override files;
+/// production always uses the embedded copy.
+pub fn parse_motion_spec(raw: &str) -> Result<MotionSpec, serde_json::Error> {
+    serde_json::from_str(raw)
+}
+
+/// The embedded repository-owned movement specification.
+pub fn motion_spec() -> &'static MotionSpec {
+    embedded_motion_spec()
+}
+
+impl MotionSpecShared {
+    /// The `MotionConfig` view of the shared tunables (everything except
+    /// `click_offset`, which is geometry consumed by the command layer).
+    pub fn motion_config(&self) -> MotionConfig {
+        MotionConfig {
+            start_handle: self.start_handle,
+            end_handle: self.end_handle,
+            arc_size: self.arc_size,
+            arc_flow: self.arc_flow,
+            spring: self.spring,
+            glide_duration_ms: self.glide_duration_ms,
+            dwell_after_click_ms: self.dwell_after_click_ms,
+            idle_hide_ms: self.idle_hide_ms,
+            press_duration_ms: self.press_duration_ms,
+            peak_speed: self.peak_speed,
+            min_start_speed: self.min_start_speed,
+            min_end_speed: self.min_end_speed,
+            turn_radius: self.turn_radius,
+        }
+    }
+}
 
 /// Runtime-tunable timing and path-shape parameters.
 /// All clamp ranges are identical to the C# reference.
@@ -38,21 +181,7 @@ pub struct MotionConfig {
 
 impl Default for MotionConfig {
     fn default() -> Self {
-        Self {
-            start_handle: 0.3,
-            end_handle: 0.3,
-            arc_size: 0.25,
-            arc_flow: 0.0,
-            spring: 0.72,
-            glide_duration_ms: 0.0, // 0 = speed-based mode
-            dwell_after_click_ms: 80.0,
-            idle_hide_ms: 20_000.0, // fade 20s after last activity (matches .NET reference)
-            press_duration_ms: 120.0,
-            peak_speed: 900.0,
-            min_start_speed: 300.0,
-            min_end_speed: 200.0,
-            turn_radius: 80.0,
-        }
+        motion_spec().shared.motion_config()
     }
 }
 
@@ -119,4 +248,76 @@ pub struct Spring {
     pub oy: f64,
     pub vx: f64,
     pub vy: f64,
+}
+
+#[cfg(test)]
+mod spec_tests {
+    use super::*;
+
+    /// Independent literal of the production defaults. This is the second
+    /// entry of the double-entry ledger: the checked-in JSON spec and this
+    /// Rust literal must agree, so tuning a default is always a conscious
+    /// two-file change a reviewer has to approve.
+    fn reference_defaults() -> MotionConfig {
+        MotionConfig {
+            start_handle: 0.3,
+            end_handle: 0.3,
+            arc_size: 0.25,
+            arc_flow: 0.0,
+            spring: 0.72,
+            glide_duration_ms: 0.0, // 0 = speed-based mode
+            dwell_after_click_ms: 80.0,
+            idle_hide_ms: 20_000.0,
+            press_duration_ms: 120.0,
+            peak_speed: 900.0,
+            min_start_speed: 300.0,
+            min_end_speed: 200.0,
+            turn_radius: 80.0,
+        }
+    }
+
+    #[test]
+    fn embedded_spec_reproduces_the_rust_motion_defaults() {
+        assert_eq!(MotionConfig::default(), reference_defaults());
+        assert_eq!(motion_spec().schema, "cua.cursor-motion/1");
+    }
+
+    #[test]
+    fn embedded_spec_values_are_within_production_clamp_ranges() {
+        let defaults = MotionConfig::default();
+        let identity =
+            defaults.with_overrides(None, None, None, None, None, None, None, None, None, None);
+        assert_eq!(identity, defaults);
+        assert_eq!(motion_spec().shared.click_offset, click_offset());
+        assert_eq!(click_offset(), 16.0);
+    }
+
+    #[test]
+    fn spec_rejects_unknown_fields_and_bad_json() {
+        assert!(parse_motion_spec("{").is_err());
+        assert!(parse_motion_spec(r#"{"schema":"cua.cursor-motion/1"}"#).is_err());
+        let raw = MOTION_SPEC_JSON.replace("\"spring\": 0.72", "\"torque\": 9.0");
+        assert!(parse_motion_spec(&raw).is_err());
+    }
+
+    #[test]
+    fn spring_settle_platform_divergence_is_recorded_deliberately() {
+        let settle = &motion_spec().spring_settle;
+        // macOS runs the fixed Swift reference constants.
+        assert_eq!(settle.macos.mode, "fixed");
+        assert_eq!(settle.macos.k, 400.0);
+        assert_eq!(settle.macos.c, 17.0);
+        assert_eq!(settle.macos.overshoot, 0.8);
+        // Windows/Linux derive from the runtime spring scalar.
+        assert_eq!(settle.windows_linux.mode, "derived");
+        assert_eq!(settle.windows_linux.k_per_spring, 400.0);
+        assert_eq!(settle.windows_linux.c_per_spring, 20.0);
+        assert_eq!(settle.windows_linux.overshoot, 0.5);
+        // At the default spring (0.72) the derived constants stay stiffer and
+        // less damped than the macOS reference: 288/14.4 vs 400/17.
+        let d = &settle.windows_linux;
+        let spring = reference_defaults().spring;
+        assert!((d.k_per_spring * spring - 288.0).abs() < 1e-9);
+        assert!((d.c_per_spring * spring - 14.4).abs() < 1e-9);
+    }
 }

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
@@ -35,6 +35,7 @@
 //!   supplies one via the optional argument).
 
 use crate::{
+    motion::{click_offset, motion_spec},
     CompiledTheme, CursorAction, CursorConfig, CursorVisualState, DeliveryModifier, MotionConfig,
     OverlayCommand, PathPlanner, PathState, PlannedPath, Spring, TargetModifier,
 };
@@ -273,8 +274,12 @@ impl RenderStateCore {
     /// Returns `true` when the planned path just ended (so the caller can
     /// fire an arrival oneshot to unblock `animate_cursor_to`).
     pub fn tick_motion(&mut self, dt: f64) -> bool {
-        let spring_k = self.motion.spring * 400.0;
-        let spring_c = self.motion.spring * 20.0;
+        // Windows/Linux settle constants are derived from the runtime `spring`
+        // scalar; the derivation factors are the repository-owned spec values.
+        let settle = &motion_spec().spring_settle.windows_linux;
+        let spring_k = self.motion.spring * settle.k_per_spring;
+        let spring_c = self.motion.spring * settle.c_per_spring;
+        let spring_overshoot = settle.overshoot;
 
         let mut fire_arrival = false;
 
@@ -316,8 +321,8 @@ impl RenderStateCore {
                 self.spring = Some(Spring {
                     ox: 0.0,
                     oy: 0.0,
-                    vx: impulse * 0.5 * vh.cos(),
-                    vy: impulse * 0.5 * vh.sin(),
+                    vx: impulse * spring_overshoot * vh.cos(),
+                    vy: impulse * spring_overshoot * vh.sin(),
                 });
                 self.spring_tgt = Some((end.x, end.y, end_heading));
                 self.pos = (end.x, end.y);
@@ -365,10 +370,15 @@ impl RenderStateCore {
         fire_arrival
     }
 
-    /// Advance the animation by `dt` seconds using the hardcoded Swift
-    /// reference constants (`peakSpeed=900`, `minStart=300`, `minEnd=200`,
-    /// `springK=400`, `springC=17`, `springOvershoot=0.8`).  Used by macOS,
-    /// which mirrors `AgentCursorRenderer.swift` 1:1.
+    /// Advance the animation by `dt` seconds using the Swift reference
+    /// settle constants from the repository-owned movement spec
+    /// (`spring_settle.macos`: `k=400`, `c=17`, `overshoot=0.8`) plus the
+    /// shared speed contract (`peak=900`, `start=300`, `end=200`).
+    /// Used by macOS, which mirrors `AgentCursorRenderer.swift` 1:1.
+    ///
+    /// Platform limitation, recorded deliberately in the spec: this path
+    /// does not scale its settle constants with the runtime `spring`
+    /// override — only the Windows/Linux `tick_motion` path does.
     ///
     /// Returns `true` when the path just ended (so the caller can fire its
     /// arrival oneshot to unblock `animate_cursor_to`).
@@ -378,12 +388,13 @@ impl RenderStateCore {
     /// peak at 1.0 at u=0.5.  The original Swift code uses the 30/1.875
     /// form so we preserve it here for parity.
     pub fn tick_swift_constants(&mut self, dt: f64) -> bool {
-        const PEAK_SPEED: f64 = 900.0;
-        const MIN_START_SPEED: f64 = 300.0;
-        const MIN_END_SPEED: f64 = 200.0;
-        const SPRING_K: f64 = 400.0;
-        const SPRING_C: f64 = 17.0;
-        const SPRING_OVERSHOOT: f64 = 0.8;
+        let spec = motion_spec();
+        let peak_speed = spec.shared.peak_speed;
+        let min_start_speed = spec.shared.min_start_speed;
+        let min_end_speed = spec.shared.min_end_speed;
+        let spring_k = spec.spring_settle.macos.k;
+        let spring_c = spec.spring_settle.macos.c;
+        let spring_overshoot = spec.spring_settle.macos.overshoot;
 
         let mut fire_arrival = false;
 
@@ -394,11 +405,11 @@ impl RenderStateCore {
             // Smootherstep speed profile (normalised: peak = 1.0).
             let profile = (30.0 * u * u * (1.0 - u) * (1.0 - u)) / 1.875;
             let floor_speed = if u < 0.5 {
-                MIN_START_SPEED
+                min_start_speed
             } else {
-                MIN_END_SPEED
+                min_end_speed
             };
-            let speed_based = floor_speed + (PEAK_SPEED - floor_speed) * profile;
+            let speed_based = floor_speed + (peak_speed - floor_speed) * profile;
             // Fixed-duration override: when `glide_duration_ms > 0` the move
             // takes exactly that long regardless of distance, so an orchestrator
             // can lock glides to a known cadence. `0` (the default) keeps the
@@ -421,15 +432,15 @@ impl RenderStateCore {
                 // stays as crisp as a speed-based glide instead of overshooting
                 // proportionally to a short duration.
                 let impulse = if self.motion.glide_duration_ms > 0.0 {
-                    MIN_END_SPEED
+                    min_end_speed
                 } else {
                     current_speed
                 };
                 self.spring = Some(Spring {
                     ox: 0.0,
                     oy: 0.0,
-                    vx: impulse * SPRING_OVERSHOOT * vh.cos(),
-                    vy: impulse * SPRING_OVERSHOOT * vh.sin(),
+                    vx: impulse * spring_overshoot * vh.cos(),
+                    vy: impulse * spring_overshoot * vh.sin(),
                 });
                 self.spring_tgt = Some((end.x, end.y, end_heading));
                 self.pos = (end.x, end.y);
@@ -450,8 +461,8 @@ impl RenderStateCore {
                 let substeps = 4;
                 let sdt = dt / substeps as f64;
                 for _ in 0..substeps {
-                    s.vx += (-SPRING_K * s.ox - SPRING_C * s.vx) * sdt;
-                    s.vy += (-SPRING_K * s.oy - SPRING_C * s.vy) * sdt;
+                    s.vx += (-spring_k * s.ox - spring_c * s.vx) * sdt;
+                    s.vy += (-spring_k * s.oy - spring_c * s.vy) * sdt;
                     s.ox += s.vx * sdt;
                     s.oy += s.vy * sdt;
                 }
@@ -560,10 +571,10 @@ impl RenderStateCore {
                 // matching Swift `moveTo(point:endAngleRadians:)`:
                 //   tx = clickPoint.x + cos(endAngle) * clickOffset
                 //   ty = clickPoint.y + sin(endAngle) * clickOffset
-                const CLICK_OFFSET: f64 = 16.0;
+                let offset = click_offset();
                 let turn_radius = self.motion.turn_radius;
-                let tx = x + end_heading_radians.cos() * CLICK_OFFSET;
-                let ty = y + end_heading_radians.sin() * CLICK_OFFSET;
+                let tx = x + end_heading_radians.cos() * offset;
+                let ty = y + end_heading_radians.sin() * offset;
 
                 // macOS-only: if the cursor is still at the initial off-screen
                 // sentinel, snap it to the offset target so the path starts on-screen.
@@ -630,12 +641,9 @@ impl RenderStateCore {
                     // After that the cursor stays where the animation landed.
                     if self.pos.0 < -50.0 {
                         // Apply same click offset so tip lands at click point.
-                        const CLICK_OFFSET: f64 = 16.0;
+                        let offset = click_offset();
                         let angle = std::f64::consts::FRAC_PI_4;
-                        self.pos = (
-                            x + angle.cos() * CLICK_OFFSET,
-                            y + angle.sin() * CLICK_OFFSET,
-                        );
+                        self.pos = (x + angle.cos() * offset, y + angle.sin() * offset);
                     }
                 } else {
                     self.pos = (x, y);

--- a/libs/cua-driver/scripts/cursor-gallery.sh
+++ b/libs/cua-driver/scripts/cursor-gallery.sh
@@ -134,11 +134,17 @@ case "${1:-help}" in
     echo "cursor-gallery: http://127.0.0.1:$PORT"
     exec python3 -m http.server "$PORT" --bind 127.0.0.1 --directory "$GALLERY_DIR"
     ;;
+  dev)
+    require cargo
+    require ffmpeg
+    require python3
+    exec python3 "$GALLERY_DIR/dev_server.py" --port "$PORT"
+    ;;
   export-docs)
     export_docs
     ;;
   *)
-    echo "usage: $0 {assets|serve|export-docs}" >&2
+    echo "usage: $0 {assets|serve|dev|export-docs}" >&2
     exit 2
     ;;
 esac

--- a/libs/cua-driver/scripts/cursor-gallery.sh
+++ b/libs/cua-driver/scripts/cursor-gallery.sh
@@ -124,6 +124,47 @@ export_docs() {
   echo "cursor-gallery: wrote documentation GIFs to $docs_dir"
 }
 
+promote_motion() {
+  require cargo
+  require python3
+
+  local override="$TARGET_DIR/motion-override.json"
+  local spec="$DRIVER_DIR/rust/crates/cursor-overlay/assets/motion.default.json"
+
+  if [[ ! -f "$override" ]]; then
+    echo "cursor-gallery: no movement override to promote ($override)." >&2
+    echo "cursor-gallery: tune values in the movement lab, then re-run." >&2
+    exit 1
+  fi
+
+  python3 "$GALLERY_DIR/promote_motion.py" \
+    --override "$override" \
+    --spec "$spec" \
+    --validate-only
+
+  python3 "$GALLERY_DIR/promote_motion.py" \
+    --override "$override" \
+    --spec "$spec"
+
+  # The Rust parity tests are the promotion gate: the embedded spec must
+  # still reproduce MotionConfig::default() exactly, including the
+  # documented macOS/Windows+Linux spring-settle divergence. A promoted
+  # value intentionally fails here until reference_defaults() in
+  # src/motion.rs is updated in the same commit — double-entry review.
+  echo "cursor-gallery: running the motion parity gate (expects failure until"
+  echo "cursor-gallery: reference_defaults() in src/motion.rs matches the new spec)."
+  if ! cargo test --quiet \
+      --manifest-path "$DRIVER_DIR/rust/Cargo.toml" \
+      -p cursor-overlay --lib -- motion; then
+    echo "cursor-gallery: parity gate FAILED — update reference_defaults() in" >&2
+    echo "cursor-gallery: rust/crates/cursor-overlay/src/motion.rs to match, then re-run." >&2
+    exit 1
+  fi
+
+  echo "cursor-gallery: promoted movement override into $spec"
+  echo "cursor-gallery: review the diff, then commit it as the new default."
+}
+
 case "${1:-help}" in
   assets)
     export_assets
@@ -143,8 +184,11 @@ case "${1:-help}" in
   export-docs)
     export_docs
     ;;
+  promote-motion)
+    promote_motion
+    ;;
   *)
-    echo "usage: $0 {assets|serve|dev|export-docs}" >&2
+    echo "usage: $0 {assets|serve|dev|export-docs|promote-motion}" >&2
     exit 2
     ;;
 esac

--- a/libs/cua-driver/tools/cursor-gallery/README.md
+++ b/libs/cua-driver/tools/cursor-gallery/README.md
@@ -6,18 +6,32 @@ is built from `cursor-overlay` and is intentionally not committed.
 From the repository root:
 
 ```bash
+./libs/cua-driver/scripts/cursor-gallery.sh dev
 ./libs/cua-driver/scripts/cursor-gallery.sh serve
 ./libs/cua-driver/scripts/cursor-gallery.sh export-docs
 ```
+
+`dev` starts a repository-only animation workbench at
+`http://127.0.0.1:3001`. It watches the default theme source generator at
+`rust/crates/cursor-overlay/assets/build_default_theme.py`, compiles its output,
+and rebuilds exact production-renderer previews. A failed edit is shown in the
+diagnostics panel while the last valid render remains available. It also adds
+timeline scrubbing, isolated/runtime scenes, a movement scene driven by the
+renderer’s production `MoveTo` path, default speed profile, and host-platform
+motion tick. On macOS the movement export uses the runtime's 16 ms render
+budget, fixed 45-degree arrival heading, first-action seed, click offset, and
+arrival-driven command sequencing. It also includes reduced-motion stills,
+background checks, and comparison with the previous valid build. The workflow does not add
+commands or options to the installed `cua-driver` executable.
 
 `serve` opens no browser and serves the gallery at `http://127.0.0.1:3001`.
 `export-docs` requires Chrome, Node.js with WebSocket support, Python 3, and
 ffmpeg. It regenerates the public documentation GIFs deterministically from the
 same rendered frames.
 
-The gallery starts with an interactive production cursor configurator covering
-all twelve actions, optional `background` / `foreground` delivery, and optional
-`ax` / `pixel` / `browser` / `desktop` targets. It then shows all fifteen badge
-context states and the twelve isolated theme-owned action animations. Delivery
-and target glyphs appear only in their authoritative runtime location inside
-the badge.
+The gallery starts with the focused animation workbench, followed by an
+interactive production cursor configurator covering all twelve actions,
+optional `background` / `foreground` delivery, and optional `ax` / `pixel` /
+`browser` / `desktop` targets. It then shows all fifteen badge context states
+and the twelve isolated theme-owned action animations. Delivery and target
+glyphs appear only in their authoritative runtime location inside the badge.

--- a/libs/cua-driver/tools/cursor-gallery/app.js
+++ b/libs/cua-driver/tools/cursor-gallery/app.js
@@ -38,6 +38,26 @@ let workbenchPlaying = true;
 let workbenchAction = 'observe';
 let devStatus = null;
 
+// Movement lab: slider state mirrors the dev-server override file. Values
+// are advisory only; Rust re-clamps everything before rendering.
+const MOTION_FIELD_BOUNDS = {
+  peak_speed: [50, 2000, 10],
+  min_start_speed: [1, 600, 1],
+  min_end_speed: [1, 600, 1],
+  turn_radius: [1, 400, 1],
+  spring: [0.3, 1, 0.01],
+  glide_duration_ms: [0, 1500, 10],
+};
+const MOTION_DEFAULTS = {
+  peak_speed: 900,
+  min_start_speed: 300,
+  min_end_speed: 200,
+  turn_radius: 80,
+  spring: 0.72,
+  glide_duration_ms: 0,
+};
+let motionOverride = {};
+
 const fallbackActionFacts = {
   idle: { authored_frames: 1, still_frame: 0, playback: 'resting' },
   click: { authored_frames: 20, still_frame: 8, playback: 'one_shot' },
@@ -292,7 +312,28 @@ function applyDevStatus(status) {
     ? `${status.build.manifest.theme_name} · ${status.build.manifest.content_hash.slice(0, 10)} · ${status.message}`
     : status.message;
   diagnostics.textContent = status.error || 'No build errors.';
+  // Echo the server-side override state so the UI never drifts from the file.
+  const echoed = status.build?.motion_override;
+  if (echoed && typeof echoed === 'object') {
+    motionOverride = { ...echoed };
+    syncMotionSliders();
+  }
+  updateMovementLab();
+  updateMovementEcho();
   if (nextBuildId !== priorBuildId || status.state === 'error') updateWorkbench();
+}
+
+function updateMovementEcho() {
+  const motion = devStatus?.build?.manifest?.motion;
+  const scene = document.querySelector('#workbench-scene')?.value;
+  const cadenceRow = document.querySelector('#inspector-cadence');
+  if (!motion || !cadenceRow) return;
+  if (scene === 'movement') {
+    const overridden = motion.overridden_fields ?? [];
+    cadenceRow.textContent = overridden.length
+      ? `62.5 fps · ${overridden.length} override${overridden.length === 1 ? '' : 's'}`
+      : '62.5 fps · spec defaults';
+  }
 }
 
 async function pollDevStatus() {
@@ -410,7 +451,10 @@ document.querySelector('#workbench-action').addEventListener('change', (event) =
   selectWorkbenchAction(event.currentTarget.value);
 });
 
-document.querySelector('#workbench-scene').addEventListener('change', updateWorkbench);
+document.querySelector('#workbench-scene').addEventListener('change', () => {
+  updateWorkbench();
+  updateMovementEcho();
+});
 document.querySelector('#reduced-motion').addEventListener('change', updateWorkbench);
 document.querySelector('#compare-build').addEventListener('change', updateWorkbench);
 
@@ -458,7 +502,84 @@ document.querySelector('#actions-grid').addEventListener('click', (event) => {
   if (card) selectWorkbenchAction(actions[Number(card.dataset.index)][0]);
 });
 
+function motionSlider(field) {
+  return document.querySelector(`#motion-${field.replace(/_/g, '-')}`);
+}
+
+function motionOutput(field) {
+  return document.querySelector(`#motion-${field.replace(/_/g, '-')}-out`);
+}
+
+function formatMotionValue(field, value) {
+  if (field === 'glide_duration_ms') return `${value} ms`;
+  if (field === 'spring') return value.toFixed(2);
+  return String(value);
+}
+
+function syncMotionSliders() {
+  const effective = { ...MOTION_DEFAULTS, ...motionOverride };
+  for (const field of Object.keys(MOTION_FIELD_BOUNDS)) {
+    const slider = motionSlider(field);
+    const output = motionOutput(field);
+    if (!slider || !output) continue;
+    slider.value = String(effective[field]);
+    output.textContent = formatMotionValue(field, effective[field]);
+  }
+}
+
+function updateMovementLab() {
+  const lab = document.querySelector('#movement-lab');
+  const badge = document.querySelector('#movement-override-badge');
+  if (!lab) return;
+  lab.hidden = !devMode;
+  if (!badge) return;
+  const overridden = Object.keys(motionOverride);
+  badge.hidden = overridden.length === 0;
+  badge.textContent = overridden.length > 0 ? '· overrides active' : '';
+}
+
+async function postMotionOverride(override) {
+  try {
+    const response = await fetch('/__cursor_dev/motion-override', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(Object.keys(override).length ? override : null),
+    });
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({}));
+      console.warn('motion override rejected:', payload.error ?? response.status);
+    }
+  } catch (error) {
+    console.warn('motion override post failed:', error);
+  }
+}
+
+function wireMovementLab() {
+  if (!devMode) return;
+  for (const field of Object.keys(MOTION_FIELD_BOUNDS)) {
+    const slider = motionSlider(field);
+    if (!slider) continue;
+    slider.addEventListener('change', () => {
+      const value = Number(slider.value);
+      if (value === MOTION_DEFAULTS[field]) delete motionOverride[field];
+      else motionOverride[field] = value;
+      syncMotionSliders();
+      void postMotionOverride(motionOverride);
+    });
+  }
+  const reset = document.querySelector('#motion-reset');
+  if (reset) {
+    reset.addEventListener('click', () => {
+      motionOverride = {};
+      syncMotionSliders();
+      void postMotionOverride(motionOverride);
+    });
+  }
+}
+
 render();
+syncMotionSliders();
+wireMovementLab();
 if (devMode) {
   void pollDevStatus();
   setInterval(() => { void pollDevStatus(); }, 900);

--- a/libs/cua-driver/tools/cursor-gallery/app.js
+++ b/libs/cua-driver/tools/cursor-gallery/app.js
@@ -31,8 +31,27 @@ const contexts = deliveries.flatMap(([delivery]) =>
   targets.map(([target]) => ({ delivery, target })),
 );
 const tones = ['light', 'dark', 'blue'];
+const devMode = document.documentElement.dataset.devServer === 'true';
 let playing = true;
 let backgroundMode = 'dark';
+let workbenchPlaying = true;
+let workbenchAction = 'observe';
+let devStatus = null;
+
+const fallbackActionFacts = {
+  idle: { authored_frames: 1, still_frame: 0, playback: 'resting' },
+  click: { authored_frames: 20, still_frame: 8, playback: 'one_shot' },
+  observe: { authored_frames: 48, still_frame: 8, playback: 'loop' },
+  drag: { authored_frames: 48, still_frame: 8, playback: 'held' },
+  scroll: { authored_frames: 48, still_frame: 8, playback: 'loop' },
+  text: { authored_frames: 48, still_frame: 8, playback: 'held' },
+  key: { authored_frames: 48, still_frame: 8, playback: 'one_shot' },
+  navigate: { authored_frames: 48, still_frame: 8, playback: 'one_shot' },
+  app: { authored_frames: 48, still_frame: 8, playback: 'one_shot' },
+  transfer: { authored_frames: 48, still_frame: 8, playback: 'loop' },
+  record: { authored_frames: 48, still_frame: 8, playback: 'loop' },
+  system: { authored_frames: 48, still_frame: 8, playback: 'one_shot' },
+};
 
 function labelFor(options, value) {
   return options.find(([id]) => id === value)?.[1] ?? value;
@@ -113,6 +132,179 @@ function playAtCurrentSettings(video) {
   else video.pause();
 }
 
+function buildForComparison() {
+  return devStatus?.previous_build ?? null;
+}
+
+function sceneGroup(scene) {
+  return scene === 'isolated' ? 'actions' : scene;
+}
+
+function mediaPath(build, action, scene) {
+  if (build) return `${build.asset_root}/${sceneGroup(scene)}/${action}.webm`;
+  if (scene === 'runtime') return previewPath(action, 'background', 'browser');
+  return `./generated/actions/${action}.webm`;
+}
+
+function actionFacts(action) {
+  const facts = devStatus?.build?.manifest?.actions?.find((item) => item.id === action);
+  return facts ?? fallbackActionFacts[action];
+}
+
+function playbackLabel(value) {
+  return {
+    resting: 'Resting loop',
+    loop: 'Loop',
+    held: 'Held',
+    one_shot: 'One shot',
+  }[value] ?? value;
+}
+
+function setVideoSource(video, source) {
+  if (!source) {
+    video.removeAttribute('src');
+    video.load();
+    return;
+  }
+  if (video.getAttribute('src') === source) return;
+  video.setAttribute('src', source);
+  video.load();
+}
+
+function syncWorkbenchPlayback() {
+  const current = document.querySelector('#workbench-video');
+  const comparison = document.querySelector('#comparison-video');
+  [current, comparison].forEach((video) => {
+    video.playbackRate = selectedSpeed();
+    if (workbenchPlaying && !document.querySelector('#reduced-motion').checked) {
+      void video.play().catch(() => {});
+    } else {
+      video.pause();
+    }
+  });
+  document.querySelector('#workbench-play').textContent = workbenchPlaying ? 'Pause' : 'Play';
+}
+
+function updateWorkbench() {
+  const scene = document.querySelector('#workbench-scene').value;
+  const currentBuild = devStatus?.build ?? null;
+  const previousBuild = buildForComparison();
+  const currentVideo = document.querySelector('#workbench-video');
+  const comparisonVideo = document.querySelector('#comparison-video');
+  const still = document.querySelector('#workbench-still');
+  const reducedToggle = document.querySelector('#reduced-motion');
+  const comparisonToggle = document.querySelector('#compare-build');
+  const comparisonFrame = document.querySelector('#comparison-frame');
+  const label = labelFor(actions, workbenchAction);
+  const facts = actionFacts(workbenchAction);
+  const sceneLabel = {
+    isolated: 'Animation only',
+    runtime: 'Runtime composition',
+    movement: 'Production movement path',
+  }[scene];
+
+  document.querySelector('#workbench-stage').dataset.scene = scene;
+
+  reducedToggle.disabled = !currentBuild;
+  if (reducedToggle.disabled) reducedToggle.checked = false;
+  const showStill = reducedToggle.checked;
+  setVideoSource(
+    currentVideo,
+    devMode && !currentBuild ? null : mediaPath(currentBuild, workbenchAction, scene),
+  );
+  currentVideo.setAttribute('aria-label', `Current ${label} animation`);
+  currentVideo.hidden = showStill;
+  still.hidden = !showStill;
+  if (showStill && currentBuild) {
+    still.src = `${currentBuild.frame_root}/reduced/${sceneGroup(scene)}/${workbenchAction}.png`;
+  }
+
+  comparisonToggle.disabled = !previousBuild || showStill;
+  if (comparisonToggle.disabled) comparisonToggle.checked = false;
+  const comparing = comparisonToggle.checked && Boolean(previousBuild);
+  comparisonFrame.hidden = !comparing;
+  if (comparing) {
+    setVideoSource(comparisonVideo, mediaPath(previousBuild, workbenchAction, scene));
+    comparisonVideo.currentTime = currentVideo.currentTime;
+  }
+
+  document.querySelector('#inspector-action').textContent = label;
+  document.querySelector('#inspector-playback').textContent = playbackLabel(facts.playback);
+  document.querySelector('#inspector-frames').textContent = `${facts.authored_frames} authored`;
+  document.querySelector('#inspector-still').textContent = `Frame ${facts.still_frame}`;
+  document.querySelector('#inspector-scene').textContent = sceneLabel;
+  const cadence = scene === 'movement'
+    ? (currentBuild?.manifest?.movement_fps ?? 62.5)
+    : (currentBuild?.manifest?.fps ?? 30);
+  document.querySelector('#inspector-cadence').textContent = `${cadence} fps`;
+  document.querySelector('#workbench-timeline').step = String(1 / cadence);
+  document.querySelectorAll('.action-rail-button').forEach((button) => {
+    button.setAttribute('aria-pressed', String(button.dataset.action === workbenchAction));
+  });
+  document.querySelector('#workbench-action').value = workbenchAction;
+  syncWorkbenchPlayback();
+}
+
+function selectWorkbenchAction(action) {
+  workbenchAction = action;
+  document.querySelector('#workbench-timeline').value = '0';
+  updateWorkbench();
+}
+
+function renderWorkbenchControls() {
+  const select = document.querySelector('#workbench-action');
+  const rail = document.querySelector('#action-rail-buttons');
+  actions.forEach(([id, label]) => {
+    const option = document.createElement('option');
+    option.value = id;
+    option.textContent = label;
+    select.append(option);
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'action-rail-button';
+    button.dataset.action = id;
+    button.textContent = label;
+    button.setAttribute('aria-pressed', String(id === workbenchAction));
+    button.addEventListener('click', () => selectWorkbenchAction(id));
+    rail.append(button);
+  });
+}
+
+function applyDevStatus(status) {
+  devStatus = status;
+  const statusElement = document.querySelector('#build-status');
+  const detail = document.querySelector('#build-detail');
+  const diagnostics = document.querySelector('#build-diagnostics');
+  const priorBuildId = document.documentElement.dataset.devBuild;
+  const nextBuildId = status.build?.id ?? '';
+
+  document.documentElement.dataset.devState = status.state;
+  document.documentElement.dataset.devBuild = nextBuildId;
+  statusElement.className = `build-status status-${status.state}`;
+  statusElement.textContent = {
+    starting: 'Starting',
+    building: 'Building',
+    ready: 'Renderer current',
+    error: 'Build failed',
+  }[status.state] ?? status.state;
+  detail.textContent = status.build
+    ? `${status.build.manifest.theme_name} · ${status.build.manifest.content_hash.slice(0, 10)} · ${status.message}`
+    : status.message;
+  diagnostics.textContent = status.error || 'No build errors.';
+  if (nextBuildId !== priorBuildId || status.state === 'error') updateWorkbench();
+}
+
+async function pollDevStatus() {
+  try {
+    const response = await fetch('/__cursor_dev/status.json', { cache: 'no-store' });
+    if (!response.ok) return;
+    applyDevStatus(await response.json());
+  } catch (_) {
+    // The ordinary static gallery intentionally has no development endpoint.
+  }
+}
+
 function updateRuntimePreview() {
   const action = document.querySelector('#preview-action').value;
   const delivery = document.querySelector('#preview-delivery').value;
@@ -153,6 +345,16 @@ function updateCardTones() {
 }
 
 function render() {
+  renderWorkbenchControls();
+  if (devMode) {
+    document.querySelector('#runtime-preview-section').hidden = true;
+    document.querySelector('#badge-contexts').hidden = true;
+    document.querySelector('[data-capture-group="actions"]').hidden = true;
+    updateWorkbench();
+    document.documentElement.dataset.galleryVideoCount = '0';
+    return;
+  }
+
   const actionSelect = document.querySelector('#preview-action');
   actions.forEach(([id, label]) => {
     const option = document.createElement('option');
@@ -170,6 +372,7 @@ function render() {
 
   updateCardTones();
   updateRuntimePreview();
+  updateWorkbench();
   document.documentElement.dataset.galleryVideoCount = String(videos().length);
 }
 
@@ -188,6 +391,7 @@ document.querySelector('#replay').addEventListener('click', () => {
 
 document.querySelector('#speed').addEventListener('change', () => {
   videos().forEach(playAtCurrentSettings);
+  syncWorkbenchPlayback();
 });
 
 document.querySelector('#background-toggle').addEventListener('click', (event) => {
@@ -202,4 +406,60 @@ document.querySelectorAll('.preview-controls select').forEach((select) => {
   select.addEventListener('change', updateRuntimePreview);
 });
 
+document.querySelector('#workbench-action').addEventListener('change', (event) => {
+  selectWorkbenchAction(event.currentTarget.value);
+});
+
+document.querySelector('#workbench-scene').addEventListener('change', updateWorkbench);
+document.querySelector('#reduced-motion').addEventListener('change', updateWorkbench);
+document.querySelector('#compare-build').addEventListener('change', updateWorkbench);
+
+document.querySelector('#workbench-background').addEventListener('change', (event) => {
+  const stage = document.querySelector('#workbench-stage');
+  stage.className = `workbench-stage stage-${event.currentTarget.value}`;
+});
+
+document.querySelector('#workbench-play').addEventListener('click', () => {
+  workbenchPlaying = !workbenchPlaying;
+  syncWorkbenchPlayback();
+});
+
+document.querySelector('#workbench-replay').addEventListener('click', () => {
+  [document.querySelector('#workbench-video'), document.querySelector('#comparison-video')]
+    .forEach((video) => { video.currentTime = 0; });
+  workbenchPlaying = true;
+  syncWorkbenchPlayback();
+});
+
+document.querySelector('#workbench-timeline').addEventListener('input', (event) => {
+  const time = Number(event.currentTarget.value);
+  workbenchPlaying = false;
+  [document.querySelector('#workbench-video'), document.querySelector('#comparison-video')]
+    .forEach((video) => { video.currentTime = time; });
+  syncWorkbenchPlayback();
+});
+
+document.querySelector('#workbench-video').addEventListener('timeupdate', (event) => {
+  const duration = Number.isFinite(event.currentTarget.duration) ? event.currentTarget.duration : 4;
+  const time = event.currentTarget.currentTime;
+  const timeline = document.querySelector('#workbench-timeline');
+  timeline.max = String(duration);
+  if (workbenchPlaying) timeline.value = String(time);
+  document.querySelector('#workbench-time').textContent = `${time.toFixed(2)} / ${duration.toFixed(2)}s`;
+  const comparison = document.querySelector('#comparison-video');
+  const comparisonFrame = document.querySelector('#comparison-frame');
+  if (!comparisonFrame.hidden && Math.abs(comparison.currentTime - time) > 0.08) {
+    comparison.currentTime = time;
+  }
+});
+
+document.querySelector('#actions-grid').addEventListener('click', (event) => {
+  const card = event.target.closest('.state-card');
+  if (card) selectWorkbenchAction(actions[Number(card.dataset.index)][0]);
+});
+
 render();
+if (devMode) {
+  void pollDevStatus();
+  setInterval(() => { void pollDevStatus(); }, 900);
+}

--- a/libs/cua-driver/tools/cursor-gallery/dev_server.py
+++ b/libs/cua-driver/tools/cursor-gallery/dev_server.py
@@ -30,6 +30,62 @@ ACTIONS = (
     "system",
 )
 
+# Loopback-only movement override contract (mirrors the Rust
+# MotionOverrideFile schema in examples/export_gallery_frames.rs).
+# Only fields the production movement path consumes are accepted.
+MOTION_OVERRIDE_SCHEMA = "cua.cursor-gallery-motion-override/1"
+MOTION_OVERRIDE_FIELDS = {
+    "peak_speed": (50.0, 5000.0),
+    "min_start_speed": (1.0, 5000.0),
+    "min_end_speed": (1.0, 5000.0),
+    "turn_radius": (1.0, 1000.0),
+    "spring": (0.3, 1.0),
+    "glide_duration_ms": (0.0, 5000.0),
+}
+MOTION_OVERRIDE_MAX_BYTES = 4096
+
+
+def sanitize_motion_override(raw: bytes) -> dict[str, float]:
+    """Validate a movement-override request body.
+
+    Accepts a flat JSON object of whitelisted numeric fields (or `null`,
+    which resets). Rejects anything else so no arbitrary keys, text, or
+    nested data ever reach the renderer build.
+    """
+    if len(raw) > MOTION_OVERRIDE_MAX_BYTES:
+        raise ValueError("override body too large")
+    text = raw.decode("utf-8", errors="strict")
+    if text.strip() == "null":
+        return {}
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"invalid JSON: {error}") from error
+    if not isinstance(payload, dict):
+        raise ValueError("override body must be a JSON object or null")
+    override: dict[str, float] = {}
+    for key, value in payload.items():
+        bounds = MOTION_OVERRIDE_FIELDS.get(key)
+        if bounds is None:
+            raise ValueError(f"unknown movement field: {key}")
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"field {key} must be a number")
+        number = float(value)
+        if number != number or number in (float("inf"), float("-inf")):
+            raise ValueError(f"field {key} must be finite")
+        low, high = bounds
+        override[key] = min(max(number, low), high)
+    return override
+
+
+def serialize_motion_override(override: dict[str, float]) -> str:
+    """One canonical writer so override-file diffs are value-only."""
+    ordered: dict[str, object] = {"schema": MOTION_OVERRIDE_SCHEMA}
+    for key in MOTION_OVERRIDE_FIELDS:
+        if key in override:
+            ordered[key] = override[key]
+    return json.dumps(ordered, indent=2) + "\n"
+
 
 class BuildState:
     def __init__(self) -> None:
@@ -115,11 +171,52 @@ class Builder:
             / "build_default_theme.py"
         )
         self.builds_root = repo_root / "target" / "cursor-gallery" / "dev-builds"
+        # Fixed-path movement override file. The loopback POST endpoint is
+        # the only writer; the renderer rebuild consumes it verbatim.
+        self.motion_override_path = repo_root / "target" / "cursor-gallery" / "motion-override.json"
         self._counter = 0
 
     @property
     def watched_paths(self) -> tuple[Path, ...]:
-        return (self.source_generator,)
+        return (self.source_generator, self.motion_override_path)
+
+    def current_motion_override(self) -> dict[str, float]:
+        try:
+            payload = json.loads(self.motion_override_path.read_text())
+        except FileNotFoundError:
+            return {}
+        except json.JSONDecodeError:
+            return {}
+        if not isinstance(payload, dict) or payload.get("schema") != MOTION_OVERRIDE_SCHEMA:
+            return {}
+        return {
+            key: float(value)
+            for key, value in payload.items()
+            if key in MOTION_OVERRIDE_FIELDS and isinstance(value, (int, float))
+        }
+
+    def exporter_command(self, frames: Path, artifact: Path) -> list[str]:
+        command = [
+            "cargo",
+            "run",
+            "--quiet",
+            "--manifest-path",
+            str(self.rust_manifest),
+            "-p",
+            "cursor-overlay",
+            "--example",
+            "export_gallery_frames",
+            "--features",
+            "theme-authoring",
+            "--",
+            str(frames),
+            "--theme",
+            str(artifact),
+            "--dev",
+        ]
+        if self.motion_override_path.exists():
+            command.extend(["--motion-overrides", str(self.motion_override_path)])
+        return command
 
     def build(self) -> None:
         self.state.begin()
@@ -154,27 +251,7 @@ class Builder:
                 ],
                 self.repo_root,
             )
-            run_checked(
-                [
-                    "cargo",
-                    "run",
-                    "--quiet",
-                    "--manifest-path",
-                    str(self.rust_manifest),
-                    "-p",
-                    "cursor-overlay",
-                    "--example",
-                    "export_gallery_frames",
-                    "--features",
-                    "theme-authoring",
-                    "--",
-                    str(frames),
-                    "--theme",
-                    str(artifact),
-                    "--dev",
-                ],
-                self.repo_root,
-            )
+            run_checked(self.exporter_command(frames, artifact), self.repo_root)
             manifest = json.loads((frames / "manifest.json").read_text())
             for group in ("actions", "runtime", "movement"):
                 destination = media / group
@@ -218,16 +295,83 @@ class Builder:
                     "source": str(self.source_generator.relative_to(self.repo_root)),
                     "completed_at": int(time.time()),
                     "manifest": manifest,
+                    "motion_override": self.current_motion_override(),
                 }
             )
         except Exception as error:  # Keep the last valid render available.
             self.state.fail(str(error))
 
 
-def make_handler(gallery_root: Path, builds_root: Path, state: BuildState):
+def make_handler(gallery_root: Path, builds_root: Path, state: BuildState, builder: Builder):
     class Handler(SimpleHTTPRequestHandler):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, directory=str(gallery_root), **kwargs)
+
+        def _send_json(self, payload: dict[str, object], status: HTTPStatus) -> None:
+            body = json.dumps(payload).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_POST(self) -> None:  # noqa: N802 - stdlib handler contract
+            path = urlparse(self.path).path
+            if path != "/__cursor_dev/motion-override":
+                self.send_error(HTTPStatus.NOT_FOUND)
+                return
+            # Loopback alone does not stop a localhost page from POSTing here;
+            # require an absent Origin (curl / tests) or this exact origin.
+            origin = self.headers.get("Origin")
+            if origin is not None:
+                port = getattr(self.server, "server_port", None)
+                allowed = {f"http://127.0.0.1:{port}", f"http://localhost:{port}"}
+                if origin not in allowed:
+                    self._send_json(
+                        {"ok": False, "error": "cross-origin POST rejected"},
+                        status=HTTPStatus.FORBIDDEN,
+                    )
+                    return
+            # Trust the declared length only up to the cap, and refuse before
+            # reading so an oversized body cannot be buffered at all.
+            try:
+                declared = int(self.headers.get("Content-Length") or 0)
+            except ValueError:
+                self._send_json(
+                    {"ok": False, "error": "invalid Content-Length"},
+                    status=HTTPStatus.BAD_REQUEST,
+                )
+                return
+            if declared > MOTION_OVERRIDE_MAX_BYTES:
+                self._send_json(
+                    {"ok": False, "error": "override body too large"},
+                    status=HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                )
+                return
+            raw = self.rfile.read(declared) if declared > 0 else b""
+            try:
+                override = sanitize_motion_override(raw)
+            except ValueError as error:
+                self._send_json(
+                    {"ok": False, "error": str(error)}, status=HTTPStatus.BAD_REQUEST
+                )
+                return
+            try:
+                if override:
+                    builder.motion_override_path.parent.mkdir(parents=True, exist_ok=True)
+                    temporary = builder.motion_override_path.with_suffix(".json.tmp")
+                    temporary.write_text(serialize_motion_override(override))
+                    temporary.replace(builder.motion_override_path)
+                else:
+                    # `null` (or an empty object) resets to production defaults.
+                    builder.motion_override_path.unlink(missing_ok=True)
+            except OSError as error:
+                self._send_json(
+                    {"ok": False, "error": str(error)}, status=HTTPStatus.INTERNAL_SERVER_ERROR
+                )
+                return
+            self._send_json({"ok": True, "override": override}, status=HTTPStatus.OK)
 
         def do_GET(self) -> None:  # noqa: N802 - stdlib handler contract
             path = urlparse(self.path).path
@@ -300,7 +444,7 @@ def main() -> None:
     watcher.start()
     server = ThreadingHTTPServer(
         ("127.0.0.1", args.port),
-        make_handler(gallery_root, builder.builds_root, state),
+        make_handler(gallery_root, builder.builds_root, state, builder),
     )
     print(f"cursor-gallery dev: http://127.0.0.1:{args.port}", flush=True)
     try:

--- a/libs/cua-driver/tools/cursor-gallery/dev_server.py
+++ b/libs/cua-driver/tools/cursor-gallery/dev_server.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Repository-only live rebuild server for the Cua cursor animation gallery."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import threading
+import time
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import unquote, urlparse
+
+
+ACTIONS = (
+    "idle",
+    "observe",
+    "click",
+    "drag",
+    "scroll",
+    "text",
+    "key",
+    "navigate",
+    "app",
+    "transfer",
+    "record",
+    "system",
+)
+
+
+class BuildState:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._status: dict[str, object] = {
+            "schema": "cua.cursor-gallery-dev/1",
+            "state": "starting",
+            "message": "Waiting for the first exact render",
+            "build": None,
+            "previous_build": None,
+            "error": None,
+        }
+
+    def begin(self) -> None:
+        with self._lock:
+            self._status["state"] = "building"
+            self._status["message"] = "Compiling theme and rendering production frames"
+            self._status["error"] = None
+
+    def succeed(self, build: dict[str, object]) -> None:
+        with self._lock:
+            current = self._status.get("build")
+            if current:
+                self._status["previous_build"] = current
+            self._status["build"] = build
+            self._status["state"] = "ready"
+            self._status["message"] = "Exact renderer preview is current"
+            self._status["error"] = None
+
+    def fail(self, message: str) -> None:
+        with self._lock:
+            self._status["state"] = "error"
+            self._status["message"] = (
+                "Build failed; showing the last valid render"
+                if self._status.get("build")
+                else "Initial build failed; no valid render is available"
+            )
+            self._status["error"] = message[-12_000:]
+
+    def snapshot(self) -> dict[str, object]:
+        with self._lock:
+            return json.loads(json.dumps(self._status))
+
+
+def watch_signature(paths: tuple[Path, ...]) -> tuple[tuple[str, int, int], ...]:
+    signature = []
+    for path in paths:
+        try:
+            stat = path.stat()
+            signature.append((str(path), stat.st_mtime_ns, stat.st_size))
+        except FileNotFoundError:
+            signature.append((str(path), -1, -1))
+    return tuple(signature)
+
+
+def run_checked(command: list[str], cwd: Path) -> str:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode != 0:
+        rendered = " ".join(command)
+        raise RuntimeError(f"{rendered}\n\n{result.stdout.strip()}")
+    return result.stdout.strip()
+
+
+class Builder:
+    def __init__(self, repo_root: Path, state: BuildState) -> None:
+        self.repo_root = repo_root
+        self.state = state
+        self.driver_dir = repo_root / "libs" / "cua-driver"
+        self.rust_manifest = self.driver_dir / "rust" / "Cargo.toml"
+        self.source_generator = (
+            self.driver_dir
+            / "rust"
+            / "crates"
+            / "cursor-overlay"
+            / "assets"
+            / "build_default_theme.py"
+        )
+        self.builds_root = repo_root / "target" / "cursor-gallery" / "dev-builds"
+        self._counter = 0
+
+    @property
+    def watched_paths(self) -> tuple[Path, ...]:
+        return (self.source_generator,)
+
+    def build(self) -> None:
+        self.state.begin()
+        self._counter += 1
+        build_id = f"build-{int(time.time() * 1000)}-{self._counter}"
+        build_root = self.builds_root / build_id
+        source = build_root / "cua.default.lottie"
+        artifact = build_root / "cua.default.cua-theme"
+        frames = build_root / "frames"
+        media = build_root / "media"
+        source.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            run_checked(
+                ["python3", str(self.source_generator), "--output", str(source)],
+                self.repo_root,
+            )
+            run_checked(
+                [
+                    "cargo",
+                    "run",
+                    "--quiet",
+                    "--manifest-path",
+                    str(self.rust_manifest),
+                    "-p",
+                    "cursor-theme-cli",
+                    "--",
+                    "build",
+                    str(source),
+                    "--output",
+                    str(artifact),
+                ],
+                self.repo_root,
+            )
+            run_checked(
+                [
+                    "cargo",
+                    "run",
+                    "--quiet",
+                    "--manifest-path",
+                    str(self.rust_manifest),
+                    "-p",
+                    "cursor-overlay",
+                    "--example",
+                    "export_gallery_frames",
+                    "--features",
+                    "theme-authoring",
+                    "--",
+                    str(frames),
+                    "--theme",
+                    str(artifact),
+                    "--dev",
+                ],
+                self.repo_root,
+            )
+            manifest = json.loads((frames / "manifest.json").read_text())
+            for group in ("actions", "runtime", "movement"):
+                destination = media / group
+                destination.mkdir(parents=True, exist_ok=True)
+                frame_rate = str(
+                    manifest["movement_fps"] if group == "movement" else manifest["fps"]
+                )
+                for action in ACTIONS:
+                    run_checked(
+                        [
+                            "ffmpeg",
+                            "-y",
+                            "-loglevel",
+                            "error",
+                            "-framerate",
+                            frame_rate,
+                            "-i",
+                            str(frames / group / action / "%04d.png"),
+                            "-c:v",
+                            "libvpx-vp9",
+                            "-pix_fmt",
+                            "yuva420p",
+                            "-auto-alt-ref",
+                            "0",
+                            "-crf",
+                            "28",
+                            "-b:v",
+                            "0",
+                            "-row-mt",
+                            "1",
+                            str(destination / f"{action}.webm"),
+                        ],
+                        self.repo_root,
+                    )
+
+            self.state.succeed(
+                {
+                    "id": build_id,
+                    "asset_root": f"/__cursor_dev/assets/{build_id}/media",
+                    "frame_root": f"/__cursor_dev/assets/{build_id}/frames",
+                    "source": str(self.source_generator.relative_to(self.repo_root)),
+                    "completed_at": int(time.time()),
+                    "manifest": manifest,
+                }
+            )
+        except Exception as error:  # Keep the last valid render available.
+            self.state.fail(str(error))
+
+
+def make_handler(gallery_root: Path, builds_root: Path, state: BuildState):
+    class Handler(SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=str(gallery_root), **kwargs)
+
+        def do_GET(self) -> None:  # noqa: N802 - stdlib handler contract
+            path = urlparse(self.path).path
+            if path in ("/", "/index.html"):
+                html = (gallery_root / "index.html").read_text()
+                payload = html.replace(
+                    '<html lang="en">',
+                    '<html lang="en" data-dev-server="true">',
+                    1,
+                ).encode()
+                self.send_response(HTTPStatus.OK)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Cache-Control", "no-store")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+                return
+            if path == "/__cursor_dev/status.json":
+                payload = json.dumps(state.snapshot()).encode()
+                self.send_response(HTTPStatus.OK)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Cache-Control", "no-store")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+                return
+            super().do_GET()
+
+        def translate_path(self, path: str) -> str:
+            parsed = urlparse(path).path
+            prefix = "/__cursor_dev/assets/"
+            if parsed.startswith(prefix):
+                relative = Path(unquote(parsed[len(prefix) :]))
+                if relative.is_absolute() or ".." in relative.parts:
+                    return str(builds_root / "invalid-path")
+                return str(builds_root / relative)
+            return super().translate_path(path)
+
+        def end_headers(self) -> None:
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("Referrer-Policy", "no-referrer")
+            super().end_headers()
+
+    return Handler
+
+
+def watch(builder: Builder, interval: float) -> None:
+    signature = None
+    while True:
+        current = watch_signature(builder.watched_paths)
+        if current != signature:
+            signature = current
+            builder.build()
+        time.sleep(interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=int(os.environ.get("CURSOR_GALLERY_PORT", "3001")))
+    parser.add_argument("--watch-interval", type=float, default=0.5)
+    args = parser.parse_args()
+
+    gallery_root = Path(__file__).resolve().parent
+    repo_root = gallery_root.parents[3]
+    state = BuildState()
+    builder = Builder(repo_root, state)
+    builder.builds_root.mkdir(parents=True, exist_ok=True)
+
+    watcher = threading.Thread(target=watch, args=(builder, args.watch_interval), daemon=True)
+    watcher.start()
+    server = ThreadingHTTPServer(
+        ("127.0.0.1", args.port),
+        make_handler(gallery_root, builder.builds_root, state),
+    )
+    print(f"cursor-gallery dev: http://127.0.0.1:{args.port}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/cua-driver/tools/cursor-gallery/index.html
+++ b/libs/cua-driver/tools/cursor-gallery/index.html
@@ -38,6 +38,97 @@
         </div>
       </header>
 
+      <section id="animation-workbench" class="workbench-section" aria-labelledby="workbench-title">
+        <div class="section-heading workbench-heading">
+          <div>
+            <p class="section-count">Repository playground</p>
+            <h2 id="workbench-title">Inspect one animation closely</h2>
+          </div>
+          <div class="build-summary" aria-live="polite">
+            <span id="build-status" class="build-status status-static">Static render</span>
+            <span id="build-detail">Run the repo-only dev mode for live rebuilds.</span>
+          </div>
+        </div>
+
+        <div class="workbench-shell">
+          <aside class="action-rail" aria-label="Cursor actions">
+            <label for="workbench-action">Action</label>
+            <select id="workbench-action" aria-label="Workbench action"></select>
+            <div id="action-rail-buttons" class="action-rail-buttons"></div>
+          </aside>
+
+          <article class="workbench-stage-card">
+            <div class="workbench-toolbar" aria-label="Preview scene controls">
+              <label>
+                <span>Scene</span>
+                <select id="workbench-scene" aria-label="Preview scene">
+                  <option value="isolated">Animation only</option>
+                  <option value="runtime">Runtime composition</option>
+                  <option value="movement">Movement path</option>
+                </select>
+              </label>
+              <label>
+                <span>Background</span>
+                <select id="workbench-background" aria-label="Preview background">
+                  <option value="dark">Dark</option>
+                  <option value="light">Light</option>
+                  <option value="blue">Brand</option>
+                  <option value="checker">Transparency</option>
+                </select>
+              </label>
+              <label class="toggle-label">
+                <input id="reduced-motion" type="checkbox" />
+                <span>Reduced motion</span>
+              </label>
+              <label class="toggle-label">
+                <input id="compare-build" type="checkbox" disabled />
+                <span>Compare previous</span>
+              </label>
+            </div>
+
+            <div id="workbench-stage" class="workbench-stage stage-dark">
+              <figure class="workbench-frame current-frame">
+                <video id="workbench-video" autoplay loop muted playsinline
+                  aria-label="Current Observe animation"></video>
+                <img id="workbench-still" alt="Reduced-motion still frame" hidden />
+                <figcaption>Current</figcaption>
+              </figure>
+              <figure id="comparison-frame" class="workbench-frame comparison-frame" hidden>
+                <video id="comparison-video" muted playsinline aria-label="Previous build comparison"></video>
+                <figcaption>Previous valid build</figcaption>
+              </figure>
+            </div>
+
+            <div class="timeline-controls" aria-label="Animation timeline">
+              <button id="workbench-play" type="button">Pause</button>
+              <button id="workbench-replay" type="button">Replay</button>
+              <input id="workbench-timeline" type="range" min="0" max="4" step="0.033333" value="0"
+                aria-label="Animation time" />
+              <output id="workbench-time" for="workbench-timeline">0.00 / 4.00s</output>
+            </div>
+          </article>
+
+          <aside class="workbench-inspector" aria-label="Build and animation details">
+            <div>
+              <p class="section-count">Animation</p>
+              <h3 id="inspector-action">Observe</h3>
+              <dl class="animation-facts">
+                <div><dt>Playback</dt><dd id="inspector-playback">Loop</dd></div>
+                <div><dt>Frames</dt><dd id="inspector-frames">48 authored</dd></div>
+                <div><dt>Still</dt><dd id="inspector-still">Frame 8</dd></div>
+                <div><dt>Scene</dt><dd id="inspector-scene">Animation only</dd></div>
+                <div><dt>Cadence</dt><dd id="inspector-cadence">30 fps</dd></div>
+                <div><dt>Renderer</dt><dd>Production Rust</dd></div>
+              </dl>
+            </div>
+            <div class="diagnostics-block">
+              <p class="section-count">Diagnostics</p>
+              <pre id="build-diagnostics">No build errors.</pre>
+            </div>
+          </aside>
+        </div>
+      </section>
+
       <section id="runtime-preview-section" class="runtime-section" aria-labelledby="runtime-title">
         <div class="section-heading">
           <div>
@@ -85,7 +176,6 @@
             <video
               id="runtime-preview"
               class="cursor-video"
-              src="./generated/previews/observe--background--browser.webm"
               data-group="previews"
               data-state="observe--background--browser"
               autoplay

--- a/libs/cua-driver/tools/cursor-gallery/index.html
+++ b/libs/cua-driver/tools/cursor-gallery/index.html
@@ -121,6 +121,52 @@
                 <div><dt>Renderer</dt><dd>Production Rust</dd></div>
               </dl>
             </div>
+            <div id="movement-lab" class="movement-lab" hidden>
+              <p class="section-count">Movement lab <span id="movement-override-badge" hidden></span></p>
+              <div class="movement-controls" aria-label="Movement physics overrides">
+                <label>
+                  <span>Peak speed</span>
+                  <input id="motion-peak-speed" data-field="peak_speed" type="range"
+                    min="50" max="2000" step="10" />
+                  <output id="motion-peak-speed-out" for="motion-peak-speed"></output>
+                </label>
+                <label>
+                  <span>Start floor</span>
+                  <input id="motion-min-start-speed" data-field="min_start_speed" type="range"
+                    min="1" max="600" step="1" />
+                  <output id="motion-min-start-speed-out" for="motion-min-start-speed"></output>
+                </label>
+                <label>
+                  <span>End floor</span>
+                  <input id="motion-min-end-speed" data-field="min_end_speed" type="range"
+                    min="1" max="600" step="1" />
+                  <output id="motion-min-end-speed-out" for="motion-min-end-speed"></output>
+                </label>
+                <label>
+                  <span>Turn radius</span>
+                  <input id="motion-turn-radius" data-field="turn_radius" type="range"
+                    min="1" max="400" step="1" />
+                  <output id="motion-turn-radius-out" for="motion-turn-radius"></output>
+                </label>
+                <label>
+                  <span>Spring</span>
+                  <input id="motion-spring" data-field="spring" type="range"
+                    min="0.3" max="1" step="0.01" />
+                  <output id="motion-spring-out" for="motion-spring"></output>
+                </label>
+                <label>
+                  <span>Glide hold</span>
+                  <input id="motion-glide-duration-ms" data-field="glide_duration_ms" type="range"
+                    min="0" max="1500" step="10" />
+                  <output id="motion-glide-duration-ms-out" for="motion-glide-duration-ms"></output>
+                </label>
+              </div>
+              <p class="movement-note">
+                Dev-only. Sliders rebuild the preview through the production
+                renderer; values are clamped to the spec bounds and never
+                persist into the repository. <button id="motion-reset" type="button">Reset</button>
+              </p>
+            </div>
             <div class="diagnostics-block">
               <p class="section-count">Diagnostics</p>
               <pre id="build-diagnostics">No build errors.</pre>

--- a/libs/cua-driver/tools/cursor-gallery/promote_motion.py
+++ b/libs/cua-driver/tools/cursor-gallery/promote_motion.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Promote a tuned movement override into the shared movement spec.
+
+Reads the fixed-path override file written by the cursor-gallery dev
+server, merges its clamped values over the current repository spec, and
+rewrites `motion.default.json` in the canonical serialization (schema
+first, fixed key order, two-space indent, trailing newline) so spec
+diffs are value-only. `--validate-only` checks without writing.
+
+The Rust parity tests in
+`rust/crates/cursor-overlay/src/motion.rs` remain the authority: they
+fail if the promoted spec no longer reproduces `MotionConfig::default`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+OVERRIDE_SCHEMA = "cua.cursor-gallery-motion-override/1"
+SPEC_SCHEMA = "cua.cursor-motion/1"
+
+# Every key the embedded Rust spec parse requires. Promotion must never
+# remove or rename one; a spec missing any of these fails the Rust
+# `deny_unknown_fields` build, so validate before writing.
+REQUIRED_SHARED_KEYS = (
+    "start_handle",
+    "end_handle",
+    "arc_size",
+    "arc_flow",
+    "spring",
+    "glide_duration_ms",
+    "dwell_after_click_ms",
+    "idle_hide_ms",
+    "press_duration_ms",
+    "peak_speed",
+    "min_start_speed",
+    "min_end_speed",
+    "turn_radius",
+    "click_offset",
+)
+REQUIRED_SETTLE = {
+    "macos": ("mode", "k", "c", "overshoot"),
+    "windows_linux": ("mode", "k_per_spring", "c_per_spring", "overshoot"),
+}
+
+# Override fields -> spec key under `shared`. Only shared-section
+# tunables are promotable; platform spring-settle divergence stays a
+# deliberate repository decision, not a playground knob.
+PROMOTABLE = {
+    "peak_speed": "peak_speed",
+    "min_start_speed": "min_start_speed",
+    "min_end_speed": "min_end_speed",
+    "turn_radius": "turn_radius",
+    "spring": "spring",
+    "glide_duration_ms": "glide_duration_ms",
+}
+
+
+def fail(message: str) -> None:
+    print(f"promote-motion: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_override(path: Path) -> dict[str, float]:
+    try:
+        payload = json.loads(path.read_text())
+    except FileNotFoundError:
+        fail(f"override file not found: {path}")
+    except json.JSONDecodeError as error:
+        fail(f"override file is not valid JSON: {error}")
+    if not isinstance(payload, dict):
+        fail("override file must be a JSON object")
+    if payload.get("schema") != OVERRIDE_SCHEMA:
+        fail(f"override schema must be {OVERRIDE_SCHEMA}")
+    unknown = set(payload) - {"schema"} - set(PROMOTABLE)
+    if unknown:
+        fail(f"override carries non-promotable fields: {sorted(unknown)}")
+    override: dict[str, float] = {}
+    for key, value in payload.items():
+        if key == "schema":
+            continue
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            fail(f"override field {key} must be a number")
+        number = float(value)
+        if number != number or number in (float("inf"), float("-inf")):
+            fail(f"override field {key} must be finite")
+        override[key] = number
+    if not override:
+        fail("override has no movement values to promote")
+    return override
+
+
+def load_spec(path: Path) -> dict:
+    try:
+        spec = json.loads(path.read_text())
+    except FileNotFoundError:
+        fail(f"spec file not found: {path}")
+    except json.JSONDecodeError as error:
+        fail(f"spec file is not valid JSON: {error}")
+    if not isinstance(spec, dict) or spec.get("schema") != SPEC_SCHEMA:
+        fail(f"spec schema must be {SPEC_SCHEMA}")
+    return spec
+
+
+def canonicalize(spec: dict) -> str:
+    """Serialize the spec in the one canonical repository shape.
+
+    Key order comes from the loaded file (json.loads preserves it), so a
+    promotion rewrites values only; keys are neither added, removed, nor
+    reordered. The complete required structure is validated first so the
+    Rust `deny_unknown_fields` parse stays exhaustive.
+    """
+    shared: dict = spec.get("shared")  # type: ignore[assignment]
+    if not isinstance(shared, dict):
+        fail("spec is missing the `shared` section")
+    missing = [key for key in REQUIRED_SHARED_KEYS if key not in shared]
+    if missing:
+        fail(f"spec `shared` is missing required keys: {missing}")
+    settle = spec.get("spring_settle")
+    if not isinstance(settle, dict):
+        fail("spec is missing the `spring_settle` section")
+    for platform, keys in REQUIRED_SETTLE.items():
+        block = settle.get(platform)
+        if not isinstance(block, dict):
+            fail(f"spec `spring_settle.{platform}` is missing")
+        absent = [key for key in keys if key not in block]
+        if absent:
+            fail(f"spec `spring_settle.{platform}` is missing keys: {absent}")
+    return json.dumps(spec, indent=2) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--override", type=Path, required=True)
+    parser.add_argument("--spec", type=Path, required=True)
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="check the override and spec without writing",
+    )
+    args = parser.parse_args()
+
+    override = load_override(args.override)
+    spec = load_spec(args.spec)
+
+    before = canonicalize(spec)
+    promoted = []
+    for field, key in PROMOTABLE.items():
+        if field not in override:
+            continue
+        current = spec["shared"].get(key)
+        if current == override[field]:
+            continue
+        spec["shared"][key] = override[field]
+        promoted.append(f"shared.{key}: {current} -> {override[field]}")
+
+    after = canonicalize(spec)
+
+    if args.validate_only:
+        print("override and spec are promotable:")
+        for line in promoted or ["(values already match the spec)"]:
+            print(f"  {line}")
+        return
+
+    if promoted:
+        args.spec.write_text(after)
+        print(f"promoted {len(promoted)} value(s) into {args.spec}:")
+        for line in promoted:
+            print(f"  {line}")
+        if before != after:
+            print("review the diff, run the motion parity tests, then commit.")
+    else:
+        print("override values already match the spec; nothing written.")
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/cua-driver/tools/cursor-gallery/promote_motion.py
+++ b/libs/cua-driver/tools/cursor-gallery/promote_motion.py
@@ -19,6 +19,8 @@ import json
 import sys
 from pathlib import Path
 
+from dev_server import sanitize_motion_override
+
 OVERRIDE_SCHEMA = "cua.cursor-gallery-motion-override/1"
 SPEC_SCHEMA = "cua.cursor-motion/1"
 
@@ -64,11 +66,20 @@ def fail(message: str) -> None:
     raise SystemExit(1)
 
 
-def load_override(path: Path) -> dict[str, float]:
+def load_override(path: Path, spec_shared: dict) -> dict[str, float]:
+    """Load and bound an override file exactly like the dev server does.
+
+    The fixed-path file can be hand-edited, so promotion re-validates
+    instead of trusting: unknown fields, non-numbers, and non-finite
+    values are rejected, and every value is clamped to the production
+    bounds before it can reach the spec.
+    """
     try:
-        payload = json.loads(path.read_text())
+        raw = path.read_bytes()
     except FileNotFoundError:
         fail(f"override file not found: {path}")
+    try:
+        payload = json.loads(raw)
     except json.JSONDecodeError as error:
         fail(f"override file is not valid JSON: {error}")
     if not isinstance(payload, dict):
@@ -78,16 +89,21 @@ def load_override(path: Path) -> dict[str, float]:
     unknown = set(payload) - {"schema"} - set(PROMOTABLE)
     if unknown:
         fail(f"override carries non-promotable fields: {sorted(unknown)}")
-    override: dict[str, float] = {}
-    for key, value in payload.items():
-        if key == "schema":
-            continue
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            fail(f"override field {key} must be a number")
-        number = float(value)
-        if number != number or number in (float("inf"), float("-inf")):
-            fail(f"override field {key} must be finite")
-        override[key] = number
+    # Reuse the dev-server sanitizer: whitelist, type, finiteness, and
+    # per-field production bounds in one place.
+    body = json.dumps({k: v for k, v in payload.items() if k != "schema"}).encode()
+    try:
+        override = sanitize_motion_override(body)
+    except ValueError as error:
+        fail(f"override rejected: {error}")
+    # Cross-field rule from the exporter: floors never exceed the
+    # effective peak speed (override peak, else the spec's peak).
+    effective_peak = override.get(
+        "peak_speed", float(spec_shared.get("peak_speed", 5000.0))
+    )
+    for floor_field in ("min_start_speed", "min_end_speed"):
+        if floor_field in override:
+            override[floor_field] = min(override[floor_field], effective_peak)
     if not override:
         fail("override has no movement values to promote")
     return override
@@ -143,8 +159,8 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    override = load_override(args.override)
     spec = load_spec(args.spec)
+    override = load_override(args.override, spec["shared"])
 
     before = canonicalize(spec)
     promoted = []

--- a/libs/cua-driver/tools/cursor-gallery/styles.css
+++ b/libs/cua-driver/tools/cursor-gallery/styles.css
@@ -535,6 +535,332 @@ footer {
   letter-spacing: 0.5px;
 }
 
+.workbench-section {
+  padding: 0 0 88px;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.workbench-heading {
+  align-items: end;
+}
+
+.build-summary {
+  display: grid;
+  justify-items: end;
+  gap: 9px;
+  color: var(--ink-muted);
+  font: 500 12px/1.35 var(--font-mono);
+  text-align: right;
+}
+
+.build-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding: 0 12px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-pill);
+  color: var(--ink-strong);
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.build-status::before {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #8d98a9;
+  content: "";
+}
+
+.status-building::before {
+  background: #f4b242;
+  box-shadow: 0 0 12px rgba(244, 178, 66, 0.6);
+}
+
+.status-ready::before {
+  background: #60daae;
+  box-shadow: 0 0 12px rgba(96, 218, 174, 0.55);
+}
+
+.status-error::before {
+  background: #e85262;
+  box-shadow: 0 0 12px rgba(232, 82, 98, 0.55);
+}
+
+.workbench-shell {
+  display: grid;
+  grid-template-columns: 176px minmax(0, 1fr) 230px;
+  overflow: hidden;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-card-lg);
+  background: var(--bg-card);
+}
+
+.action-rail,
+.workbench-inspector {
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.action-rail {
+  border-right: 1px solid var(--line-soft);
+}
+
+.action-rail > label {
+  display: block;
+  margin-bottom: 9px;
+  color: var(--ink-muted);
+  font: 600 10px/1 var(--font-mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.action-rail select {
+  display: none;
+}
+
+.action-rail-buttons {
+  display: grid;
+  gap: 4px;
+}
+
+.action-rail-button {
+  width: 100%;
+  padding: 9px 11px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--ink-muted);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.action-rail-button:hover {
+  color: var(--ink-strong);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.action-rail-button[aria-pressed="true"] {
+  border-color: rgba(159, 215, 255, 0.28);
+  color: var(--brand-soft);
+  background: rgba(159, 215, 255, 0.11);
+}
+
+.workbench-stage-card {
+  min-width: 0;
+}
+
+.workbench-toolbar {
+  display: flex;
+  min-height: 68px;
+  align-items: center;
+  gap: 18px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.workbench-toolbar label:not(.toggle-label) {
+  display: grid;
+  gap: 5px;
+}
+
+.workbench-toolbar label > span:first-child {
+  color: var(--ink-muted);
+  font: 600 9px/1 var(--font-mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.workbench-toolbar select {
+  border: 0;
+  color: var(--ink-strong);
+  background: transparent;
+}
+
+.toggle-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  color: var(--ink-body);
+  font-size: 12px;
+}
+
+.toggle-label + .toggle-label {
+  margin-left: 0;
+}
+
+.workbench-stage {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
+  min-height: 430px;
+  place-items: stretch;
+  transition: background 160ms ease;
+}
+
+.stage-dark {
+  background: radial-gradient(circle at 50% 46%, #2b3440, #080a0d 68%);
+}
+
+.stage-light {
+  background: radial-gradient(circle at 50% 46%, #ffffff, #dfe6ee 72%);
+}
+
+.stage-blue {
+  background: radial-gradient(circle at 50% 46%, #215b7a, #061b2a 72%);
+}
+
+.stage-checker {
+  background-color: #bfc5cc;
+  background-image:
+    linear-gradient(45deg, #e9edf2 25%, transparent 25%),
+    linear-gradient(-45deg, #e9edf2 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #e9edf2 75%),
+    linear-gradient(-45deg, transparent 75%, #e9edf2 75%);
+  background-position: 0 0, 0 12px, 12px -12px, -12px 0;
+  background-size: 24px 24px;
+}
+
+.workbench-frame {
+  position: relative;
+  display: grid;
+  min-width: 0;
+  margin: 0;
+  place-items: center;
+}
+
+.workbench-frame[hidden],
+.workbench-frame video[hidden],
+.workbench-frame img[hidden] {
+  display: none;
+}
+
+.workbench-frame + .workbench-frame {
+  border-left: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.workbench-frame video,
+.workbench-frame img {
+  width: min(80%, 360px);
+  aspect-ratio: 1;
+  object-fit: contain;
+  filter: drop-shadow(0 24px 42px rgba(0, 0, 0, 0.24));
+}
+
+.workbench-stage[data-scene="movement"] .workbench-frame video,
+.workbench-stage[data-scene="movement"] .workbench-frame img {
+  width: min(94%, 720px);
+  aspect-ratio: 16 / 9;
+}
+
+.workbench-frame figcaption {
+  position: absolute;
+  left: 16px;
+  bottom: 14px;
+  padding: 6px 9px;
+  border-radius: var(--radius-pill);
+  color: rgba(255, 255, 255, 0.82);
+  background: rgba(0, 0, 0, 0.5);
+  font: 600 9px/1 var(--font-mono);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.timeline-controls {
+  display: grid;
+  grid-template-columns: auto auto minmax(120px, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  min-height: 66px;
+  padding: 12px 18px;
+  border-top: 1px solid var(--line-soft);
+}
+
+.timeline-controls button {
+  min-height: 34px;
+  padding: 0 13px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-pill);
+  color: var(--ink-strong);
+  background: rgba(255, 255, 255, 0.05);
+  cursor: pointer;
+}
+
+.timeline-controls input[type="range"] {
+  width: 100%;
+  accent-color: var(--brand);
+}
+
+.timeline-controls output {
+  min-width: 88px;
+  color: var(--ink-muted);
+  font: 500 11px/1 var(--font-mono);
+  text-align: right;
+}
+
+.workbench-inspector {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 28px;
+  border-left: 1px solid var(--line-soft);
+}
+
+.workbench-inspector h3 {
+  margin: -8px 0 22px;
+  color: var(--ink-strong);
+  font: 400 32px/1 var(--font-display);
+}
+
+.animation-facts {
+  display: grid;
+  gap: 11px;
+  margin: 0;
+}
+
+.animation-facts div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 9px;
+  border-bottom: 1px solid var(--line-soft);
+  font-size: 12px;
+}
+
+.animation-facts dt {
+  color: var(--ink-muted);
+}
+
+.animation-facts dd {
+  margin: 0;
+  color: var(--ink-strong);
+  text-align: right;
+}
+
+.diagnostics-block pre {
+  max-height: 180px;
+  overflow: auto;
+  margin: 0;
+  padding: 12px;
+  border: 1px solid var(--line-soft);
+  border-radius: 8px;
+  color: #c8d0dc;
+  background: #0c0d0f;
+  font: 500 10px/1.55 var(--font-mono);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+html[data-dev-state="error"] .diagnostics-block pre {
+  border-color: rgba(232, 82, 98, 0.42);
+  color: #ffb8c0;
+}
+
 @media (max-width: 1160px) {
   .state-grid {
     grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -568,6 +894,18 @@ footer {
 
   .runtime-anatomy > div:last-child {
     border-right: 0;
+  }
+
+  .workbench-shell {
+    grid-template-columns: 150px minmax(0, 1fr);
+  }
+
+  .workbench-inspector {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    border-top: 1px solid var(--line-soft);
+    border-left: 0;
   }
 }
 
@@ -627,5 +965,59 @@ footer {
   footer {
     flex-direction: column;
     gap: 8px;
+  }
+
+  .workbench-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .action-rail,
+  .workbench-inspector {
+    border: 0;
+  }
+
+  .action-rail {
+    border-bottom: 1px solid var(--line-soft);
+  }
+
+  .action-rail select {
+    display: block;
+    width: 100%;
+  }
+
+  .action-rail-buttons {
+    display: none;
+  }
+
+  .workbench-toolbar {
+    flex-wrap: wrap;
+  }
+
+  .toggle-label {
+    margin-left: 0;
+  }
+
+  .workbench-stage {
+    min-height: 320px;
+  }
+
+  .timeline-controls {
+    grid-template-columns: auto auto 1fr;
+  }
+
+  .timeline-controls input[type="range"] {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
+  .timeline-controls output {
+    grid-column: 3;
+    grid-row: 1;
+  }
+
+  .workbench-inspector {
+    display: flex;
+    grid-column: auto;
+    border-top: 1px solid var(--line-soft);
   }
 }

--- a/libs/cua-driver/tools/cursor-gallery/styles.css
+++ b/libs/cua-driver/tools/cursor-gallery/styles.css
@@ -861,6 +861,63 @@ html[data-dev-state="error"] .diagnostics-block pre {
   color: #ffb8c0;
 }
 
+.movement-lab {
+  display: grid;
+  gap: 12px;
+}
+
+.movement-controls {
+  display: grid;
+  gap: 10px;
+}
+
+.movement-controls label {
+  display: grid;
+  grid-template-columns: 88px 1fr auto;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.movement-controls span {
+  color: var(--ink-muted);
+}
+
+.movement-controls output {
+  min-width: 52px;
+  text-align: right;
+  font: 500 11px/1.2 var(--font-mono);
+  color: var(--ink-strong);
+}
+
+.movement-controls input[type="range"] {
+  width: 100%;
+  accent-color: #6c8cff;
+}
+
+.movement-note {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.movement-note button {
+  margin-left: 6px;
+  padding: 2px 10px;
+  border: 1px solid var(--line-soft);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ink-strong);
+  font: inherit;
+  cursor: pointer;
+}
+
+#movement-override-badge {
+  color: #e8a34a;
+  font-weight: 600;
+}
+
 @media (max-width: 1160px) {
   .state-grid {
     grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/libs/cua-driver/tools/cursor-gallery/test_dev_server.py
+++ b/libs/cua-driver/tools/cursor-gallery/test_dev_server.py
@@ -1,12 +1,21 @@
+import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from threading import Thread
-from urllib.request import urlopen
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
 
 from http.server import ThreadingHTTPServer
 
-from dev_server import BuildState, make_handler
+from dev_server import (
+    BuildState,
+    Builder,
+    MOTION_OVERRIDE_FIELDS,
+    make_handler,
+    sanitize_motion_override,
+    serialize_motion_override,
+)
 
 
 class BuildStateTests(unittest.TestCase):
@@ -50,18 +59,23 @@ class BuildStateTests(unittest.TestCase):
 
 
 class HandlerTests(unittest.TestCase):
+    def make_server(self, root: Path):
+        gallery = root / "gallery"
+        builds = root / "builds"
+        gallery.mkdir()
+        builds.mkdir()
+        (gallery / "index.html").write_text('<html lang="en"><body>Gallery</body></html>')
+        state = BuildState()
+        builder = Builder(root, state)
+        server = ThreadingHTTPServer(
+            ("127.0.0.1", 0),
+            make_handler(gallery, builds, state, builder),
+        )
+        return server, builder
+
     def test_index_marks_repo_dev_mode(self) -> None:
         with TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            gallery = root / "gallery"
-            builds = root / "builds"
-            gallery.mkdir()
-            builds.mkdir()
-            (gallery / "index.html").write_text('<html lang="en"><body>Gallery</body></html>')
-            server = ThreadingHTTPServer(
-                ("127.0.0.1", 0),
-                make_handler(gallery, builds, BuildState()),
-            )
+            server, _builder = self.make_server(Path(temporary))
             thread = Thread(target=server.serve_forever, daemon=True)
             thread.start()
             try:
@@ -73,6 +87,160 @@ class HandlerTests(unittest.TestCase):
                 server.shutdown()
                 server.server_close()
                 thread.join()
+
+    def test_motion_override_post_round_trips_to_the_fixed_path(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            server, builder = self.make_server(root)
+            thread = Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            base = f"http://127.0.0.1:{server.server_port}"
+            try:
+                request = Request(
+                    f"{base}/__cursor_dev/motion-override",
+                    data=b'{"peak_speed": 450.0, "turn_radius": 120.0}',
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                with urlopen(request) as response:
+                    self.assertEqual(response.status, 200)
+                    payload = json.loads(response.read().decode())
+                self.assertTrue(payload["ok"])
+                self.assertEqual(payload["override"]["peak_speed"], 450.0)
+
+                written = builder.motion_override_path.read_text()
+                self.assertIn('"schema": "cua.cursor-gallery-motion-override/1"', written)
+                self.assertEqual(json.loads(written)["turn_radius"], 120.0)
+                # The builder now reports the override for the exporter command.
+                self.assertIn(
+                    "--motion-overrides",
+                    " ".join(builder.exporter_command(Path("f"), Path("a"))),
+                )
+
+                # Reset with `null` removes the file.
+                reset = Request(
+                    f"{base}/__cursor_dev/motion-override",
+                    data=b"null",
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                with urlopen(reset) as response:
+                    self.assertEqual(response.status, 200)
+                self.assertFalse(builder.motion_override_path.exists())
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join()
+
+    def test_motion_override_post_rejects_hostile_bodies(self) -> None:
+        with TemporaryDirectory() as temporary:
+            server, _builder = self.make_server(Path(temporary))
+            thread = Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            base = f"http://127.0.0.1:{server.server_port}"
+            try:
+                for hostile in (
+                    b'{"idle_hide_ms": 5}',
+                    b'{"peak_speed": "fast"}',
+                    b'{"peak_speed": [900]}',
+                    b'"just a string"',
+                    b'{"schema": "other/1"}',
+                ):
+                    request = Request(
+                        f"{base}/__cursor_dev/motion-override",
+                        data=hostile,
+                        headers={"Content-Type": "application/json"},
+                        method="POST",
+                    )
+                    with self.assertRaises(HTTPError) as caught:
+                        urlopen(request)
+                    self.assertEqual(caught.exception.code, 400)
+                # Unknown POST paths are simply not found.
+                request = Request(
+                    f"{base}/__cursor_dev/other",
+                    data=b"{}",
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                with self.assertRaises(HTTPError) as caught:
+                    urlopen(request)
+                self.assertEqual(caught.exception.code, 404)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join()
+
+
+    def test_motion_override_post_rejects_oversized_and_cross_origin(self) -> None:
+        with TemporaryDirectory() as temporary:
+            server, _builder = self.make_server(Path(temporary))
+            thread = Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            base = f"http://127.0.0.1:{server.server_port}"
+            try:
+                # Declared length over the cap is refused before the body is read.
+                request = Request(
+                    f"{base}/__cursor_dev/motion-override",
+                    data=b'{"peak_speed": 900.0}',
+                    headers={"Content-Length": str(1024 * 1024)},
+                    method="POST",
+                )
+                with self.assertRaises(HTTPError) as caught:
+                    urlopen(request)
+                self.assertEqual(caught.exception.code, 413)
+
+                # A foreign Origin (localhost CSRF from another page) is rejected.
+                csrf = Request(
+                    f"{base}/__cursor_dev/motion-override",
+                    data=b'{"peak_speed": 900.0}',
+                    headers={"Origin": "http://evil.example"},
+                    method="POST",
+                )
+                with self.assertRaises(HTTPError) as caught:
+                    urlopen(csrf)
+                self.assertEqual(caught.exception.code, 403)
+
+                # Same-origin Origin headers are accepted.
+                ok = Request(
+                    f"{base}/__cursor_dev/motion-override",
+                    data=b"null",
+                    headers={"Origin": base},
+                    method="POST",
+                )
+                with urlopen(ok) as response:
+                    self.assertEqual(response.status, 200)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join()
+
+
+class MotionOverrideValidationTests(unittest.TestCase):
+    def test_clamps_values_into_the_production_bounds(self) -> None:
+        override = sanitize_motion_override(
+            b'{"peak_speed": 99999.0, "min_end_speed": -5.0, "spring": 9.0}'
+        )
+        self.assertEqual(override["peak_speed"], 5000.0)
+        self.assertEqual(override["min_end_speed"], 1.0)
+        self.assertEqual(override["spring"], 1.0)
+
+    def test_null_resets_and_unknown_fields_are_rejected(self) -> None:
+        self.assertEqual(sanitize_motion_override(b"null"), {})
+        with self.assertRaises(ValueError):
+            sanitize_motion_override(b'{"start_handle": 0.9}')
+        with self.assertRaises(ValueError):
+            sanitize_motion_override(b'{"peak_speed": true}')
+        with self.assertRaises(ValueError):
+            sanitize_motion_override(b"not json")
+
+    def test_serializer_emits_one_canonical_shape(self) -> None:
+        first = serialize_motion_override({"turn_radius": 90.0, "peak_speed": 800.0})
+        second = serialize_motion_override({"peak_speed": 800.0, "turn_radius": 90.0})
+        self.assertEqual(first, second)
+        parsed = json.loads(first)
+        # Only the supplied fields are serialized, in canonical field order.
+        self.assertEqual(list(parsed), ["schema", "peak_speed", "turn_radius"])
+        self.assertEqual(parsed["schema"], "cua.cursor-gallery-motion-override/1")
 
 
 if __name__ == "__main__":

--- a/libs/cua-driver/tools/cursor-gallery/test_dev_server.py
+++ b/libs/cua-driver/tools/cursor-gallery/test_dev_server.py
@@ -1,0 +1,79 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from threading import Thread
+from urllib.request import urlopen
+
+from http.server import ThreadingHTTPServer
+
+from dev_server import BuildState, make_handler
+
+
+class BuildStateTests(unittest.TestCase):
+    def test_initial_failure_reports_that_no_render_exists(self) -> None:
+        state = BuildState()
+
+        state.fail("synthetic compiler failure")
+
+        status = state.snapshot()
+        self.assertEqual(status["state"], "error")
+        self.assertIsNone(status["build"])
+        self.assertIn("no valid render", status["message"])
+
+    def test_failed_rebuild_retains_last_valid_build(self) -> None:
+        state = BuildState()
+        first = {"id": "build-1", "manifest": {"theme_name": "Test"}}
+
+        state.succeed(first)
+        state.begin()
+        state.fail("synthetic compiler failure")
+
+        status = state.snapshot()
+        self.assertEqual(status["state"], "error")
+        self.assertEqual(status["build"], first)
+        self.assertIsNone(status["previous_build"])
+        self.assertIn("last valid render", status["message"])
+        self.assertEqual(status["error"], "synthetic compiler failure")
+
+    def test_successful_rebuild_exposes_previous_build_for_comparison(self) -> None:
+        state = BuildState()
+        first = {"id": "build-1"}
+        second = {"id": "build-2"}
+
+        state.succeed(first)
+        state.succeed(second)
+
+        status = state.snapshot()
+        self.assertEqual(status["state"], "ready")
+        self.assertEqual(status["build"], second)
+        self.assertEqual(status["previous_build"], first)
+
+
+class HandlerTests(unittest.TestCase):
+    def test_index_marks_repo_dev_mode(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            gallery = root / "gallery"
+            builds = root / "builds"
+            gallery.mkdir()
+            builds.mkdir()
+            (gallery / "index.html").write_text('<html lang="en"><body>Gallery</body></html>')
+            server = ThreadingHTTPServer(
+                ("127.0.0.1", 0),
+                make_handler(gallery, builds, BuildState()),
+            )
+            thread = Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                with urlopen(f"http://127.0.0.1:{server.server_port}/") as response:
+                    body = response.read().decode()
+                self.assertIn('data-dev-server="true"', body)
+                self.assertEqual(body.count('data-dev-server="true"'), 1)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/libs/cua-driver/tools/cursor-gallery/test_promote_motion.py
+++ b/libs/cua-driver/tools/cursor-gallery/test_promote_motion.py
@@ -130,14 +130,61 @@ class PromoteMotionTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("schema", result.stderr)
 
-            # Non-promotable field sneaking through is refused.
+            # Non-promotable field sneaking through is refused by the
+            # promotion whitelist first...
             hostile = root / "hostile.json"
             write(hostile, {"schema": "cua.cursor-gallery-motion-override/1",
                             "idle_hide_ms": 5.0})
             result = self.run_tool("--override", str(hostile), "--spec", str(spec))
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("non-promotable", result.stderr)
+            # ...and a whitelisted field with a hostile value reaches the
+            # shared dev-server sanitizer, which rejects it.
+            sneaky = root / "sneaky.json"
+            write(sneaky, {"schema": "cua.cursor-gallery-motion-override/1",
+                           "peak_speed": "fast"})
+            result = self.run_tool("--override", str(sneaky), "--spec", str(spec))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("override rejected", result.stderr)
             self.assertEqual(spec.read_text(), json.dumps(spec_with(), indent=2) + "\n")
+
+    def test_hand_edited_out_of_range_values_are_bounded_before_promotion(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            override = root / "motion-override.json"
+            spec = root / "motion.default.json"
+            # A hand-edited file carrying values outside every bound.
+            write(override, {"schema": "cua.cursor-gallery-motion-override/1",
+                             "peak_speed": 99999.0,
+                             "min_start_speed": -50.0,
+                             "min_end_speed": 0.0,
+                             "turn_radius": 5000.0,
+                             "spring": 4.0,
+                             "glide_duration_ms": 90000.0})
+            write(spec, spec_with())
+
+            result = self.run_tool("--override", str(override), "--spec", str(spec))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            promoted = json.loads(spec.read_text())
+            self.assertEqual(promoted["shared"]["peak_speed"], 5000.0)
+            self.assertEqual(promoted["shared"]["min_start_speed"], 1.0)
+            self.assertEqual(promoted["shared"]["min_end_speed"], 1.0)
+            self.assertEqual(promoted["shared"]["turn_radius"], 1000.0)
+            self.assertEqual(promoted["shared"]["spring"], 1.0)
+            self.assertEqual(promoted["shared"]["glide_duration_ms"], 5000.0)
+
+            # Cross-field: floors capped to the overridden peak.
+            capped = root / "capped.json"
+            write(capped, {"schema": "cua.cursor-gallery-motion-override/1",
+                           "peak_speed": 120.0,
+                           "min_start_speed": 400.0,
+                           "min_end_speed": 350.0})
+            write(spec, spec_with())
+            result = self.run_tool("--override", str(capped), "--spec", str(spec))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            promoted = json.loads(spec.read_text())
+            self.assertEqual(promoted["shared"]["min_start_speed"], 120.0)
+            self.assertEqual(promoted["shared"]["min_end_speed"], 120.0)
 
     def test_no_change_leaves_file_untouched(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/libs/cua-driver/tools/cursor-gallery/test_promote_motion.py
+++ b/libs/cua-driver/tools/cursor-gallery/test_promote_motion.py
@@ -1,0 +1,159 @@
+"""Tests for the movement-spec promotion tool."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+TOOL = Path(__file__).resolve().parent / "promote_motion.py"
+
+
+def write(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def spec_with(shared_overrides: dict | None = None) -> dict:
+    shared = {
+        "start_handle": 0.3,
+        "end_handle": 0.3,
+        "arc_size": 0.25,
+        "arc_flow": 0.0,
+        "spring": 0.72,
+        "glide_duration_ms": 0.0,
+        "dwell_after_click_ms": 80.0,
+        "idle_hide_ms": 20000.0,
+        "press_duration_ms": 120.0,
+        "peak_speed": 900.0,
+        "min_start_speed": 300.0,
+        "min_end_speed": 200.0,
+        "turn_radius": 80.0,
+        "click_offset": 16.0,
+    }
+    shared.update(shared_overrides or {})
+    return {
+        "schema": "cua.cursor-motion/1",
+        "shared": shared,
+        "spring_settle": {
+            "macos": {"mode": "fixed", "k": 400.0, "c": 17.0, "overshoot": 0.8},
+            "windows_linux": {
+                "mode": "derived",
+                "k_per_spring": 400.0,
+                "c_per_spring": 20.0,
+                "overshoot": 0.5,
+            },
+        },
+    }
+
+
+class PromoteMotionTests(unittest.TestCase):
+    def run_tool(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(TOOL), *args],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_promotes_override_values_into_the_spec(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            override = root / "motion-override.json"
+            spec = root / "motion.default.json"
+            write(override, {"schema": "cua.cursor-gallery-motion-override/1",
+                             "peak_speed": 640.0, "turn_radius": 110.0})
+            original = spec_with()
+            write(spec, original)
+
+            result = self.run_tool("--override", str(override), "--spec", str(spec))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            promoted = json.loads(spec.read_text())
+            self.assertEqual(promoted["shared"]["peak_speed"], 640.0)
+            self.assertEqual(promoted["shared"]["turn_radius"], 110.0)
+            # Untouched values keep the spec defaults.
+            self.assertEqual(promoted["shared"]["spring"], 0.72)
+            self.assertEqual(promoted["spring_settle"], original["spring_settle"])
+
+    def test_promotion_diff_is_value_only(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            override = root / "motion-override.json"
+            spec = root / "motion.default.json"
+            write(override, {"schema": "cua.cursor-gallery-motion-override/1",
+                             "min_end_speed": 240.0})
+            write(spec, spec_with())
+
+            before = spec.read_text()
+            self.run_tool("--override", str(override), "--spec", str(spec))
+            after = spec.read_text()
+
+            before_lines = {line.strip() for line in before.splitlines()}
+            after_lines = {line.strip() for line in after.splitlines()}
+            changed = before_lines - after_lines
+            added = after_lines - before_lines
+            self.assertEqual(changed, {'"min_end_speed": 200.0,'})
+            self.assertEqual(added, {'"min_end_speed": 240.0,'})
+
+    def test_validate_only_never_writes(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            override = root / "motion-override.json"
+            spec = root / "motion.default.json"
+            write(override, {"schema": "cua.cursor-gallery-motion-override/1",
+                             "spring": 0.66})
+            write(spec, spec_with())
+            before = spec.read_text()
+
+            result = self.run_tool("--override", str(override), "--spec", str(spec),
+                                   "--validate-only")
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("shared.spring: 0.72 -> 0.66", result.stdout)
+            self.assertEqual(spec.read_text(), before)
+
+    def test_rejects_bad_overrides(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            spec = root / "motion.default.json"
+            write(spec, spec_with())
+
+            empty = root / "empty.json"
+            write(empty, {"schema": "cua.cursor-gallery-motion-override/1"})
+            result = self.run_tool("--override", str(empty), "--spec", str(spec))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("no movement values", result.stderr)
+
+            wrong_schema = root / "wrong.json"
+            write(wrong_schema, {"schema": "cua.other/1", "peak_speed": 5.0})
+            result = self.run_tool("--override", str(wrong_schema), "--spec", str(spec))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("schema", result.stderr)
+
+            # Non-promotable field sneaking through is refused.
+            hostile = root / "hostile.json"
+            write(hostile, {"schema": "cua.cursor-gallery-motion-override/1",
+                            "idle_hide_ms": 5.0})
+            result = self.run_tool("--override", str(hostile), "--spec", str(spec))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("non-promotable", result.stderr)
+            self.assertEqual(spec.read_text(), json.dumps(spec_with(), indent=2) + "\n")
+
+    def test_no_change_leaves_file_untouched(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            override = root / "motion-override.json"
+            spec = root / "motion.default.json"
+            write(override, {"schema": "cua.cursor-gallery-motion-override/1",
+                             "peak_speed": 900.0})
+            write(spec, spec_with())
+            before = spec.read_text()
+
+            result = self.run_tool("--override", str(override), "--spec", str(spec))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("nothing written", result.stdout)
+            self.assertEqual(spec.read_text(), before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Promotes the playground's movement parameters into a shared, repository-owned movement spec, so the gallery and the production platform overlays consume one source of truth for cursor motion.

- **Shared spec** (`assets/motion.default.json`, schema `cua.cursor-motion/1`): embedded at compile time via `include_str!` and parsed once. `MotionConfig::default()`, the Windows/Linux spring derivation, the macOS reference settle constants, and the thrice-duplicated `CLICK_OFFSET` all now derive from this single file. The per-platform `spring_settle` sections are explicit (macOS `k=400, c=17, overshoot=0.8`; Windows/Linux derived `spring*400 / spring*20`, overshoot 0.5) — behavior-preserving, not unified.
- **Strict checked-in contract**: parsing validates the exact schema, typed `fixed`/`derived` platform modes, finite production bounds, and speed-floor cross-fields. An invalid embedded asset fails fast with no shadow defaults.
- **Parity gates**: a double-entry test pins the embedded spec against an independent Rust literal (`reference_defaults()`), and a thrown-away harness proved trajectories bit-identical to the pre-change build on both platform tick paths before being discarded.
- **Gallery manifest v2**: the exporter records the exact movement contract it rendered (effective values, spring mode, overridden fields), so an overridden recording can never be mistaken for production defaults.
- **Movement lab UI** (dev-only): six sliders bounded to production ranges rebuild the preview through the production renderer; state echoes from the server so UI and file never drift.
- **Dev server**: one whitelisted loopback POST endpoint writes the override to a fixed ignored path; payload size-capped, origin-checked, and sanitized (unknown fields/non-finite/out-of-range rejected).
- **Promotion workflow**: `cursor-gallery.sh promote-motion` merges a tuned override into the shared spec with a value-only canonical diff, re-validating hand-edited files through the same sanitizer and the exporter's cross-field rule (floors ≤ effective peak). Parity tests gate the promotion.

## Decision record

An advisory architecture review (Claude Code Fable, read-only plan mode) recommended the JSON-spec + `include_str!` + parse-once-static approach, per-platform spring-settle sections instead of unification, a single whitelisted dev endpoint, and promotion with contract tests. The implemented design follows it. Full advisory archived in the linked card.

## Validation

Local, at candidate SHA `a5690ed2f`:

- `cargo test -p cursor-overlay --lib` — 49 passed (incl. spec parity and rejection tests)
- `cargo test -p cursor-overlay --example export_gallery_frames --features theme-authoring` — 11 passed
- `python3 -m unittest discover -s libs/cua-driver/tools/cursor-gallery -p "test_*.py"` — 16 passed
- `cargo fmt --check`, `bash -n`, `node --check` clean; `platform-macos/windows/linux` `cargo check` clean
- Loopback e2e: POST override → rebuild → manifest echoes `overridden_fields` + effective values
- Trajectory parity: bit-identical pre/post refactor on both tick paths (throwaway harness, not committed)

Platform evidence at exact candidate SHA `a5690ed2f` (workflow_dispatch with requested SHA; the resolve job pinned `CUA_E2E_SOURCE_SHA` and every downstream job fetched this commit):

- **Linux X11 — exact-candidate recert** ([run 32519842962](https://github.com/trycua/cua/actions/runs/32519842962)): success — all 6 jobs (install-local.sh smoke, shared Electron + Tauri, capture and desktop scope, GTK3 + GTK4 native harnesses, matrix summary); this run's head SHA is `a5690ed2f` directly, pinning the interactive X11 gate to the exact candidate.
- **Linux X11 — companion recert** ([run 32517328710](https://github.com/trycua/cua/actions/runs/32517328710)): success — all 6 jobs, confirming the same gate.
- **Standalone browsers at `a5690ed2f`** ([run 32519839892](https://github.com/trycua/cua/actions/runs/32519839892) + companion [run 32517331028](https://github.com/trycua/cua/actions/runs/32517331028)): both runs conclusive. Linux X11/chrome succeeded in both. Windows chrome+edge failed with the pre-existing attestation defect — decisive: the test `standalone_browser_prepare_isolated` panicked at `standalone_browser_behavior_test.rs:2229` (`left: String("refused")` / `right: "ok"`), structured `code: browser_route_unavailable`, message `no vendor-signed protected Chromium executable is available for isolated launch`, identical on Chrome and Edge — a runner-environment attestation gap, not a movement-spec regression; tracked separately on the Windows triage card.

Pre-hardening platform diagnostics at SHA `5ebe5f012`:

- **Windows** ([run 32509120689](https://github.com/trycua/cua/actions/runs/32509120689)): success — native WPF + WinUI3 + WebView2, capture + desktop scope, shared Electron + Tauri, installer + update smoke, matrix summary
- **Linux X11** ([run 32509122525](https://github.com/trycua/cua/actions/runs/32509122525)): success
- **Standalone browsers** ([run 32512934295](https://github.com/trycua/cua/actions/runs/32512934295)): Linux X11/chrome success. Windows chrome+edge failed with `browser_route_unavailable: no vendor-signed protected Chromium executable is available for isolated launch` — a runner-environment issue pre-existing on `main` (the last 7 main runs of this workflow failed identically), not caused by this change.

## Interactive playground evidence

Real Movement Lab interaction was verified at exact candidate `a5690ed2f` through an exactly bound, driver-owned Chrome window using Cua Driver's snapshot-before/action/fresh-snapshot-after loop:

- A real pointer drag changed `peak_speed` from `900` to `2000`. macOS correctly refused the background gesture; the explicit foreground fallback delivered it with input route `global_input`.
- The page moved from `ready` to `building`, then returned to `ready` after rebuilding through the production Rust renderer.
- Gallery manifest v2 echoed effective `peak_speed: 2000` with `overridden_fields: ["peak_speed"]`; all other effective fields remained at production defaults.
- All 3,000 generated movement frames retained transparent canvas margin: zero frames touched an image edge and the minimum margin was 56 pixels.
- The rendered Reset control rebuilt the preview to production defaults (`peak_speed: 900`, no overridden fields) and removed the fixed override file.
- Browser binding quality was `exact`, endpoint access was `driver_owned`, mutation was allowed, and the slider gesture's successful input trust class was native foreground `global_input` after the platform-declared background refusal.

## Pending requested platform evidence

This pull request remains draft and the following user-requested exact-candidate rows remain gates for the active validation goal:

- Exact-candidate Azure Windows replay after independently observing a live interactive non-Session-0 desktop through FreeRDP/RDP. GitHub-hosted Windows evidence is supplemental and does not replace this named environment-parity replay.
- Exact-candidate macOS Lume canonical harness (`libs/cua-driver/tests/runners/macos-lume/run-all.sh --standalone-browser`) in the logged-in, TCC-authorized guest.

The Windows standalone-browser leg at `a5690ed2f` remains a separate pre-existing `browser_route_unavailable` runner-environment attestation gap; Linux X11/chrome succeeded and the Windows defect is tracked independently rather than attributed to this movement-spec change.

## Release

`no-release` label kept: repository playground + internal refactor with no user-visible behavior change (proven bit-identical trajectories). Will revisit if release-metadata review disagrees.
