### PR TITLE
fix(cua-driver): sign Windows release binaries

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -576,6 +576,54 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
             1,
         )
 
+    def test_driver_windows_release_signs_every_pe_binary_before_packaging(self) -> None:
+        workflow = self.read(".github/workflows/cd-rust-cua-driver.yml")
+        windows = workflow.index("  build-windows:")
+        next_job = workflow.index("  verify-windows-node-runtime:", windows)
+        block = workflow[windows:next_job]
+
+        self.assertIn("  id-token: write\n", workflow)
+        self.assertIn("    environment: cua-driver-release-signing\n", block)
+        self.assertIn(
+            "azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca",
+            block,
+        )
+        self.assertIn(
+            "azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82",
+            block,
+        )
+        self.assertIn("${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}", block)
+        self.assertIn("${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME }}", block)
+        self.assertIn(
+            "${{ vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}",
+            block,
+        )
+        for binary in (
+            "cua-driver.exe",
+            "cua-cursor-theme.exe",
+            "cua-driver-uia.exe",
+            "cua_driver_sdk.dll",
+            "cua_driver_node_runtime.node",
+        ):
+            self.assertIn(binary, block)
+
+        login = block.index("- name: Azure login for Artifact Signing")
+        signing = block.index("- name: Sign Windows binaries", login)
+        verify = block.index("- name: Verify Authenticode signatures", signing)
+        package = block.index("- name: Package", verify)
+        self.assertLess(login, signing)
+        self.assertLess(signing, verify)
+        self.assertLess(verify, package)
+        self.assertIn("Get-AuthenticodeSignature", block)
+        self.assertIn("$signature.Status -ne 'Valid'", block)
+        self.assertIn("Cua AI, Inc", block)
+        self.assertNotIn("currently shipped UNSIGNED", block)
+
+    def test_driver_nightly_grants_oidc_to_reusable_signing_workflow(self) -> None:
+        workflow = self.read(".github/workflows/nightly-cua-driver.yml")
+        self.assertIn("  id-token: write\n", workflow)
+        self.assertIn("uses: ./.github/workflows/cd-rust-cua-driver.yml", workflow)
+
     def test_driver_tag_build_cannot_publish_before_manual_e2e_gate(self) -> None:
         workflow = self.read(".github/workflows/cd-rust-cua-driver.yml")
         self.assertIn(

--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -72,6 +72,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   issues: read
   pull-requests: read
 
@@ -265,6 +266,7 @@ jobs:
     name: windows-${{ matrix.arch }}
     needs: release-attribution-preflight
     runs-on: windows-latest
+    environment: cua-driver-release-signing
     strategy:
       fail-fast: false
       matrix:
@@ -360,6 +362,51 @@ jobs:
           if ($dynamicCrt) {
             throw "Windows Node runtime has a dynamic VC/UCRT dependency: $($dynamicCrt -join ', ')"
           }
+      - name: Azure login for Artifact Signing
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - name: Sign Windows binaries
+        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
+        with:
+          endpoint: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          files: |
+            ${{ github.workspace }}\libs\cua-driver\rust\target\${{ matrix.target }}\release\cua-driver.exe
+            ${{ github.workspace }}\libs\cua-driver\rust\target\${{ matrix.target }}\release\cua-cursor-theme.exe
+            ${{ github.workspace }}\libs\cua-driver\rust\target\${{ matrix.target }}\release\cua-driver-uia.exe
+            ${{ github.workspace }}\libs\cua-driver\rust\target\${{ matrix.target }}\release\cua_driver_sdk.dll
+            ${{ github.workspace }}\libs\cua-driver\rust\target\${{ matrix.target }}\release\cua_driver_node_runtime.node
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          description: Cua Driver
+          description-url: https://cua.ai
+      - name: Verify Authenticode signatures
+        working-directory: libs/cua-driver/rust
+        shell: pwsh
+        run: |
+          $target = "${{ matrix.target }}"
+          $files = @(
+            "target/$target/release/cua-driver.exe",
+            "target/$target/release/cua-cursor-theme.exe",
+            "target/$target/release/cua-driver-uia.exe",
+            "target/$target/release/cua_driver_sdk.dll",
+            "target/$target/release/cua_driver_node_runtime.node"
+          )
+          foreach ($file in $files) {
+            $signature = Get-AuthenticodeSignature -FilePath $file
+            $signature | Format-List Status, StatusMessage, Path, SignerCertificate
+            if ($signature.Status -ne 'Valid') {
+              throw "Invalid Authenticode signature for ${file}: $($signature.StatusMessage)"
+            }
+            if ($signature.SignerCertificate.Subject -notmatch 'CN="?Cua AI, Inc\."?') {
+              throw "Unexpected Authenticode signer for ${file}: $($signature.SignerCertificate.Subject)"
+            }
+          }
       - name: Package
         working-directory: libs/cua-driver/rust
         shell: pwsh
@@ -383,12 +430,7 @@ jobs:
           # wrapper and dumps the files at the archive root, which breaks
           # the installer's path lookup.
           Compress-Archive -Path "release/$stage" -DestinationPath "release/$stage.zip" -Force
-          # Bare-binaries zip: both exes side-by-side (no wrapper dir).
-          # `cua-driver-uia.exe` is currently shipped UNSIGNED in this archive
-          # — until #1602 wires an EV cert into CD, the worker won't elevate
-          # to UIAccess integrity on a default-policy machine. The main CLI/MCP
-          # binary stays fully functional regardless; uia is opt-in dead-weight
-          # until signed.
+          # Bare-binaries zip: all runtime binaries side-by-side (no wrapper dir).
           Compress-Archive -Path "release/$stage/cua-driver.exe","release/$stage/cua-cursor-theme.exe","release/$stage/cua-driver-uia.exe","release/$stage/cua_driver_sdk.dll","release/$stage/cua_driver_node_runtime.node","release/$stage/cua_driver_abi.h" -DestinationPath "release/$stage-binary.zip" -Force
           Get-ChildItem "release/$stage*.zip"
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly-cua-driver.yml
+++ b/.github/workflows/nightly-cua-driver.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   issues: read
   pull-requests: read
 


### PR DESCRIPTION
## What changed

- configure Azure Artifact Signing for both Cua Driver Windows architectures
- authenticate GitHub Actions to Azure with environment-scoped OIDC and no client secret
- sign every packaged PE runtime before archive creation
- fail release builds unless every Authenticode signature is valid and issued to Cua AI, Inc.
- grant the reusable nightly caller the required OIDC permission

## Verification

- `python3 .github/scripts/tests/test_cua_driver_release_wiring.py` (43 tests)
- non-publishing release workflow: https://github.com/trycua/cua/actions/runs/32524260777/attempts/2
- x86_64 and ARM64 both passed Azure OIDC login, Artifact Signing, and Authenticode verification
- verified signer subject: `CN="Cua AI, Inc.", O="Cua AI, Inc.", L=San Francisco, S=California, C=US`
- signed x86_64 `cua-driver.exe` SHA-256: `614eccdd76966af8e51eb4c923126446ceb2a06d350ef0a08ba7f9c60c4161a9`

This does not publish a release.