### PR TITLE
fix(cua-driver): report macOS Retina backing scale

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -598,16 +598,14 @@ unsafe fn run_appkit(_cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
     let win_h = screen_frame.size.height;
     // NSScreen.backingScaleFactor is the most direct source of truth — it's
     // what AppKit will use for the layer's native backing surface anyway.
-    // Fall back to the CG estimator (pixel mode width ÷ logical bounds) when
+    // Fall back to the CG estimator (current-mode pixels ÷ points) when
     // the AppKit call returns a non-positive value, since downstream paint
     // math divides by this and a 0.0 would zero out the cursor.
     let mut backing_scale: f64 = msg_send![main_screen, backingScaleFactor];
     if backing_scale.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
-        use core_graphics::display::{CGDisplayBounds, CGMainDisplayID};
+        use core_graphics::display::CGMainDisplayID;
         let display_id = CGMainDisplayID();
-        let bounds = CGDisplayBounds(display_id);
-        backing_scale =
-            crate::tools::get_screen_size::get_backing_scale(display_id, bounds.size.width as i64);
+        backing_scale = crate::tools::get_screen_size::get_backing_scale(display_id);
         if backing_scale.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
             backing_scale = 1.0;
         }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/get_screen_size.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/get_screen_size.rs
@@ -73,20 +73,60 @@ pub(crate) fn main_screen_size() -> Option<(i64, i64, f64)> {
         return None;
     }
 
-    let scale = get_backing_scale(display_id, w);
+    let scale = get_backing_scale(display_id);
     Some((w, h, scale))
 }
 
-/// Estimate backing scale by comparing the display's pixel mode width to its
-/// logical (CoreGraphics) bounds width.
-pub(crate) fn get_backing_scale(display_id: u32, logical_w: i64) -> f64 {
-    use core_graphics::display::CGDisplayPixelsWide;
-    let pixel_w = unsafe { CGDisplayPixelsWide(display_id) } as i64;
-    if pixel_w > 0 && logical_w > 0 {
-        let ratio = pixel_w as f64 / logical_w as f64;
-        // Round to nearest 0.5 to avoid floating point noise.
-        (ratio * 2.0).round() / 2.0
-    } else {
-        1.0
+/// Return the current display mode's backing-pixel to point ratio.
+pub(crate) fn get_backing_scale(display_id: u32) -> f64 {
+    use core_graphics::display::CGDisplay;
+
+    let Some(mode) = CGDisplay::new(display_id).display_mode() else {
+        return 1.0;
+    };
+    backing_scale_from_widths(mode.width(), mode.pixel_width())
+}
+
+fn backing_scale_from_widths(point_width: u64, pixel_width: u64) -> f64 {
+    if point_width == 0 || pixel_width == 0 {
+        return 1.0;
+    }
+    let ratio = pixel_width as f64 / point_width as f64;
+    // Round to nearest 0.5 to avoid floating point noise.
+    (ratio * 2.0).round() / 2.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_graphics::display::CGDisplay;
+
+    #[test]
+    fn main_display_scale_matches_current_mode() {
+        let display = CGDisplay::main();
+        let mode = display
+            .display_mode()
+            .expect("main display should expose its current mode");
+        assert!(mode.width() > 0, "display mode should have a point width");
+        assert!(
+            mode.pixel_width() > 0,
+            "display mode should have a pixel width"
+        );
+
+        let expected = ((mode.pixel_width() as f64 / mode.width() as f64) * 2.0).round() / 2.0;
+        let actual = get_backing_scale(display.id);
+
+        assert_eq!(
+            actual, expected,
+            "backing scale should use the current mode's pixel and point widths"
+        );
+    }
+
+    #[test]
+    fn display_mode_widths_preserve_rounding_and_fallbacks() {
+        assert_eq!(backing_scale_from_widths(1920, 3840), 2.0);
+        assert_eq!(backing_scale_from_widths(1920, 2880), 1.5);
+        assert_eq!(backing_scale_from_widths(0, 3840), 1.0);
+        assert_eq!(backing_scale_from_widths(1920, 0), 1.0);
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/get_screen_size.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/get_screen_size.rs
@@ -108,13 +108,16 @@ mod tests {
         let mode = display
             .display_mode()
             .expect("main display should expose its current mode");
-        assert!(mode.width() > 0, "display mode should have a point width");
+        let point_width = mode.width();
+        let pixel_width = mode.pixel_width();
+        assert!(point_width > 0, "display mode should have a point width");
+        assert!(pixel_width > 0, "display mode should have a pixel width");
         assert!(
-            mode.pixel_width() > 0,
-            "display mode should have a pixel width"
+            pixel_width > point_width,
+            "native Retina validation requires more backing pixels than points; got {pixel_width}px for {point_width}pt"
         );
 
-        let expected = ((mode.pixel_width() as f64 / mode.width() as f64) * 2.0).round() / 2.0;
+        let expected = ((pixel_width as f64 / point_width as f64) * 2.0).round() / 2.0;
         let actual = get_backing_scale(display.id);
 
         assert_eq!(

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/get_screen_size.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/get_screen_size.rs
@@ -102,6 +102,7 @@ mod tests {
     use core_graphics::display::CGDisplay;
 
     #[test]
+    #[ignore = "requires an attached macOS display; run explicitly on a native Retina host"]
     fn main_display_scale_matches_current_mode() {
         let display = CGDisplay::main();
         let mode = display


### PR DESCRIPTION
## Summary

- Fix macOS Retina scale detection by comparing the current display mode's pixel width with its point width.
- Keep the existing half-step rounding and `1.0` fallback behavior.
- Add a native regression test for the active display mode plus deterministic coverage for rounding and invalid widths.

## Related work

Fixes #3326.

RFC: Not required. This is a platform-local correction to the existing `get_screen_size` scale-factor contract.

## Compatibility and risk

- User-visible behavior: `get_screen_size` and `get_desktop_state` now report the correct Retina backing scale on macOS scaled modes.
- Compatibility: no protocol, schema, capture, or multi-display behavior changes.
- Risk and rollback: limited to macOS scale detection; reverting this commit restores the previous estimator.

## Validation

- Reproduced on an Intel Retina Mac: CoreGraphics reported `2048` for both the logical bounds and legacy pixel-width API, while the current display mode reported `4096` backing pixels.
- Regression test before the fix: expected `2.0`, got `1.0`.
- Rebased onto current `cua-driver 0.22.0` `main` (`cb914ed90`).
- Native Retina regression (`...main_display_scale_matches_current_mode -- --ignored --exact`): verified `4096px > 2048pt`, then passed the 2x scale check.
- Full `platform-macos` suite: 343 passed, 0 failed, 2 ignored (the native-display regression and an existing Keychain qualification test).
- `cua-driver` protocol test `get_screen_size_and_cursor_position`: 1 passed, 0 failed.
- `cargo fmt --all -- --check`: passed.
- Spec review found no missing requirements, scope creep, or incorrect implementation.
- The canonical macOS desktop harness requires the maintainers' Lume golden image and signing/TCC environment. It has not run at this SHA, so that merge-readiness evidence remains external.

## Contributor and release checks

- [x] I added or updated tests for the behavior change.
- [x] I kept the change scoped to the reported macOS bug.
- [ ] I completed the full platform validation described in the repository testing guide.
