### PR TITLE
ci(cua-sandbox): dispatchable amd64 local Docker live check

### DIFF
--- a/.github/workflows/ci-py-sandbox-local-docker-live.yml
+++ b/.github/workflows/ci-py-sandbox-local-docker-live.yml
@@ -1,0 +1,45 @@
+name: "CI: cua-sandbox local Linux Docker live (amd64)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Candidate image ref (blank = built-in default)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  live-local-docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Record environment
+        run: |
+          uname -a
+          docker version
+          uv --version
+      - name: Run live local Docker sandbox test
+        env:
+          CANDIDATE_IMAGE: ${{ inputs.image }}
+        run: |
+          set -euo pipefail
+          args=(--allow-non-arm64 --artifact-dir "$RUNNER_TEMP/cua-linux-live")
+          if [[ -n "$CANDIDATE_IMAGE" ]]; then
+            args+=(--image "$CANDIDATE_IMAGE")
+          fi
+          uv run --script libs/python/cua-sandbox/scripts/live_local_linux_docker.py "${args[@]}"
+      - name: Show summary
+        if: always()
+        run: cat "$RUNNER_TEMP/cua-linux-live/summary.json" || true
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cua-linux-live-amd64
+          path: ${{ runner.temp }}/cua-linux-live
+          if-no-files-found: ignore

--- a/.github/workflows/ci-py-sandbox-local-docker-live.yml
+++ b/.github/workflows/ci-py-sandbox-local-docker-live.yml
@@ -1,6 +1,8 @@
 name: "CI: cua-sandbox local Linux Docker live (amd64)"
 
 on:
+  push:
+    branches: [ci/sandbox-local-docker-live-amd64]
   workflow_dispatch:
     inputs:
       image:

--- a/.github/workflows/ci-py-sandbox-local-docker-live.yml
+++ b/.github/workflows/ci-py-sandbox-local-docker-live.yml
@@ -1,8 +1,6 @@
 name: "CI: cua-sandbox local Linux Docker live (amd64)"
 
 on:
-  push:
-    branches: [ci/sandbox-local-docker-live-amd64]
   workflow_dispatch:
     inputs:
       image:


### PR DESCRIPTION
Adds a `workflow_dispatch` workflow that runs `libs/python/cua-sandbox/scripts/live_local_linux_docker.py --allow-non-arm64` on `ubuntu-latest` (x86_64, real Docker daemon), optionally against a candidate `--image`. Uploads `summary.json` + `screenshot.png`.

Proven on this branch via a temporary push trigger: run 32547646678 → PASS (container `x86_64`, screenshot 25279 B, clipboard + cleanup OK) against the default `cua-ubuntu-24.04:docker-latest`.

Refs #3254, #3257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)