### PR TITLE
feat(sandbox): forward raw Fleet service bodies unchanged

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/interfaces/services.py
+++ b/libs/python/cua-sandbox/cua_sandbox/interfaces/services.py
@@ -20,14 +20,17 @@ class Services:
         method: str,
         path: str,
         json: Any = None,
+        content: bytes | None = None,
         headers: dict[str, str] | None = None,
     ) -> Any:
         """Send a request to a named service on this sandbox.
 
-        Fleet routes the request through the authenticated lease. Other
-        transports raise :class:`NotImplementedError` unless they expose named
+        Pass ``json`` for JSON RPC-style services or ``content`` for an opaque
+        HTTP body; the two are mutually exclusive. Fleet routes the request
+        through the authenticated lease without base64 encoding or rechunking.
+        Other transports raise :class:`NotImplementedError` unless they expose named
         services as well.
         """
         return await self._transport.request_service(
-            name, method=method, path=path, json_body=json, headers=headers
+            name, method=method, path=path, json_body=json, content=content, headers=headers
         )

--- a/libs/python/cua-sandbox/cua_sandbox/transport/base.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/base.py
@@ -73,6 +73,7 @@ class Transport(ABC):
         method: str,
         path: str,
         json_body: Any = None,
+        content: bytes | None = None,
         headers: Any = None,
     ) -> Any:
         """Request an auxiliary named service exposed by this sandbox."""

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
@@ -90,12 +90,18 @@ class FleetTransport(Transport):
         method: str,
         path: str,
         json_body: Any = None,
+        content: bytes | None = None,
         headers: dict[str, str] | None = None,
     ) -> httpx.Response:
         if name not in self._bound.services:
             raise ValueError(f"Fleet sandbox does not expose service {name!r}")
         return await self._request(
-            method, path, json_body=json_body, service_name=name, extra_headers=headers
+            method,
+            path,
+            json_body=json_body,
+            content=content,
+            service_name=name,
+            extra_headers=headers,
         )
 
     async def _request(
@@ -104,13 +110,20 @@ class FleetTransport(Transport):
         path: str,
         *,
         json_body: Any = None,
+        content: bytes | None = None,
         service_name: str | None = None,
         extra_headers: dict[str, str] | None = None,
     ) -> httpx.Response:
         assert self._connected, "Transport not connected"
-        body = None if json_body is None else json.dumps(json_body).encode()
+        if json_body is not None and content is not None:
+            raise ValueError("json_body and content are mutually exclusive")
+        body = (
+            content
+            if content is not None
+            else (None if json_body is None else json.dumps(json_body).encode())
+        )
         headers = (
-            [] if body is None else [HttpHeader(name="content-type", value="application/json")]
+            [] if json_body is None else [HttpHeader(name="content-type", value="application/json")]
         )
         for name, value in (extra_headers or {}).items():
             headers.append(HttpHeader(name=name, value=value))

--- a/libs/python/cua-sandbox/tests/test_fleet_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_transport.py
@@ -38,6 +38,41 @@ async def test_service_request_forwards_command_json():
 
 
 @pytest.mark.asyncio
+async def test_named_service_request_forwards_large_raw_body_unchanged():
+    sdk = FakeSDK([response(body=b"accepted")])
+    transport = FleetTransport(sdk=sdk, bound=sandbox())
+    await transport.connect()
+    payload = bytes(range(256)) * 5000
+
+    result = await transport.request_service(
+        "api",
+        method="POST",
+        path="/upload",
+        content=payload,
+        headers={"content-type": "application/octet-stream"},
+    )
+
+    assert result.content == b"accepted"
+    _, service, path, request = sdk.calls[0]
+    assert (service, path, request.method) == ("api", "/upload", "POST")
+    assert request.body == payload
+    assert [(header.name, header.value) for header in request.headers] == [
+        ("content-type", "application/octet-stream")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_named_service_request_rejects_json_and_raw_body_together():
+    transport = FleetTransport(sdk=FakeSDK([]), bound=sandbox())
+    await transport.connect()
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        await transport.request_service(
+            "api", method="POST", path="/upload", json_body={"ok": True}, content=b"raw"
+        )
+
+
+@pytest.mark.asyncio
 async def test_screenshot_and_pty_use_service_request():
     encoded = base64.b64encode(b"png-data").decode()
     sdk = FakeSDK(


### PR DESCRIPTION
## What changed

- let the public named-service API send an opaque `bytes` body without JSON parsing, base64 encoding, or SDK-level rechunking;
- preserve the existing JSON behavior for computer-server `/cmd` and reject ambiguous calls that provide both JSON and raw content;
- prove a 1,280,000-byte raw body is forwarded as one byte-identical Fleet service request;
- preserve the existing per-request timeout behavior.

This is the SDK companion to https://github.com/trycua/cloud/pull/7129. Once the cloud proxy no longer imposes the 1 MiB nginx limit, PR #3310's file-specific base64 chunking workaround is no longer appropriate. This PR is intentionally separate rather than rewriting another contributor's branch; #3310 can be closed after the cloud fix lands.

## TDD evidence

RED:
- `uv run --python 3.12 --project libs/python/cua-sandbox pytest libs/python/cua-sandbox/tests/test_fleet_transport.py -q` — 1 failed, 5 passed because `FleetTransport.request_service` did not accept raw `content`.

GREEN / broader:
- focused Fleet transport tests: 7 passed;
- Fleet transport + pool tests: 69 passed;
- `uvx ruff check ...`;
- `uvx ruff format --check ...`;
- `uv build --python 3.12 --out-dir /tmp/cua-sandbox-dist libs/python/cua-sandbox`;
- `git diff --check`.
