### PR TITLE
docs(lume): fix broken GPU passthrough blog links returning 404

### DIFF
--- a/docs/content/docs/how-to-guides/lume/gpu-passthrough.mdx
+++ b/docs/content/docs/how-to-guides/lume/gpu-passthrough.mdx
@@ -13,7 +13,7 @@ the guest kernel. If you're looking for computer-use automation instead, start w
 [Cua Driver](/tutorials/drive-your-first-app) or
 [Cua Sandbox](/tutorials/your-first-local-sandbox).
 
-Read the [technical writeup](/blog/gpu-passthrough-macos-vms) for the mechanism, benchmark evidence,
+Read the [technical writeup](https://cua.ai/blog/gpu-passthrough-macos-vms) for the mechanism, benchmark evidence,
 and architectural context. Apple's [Metal capability tables](https://developer.apple.com/metal/capabilities/)
 and [feature-detection guide](https://developer.apple.com/documentation/metal/detecting-gpu-features-and-metal-software-versions)
 explain how applications select behavior from reported device support.
@@ -282,6 +282,6 @@ unrestricted feature level.
 ## See also
 
 - [Lume source tree](https://github.com/trycua/cua/tree/main/libs/lume)
-- [Technical writeup and benchmark evidence](/blog/gpu-passthrough-macos-vms)
+- [Technical writeup and benchmark evidence](https://cua.ai/blog/gpu-passthrough-macos-vms)
 - [Install and run Lume](/how-to-guides/lume/install-lume)
 - [How SIP works in Lume VMs](/concepts/how-sip-works-in-lume-vms)


### PR DESCRIPTION
<!--
Keep this description current as scope and evidence change. Do not include
credentials, private user data, sensitive screenshots, or vulnerability details.
Preserve external contributor authorship when their code or design ships.
While this pull request is a draft, use this description as the live record of
scope, progress, blockers, and evidence rather than posting periodic status comments.
-->

## Summary

- Problem this solves:
  The GPU passthrough guide (`docs/content/docs/how-to-guides/lume/gpu-passthrough.mdx`) links the supporting blog post as `/blog/gpu-passthrough-macos-vms`, which resolves to `https://cua.ai/docs/blog/gpu-passthrough-macos-vms` and returns 404. Reported in #3230.

- What changed:
  Replaced the two relative `/blog/gpu-passthrough-macos-vms` links (intro writeup link and the Resources link) with the absolute, live URL `https://cua.ai/blog/gpu-passthrough-macos-vms` (returns 200). No other content changed.

## Related work

<!-- Use Fixes only when this PR fully resolves the issue. Otherwise use Refs. -->

Fixes #3230

RFC (required for a public SDK, CLI, MCP, protocol, compatibility, permission,
or cross-component contract change):

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact:
  Docs-only change. No code, API, CLI, or runtime behavior affected. Readers of the GPU passthrough guide now reach the live benchmark writeup instead of a 404.

- Risk and rollback:
  Minimal. Pure markdown link edit. Rollback is a single-file revert.

## Validation

- Focused tests and checks:
  - Confirmed `https://cua.ai/blog/gpu-passthrough-macos-vms` returns HTTP 200 and `https://cua.ai/docs/blog/gpu-passthrough-macos-vms` returns HTTP 404 (verified via curl).
  - Verified the final file contains no remaining relative `/blog/` links (grep clean).

- Manual or platform evidence:
  - macOS / Linux docs rendering: both links now point to the canonical live article.
  - `git diff` is limited to 2 lines (2 insertions, 2 deletions) in a single file.

- Known gaps or CI still required:
  None. This is a documentation link fix; no build or unit-test execution is affected.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [x] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.
