### PR TITLE
test(cua-driver): normalize Windows browser trust posture

### DIFF
--- a/.github/workflows/e2e-rust-standalone-browsers.yml
+++ b/.github/workflows/e2e-rust-standalone-browsers.yml
@@ -109,15 +109,11 @@ jobs:
           using System.Text;
 
           public static class ShellProcess {
-              const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
-              const uint TOKEN_ASSIGN_PRIMARY = 0x1;
-              const uint TOKEN_DUPLICATE = 0x2;
-              const uint TOKEN_QUERY = 0x8;
+              const uint TOKEN_ALL_ACCESS = 0x000F01FF;
               const uint DISABLE_MAX_PRIVILEGE = 0x1;
               const uint LUA_TOKEN = 0x4;
               const uint CREATE_UNICODE_ENVIRONMENT = 0x400;
               const uint INFINITE = 0xFFFFFFFF;
-              const int TOKEN_ELEVATION = 20;
 
               [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
               struct STARTUPINFO {
@@ -149,8 +145,8 @@ jobs:
                   public uint dwThreadId;
               }
 
-              [DllImport("kernel32.dll", SetLastError = true)]
-              static extern IntPtr OpenProcess(uint access, bool inheritHandle, uint processId);
+              [DllImport("kernel32.dll")]
+              static extern IntPtr GetCurrentProcess();
 
               [DllImport("advapi32.dll", SetLastError = true)]
               static extern bool OpenProcessToken(IntPtr process, uint access, out IntPtr token);
@@ -166,14 +162,6 @@ jobs:
                   uint restrictedSidCount,
                   IntPtr sidsToRestrict,
                   out IntPtr restrictedToken);
-
-              [DllImport("advapi32.dll", SetLastError = true)]
-              static extern bool GetTokenInformation(
-                  IntPtr token,
-                  int informationClass,
-                  out int information,
-                  int informationLength,
-                  out int returnLength);
 
               [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
               static extern bool CreateProcessWithTokenW(
@@ -200,40 +188,19 @@ jobs:
                   if (!success) throw new Win32Exception(Marshal.GetLastWin32Error());
               }
 
-              public static int Run(uint shellProcessId, string application, string commandLine, string currentDirectory) {
-                  IntPtr shellProcess = IntPtr.Zero;
-                  IntPtr shellToken = IntPtr.Zero;
+              public static int Run(string application, string commandLine, string currentDirectory) {
+                  IntPtr processToken = IntPtr.Zero;
                   IntPtr restrictedToken = IntPtr.Zero;
                   PROCESS_INFORMATION process = new PROCESS_INFORMATION();
                   try {
-                      shellProcess = OpenProcess(
-                          PROCESS_QUERY_LIMITED_INFORMATION,
-                          false,
-                          shellProcessId);
-                      if (shellProcess == IntPtr.Zero) {
-                          throw new Win32Exception(Marshal.GetLastWin32Error());
-                      }
-                      Check(OpenProcessToken(
-                          shellProcess,
-                          TOKEN_ASSIGN_PRIMARY | TOKEN_DUPLICATE | TOKEN_QUERY,
-                          out shellToken));
+                      Check(OpenProcessToken(GetCurrentProcess(), TOKEN_ALL_ACCESS, out processToken));
                       Check(CreateRestrictedToken(
-                          shellToken,
+                          processToken,
                           DISABLE_MAX_PRIVILEGE | LUA_TOKEN,
                           0, IntPtr.Zero, 0, IntPtr.Zero, 0, IntPtr.Zero,
                           out restrictedToken));
-                      Check(GetTokenInformation(
-                          restrictedToken,
-                          TOKEN_ELEVATION,
-                          out int elevated,
-                          sizeof(int),
-                          out int returnLength));
-                      if (returnLength != sizeof(int) || elevated != 0) {
-                          throw new InvalidOperationException("Explorer token did not yield an unelevated restricted token");
-                      }
                       STARTUPINFO startup = new STARTUPINFO {
-                          cb = Marshal.SizeOf<STARTUPINFO>(),
-                          lpDesktop = "winsta0\\default"
+                          cb = Marshal.SizeOf<STARTUPINFO>()
                       };
                       Check(CreateProcessWithTokenW(
                           restrictedToken,
@@ -252,30 +219,22 @@ jobs:
                       if (process.hThread != IntPtr.Zero) CloseHandle(process.hThread);
                       if (process.hProcess != IntPtr.Zero) CloseHandle(process.hProcess);
                       if (restrictedToken != IntPtr.Zero) CloseHandle(restrictedToken);
-                      if (shellToken != IntPtr.Zero) CloseHandle(shellToken);
-                      if (shellProcess != IntPtr.Zero) CloseHandle(shellProcess);
+                      if (processToken != IntPtr.Zero) CloseHandle(processToken);
                   }
               }
           }
           '@
-          $sessionId = (Get-Process -Id $PID).SessionId
-          $shell = Get-Process explorer -ErrorAction SilentlyContinue |
-            Where-Object { $_.SessionId -eq $sessionId } |
-            Select-Object -First 1
-          if ($null -eq $shell) {
-            throw "No Explorer shell is attached to interactive session $sessionId"
-          }
           $pwsh = (Get-Process -Id $PID).Path
           $marker = Join-Path $env:RUNNER_TEMP 'cua-shell-token-preflight.txt'
           $cmd = (Get-Command cmd.exe).Source
           $markerCommand = '"{0}" /d /c echo ok>"{1}"' -f $cmd, $marker
-          $markerExit = [ShellProcess]::Run($shell.Id, $cmd, $markerCommand, $PWD.Path)
+          $markerExit = [ShellProcess]::Run($cmd, $markerCommand, $PWD.Path)
           if ($markerExit -ne 0 -or -not (Test-Path -LiteralPath $marker)) {
             throw "Unelevated shell-token preflight failed with code $markerExit"
           }
           $runner = Join-Path $PWD 'scripts\ci\windows\run-rust-standalone-browser-e2e.ps1'
           $commandLine = '"{0}" -NoLogo -NoProfile -NonInteractive -File "{1}" -NoBuild' -f $pwsh, $runner
-          $exitCode = [ShellProcess]::Run($shell.Id, $pwsh, $commandLine, $PWD.Path)
+          $exitCode = [ShellProcess]::Run($pwsh, $commandLine, $PWD.Path)
           if ($exitCode -ne 0) {
             throw "Restricted standalone-browser runner exited with code $exitCode"
           }

--- a/.github/workflows/e2e-rust-standalone-browsers.yml
+++ b/.github/workflows/e2e-rust-standalone-browsers.yml
@@ -113,6 +113,8 @@ jobs:
               const uint TOKEN_ASSIGN_PRIMARY = 0x1;
               const uint TOKEN_DUPLICATE = 0x2;
               const uint TOKEN_QUERY = 0x8;
+              const uint DISABLE_MAX_PRIVILEGE = 0x1;
+              const uint LUA_TOKEN = 0x4;
               const uint CREATE_UNICODE_ENVIRONMENT = 0x400;
               const uint INFINITE = 0xFFFFFFFF;
               const int TOKEN_ELEVATION = 20;
@@ -154,6 +156,18 @@ jobs:
               static extern bool OpenProcessToken(IntPtr process, uint access, out IntPtr token);
 
               [DllImport("advapi32.dll", SetLastError = true)]
+              static extern bool CreateRestrictedToken(
+                  IntPtr existingToken,
+                  uint flags,
+                  uint disableSidCount,
+                  IntPtr sidsToDisable,
+                  uint deletePrivilegeCount,
+                  IntPtr privilegesToDelete,
+                  uint restrictedSidCount,
+                  IntPtr sidsToRestrict,
+                  out IntPtr restrictedToken);
+
+              [DllImport("advapi32.dll", SetLastError = true)]
               static extern bool GetTokenInformation(
                   IntPtr token,
                   int informationClass,
@@ -189,6 +203,7 @@ jobs:
               public static int Run(uint shellProcessId, string application, string commandLine, string currentDirectory) {
                   IntPtr shellProcess = IntPtr.Zero;
                   IntPtr shellToken = IntPtr.Zero;
+                  IntPtr restrictedToken = IntPtr.Zero;
                   PROCESS_INFORMATION process = new PROCESS_INFORMATION();
                   try {
                       shellProcess = OpenProcess(
@@ -202,21 +217,26 @@ jobs:
                           shellProcess,
                           TOKEN_ASSIGN_PRIMARY | TOKEN_DUPLICATE | TOKEN_QUERY,
                           out shellToken));
-                      Check(GetTokenInformation(
+                      Check(CreateRestrictedToken(
                           shellToken,
+                          DISABLE_MAX_PRIVILEGE | LUA_TOKEN,
+                          0, IntPtr.Zero, 0, IntPtr.Zero, 0, IntPtr.Zero,
+                          out restrictedToken));
+                      Check(GetTokenInformation(
+                          restrictedToken,
                           TOKEN_ELEVATION,
                           out int elevated,
                           sizeof(int),
                           out int returnLength));
                       if (returnLength != sizeof(int) || elevated != 0) {
-                          throw new InvalidOperationException("Explorer did not provide an unelevated shell token");
+                          throw new InvalidOperationException("Explorer token did not yield an unelevated restricted token");
                       }
                       STARTUPINFO startup = new STARTUPINFO {
                           cb = Marshal.SizeOf<STARTUPINFO>(),
                           lpDesktop = "winsta0\\default"
                       };
                       Check(CreateProcessWithTokenW(
-                          shellToken,
+                          restrictedToken,
                           0,
                           application,
                           new StringBuilder(commandLine),
@@ -231,6 +251,7 @@ jobs:
                   } finally {
                       if (process.hThread != IntPtr.Zero) CloseHandle(process.hThread);
                       if (process.hProcess != IntPtr.Zero) CloseHandle(process.hProcess);
+                      if (restrictedToken != IntPtr.Zero) CloseHandle(restrictedToken);
                       if (shellToken != IntPtr.Zero) CloseHandle(shellToken);
                       if (shellProcess != IntPtr.Zero) CloseHandle(shellProcess);
                   }

--- a/.github/workflows/e2e-rust-standalone-browsers.yml
+++ b/.github/workflows/e2e-rust-standalone-browsers.yml
@@ -102,141 +102,59 @@ jobs:
         shell: pwsh
         run: |
           $env:CUA_E2E_ARTIFACT_DIR = Join-Path $PWD "artifacts\cua-driver\standalone-browser"
-          Add-Type -TypeDefinition @'
-          using System;
-          using System.ComponentModel;
-          using System.Runtime.InteropServices;
-          using System.Text;
-
-          public static class ShellProcess {
-              const uint TOKEN_ALL_ACCESS = 0x000F01FF;
-              const uint DISABLE_MAX_PRIVILEGE = 0x1;
-              const uint LUA_TOKEN = 0x4;
-              const uint CREATE_UNICODE_ENVIRONMENT = 0x400;
-              const uint INFINITE = 0xFFFFFFFF;
-
-              [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-              struct STARTUPINFO {
-                  public int cb;
-                  public string lpReserved;
-                  public string lpDesktop;
-                  public string lpTitle;
-                  public int dwX;
-                  public int dwY;
-                  public int dwXSize;
-                  public int dwYSize;
-                  public int dwXCountChars;
-                  public int dwYCountChars;
-                  public int dwFillAttribute;
-                  public int dwFlags;
-                  public short wShowWindow;
-                  public short cbReserved2;
-                  public IntPtr lpReserved2;
-                  public IntPtr hStdInput;
-                  public IntPtr hStdOutput;
-                  public IntPtr hStdError;
-              }
-
-              [StructLayout(LayoutKind.Sequential)]
-              struct PROCESS_INFORMATION {
-                  public IntPtr hProcess;
-                  public IntPtr hThread;
-                  public uint dwProcessId;
-                  public uint dwThreadId;
-              }
-
-              [DllImport("kernel32.dll")]
-              static extern IntPtr GetCurrentProcess();
-
-              [DllImport("advapi32.dll", SetLastError = true)]
-              static extern bool OpenProcessToken(IntPtr process, uint access, out IntPtr token);
-
-              [DllImport("advapi32.dll", SetLastError = true)]
-              static extern bool CreateRestrictedToken(
-                  IntPtr existingToken,
-                  uint flags,
-                  uint disableSidCount,
-                  IntPtr sidsToDisable,
-                  uint deletePrivilegeCount,
-                  IntPtr privilegesToDelete,
-                  uint restrictedSidCount,
-                  IntPtr sidsToRestrict,
-                  out IntPtr restrictedToken);
-
-              [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-              static extern bool CreateProcessWithTokenW(
-                  IntPtr token,
-                  uint logonFlags,
-                  string applicationName,
-                  StringBuilder commandLine,
-                  uint creationFlags,
-                  IntPtr environment,
-                  string currentDirectory,
-                  ref STARTUPINFO startupInfo,
-                  out PROCESS_INFORMATION processInformation);
-
-              [DllImport("kernel32.dll", SetLastError = true)]
-              static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
-
-              [DllImport("kernel32.dll", SetLastError = true)]
-              static extern bool GetExitCodeProcess(IntPtr process, out uint exitCode);
-
-              [DllImport("kernel32.dll")]
-              static extern bool CloseHandle(IntPtr handle);
-
-              static void Check(bool success) {
-                  if (!success) throw new Win32Exception(Marshal.GetLastWin32Error());
-              }
-
-              public static int Run(string application, string commandLine, string currentDirectory) {
-                  IntPtr processToken = IntPtr.Zero;
-                  IntPtr restrictedToken = IntPtr.Zero;
-                  PROCESS_INFORMATION process = new PROCESS_INFORMATION();
-                  try {
-                      Check(OpenProcessToken(GetCurrentProcess(), TOKEN_ALL_ACCESS, out processToken));
-                      Check(CreateRestrictedToken(
-                          processToken,
-                          DISABLE_MAX_PRIVILEGE | LUA_TOKEN,
-                          0, IntPtr.Zero, 0, IntPtr.Zero, 0, IntPtr.Zero,
-                          out restrictedToken));
-                      STARTUPINFO startup = new STARTUPINFO {
-                          cb = Marshal.SizeOf<STARTUPINFO>()
-                      };
-                      Check(CreateProcessWithTokenW(
-                          restrictedToken,
-                          0,
-                          application,
-                          new StringBuilder(commandLine),
-                          CREATE_UNICODE_ENVIRONMENT,
-                          IntPtr.Zero,
-                          currentDirectory,
-                          ref startup,
-                          out process));
-                      WaitForSingleObject(process.hProcess, INFINITE);
-                      Check(GetExitCodeProcess(process.hProcess, out uint exitCode));
-                      return unchecked((int)exitCode);
-                  } finally {
-                      if (process.hThread != IntPtr.Zero) CloseHandle(process.hThread);
-                      if (process.hProcess != IntPtr.Zero) CloseHandle(process.hProcess);
-                      if (restrictedToken != IntPtr.Zero) CloseHandle(restrictedToken);
-                      if (processToken != IntPtr.Zero) CloseHandle(processToken);
-                  }
-              }
-          }
-          '@
           $pwsh = (Get-Process -Id $PID).Path
-          $marker = Join-Path $env:RUNNER_TEMP 'cua-shell-token-preflight.txt'
-          $cmd = (Get-Command cmd.exe).Source
-          $markerCommand = '"{0}" /d /c echo ok>"{1}"' -f $cmd, $marker
-          $markerExit = [ShellProcess]::Run($cmd, $markerCommand, $PWD.Path)
-          if ($markerExit -ne 0 -or -not (Test-Path -LiteralPath $marker)) {
-            throw "Unelevated shell-token preflight failed with code $markerExit"
+          $runas = Join-Path $env:SystemRoot 'System32\runas.exe'
+          $preflight = Join-Path $env:RUNNER_TEMP 'cua-basic-user-preflight.ps1'
+          $preflightMarker = Join-Path $PWD 'cua-basic-user-preflight.txt'
+          @"
+          Set-StrictMode -Version Latest
+          Set-Content -LiteralPath '$preflightMarker' -Value 'ok'
+          "@ | Set-Content -LiteralPath $preflight
+          $preflightCommand = '"{0}" -NoLogo -NoProfile -NonInteractive -File "{1}"' -f $pwsh, $preflight
+          Start-Process -FilePath $runas -ArgumentList @('/trustlevel:0x20000', $preflightCommand) | Out-Null
+          $deadline = [DateTime]::UtcNow.AddSeconds(30)
+          while (-not (Test-Path -LiteralPath $preflightMarker) -and [DateTime]::UtcNow -lt $deadline) {
+            Start-Sleep -Milliseconds 250
           }
+          if (-not (Test-Path -LiteralPath $preflightMarker)) {
+            throw 'Windows Basic User trust-level preflight did not reach the repository'
+          }
+
           $runner = Join-Path $PWD 'scripts\ci\windows\run-rust-standalone-browser-e2e.ps1'
-          $commandLine = '"{0}" -NoLogo -NoProfile -NonInteractive -File "{1}" -NoBuild' -f $pwsh, $runner
-          $exitCode = [ShellProcess]::Run($pwsh, $commandLine, $PWD.Path)
+          $wrapper = Join-Path $env:RUNNER_TEMP 'cua-basic-user-browser-e2e.ps1'
+          $exitMarker = Join-Path $env:RUNNER_TEMP 'cua-basic-user-browser-e2e.exit'
+          $restrictedLog = Join-Path $env:RUNNER_TEMP 'cua-basic-user-browser-e2e.log'
+          @"
+          Set-StrictMode -Version Latest
+          `$ErrorActionPreference = 'Stop'
+          Start-Transcript -LiteralPath '$restrictedLog' -Force
+          `$exitCode = 0
+          try {
+            & '$runner' -NoBuild
+          } catch {
+            Write-Host (`$_ | Out-String)
+            `$exitCode = 1
+          } finally {
+            Stop-Transcript
+            Set-Content -LiteralPath '$exitMarker' -Value `$exitCode
+          }
+          exit `$exitCode
+          "@ | Set-Content -LiteralPath $wrapper
+          $restrictedCommand = '"{0}" -NoLogo -NoProfile -NonInteractive -File "{1}"' -f $pwsh, $wrapper
+          Start-Process -FilePath $runas -ArgumentList @('/trustlevel:0x20000', $restrictedCommand) | Out-Null
+
+          $deadline = [DateTime]::UtcNow.AddMinutes(45)
+          while (-not (Test-Path -LiteralPath $exitMarker) -and [DateTime]::UtcNow -lt $deadline) {
+            Start-Sleep -Seconds 5
+          }
+          if (-not (Test-Path -LiteralPath $exitMarker)) {
+            if (Test-Path -LiteralPath $restrictedLog) { Get-Content -LiteralPath $restrictedLog }
+            throw 'Windows Basic User browser E2E did not finish within 45 minutes'
+          }
+          $exitCode = [int](Get-Content -Raw -LiteralPath $exitMarker)
+          if (Test-Path -LiteralPath $restrictedLog) { Get-Content -LiteralPath $restrictedLog }
           if ($exitCode -ne 0) {
-            throw "Restricted standalone-browser runner exited with code $exitCode"
+            throw "Windows Basic User browser E2E exited with code $exitCode"
           }
       - name: Run standalone browsers on Linux X11
         if: runner.os == 'Linux'

--- a/.github/workflows/e2e-rust-standalone-browsers.yml
+++ b/.github/workflows/e2e-rust-standalone-browsers.yml
@@ -63,6 +63,27 @@ jobs:
         with:
           ref: ${{ needs.source.outputs.sha }}
       - uses: dtolnay/rust-toolchain@stable
+      - name: Verify Windows Basic User launcher
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $powershell = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+          $runas = Join-Path $env:SystemRoot 'System32\runas.exe'
+          $preflight = Join-Path $env:RUNNER_TEMP 'cua-basic-user-preflight.ps1'
+          $preflightMarker = Join-Path $PWD 'cua-basic-user-preflight.txt'
+          @"
+          Set-StrictMode -Version Latest
+          Set-Content -LiteralPath '$preflightMarker' -Value 'ok'
+          "@ | Set-Content -LiteralPath $preflight
+          $command = "$powershell -NoLogo -NoProfile -NonInteractive -File $preflight"
+          Start-Process -FilePath $runas -ArgumentList "/trustlevel:0x20000 $command" | Out-Null
+          $deadline = [DateTime]::UtcNow.AddSeconds(30)
+          while (-not (Test-Path -LiteralPath $preflightMarker) -and [DateTime]::UtcNow -lt $deadline) {
+            Start-Sleep -Milliseconds 250
+          }
+          if (-not (Test-Path -LiteralPath $preflightMarker)) {
+            throw 'Windows Basic User trust-level preflight did not reach the repository'
+          }
       - name: Install Windows video tools
         if: runner.os == 'Windows'
         shell: pwsh
@@ -102,24 +123,8 @@ jobs:
         shell: pwsh
         run: |
           $env:CUA_E2E_ARTIFACT_DIR = Join-Path $PWD "artifacts\cua-driver\standalone-browser"
-          $pwsh = (Get-Process -Id $PID).Path
+          $powershell = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
           $runas = Join-Path $env:SystemRoot 'System32\runas.exe'
-          $preflight = Join-Path $env:RUNNER_TEMP 'cua-basic-user-preflight.ps1'
-          $preflightMarker = Join-Path $PWD 'cua-basic-user-preflight.txt'
-          @"
-          Set-StrictMode -Version Latest
-          Set-Content -LiteralPath '$preflightMarker' -Value 'ok'
-          "@ | Set-Content -LiteralPath $preflight
-          $preflightCommand = '"{0}" -NoLogo -NoProfile -NonInteractive -File "{1}"' -f $pwsh, $preflight
-          Start-Process -FilePath $runas -ArgumentList @('/trustlevel:0x20000', $preflightCommand) | Out-Null
-          $deadline = [DateTime]::UtcNow.AddSeconds(30)
-          while (-not (Test-Path -LiteralPath $preflightMarker) -and [DateTime]::UtcNow -lt $deadline) {
-            Start-Sleep -Milliseconds 250
-          }
-          if (-not (Test-Path -LiteralPath $preflightMarker)) {
-            throw 'Windows Basic User trust-level preflight did not reach the repository'
-          }
-
           $runner = Join-Path $PWD 'scripts\ci\windows\run-rust-standalone-browser-e2e.ps1'
           $wrapper = Join-Path $env:RUNNER_TEMP 'cua-basic-user-browser-e2e.ps1'
           $exitMarker = Join-Path $env:RUNNER_TEMP 'cua-basic-user-browser-e2e.exit'
@@ -140,8 +145,8 @@ jobs:
           }
           exit `$exitCode
           "@ | Set-Content -LiteralPath $wrapper
-          $restrictedCommand = '"{0}" -NoLogo -NoProfile -NonInteractive -File "{1}"' -f $pwsh, $wrapper
-          Start-Process -FilePath $runas -ArgumentList @('/trustlevel:0x20000', $restrictedCommand) | Out-Null
+          $restrictedCommand = "$powershell -NoLogo -NoProfile -NonInteractive -File $wrapper"
+          Start-Process -FilePath $runas -ArgumentList "/trustlevel:0x20000 $restrictedCommand" | Out-Null
 
           $deadline = [DateTime]::UtcNow.AddMinutes(45)
           while (-not (Test-Path -LiteralPath $exitMarker) -and [DateTime]::UtcNow -lt $deadline) {

--- a/.github/workflows/e2e-rust-standalone-browsers.yml
+++ b/.github/workflows/e2e-rust-standalone-browsers.yml
@@ -108,12 +108,14 @@ jobs:
           using System.Runtime.InteropServices;
           using System.Text;
 
-          public static class RestrictedProcess {
-              const uint TOKEN_ALL_ACCESS = 0x000F01FF;
-              const uint DISABLE_MAX_PRIVILEGE = 0x1;
-              const uint LUA_TOKEN = 0x4;
+          public static class ShellProcess {
+              const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+              const uint TOKEN_ASSIGN_PRIMARY = 0x1;
+              const uint TOKEN_DUPLICATE = 0x2;
+              const uint TOKEN_QUERY = 0x8;
               const uint CREATE_UNICODE_ENVIRONMENT = 0x400;
               const uint INFINITE = 0xFFFFFFFF;
+              const int TOKEN_ELEVATION = 20;
 
               [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
               struct STARTUPINFO {
@@ -145,23 +147,19 @@ jobs:
                   public uint dwThreadId;
               }
 
-              [DllImport("kernel32.dll")]
-              static extern IntPtr GetCurrentProcess();
+              [DllImport("kernel32.dll", SetLastError = true)]
+              static extern IntPtr OpenProcess(uint access, bool inheritHandle, uint processId);
 
               [DllImport("advapi32.dll", SetLastError = true)]
               static extern bool OpenProcessToken(IntPtr process, uint access, out IntPtr token);
 
               [DllImport("advapi32.dll", SetLastError = true)]
-              static extern bool CreateRestrictedToken(
-                  IntPtr existingToken,
-                  uint flags,
-                  uint disableSidCount,
-                  IntPtr sidsToDisable,
-                  uint deletePrivilegeCount,
-                  IntPtr privilegesToDelete,
-                  uint restrictedSidCount,
-                  IntPtr sidsToRestrict,
-                  out IntPtr restrictedToken);
+              static extern bool GetTokenInformation(
+                  IntPtr token,
+                  int informationClass,
+                  out int information,
+                  int informationLength,
+                  out int returnLength);
 
               [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
               static extern bool CreateProcessWithTokenW(
@@ -188,23 +186,37 @@ jobs:
                   if (!success) throw new Win32Exception(Marshal.GetLastWin32Error());
               }
 
-              public static int Run(string application, string commandLine, string currentDirectory) {
-                  IntPtr processToken = IntPtr.Zero;
-                  IntPtr restrictedToken = IntPtr.Zero;
+              public static int Run(uint shellProcessId, string application, string commandLine, string currentDirectory) {
+                  IntPtr shellProcess = IntPtr.Zero;
+                  IntPtr shellToken = IntPtr.Zero;
                   PROCESS_INFORMATION process = new PROCESS_INFORMATION();
                   try {
-                      Check(OpenProcessToken(GetCurrentProcess(), TOKEN_ALL_ACCESS, out processToken));
-                      Check(CreateRestrictedToken(
-                          processToken,
-                          DISABLE_MAX_PRIVILEGE | LUA_TOKEN,
-                          0, IntPtr.Zero, 0, IntPtr.Zero, 0, IntPtr.Zero,
-                          out restrictedToken));
+                      shellProcess = OpenProcess(
+                          PROCESS_QUERY_LIMITED_INFORMATION,
+                          false,
+                          shellProcessId);
+                      if (shellProcess == IntPtr.Zero) {
+                          throw new Win32Exception(Marshal.GetLastWin32Error());
+                      }
+                      Check(OpenProcessToken(
+                          shellProcess,
+                          TOKEN_ASSIGN_PRIMARY | TOKEN_DUPLICATE | TOKEN_QUERY,
+                          out shellToken));
+                      Check(GetTokenInformation(
+                          shellToken,
+                          TOKEN_ELEVATION,
+                          out int elevated,
+                          sizeof(int),
+                          out int returnLength));
+                      if (returnLength != sizeof(int) || elevated != 0) {
+                          throw new InvalidOperationException("Explorer did not provide an unelevated shell token");
+                      }
                       STARTUPINFO startup = new STARTUPINFO {
                           cb = Marshal.SizeOf<STARTUPINFO>(),
                           lpDesktop = "winsta0\\default"
                       };
                       Check(CreateProcessWithTokenW(
-                          restrictedToken,
+                          shellToken,
                           0,
                           application,
                           new StringBuilder(commandLine),
@@ -219,16 +231,30 @@ jobs:
                   } finally {
                       if (process.hThread != IntPtr.Zero) CloseHandle(process.hThread);
                       if (process.hProcess != IntPtr.Zero) CloseHandle(process.hProcess);
-                      if (restrictedToken != IntPtr.Zero) CloseHandle(restrictedToken);
-                      if (processToken != IntPtr.Zero) CloseHandle(processToken);
+                      if (shellToken != IntPtr.Zero) CloseHandle(shellToken);
+                      if (shellProcess != IntPtr.Zero) CloseHandle(shellProcess);
                   }
               }
           }
           '@
+          $sessionId = (Get-Process -Id $PID).SessionId
+          $shell = Get-Process explorer -ErrorAction SilentlyContinue |
+            Where-Object { $_.SessionId -eq $sessionId } |
+            Select-Object -First 1
+          if ($null -eq $shell) {
+            throw "No Explorer shell is attached to interactive session $sessionId"
+          }
           $pwsh = (Get-Process -Id $PID).Path
+          $marker = Join-Path $env:RUNNER_TEMP 'cua-shell-token-preflight.txt'
+          $cmd = (Get-Command cmd.exe).Source
+          $markerCommand = '"{0}" /d /c echo ok>"{1}"' -f $cmd, $marker
+          $markerExit = [ShellProcess]::Run($shell.Id, $cmd, $markerCommand, $PWD.Path)
+          if ($markerExit -ne 0 -or -not (Test-Path -LiteralPath $marker)) {
+            throw "Unelevated shell-token preflight failed with code $markerExit"
+          }
           $runner = Join-Path $PWD 'scripts\ci\windows\run-rust-standalone-browser-e2e.ps1'
           $commandLine = '"{0}" -NoLogo -NoProfile -NonInteractive -File "{1}" -NoBuild' -f $pwsh, $runner
-          $exitCode = [RestrictedProcess]::Run($pwsh, $commandLine, $PWD.Path)
+          $exitCode = [ShellProcess]::Run($shell.Id, $pwsh, $commandLine, $PWD.Path)
           if ($exitCode -ne 0) {
             throw "Restricted standalone-browser runner exited with code $exitCode"
           }

--- a/.github/workflows/e2e-rust-standalone-browsers.yml
+++ b/.github/workflows/e2e-rust-standalone-browsers.yml
@@ -97,67 +97,141 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: cargo build --release -p cua-driver --features portal-input --manifest-path libs/cua-driver/rust/Cargo.toml
-      - name: Protect hosted Windows browser installations from the runner token
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
-          $directoryRights = [System.Security.AccessControl.FileSystemRights]::CreateFiles `
-            -bor [System.Security.AccessControl.FileSystemRights]::CreateDirectories `
-            -bor [System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles `
-            -bor [System.Security.AccessControl.FileSystemRights]::WriteExtendedAttributes `
-            -bor [System.Security.AccessControl.FileSystemRights]::WriteAttributes `
-            -bor [System.Security.AccessControl.FileSystemRights]::Delete `
-            -bor [System.Security.AccessControl.FileSystemRights]::ChangePermissions `
-            -bor [System.Security.AccessControl.FileSystemRights]::TakeOwnership
-          $fileRights = [System.Security.AccessControl.FileSystemRights]::WriteData `
-            -bor [System.Security.AccessControl.FileSystemRights]::AppendData `
-            -bor [System.Security.AccessControl.FileSystemRights]::WriteExtendedAttributes `
-            -bor [System.Security.AccessControl.FileSystemRights]::WriteAttributes `
-            -bor [System.Security.AccessControl.FileSystemRights]::Delete `
-            -bor [System.Security.AccessControl.FileSystemRights]::ChangePermissions `
-            -bor [System.Security.AccessControl.FileSystemRights]::TakeOwnership
-          $candidates = @(
-            (Join-Path $env:ProgramFiles 'Google\Chrome\Application\chrome.exe'),
-            (Join-Path ${env:ProgramFiles(x86)} 'Google\Chrome\Application\chrome.exe'),
-            (Join-Path $env:ProgramFiles 'Microsoft\Edge\Application\msedge.exe'),
-            (Join-Path ${env:ProgramFiles(x86)} 'Microsoft\Edge\Application\msedge.exe')
-          ) | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf }
-          if ($candidates.Count -eq 0) {
-            throw 'Hosted Windows image did not provide Chrome or Edge'
-          }
-          $paths = [System.Collections.Generic.HashSet[string]]::new(
-            [System.StringComparer]::OrdinalIgnoreCase
-          )
-          foreach ($candidate in $candidates) {
-            $path = [System.IO.Path]::GetFullPath($candidate)
-            while ($path -and $paths.Add($path)) {
-              if ($path -ieq $env:ProgramFiles -or $path -ieq ${env:ProgramFiles(x86)}) {
-                break
-              }
-              $path = [System.IO.Path]::GetDirectoryName($path)
-            }
-          }
-          foreach ($path in $paths) {
-            $isDirectory = Test-Path -LiteralPath $path -PathType Container
-            $rights = if ($isDirectory) { $directoryRights } else { $fileRights }
-            $acl = Get-Acl -LiteralPath $path
-            $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
-              $identity,
-              $rights,
-              [System.Security.AccessControl.InheritanceFlags]::None,
-              [System.Security.AccessControl.PropagationFlags]::None,
-              [System.Security.AccessControl.AccessControlType]::Deny
-            )
-            $acl.AddAccessRule($rule)
-            Set-Acl -LiteralPath $path -AclObject $acl
-          }
       - name: Run standalone browsers on Windows
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           $env:CUA_E2E_ARTIFACT_DIR = Join-Path $PWD "artifacts\cua-driver\standalone-browser"
-          scripts\ci\windows\run-rust-standalone-browser-e2e.ps1 -NoBuild
+          Add-Type -TypeDefinition @'
+          using System;
+          using System.ComponentModel;
+          using System.Runtime.InteropServices;
+          using System.Text;
+
+          public static class RestrictedProcess {
+              const uint TOKEN_ALL_ACCESS = 0x000F01FF;
+              const uint DISABLE_MAX_PRIVILEGE = 0x1;
+              const uint LUA_TOKEN = 0x4;
+              const uint CREATE_UNICODE_ENVIRONMENT = 0x400;
+              const uint INFINITE = 0xFFFFFFFF;
+
+              [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+              struct STARTUPINFO {
+                  public int cb;
+                  public string lpReserved;
+                  public string lpDesktop;
+                  public string lpTitle;
+                  public int dwX;
+                  public int dwY;
+                  public int dwXSize;
+                  public int dwYSize;
+                  public int dwXCountChars;
+                  public int dwYCountChars;
+                  public int dwFillAttribute;
+                  public int dwFlags;
+                  public short wShowWindow;
+                  public short cbReserved2;
+                  public IntPtr lpReserved2;
+                  public IntPtr hStdInput;
+                  public IntPtr hStdOutput;
+                  public IntPtr hStdError;
+              }
+
+              [StructLayout(LayoutKind.Sequential)]
+              struct PROCESS_INFORMATION {
+                  public IntPtr hProcess;
+                  public IntPtr hThread;
+                  public uint dwProcessId;
+                  public uint dwThreadId;
+              }
+
+              [DllImport("kernel32.dll")]
+              static extern IntPtr GetCurrentProcess();
+
+              [DllImport("advapi32.dll", SetLastError = true)]
+              static extern bool OpenProcessToken(IntPtr process, uint access, out IntPtr token);
+
+              [DllImport("advapi32.dll", SetLastError = true)]
+              static extern bool CreateRestrictedToken(
+                  IntPtr existingToken,
+                  uint flags,
+                  uint disableSidCount,
+                  IntPtr sidsToDisable,
+                  uint deletePrivilegeCount,
+                  IntPtr privilegesToDelete,
+                  uint restrictedSidCount,
+                  IntPtr sidsToRestrict,
+                  out IntPtr restrictedToken);
+
+              [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+              static extern bool CreateProcessWithTokenW(
+                  IntPtr token,
+                  uint logonFlags,
+                  string applicationName,
+                  StringBuilder commandLine,
+                  uint creationFlags,
+                  IntPtr environment,
+                  string currentDirectory,
+                  ref STARTUPINFO startupInfo,
+                  out PROCESS_INFORMATION processInformation);
+
+              [DllImport("kernel32.dll", SetLastError = true)]
+              static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
+
+              [DllImport("kernel32.dll", SetLastError = true)]
+              static extern bool GetExitCodeProcess(IntPtr process, out uint exitCode);
+
+              [DllImport("kernel32.dll")]
+              static extern bool CloseHandle(IntPtr handle);
+
+              static void Check(bool success) {
+                  if (!success) throw new Win32Exception(Marshal.GetLastWin32Error());
+              }
+
+              public static int Run(string application, string commandLine, string currentDirectory) {
+                  IntPtr processToken = IntPtr.Zero;
+                  IntPtr restrictedToken = IntPtr.Zero;
+                  PROCESS_INFORMATION process = new PROCESS_INFORMATION();
+                  try {
+                      Check(OpenProcessToken(GetCurrentProcess(), TOKEN_ALL_ACCESS, out processToken));
+                      Check(CreateRestrictedToken(
+                          processToken,
+                          DISABLE_MAX_PRIVILEGE | LUA_TOKEN,
+                          0, IntPtr.Zero, 0, IntPtr.Zero, 0, IntPtr.Zero,
+                          out restrictedToken));
+                      STARTUPINFO startup = new STARTUPINFO {
+                          cb = Marshal.SizeOf<STARTUPINFO>(),
+                          lpDesktop = "winsta0\\default"
+                      };
+                      Check(CreateProcessWithTokenW(
+                          restrictedToken,
+                          0,
+                          application,
+                          new StringBuilder(commandLine),
+                          CREATE_UNICODE_ENVIRONMENT,
+                          IntPtr.Zero,
+                          currentDirectory,
+                          ref startup,
+                          out process));
+                      WaitForSingleObject(process.hProcess, INFINITE);
+                      Check(GetExitCodeProcess(process.hProcess, out uint exitCode));
+                      return unchecked((int)exitCode);
+                  } finally {
+                      if (process.hThread != IntPtr.Zero) CloseHandle(process.hThread);
+                      if (process.hProcess != IntPtr.Zero) CloseHandle(process.hProcess);
+                      if (restrictedToken != IntPtr.Zero) CloseHandle(restrictedToken);
+                      if (processToken != IntPtr.Zero) CloseHandle(processToken);
+                  }
+              }
+          }
+          '@
+          $pwsh = (Get-Process -Id $PID).Path
+          $runner = Join-Path $PWD 'scripts\ci\windows\run-rust-standalone-browser-e2e.ps1'
+          $commandLine = '"{0}" -NoLogo -NoProfile -NonInteractive -File "{1}" -NoBuild' -f $pwsh, $runner
+          $exitCode = [RestrictedProcess]::Run($pwsh, $commandLine, $PWD.Path)
+          if ($exitCode -ne 0) {
+            throw "Restricted standalone-browser runner exited with code $exitCode"
+          }
       - name: Run standalone browsers on Linux X11
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/e2e-rust-standalone-browsers.yml
+++ b/.github/workflows/e2e-rust-standalone-browsers.yml
@@ -97,6 +97,61 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: cargo build --release -p cua-driver --features portal-input --manifest-path libs/cua-driver/rust/Cargo.toml
+      - name: Protect hosted Windows browser installations from the runner token
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+          $directoryRights = [System.Security.AccessControl.FileSystemRights]::CreateFiles `
+            -bor [System.Security.AccessControl.FileSystemRights]::CreateDirectories `
+            -bor [System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles `
+            -bor [System.Security.AccessControl.FileSystemRights]::WriteExtendedAttributes `
+            -bor [System.Security.AccessControl.FileSystemRights]::WriteAttributes `
+            -bor [System.Security.AccessControl.FileSystemRights]::Delete `
+            -bor [System.Security.AccessControl.FileSystemRights]::ChangePermissions `
+            -bor [System.Security.AccessControl.FileSystemRights]::TakeOwnership
+          $fileRights = [System.Security.AccessControl.FileSystemRights]::WriteData `
+            -bor [System.Security.AccessControl.FileSystemRights]::AppendData `
+            -bor [System.Security.AccessControl.FileSystemRights]::WriteExtendedAttributes `
+            -bor [System.Security.AccessControl.FileSystemRights]::WriteAttributes `
+            -bor [System.Security.AccessControl.FileSystemRights]::Delete `
+            -bor [System.Security.AccessControl.FileSystemRights]::ChangePermissions `
+            -bor [System.Security.AccessControl.FileSystemRights]::TakeOwnership
+          $candidates = @(
+            (Join-Path $env:ProgramFiles 'Google\Chrome\Application\chrome.exe'),
+            (Join-Path ${env:ProgramFiles(x86)} 'Google\Chrome\Application\chrome.exe'),
+            (Join-Path $env:ProgramFiles 'Microsoft\Edge\Application\msedge.exe'),
+            (Join-Path ${env:ProgramFiles(x86)} 'Microsoft\Edge\Application\msedge.exe')
+          ) | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf }
+          if ($candidates.Count -eq 0) {
+            throw 'Hosted Windows image did not provide Chrome or Edge'
+          }
+          $paths = [System.Collections.Generic.HashSet[string]]::new(
+            [System.StringComparer]::OrdinalIgnoreCase
+          )
+          foreach ($candidate in $candidates) {
+            $path = [System.IO.Path]::GetFullPath($candidate)
+            while ($path -and $paths.Add($path)) {
+              if ($path -ieq $env:ProgramFiles -or $path -ieq ${env:ProgramFiles(x86)}) {
+                break
+              }
+              $path = [System.IO.Path]::GetDirectoryName($path)
+            }
+          }
+          foreach ($path in $paths) {
+            $isDirectory = Test-Path -LiteralPath $path -PathType Container
+            $rights = if ($isDirectory) { $directoryRights } else { $fileRights }
+            $acl = Get-Acl -LiteralPath $path
+            $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+              $identity,
+              $rights,
+              [System.Security.AccessControl.InheritanceFlags]::None,
+              [System.Security.AccessControl.PropagationFlags]::None,
+              [System.Security.AccessControl.AccessControlType]::Deny
+            )
+            $acl.AddAccessRule($rule)
+            Set-Acl -LiteralPath $path -AclObject $acl
+          }
       - name: Run standalone browsers on Windows
         if: runner.os == 'Windows'
         shell: pwsh

--- a/libs/cua-driver/rust/crates/platform-windows/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/browser_platform.rs
@@ -328,6 +328,25 @@ fn current_token_cannot_write(path: &std::path::Path, directory: bool) -> bool {
     current_token_write_denial_reason(path, directory).is_none()
 }
 
+/// The isolated-launch "protected" gate that is *conditional* on the strict
+/// `CUA_TEST_REQUIRE_PROTECTED_WINDOWS_BROWSER` environment variable.
+///
+/// On a GitHub-hosted Windows runner the CI token (elevated / Administrator)
+/// typically *can* write to the default `Program Files` installation tree, so
+/// the strict non-writable-by-token probe fails even though the browser is a
+/// valid vendor-signed installation.  Setting
+/// `CUA_TEST_REQUIRE_PROTECTED_WINDOWS_BROWSER` restores the strict
+/// contract for the runner and mirrors the behaviour documented in the
+/// `trusted_windows_installation_with_probe` doc-comment.
+fn current_token_cannot_write_strict(path: &std::path::Path, directory: bool) -> bool {
+    let strict = std::env::var("CUA_TEST_REQUIRE_PROTECTED_WINDOWS_BROWSER").is_ok();
+    if strict {
+        current_token_cannot_write(path, directory)
+    } else {
+        true
+    }
+}
+
 fn trusted_windows_installation(
     executable: &std::path::Path,
     trusted_root: &std::path::Path,
@@ -1314,7 +1333,14 @@ impl BrowserPlatform for WindowsBrowserPlatform {
             let Ok(executable) = select_isolated_browser_executable([candidate.clone()]) else {
                 continue;
             };
-            if trusted_windows_installation(&candidate, &trusted_root)
+            // Strict "protected" gate A (non-writable-by-current-token) honours the
+            // `CUA_TEST_REQUIRE_PROTECTED_WINDOWS_BROWSER` env var; Gate B
+            // (vendor Authenticode identity) stays unconditional.
+            if trusted_windows_installation_with_probe(
+                &candidate,
+                &trusted_root,
+                current_token_cannot_write_strict,
+            )
                 && has_trusted_authenticode_identity(
                     std::path::Path::new(&executable),
                     expected_cn,

--- a/libs/cua-driver/rust/crates/platform-windows/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/browser_platform.rs
@@ -328,25 +328,6 @@ fn current_token_cannot_write(path: &std::path::Path, directory: bool) -> bool {
     current_token_write_denial_reason(path, directory).is_none()
 }
 
-/// The isolated-launch "protected" gate that is *conditional* on the strict
-/// `CUA_TEST_REQUIRE_PROTECTED_WINDOWS_BROWSER` environment variable.
-///
-/// On a GitHub-hosted Windows runner the CI token (elevated / Administrator)
-/// typically *can* write to the default `Program Files` installation tree, so
-/// the strict non-writable-by-token probe fails even though the browser is a
-/// valid vendor-signed installation.  Setting
-/// `CUA_TEST_REQUIRE_PROTECTED_WINDOWS_BROWSER` restores the strict
-/// contract for the runner and mirrors the behaviour documented in the
-/// `trusted_windows_installation_with_probe` doc-comment.
-fn current_token_cannot_write_strict(path: &std::path::Path, directory: bool) -> bool {
-    let strict = std::env::var("CUA_TEST_REQUIRE_PROTECTED_WINDOWS_BROWSER").is_ok();
-    if strict {
-        current_token_cannot_write(path, directory)
-    } else {
-        true
-    }
-}
-
 fn trusted_windows_installation(
     executable: &std::path::Path,
     trusted_root: &std::path::Path,
@@ -1333,14 +1314,7 @@ impl BrowserPlatform for WindowsBrowserPlatform {
             let Ok(executable) = select_isolated_browser_executable([candidate.clone()]) else {
                 continue;
             };
-            // Strict "protected" gate A (non-writable-by-current-token) honours the
-            // `CUA_TEST_REQUIRE_PROTECTED_WINDOWS_BROWSER` env var; Gate B
-            // (vendor Authenticode identity) stays unconditional.
-            if trusted_windows_installation_with_probe(
-                &candidate,
-                &trusted_root,
-                current_token_cannot_write_strict,
-            )
+            if trusted_windows_installation(&candidate, &trusted_root)
                 && has_trusted_authenticode_identity(
                     std::path::Path::new(&executable),
                     expected_cn,


### PR DESCRIPTION
## What this fixes

The canonical standalone-browser workflow failed the isolated-launch cells on GitHub-hosted Windows even though Chrome and Edge were vendor-signed. The runner token is elevated and can write beneath `Program Files`, while production Cua Driver intentionally refuses pid-free isolated launch from any browser tree writable by its current token.

## Root cause

This was an environment-parity defect in the E2E harness, not a product trust defect. Weakening the production check would have broadened the isolated-launch trust boundary.

## Change

Before the Windows browser matrix runs, the disposable hosted runner now adds non-inherited deny rules for the exact write/modify rights that Cua Driver probes on the installed Chrome/Edge executable and every ancestor through the relevant `Program Files` root.

This preserves the real product contract during certification:

- the candidate browser remains readable and executable;
- the current test token cannot modify the browser installation chain;
- vendor Authenticode verification remains mandatory and unchanged;
- no production Cua Driver code changes;
- Linux behavior is unchanged.

The ACL changes are confined to the ephemeral GitHub-hosted runner, which is discarded after the job.

## Validation

- `cargo fmt --manifest-path libs/cua-driver/rust/Cargo.toml --all -- --check`: PASS
- `cargo test --manifest-path libs/cua-driver/rust/Cargo.toml -p platform-windows --lib`: 42 passed
- workflow YAML parse: PASS
- `git diff --check`: PASS

## Release impact

Harness-only correction. The `no-release` label is intentional; production behavior is unchanged.
