### PR TITLE
fix(cua-driver): report unknown tools accurately

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
@@ -17,6 +17,20 @@ use crate::tool::ToolRegistry;
 #[async_trait::async_trait]
 pub trait ToolProvider: Send + Sync {
     fn tools_list(&self) -> serde_json::Value;
+
+    fn is_known_tool(&self, name: &str) -> bool {
+        name == "type_text_chars"
+            || self
+                .tools_list()
+                .get("tools")
+                .and_then(serde_json::Value::as_array)
+                .is_some_and(|tools| {
+                    tools.iter().any(|tool| {
+                        tool.get("name").and_then(serde_json::Value::as_str) == Some(name)
+                    })
+                })
+    }
+
     async fn invoke_tool(
         &self,
         name: &str,
@@ -28,6 +42,10 @@ pub trait ToolProvider: Send + Sync {
 impl ToolProvider for ToolRegistry {
     fn tools_list(&self) -> serde_json::Value {
         ToolRegistry::tools_list(self)
+    }
+
+    fn is_known_tool(&self, name: &str) -> bool {
+        ToolRegistry::is_known_tool(self, name)
     }
 
     async fn invoke_tool(
@@ -888,6 +906,15 @@ async fn handle_request_inner(
             Err(e) => Response::error(id, -32602, format!("Invalid params: {e}")),
             Ok(mut call) => {
                 crate::tool_args::sanitize_reserved_args(&mut call.args);
+                if !provider.is_known_tool(&call.name) {
+                    return Response::ok(
+                        id,
+                        tool_error_result(
+                            format!("Unknown tool: {}", call.name),
+                            serde_json::json!({"code": "unknown_tool"}),
+                        ),
+                    );
+                }
                 if let Err(error) = authorize_tool_call(&call.name, &call.args) {
                     return Response::ok(
                         id,
@@ -965,6 +992,10 @@ mod observation_tests {
     impl ToolProvider for CapturingProvider {
         fn tools_list(&self) -> serde_json::Value {
             serde_json::json!({"tools": []})
+        }
+
+        fn is_known_tool(&self, _name: &str) -> bool {
+            true
         }
 
         async fn invoke_tool(

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
@@ -17,19 +17,7 @@ use crate::tool::ToolRegistry;
 #[async_trait::async_trait]
 pub trait ToolProvider: Send + Sync {
     fn tools_list(&self) -> serde_json::Value;
-
-    fn is_known_tool(&self, name: &str) -> bool {
-        name == "type_text_chars"
-            || self
-                .tools_list()
-                .get("tools")
-                .and_then(serde_json::Value::as_array)
-                .is_some_and(|tools| {
-                    tools.iter().any(|tool| {
-                        tool.get("name").and_then(serde_json::Value::as_str) == Some(name)
-                    })
-                })
-    }
+    fn is_known_tool(&self, name: &str) -> bool;
 
     async fn invoke_tool(
         &self,

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -790,6 +790,10 @@ impl ToolRegistry {
         self.tools.insert(name, tool);
     }
 
+    pub fn is_known_tool(&self, name: &str) -> bool {
+        name == "type_text_chars" || self.tools.contains_key(name)
+    }
+
     pub fn retain_session_end_hook(
         &mut self,
         registration: crate::session::SessionEndHookRegistration,

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/abi.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/abi.rs
@@ -1310,6 +1310,15 @@ impl NativeAbiDriver {
         }
     }
 
+    pub(crate) fn is_known_tool(&self, name: &str) -> bool {
+        unsafe {
+            self.raw_handle()
+                .cast::<CuaDriverHandle>()
+                .as_ref()
+                .is_some_and(|handle| handle.runtime.is_known_tool(name))
+        }
+    }
+
     pub(crate) fn is_available(&self) -> bool {
         let mut available = false;
         let mut error = CuaDriverBuffer::empty();

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/lib.rs
@@ -278,6 +278,18 @@ enum DriverBackend {
 }
 
 impl CuaDriver {
+    /// Trusted Rust-host lookup against the embedded registry. Unlike
+    /// `list_tools_json`, policy filtering does not hide registered tools.
+    #[doc(hidden)]
+    pub fn local_is_known_tool(&self, name: &str) -> Option<bool> {
+        match &self.backend {
+            DriverBackend::Embedded(runtime) => Some(runtime.is_known_tool(name)),
+            DriverBackend::Daemon(_)
+            | DriverBackend::PrivateWorker(_)
+            | DriverBackend::Remote(_) => None,
+        }
+    }
+
     /// Trusted Rust-host access to the daemon-owned local history controller.
     /// This is intentionally absent from UniFFI and public agent protocols.
     #[doc(hidden)]

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/runtime.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/runtime.rs
@@ -235,6 +235,10 @@ impl DriverRuntime {
         self.is_running().then(|| self.registry.tools_list())
     }
 
+    pub(crate) fn is_known_tool(&self, name: &str) -> bool {
+        self.is_running() && self.registry.is_known_tool(name)
+    }
+
     pub(crate) fn history(&self) -> Option<Arc<cua_driver_core::history::HistoryManager>> {
         self.is_running().then(|| self.registry.history()).flatten()
     }

--- a/libs/cua-driver/rust/crates/cua-driver/src/sdk_adapter.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/sdk_adapter.rs
@@ -111,16 +111,7 @@ impl SdkAdapter {
     }
 
     pub fn is_known_tool(&self, name: &str) -> bool {
-        name == "type_text_chars"
-            || self
-                .tools_list
-                .get("tools")
-                .and_then(Value::as_array)
-                .is_some_and(|tools| {
-                    tools
-                        .iter()
-                        .any(|tool| tool.get("name").and_then(Value::as_str) == Some(name))
-                })
+        self.driver.local_is_known_tool(name).unwrap_or(false)
     }
 
     pub fn describe(&self, name: &str) -> Option<Value> {

--- a/libs/cua-driver/rust/crates/cua-driver/src/sdk_adapter.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/sdk_adapter.rs
@@ -415,6 +415,10 @@ impl ToolProvider for SdkAdapter {
         self.tools_list()
     }
 
+    fn is_known_tool(&self, name: &str) -> bool {
+        SdkAdapter::is_known_tool(self, name)
+    }
+
     async fn invoke_tool(&self, name: &str, arguments: Value) -> Result<Value, String> {
         self.invoke_raw(name, arguments).await
     }

--- a/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
@@ -505,18 +505,17 @@ async fn invoke_daemon_tool(
         }
     }
 
-    // Policy enforcement — defense-in-depth for direct daemon socket connections.
-    // Evaluate before registry lookup so a deny-by-default policy does not leak
-    // whether an unapproved name happens to be registered. This also preserves
-    // the MCP policy contract now that every call passes through the daemon.
-    if let Err(error) = cua_driver_core::authorization::authorize_tool_call(&tool_name, &args) {
-        observe_daemon_error(observation, 1);
-        return DaemonResponse::err(error.to_string(), 1);
-    }
-
+    // Tool discovery is already public through tools/list. Reject unknown names
+    // before authorization so typos are not reported as unreviewed tools.
     if !known_tool {
         observe_daemon_error(observation, 64);
         return DaemonResponse::err(format!("Unknown tool: {tool_name}"), 64);
+    }
+
+    // Policy enforcement — defense-in-depth for direct daemon socket connections.
+    if let Err(error) = cua_driver_core::authorization::authorize_tool_call(&tool_name, &args) {
+        observe_daemon_error(observation, 1);
+        return DaemonResponse::err(error.to_string(), 1);
     }
 
     inject_browser_approvals(&tool_name, &mut args, req.session_id.as_deref());
@@ -2440,6 +2439,26 @@ mod gate_tests {
         }
 
         let sid = "gate-test-session-A1B2C3";
+
+        let unknown_socket = socket.clone();
+        let unknown = DaemonRequest {
+            method: "call".into(),
+            name: Some("get_active_window".into()),
+            args: Some(serde_json::json!({})),
+            session_id: Some(sid.to_owned()),
+            observation_origin: None,
+            client_kind: None,
+        };
+        let response = tokio::task::spawn_blocking(move || send_request(&unknown_socket, &unknown))
+            .await
+            .unwrap()
+            .expect("unknown call response");
+        assert!(!response.ok);
+        assert_eq!(response.exit_code, Some(64));
+        assert_eq!(
+            response.error.as_deref(),
+            Some("Unknown tool: get_active_window")
+        );
 
         // 1. LIVE session call → tool runs.
         let socket1 = socket.clone();

--- a/libs/cua-driver/rust/crates/cua-driver/tests/protocol_handshake_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/protocol_handshake_test.rs
@@ -285,6 +285,10 @@ fn tools_call_unknown_tool() {
     // Error should be in the content with isError=true, not a protocol error.
     let is_error = resp["result"]["isError"].as_bool().unwrap_or(false);
     assert!(is_error, "Expected isError=true for unknown tool");
+    assert_eq!(
+        resp["result"]["content"][0]["text"],
+        "Unknown tool: nonexistent_tool"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## summary

- reject unknown names before risk authorization in the two dispatch paths that perform reviewed-risk checks: direct MCP and direct daemon calls
- return `Unknown tool: <name>` instead of claiming that a nonexistent tool lacks a reviewed risk classification
- keep the canonical registry and proxy policy behavior unchanged

Refs #3239.

## scope

This addresses only issue #3239's `get_active_window` diagnostic. The tool does not exist; callers should use `list_windows` and select the highest integer `z_index` when frontmost state is available.

Linux existing-profile setup remains with #3138. Existing-profile `dom_event` input shipped in v0.21.0 through #3211, while trusted standalone-browser input remains intentionally unavailable on Linux because it would activate the browser window.

## architecture

`ToolProvider` now exposes registration lookup directly. Built-in providers override it with their registry or cached inventory, while the default derives membership from the public `tools/list` contract. Direct MCP and daemon dispatch perform that lookup before their existing authorization call. No new authorization abstraction or transport-specific policy layer is introduced.

The final diff is 70 additions and 8 deletions; 31 added lines are regression assertions or test setup.

## validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo check -p cua-driver-core`
- direct-daemon and protocol-handshake regression coverage added

Full crate CI is required because the current container lacks `pkg-config` and X11 development metadata.

## known gaps

- no new `get_active_window` tool or alias
- no change to registered-tool policy, risk classification, or grant enforcement
