### PR TITLE
fix(cua-driver): recover foreground pointer activation

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/browser_consent_ui.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/browser_consent_ui.rs
@@ -202,7 +202,7 @@ mod tests {
             actions: actions.iter().map(|value| (*value).to_owned()).collect(),
             enabled: None,
             selected: None,
-            element_ptr: 7,
+            element_ptr: if actions.is_empty() { 0 } else { 7 },
             center_x: 0,
             center_y: 0,
             rect: None,

--- a/libs/cua-driver/rust/crates/platform-windows/src/browser_setup_ui.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/browser_setup_ui.rs
@@ -594,7 +594,7 @@ mod tests {
             actions: actions.iter().map(|value| (*value).to_owned()).collect(),
             enabled: None,
             selected: None,
-            element_ptr: 7,
+            element_ptr: if actions.is_empty() { 0 } else { 7 },
             center_x: 0,
             center_y: 0,
             rect: None,

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/keyboard.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/keyboard.rs
@@ -125,6 +125,10 @@ pub fn is_xaml_host_hwnd(hwnd: u64) -> bool {
 }
 
 const KEY_DELAY_MS: u64 = 4;
+// Foreground key presses must remain down long enough for frame-polled input
+// loops to observe them. Sending down and up in one SendInput batch is valid
+// for message-driven controls but can disappear between game frames.
+const FOREGROUND_KEY_HOLD_MS: u64 = 35;
 
 /// If any UI thread under the target has a focused child window that's a
 /// descendant of `parent`, return that child. Otherwise `None`. Used to retarget
@@ -458,28 +462,39 @@ pub fn send_key_synthesized_after_focus(
     let key_vk = key_name_to_vk(key)?;
     let mod_vks: Vec<VIRTUAL_KEY> = modifiers.iter().filter_map(|m| modifier_vk(m)).collect();
 
-    // Build the INPUT sequence: modifiers down, key down, key up, modifiers up
-    // (reverse order). Each event sends the scancode + EXTENDEDKEY flag where
-    // appropriate so apps that read scancodes (not virtual keys) work too.
-    let mut events: Vec<INPUT> = Vec::with_capacity(mod_vks.len() * 2 + 2);
+    // Build separate press and release phases. Each event sends the scancode +
+    // EXTENDEDKEY flag where appropriate so apps that read scancodes work too.
+    let mut press_events: Vec<INPUT> = Vec::with_capacity(mod_vks.len() + 1);
     for mvk in &mod_vks {
-        events.push(key_input(*mvk, false));
+        press_events.push(key_input(*mvk, false));
     }
-    events.push(key_input(key_vk, false));
-    events.push(key_input(key_vk, true));
+    press_events.push(key_input(key_vk, false));
+    let mut release_events: Vec<INPUT> = Vec::with_capacity(mod_vks.len() + 1);
+    release_events.push(key_input(key_vk, true));
     for mvk in mod_vks.iter().rev() {
-        events.push(key_input(*mvk, true));
+        release_events.push(key_input(*mvk, true));
     }
 
     with_confirmed_foreground(target, "key delivery", focus, || unsafe {
-        let sent = SendInput(&events, std::mem::size_of::<INPUT>() as i32);
-        if sent as usize != events.len() {
+        let pressed = SendInput(&press_events, std::mem::size_of::<INPUT>() as i32);
+        if pressed as usize != press_events.len() {
             bail!(
-                "SendInput inserted only {sent} of {} events. Likely cause: \
+                "SendInput inserted only {pressed} of {} key-down events. Likely cause: \
                  the daemon is not at UIAccess integrity, so SetForegroundWindow \
                  was rejected and the events landed on the wrong window. Run \
                  hotkey through the cua-driver-uia worker.",
-                events.len()
+                press_events.len()
+            );
+        }
+        sleep(Duration::from_millis(FOREGROUND_KEY_HOLD_MS));
+        let released = SendInput(&release_events, std::mem::size_of::<INPUT>() as i32);
+        if released as usize != release_events.len() {
+            // Retry releases once so a partial SendInput does not leave a key
+            // or modifier held while still reporting the failure honestly.
+            let _ = SendInput(&release_events, std::mem::size_of::<INPUT>() as i32);
+            bail!(
+                "SendInput inserted only {released} of {} key-up events.",
+                release_events.len()
             );
         }
         Ok(())

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
@@ -588,19 +588,38 @@ fn send_click_synthesized_mods_impl(
         } else {
             None
         };
+        let mut activation_via_click = false;
         if activate && !crate::input::force_foreground_assisted(target).0 {
             let actual = GetForegroundWindow();
             if !crate::win32::foreground_matches_target_owner(
                 foreground_target.expect("foreground target captured before activation"),
                 actual.0 as usize as u64,
             ) {
-                bail!(
-                    "foreground_unavailable: Windows did not activate exact target HWND {:?} \
-                     or retain its verified same-process owner (actual foreground HWND {:?}); \
-                     no mouse input was sent",
-                    target.0,
-                    actual.0
-                );
+                // A system-routed pointer press on a visible top-level window is
+                // itself allowed to establish foreground ownership. Raise only
+                // the already-verified target, then let the requested click make
+                // that transition. The post-action foreground check below still
+                // fails closed if Windows routes the input anywhere else.
+                let raised = SetWindowPos(
+                    target,
+                    HWND_TOPMOST,
+                    0,
+                    0,
+                    0,
+                    0,
+                    SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE,
+                )
+                .is_ok();
+                if !raised {
+                    bail!(
+                        "foreground_unavailable: Windows did not activate exact target HWND {:?} \
+                         or retain its verified same-process owner (actual foreground HWND {:?}); \
+                         target could not be raised for click-assisted activation",
+                        target.0,
+                        actual.0
+                    );
+                }
+                activation_via_click = true;
             }
         }
         let noactivate = (!activate).then(|| crate::input::NoActivateGuard::arm(target));
@@ -668,7 +687,7 @@ fn send_click_synthesized_mods_impl(
         // lose the click if the real cursor is warped away while those queued
         // messages are still being dispatched.
         sleep(Duration::from_millis(if activate { 120 } else { 40 }));
-        if !was_topmost && !activate {
+        if !was_topmost && (!activate || activation_via_click) {
             let _ = SetWindowPos(
                 target,
                 HWND_NOTOPMOST,

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
@@ -576,15 +576,6 @@ fn send_click_synthesized_mods_impl(
         // Capture whether the target was ALREADY always-on-top so we don't strip
         // that state on restore — only demote below if WE promoted it.
         let was_topmost = (GetWindowLongPtrW(target, GWL_EXSTYLE) as u32) & WS_EX_TOPMOST.0 != 0;
-        if activate && !crate::input::force_foreground_assisted(target).0 {
-            let actual = GetForegroundWindow();
-            bail!(
-                "foreground_unavailable: Windows did not activate exact target HWND {:?} \
-                 (actual foreground HWND {:?}); no mouse input was sent",
-                target.0,
-                actual.0
-            );
-        }
         let foreground_target = if activate {
             match crate::win32::capture_foreground_target(target.0 as usize as u64) {
                 Some(target) => Some(target),
@@ -597,6 +588,21 @@ fn send_click_synthesized_mods_impl(
         } else {
             None
         };
+        if activate && !crate::input::force_foreground_assisted(target).0 {
+            let actual = GetForegroundWindow();
+            if !crate::win32::foreground_matches_target_owner(
+                foreground_target.expect("foreground target captured before activation"),
+                actual.0 as usize as u64,
+            ) {
+                bail!(
+                    "foreground_unavailable: Windows did not activate exact target HWND {:?} \
+                     or retain its verified same-process owner (actual foreground HWND {:?}); \
+                     no mouse input was sent",
+                    target.0,
+                    actual.0
+                );
+            }
+        }
         let noactivate = (!activate).then(|| crate::input::NoActivateGuard::arm(target));
         if !activate {
             let _ = SetWindowPos(
@@ -696,8 +702,12 @@ fn send_click_synthesized_mods_impl(
         }
         if activate {
             let actual = GetForegroundWindow();
+            let captured = foreground_target.expect("foreground target captured before input");
             if !crate::win32::foreground_matches_target_or_owned_window(
-                foreground_target.expect("foreground target captured before input"),
+                captured,
+                actual.0 as usize as u64,
+            ) && !crate::win32::foreground_matches_target_owner(
+                captured,
                 actual.0 as usize as u64,
             ) {
                 bail!(

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
@@ -30,6 +30,11 @@ const MK_MBUTTON: u32 = 0x0010;
 const MK_RBUTTON: u32 = 0x0002;
 
 const CLICK_DELAY_MS: u64 = 35;
+// Keep foreground pointer phases visible across at least one 30 Hz frame.
+// Some games sample hover and button state once per render frame instead of
+// consuming the complete Win32 input queue. A single move/down/up SendInput
+// batch can therefore update hover without ever exposing a pressed state.
+const FOREGROUND_POINTER_PHASE_MS: u64 = 35;
 
 fn posted_press_message(down: u32, double: u32, click_index: usize, wants_double: bool) -> u32 {
     if wants_double && click_index % 2 == 1 {
@@ -657,12 +662,17 @@ fn send_click_synthesized_mods_impl(
             if !sent_ok {
                 break;
             }
-            // Only the move record carries absolute coordinates. Button-only
-            // records act at the current pointer position; adding ABSOLUTE to
-            // them can prevent retained-mode controls from seeing the press.
-            let events = [move_input, down_input, up_input];
-            let sent = SendInput(&events, std::mem::size_of::<INPUT>() as i32);
-            if sent as usize != events.len() {
+            // Submit a frame-visible pointer lifecycle. Retained-mode desktop
+            // controls dispatch hover asynchronously, while games commonly
+            // sample hover and button state once per render frame. Sending the
+            // full lifecycle in one batch lets those targets observe only the
+            // final released state.
+            let moved = SendInput(&[move_input], std::mem::size_of::<INPUT>() as i32);
+            sleep(Duration::from_millis(FOREGROUND_POINTER_PHASE_MS));
+            let pressed = SendInput(&[down_input], std::mem::size_of::<INPUT>() as i32);
+            sleep(Duration::from_millis(FOREGROUND_POINTER_PHASE_MS));
+            let released = SendInput(&[up_input], std::mem::size_of::<INPUT>() as i32);
+            if moved != 1 || pressed != 1 || released != 1 {
                 sent_ok = false;
                 break;
             }

--- a/libs/cua-driver/rust/crates/platform-windows/src/msaa.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/msaa.rs
@@ -170,60 +170,45 @@ unsafe fn walk(
     let has_content = name.is_some();
 
     if is_actionable || has_content {
-        // Retain the IAccessible pointer for the cache. Mirror what the UIA
-        // walker does: clone, get raw, forget the local — the cache's Drop
-        // releases via IUnknown.
-        let retained: IAccessible = acc.clone();
-        let ptr = retained.as_raw() as usize;
-        std::mem::forget(retained);
-
-        let (center_x, center_y) = rect
-            .map(|(l, t, r, b)| ((l + r) / 2, (t + b) / 2))
-            .unwrap_or((0, 0));
-
-        let node = if is_actionable {
+        let element_index = if is_actionable {
             let idx = *counter;
             *counter += 1;
-            UiaNode {
-                element_index: Some(idx),
-                control_type: control_type.clone(),
-                name: name.clone(),
-                value: None,
-                automation_id: None,
-                help_text: None,
-                actions: actions.clone(),
-                enabled: None,
-                selected: None,
-                element_ptr: ptr,
-                center_x,
-                center_y,
-                rect,
-                msaa_role: role_int,
-                depth,
-                parent_element_index: parent_index,
-                in_web_content: false,
-            }
+            Some(idx)
         } else {
-            UiaNode {
-                element_index: None,
-                control_type: control_type.clone(),
-                name: name.clone(),
-                value: None,
-                automation_id: None,
-                help_text: None,
-                actions: Vec::new(),
-                enabled: None,
-                selected: None,
-                element_ptr: ptr,
-                center_x: 0,
-                center_y: 0,
-                rect,
-                msaa_role: role_int,
-                depth,
-                parent_element_index: parent_index,
-                in_web_content: false,
-            }
+            None
         };
+        let (element_ptr, center_x, center_y) = if element_index.is_some() {
+            // The cache adopts this reference when the walk becomes a snapshot.
+            let retained: IAccessible = acc.clone();
+            let ptr = retained.as_raw() as usize;
+            std::mem::forget(retained);
+            let (center_x, center_y) = rect
+                .map(|(l, t, r, b)| ((l + r) / 2, (t + b) / 2))
+                .unwrap_or((0, 0));
+            (ptr, center_x, center_y)
+        } else {
+            (0, 0, 0)
+        };
+        let node = UiaNode {
+            element_index,
+            control_type: control_type.clone(),
+            name: name.clone(),
+            value: None,
+            automation_id: None,
+            help_text: None,
+            actions: actions.clone(),
+            enabled: None,
+            selected: None,
+            element_ptr,
+            center_x,
+            center_y,
+            rect,
+            msaa_role: role_int,
+            depth,
+            parent_element_index: parent_index,
+            in_web_content: false,
+        };
+        debug_assert_eq!(node.element_ptr != 0, node.element_index.is_some());
         // Track this node as the parent_index for its descendants only when
         // it received an element_index (mirrors what the markdown shows:
         // only indexed rows are addressable).

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -2888,7 +2888,8 @@ impl Tool for ClickTool {
                     "modifier": cua_driver_core::tool_schema::modifier_schema(),
                     "from_zoom":{"type":"boolean","description":"When true, x and y are pixel coordinates in the last `zoom` image for this pid. The driver maps them back to window coords."},
                     "scope":{"type":"string","enum":["window","desktop"],"default":"window"},
-                    "delivery_mode": crate::input::delivery::delivery_mode_schema()
+                    "delivery_mode": crate::input::delivery::delivery_mode_schema(),
+                    "retain_foreground":{"type":"boolean","default":false,"description":"With foreground delivery, leave the verified target foreground after the click instead of restoring the prior window. Use only for an explicitly authorized multi-step focus session."}
                 },"additionalProperties":false
             }),
             read_only: false, destructive: true, idempotent: false, open_world: true,
@@ -3052,6 +3053,7 @@ impl Tool for ClickTool {
         // a modifier passed to a background click is necessarily ignored there.
         let modifiers: Vec<String> = args.str_array("modifier");
         let delivery = DeliveryMode::from_args(&args);
+        let retain_foreground = args.bool_or("retain_foreground", false);
         if !modifiers.is_empty() && delivery != DeliveryMode::Foreground {
             return ToolResult::error(
                 "click modifiers require delivery_mode:\"foreground\" on Windows; UIA and \
@@ -3203,7 +3205,9 @@ impl Tool for ClickTool {
                     }
                 })
                 .await;
-                tokio::spawn(restore_foreground_polling_best_effort(prev_fg_addr, pid));
+                if !retain_foreground {
+                    tokio::spawn(restore_foreground_polling_best_effort(prev_fg_addr, pid));
+                }
                 let half = if want_expand { "dropdown" } else { "press" };
                 return match send_result {
                     Ok(Ok(())) => ToolResult::text(format!(
@@ -3350,7 +3354,9 @@ impl Tool for ClickTool {
                     )
                 })
                 .await;
-                tokio::spawn(restore_foreground_polling_best_effort(prev_fg_addr, pid));
+                if !retain_foreground {
+                    tokio::spawn(restore_foreground_polling_best_effort(prev_fg_addr, pid));
+                }
                 return match send_result {
                     Ok(Ok(())) => ToolResult::text(format!(
                         "✅ Performed SendInput click on [{idx}] at screen ({cx},{cy}) (delivery_mode:foreground)."
@@ -3663,7 +3669,9 @@ impl Tool for ClickTool {
                     )
                 })
                 .await;
-                tokio::spawn(restore_foreground_polling_best_effort(prev_fg_addr, pid));
+                if !retain_foreground {
+                    tokio::spawn(restore_foreground_polling_best_effort(prev_fg_addr, pid));
+                }
                 return match send_result {
                     Ok(Ok(())) => {
                         let click_word = match count {
@@ -10100,6 +10108,29 @@ mod click_button_schema_tests {
         for need in ["left", "right", "middle"] {
             assert!(enum_vals.contains(&need), "missing {need} in button.enum");
         }
+    }
+
+    #[test]
+    fn retain_foreground_is_an_opt_in_boolean() {
+        let tool = ClickTool {
+            state: super::ToolState::new(),
+        };
+        let properties = tool
+            .def()
+            .input_schema
+            .get("properties")
+            .expect("properties");
+        let retain = properties
+            .get("retain_foreground")
+            .expect("retain_foreground field present");
+        assert_eq!(
+            retain.get("type").and_then(|value| value.as_str()),
+            Some("boolean")
+        );
+        assert_eq!(
+            retain.get("default").and_then(|value| value.as_bool()),
+            Some(false)
+        );
     }
 }
 

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -1456,6 +1456,11 @@ impl Tool for GetWindowStateTool {
                                        screenshot in this response (an element px action)."
                         });
                     }
+                    if observation_only {
+                        // No cache adopts these actionable COM references, so
+                        // release them after building the observation payload.
+                        unsafe { crate::uia::release_walk_nodes(tr.nodes) };
+                    }
                 }
 
                 if let Some((b64_opt, file_path, w, h, orig_w)) = screenshot_opt {

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -1131,6 +1131,7 @@ impl Tool for GetWindowStateTool {
                 "window_id":{"type":"integer","description":"HWND of the target window. Must belong to `pid`. Enumerate via `list_windows` or read from `launch_app`'s `windows` array."},
                 "capture_mode": cua_driver_core::capture_mode::capture_mode_schema(),
                 "include_screenshot":{"type":"boolean","description":"Default true — returns a grounding screenshot alongside the tree. Set false to skip the grab and return tree only (the cheap path for re-indexing before an element ax action)."},
+                "include_accessibility":{"type":"boolean","default":true,"description":"Default true — returns the accessibility tree. Set false for screenshot-only recovery when the target's accessibility provider is known to be unresponsive."},
                 "screenshot_out_file":{"type":"string","description":"When set, write the PNG to this file path instead of embedding base64 in the response. The structured output will contain `screenshot_file_path` instead."},
                 "query":{"type":"string","description":"Optional case-insensitive substring. Projects both tree_markdown and structured elements to matches plus ancestors while preserving original indices. Compare total_element_count with returned_element_count."},
                 "max_elements":{"type":"integer","minimum":1,"description":"Cap on the total number of UIA nodes walked. Truncates depth-first; markdown and structured elements truncate together. Omit for the default (5 000). Lower for Electron / large web apps that produce 10k+ element trees."},
@@ -1213,16 +1214,53 @@ impl Tool for GetWindowStateTool {
         // `screenshot_out_file` the bytes go to disk and the path is surfaced
         // instead of embedding base64; otherwise the base64 PNG is embedded.
         let include_screenshot = args.get("include_screenshot").and_then(|v| v.as_bool());
+        let include_accessibility = args
+            .get("include_accessibility")
+            .and_then(|value| value.as_bool());
         let observation_only = args
             .get("_observation_only")
             .and_then(|value| value.as_bool())
             == Some(true);
-        let do_tree = true;
+        let do_tree = include_accessibility != Some(false);
         let do_shot = include_screenshot != Some(false) || screenshot_out_file.is_some();
 
         let state = self.state.clone();
         let q = query.clone();
         let out_file = screenshot_out_file.clone();
+        // Capture independently from UIA. A provider can hang before a combined
+        // task reaches screenshot capture, leaving visual callers without the
+        // image they need for pixel or keyboard recovery.
+        let screenshot_task = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+            if !do_shot {
+                return Ok((None, None));
+            }
+            match crate::capture::screenshot_window_bytes(hwnd) {
+                Ok(raw) => {
+                    let orig_w = crate::capture::png_dimensions_pub(&raw)
+                        .map(|(w, _)| w)
+                        .unwrap_or(0);
+                    let png = crate::capture::resize_png_if_needed(&raw, max_dim)?;
+                    let (w, h) = crate::capture::png_dimensions_pub(&png)?;
+                    let original_w = if w < orig_w { Some(orig_w) } else { None };
+                    if let Some(ref path) = out_file {
+                        std::fs::write(path, &png)?;
+                        Ok((Some((None, Some(path.clone()), w, h, original_w)), None))
+                    } else {
+                        use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+                        Ok((Some((Some(B64.encode(&png)), None, w, h, original_w)), None))
+                    }
+                }
+                Err(error) => Ok((None, Some(format!("{error}")))),
+            }
+        });
+        let (screenshot, screenshot_err) = match screenshot_task.await {
+            Ok(Ok(value)) => value,
+            Ok(Err(error)) => return ToolResult::error(format!("Error: {error}")),
+            Err(error) => {
+                return ToolResult::error(format!("Error: screenshot task panic: {error}"));
+            }
+        };
+
         let blocking = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
             let tree_result = if do_tree {
                 Some(crate::uia::walk_tree_bounded(
@@ -1234,44 +1272,16 @@ impl Tool for GetWindowStateTool {
             } else {
                 None
             };
-            // Capture screenshot AND any error message so the response can
-            // surface *why* there's no image (the iconic-window guard from
-            // #1973 / PR #1974 is the load-bearing case: minimized windows
-            // legitimately can't be captured, and the caller needs to know
-            // to call `bring_to_front` instead of retrying).
-            // The previous `Err(_) => None` silently dropped the error and
-            // upstream agents saw an empty response with no signal.
-            let (screenshot, screenshot_err) = if do_shot {
-                match crate::capture::screenshot_window_bytes(hwnd) {
-                    Ok(raw) => {
-                        let orig_w = crate::capture::png_dimensions_pub(&raw)
-                            .map(|(w, _)| w)
-                            .unwrap_or(0);
-                        let png = crate::capture::resize_png_if_needed(&raw, max_dim)?;
-                        let (w, h) = crate::capture::png_dimensions_pub(&png)?;
-                        let original_w = if w < orig_w { Some(orig_w) } else { None };
-                        // `screenshot_out_file` set (any mode) → write to disk and
-                        // surface the path, never embed bytes. Otherwise (vision,
-                        // no out_file) → embed base64.
-                        if let Some(ref path) = out_file {
-                            std::fs::write(path, &png)?;
-                            (Some((None, Some(path.clone()), w, h, original_w)), None)
-                        } else {
-                            use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
-                            (Some((Some(B64.encode(&png)), None, w, h, original_w)), None)
-                        }
-                    }
-                    Err(e) => (None, Some(format!("{e}"))),
-                }
-            } else {
-                (None, None)
-            };
-            Ok((tree_result, screenshot, screenshot_err))
+            Ok(tree_result)
         });
         // Timeout: Chrome's UIA provider can block indefinitely on property reads.
-        let result: Result<anyhow::Result<_>, _> =
+        let (tree_result, accessibility_err) =
             match tokio::time::timeout(std::time::Duration::from_secs(4), blocking).await {
-                Ok(join_result) => join_result.map_err(|e| anyhow::anyhow!("task panic: {e}")),
+                Ok(join_result) => match join_result {
+                    Ok(Ok(tree)) => (tree, None),
+                    Ok(Err(error)) => (None, Some(format!("{error}"))),
+                    Err(error) => (None, Some(format!("task panic: {error}"))),
+                },
                 Err(_elapsed) => {
                     // Surface the target's window class + an actionable hint
                     // instead of just "UIA provider unresponsive". The class
@@ -1280,8 +1290,10 @@ impl Tool for GetWindowStateTool {
                     // class → re-call with a depth-limited scan and act by pixel
                     // off the screenshot if the tree stays unusable).
                     let class = crate::input::delivery::read_class_name(hwnd);
-                    Err(anyhow::anyhow!(
-                        "get_window_state timed out after 4s (UIA provider unresponsive on \
+                    (
+                        None,
+                        Some(format!(
+                            "get_window_state timed out after 4s (UIA provider unresponsive on \
                      hwnd 0x{hwnd:x}, class '{class}'). Fallback options: \
                      (a) re-call this tool with a depth-limited scan \
                      (`max_elements` / `max_depth`) — if the tree stays unusable, act \
@@ -1289,13 +1301,15 @@ impl Tool for GetWindowStateTool {
                      (b) if the target is a transient VCL / message-box dialog, send \
                      `press_key` with `delivery_mode:\"foreground\"` (SendInput) to fire the \
                      default accelerator (Esc / Enter / Y / N) without needing the tree."
-                    ))
+                        )),
+                    )
                 }
             };
-        let result = result.and_then(|r| r);
+        let result: anyhow::Result<_> =
+            Ok((tree_result, screenshot, screenshot_err, accessibility_err));
 
         match result {
-            Ok((tree_opt, screenshot_opt, screenshot_err)) => {
+            Ok((tree_opt, screenshot_opt, screenshot_err, accessibility_err)) => {
                 let mut content = Vec::new();
                 let mut structured = json!({ "window_id": hwnd, "pid": pid });
 
@@ -1500,6 +1514,21 @@ impl Tool for GetWindowStateTool {
                         "screenshot unavailable: {err}"
                     )));
                     structured["screenshot_error"] = json!(err);
+                }
+
+                if let Some(err) = accessibility_err {
+                    content.push(cua_driver_core::protocol::Content::text(format!(
+                        "accessibility unavailable: {err}"
+                    )));
+                    structured["accessibility_error"] = json!(err);
+                    structured["degraded"] = json!(true);
+                    structured["degraded_reason"] = json!(
+                        "accessibility_unavailable: use the screenshot with pixel or foreground keyboard input."
+                    );
+                    structured["escalation"] = json!({
+                        "recommended": "px",
+                        "reason": "The accessibility provider was unavailable; act from the screenshot."
+                    });
                 }
 
                 cua_driver_core::window_inspection::mark_browser_chrome_capture_coverage(
@@ -10135,6 +10164,39 @@ mod click_button_schema_tests {
         assert_eq!(
             retain.get("default").and_then(|value| value.as_bool()),
             Some(false)
+        );
+    }
+}
+
+#[cfg(test)]
+mod get_window_state_schema_tests {
+    use super::GetWindowStateTool;
+    use cua_driver_core::tool::Tool;
+
+    #[test]
+    fn accessibility_is_enabled_by_default_but_can_be_skipped() {
+        let tool = GetWindowStateTool {
+            state: super::ToolState::new(),
+        };
+        let properties = tool
+            .def()
+            .input_schema
+            .get("properties")
+            .expect("properties");
+        let include_accessibility = properties
+            .get("include_accessibility")
+            .expect("include_accessibility field present");
+        assert_eq!(
+            include_accessibility
+                .get("type")
+                .and_then(|value| value.as_str()),
+            Some("boolean")
+        );
+        assert_eq!(
+            include_accessibility
+                .get("default")
+                .and_then(|value| value.as_bool()),
+            Some(true)
         );
     }
 }

--- a/libs/cua-driver/rust/crates/platform-windows/src/uia/cache.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/uia/cache.rs
@@ -162,6 +162,12 @@ impl ElementCache {
     }
 
     fn update_with_kind(&self, pid: u32, hwnd: u64, nodes: &[UiaNode], kind: SnapshotKind) {
+        debug_assert!(
+            nodes
+                .iter()
+                .all(|node| (node.element_ptr != 0) == node.element_index.is_some()),
+            "UiaNode element pointer/index invariant violated"
+        );
         let actionable: Vec<&UiaNode> =
             nodes.iter().filter(|n| n.element_index.is_some()).collect();
         let elements: Vec<usize> = actionable.iter().map(|n| n.element_ptr).collect();

--- a/libs/cua-driver/rust/crates/platform-windows/src/uia/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/uia/mod.rs
@@ -66,8 +66,9 @@ pub struct UiaNode {
     /// Toggle/selection state when the element exposes one of those patterns.
     pub selected: Option<bool>,
     /// Raw COM pointer (IUIAutomationElement for UIA path, IAccessible for
-    /// MSAA path) as usize. Retained — `ElementCache` Drop releases it via
-    /// the `kind`-appropriate vtable.
+    /// MSAA path) as usize. Non-zero if and only if `element_index` is `Some`.
+    /// A stored snapshot adopts the retained reference for indexed nodes. A
+    /// walk that is not cached must release it through the matching vtable.
     pub element_ptr: usize,
     /// Screen-coordinate center, captured at walk time to avoid later COM calls.
     pub center_x: i32,
@@ -146,7 +147,7 @@ fn exact_menu_path_matches(nodes: &[UiaNode], path: &[String]) -> Vec<usize> {
         .collect()
 }
 
-unsafe fn release_walk_nodes(nodes: Vec<UiaNode>) {
+pub(crate) unsafe fn release_walk_nodes(nodes: Vec<UiaNode>) {
     use windows::Win32::UI::Accessibility::IAccessible;
     for node in nodes {
         if node.element_ptr == 0 {
@@ -695,55 +696,43 @@ unsafe fn walk_cached_bounded(
 
     let mut emitted_parent: Option<usize> = parent_index;
     if is_actionable || has_content {
-        let retained: IUIAutomationElement = element.clone();
-        let ptr = retained.as_raw() as usize;
-        std::mem::forget(retained);
-
-        let node = if is_actionable {
+        let element_index = if is_actionable {
             let idx = *counter;
             *counter += 1;
-            let (center_x, center_y, rect) = read_cached_bounding_rect_full(element);
             emitted_parent = Some(idx);
-            UiaNode {
-                element_index: Some(idx),
-                control_type: control_type.clone(),
-                name: name.clone(),
-                value: value.clone(),
-                automation_id: automation_id.clone(),
-                help_text: help_text.clone(),
-                actions: actions.clone(),
-                enabled,
-                selected,
-                element_ptr: ptr,
-                center_x,
-                center_y,
-                rect,
-                msaa_role: None,
-                depth,
-                parent_element_index: parent_index,
-                in_web_content,
-            }
+            Some(idx)
         } else {
-            UiaNode {
-                element_index: None,
-                control_type: control_type.clone(),
-                name: name.clone(),
-                value: value.clone(),
-                automation_id: automation_id.clone(),
-                help_text: help_text.clone(),
-                actions: vec![],
-                enabled,
-                selected,
-                element_ptr: ptr,
-                center_x: 0,
-                center_y: 0,
-                rect: None,
-                msaa_role: None,
-                depth,
-                parent_element_index: parent_index,
-                in_web_content,
-            }
+            None
         };
+        let (element_ptr, center_x, center_y, rect) = if element_index.is_some() {
+            let retained: IUIAutomationElement = element.clone();
+            let ptr = retained.as_raw() as usize;
+            std::mem::forget(retained);
+            let (center_x, center_y, rect) = read_cached_bounding_rect_full(element);
+            (ptr, center_x, center_y, rect)
+        } else {
+            (0, 0, 0, None)
+        };
+        let node = UiaNode {
+            element_index,
+            control_type: control_type.clone(),
+            name: name.clone(),
+            value: value.clone(),
+            automation_id: automation_id.clone(),
+            help_text: help_text.clone(),
+            actions: actions.clone(),
+            enabled,
+            selected,
+            element_ptr,
+            center_x,
+            center_y,
+            rect,
+            msaa_role: None,
+            depth,
+            parent_element_index: parent_index,
+            in_web_content,
+        };
+        debug_assert_eq!(node.element_ptr != 0, node.element_index.is_some());
 
         lines.push((depth, format_node_line(&node)));
         nodes.push(node);
@@ -1117,7 +1106,7 @@ mod tests {
             actions: actions.iter().map(|action| (*action).into()).collect(),
             enabled,
             selected,
-            element_ptr: 0,
+            element_ptr: usize::from(element_index.is_some()),
             center_x: 0,
             center_y: 0,
             rect: None,

--- a/libs/cua-driver/rust/crates/platform-windows/src/uia/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/uia/mod.rs
@@ -394,6 +394,7 @@ unsafe fn walk_tree_unsafe(
         0,
         None,
         false,
+        true,
         &mut nodes,
         &mut lines,
         &mut counter,
@@ -615,6 +616,7 @@ unsafe fn walk_root_by_pid(
             0,
             None,
             false,
+            true,
             nodes,
             lines,
             counter,
@@ -639,6 +641,7 @@ unsafe fn walk_cached(
         depth,
         None,
         false,
+        true,
         nodes,
         lines,
         counter,
@@ -654,6 +657,7 @@ unsafe fn walk_cached_bounded(
     depth: usize,
     parent_index: Option<usize>,
     in_web_content: bool,
+    ancestors_enabled: bool,
     nodes: &mut Vec<UiaNode>,
     lines: &mut Vec<(usize, String)>,
     counter: &mut usize,
@@ -671,10 +675,12 @@ unsafe fn walk_cached_bounded(
     let value = read_cached_bstr_value(element);
     let automation_id = read_cached_bstr(element, UIA_AutomationIdPropertyId);
     let help_text = read_cached_bstr(element, UIA_HelpTextPropertyId);
-    let enabled = read_cached_bool(element, UIA_IsEnabledPropertyId);
-    // Missing UIA state must remain unknown on the structured observation
-    // surface. Action discovery keeps its historical best-effort assumption.
-    let is_enabled = enabled.unwrap_or(true);
+    let reported_enabled = read_cached_bool(element, UIA_IsEnabledPropertyId);
+    // UIA providers may report enabled children beneath a disabled parent.
+    // Those children cannot actually be acted on, so expose and index them
+    // according to their effective state. Missing state remains unknown only
+    // while every known ancestor is enabled.
+    let (enabled, is_enabled) = effective_enabled(reported_enabled, ancestors_enabled);
     let selected = read_cached_selected(element);
     let actions = detect_cached_actions(element, &control_type, is_enabled);
     let is_actionable = !actions.is_empty() && is_enabled;
@@ -753,6 +759,7 @@ unsafe fn walk_cached_bounded(
                     depth + 1,
                     emitted_parent,
                     in_web_content || control_type.eq_ignore_ascii_case("Document"),
+                    is_enabled,
                     nodes,
                     lines,
                     counter,
@@ -763,6 +770,16 @@ unsafe fn walk_cached_bounded(
             }
         }
     }
+}
+
+fn effective_enabled(
+    reported_enabled: Option<bool>,
+    ancestors_enabled: bool,
+) -> (Option<bool>, bool) {
+    if !ancestors_enabled {
+        return (Some(false), false);
+    }
+    (reported_enabled, reported_enabled.unwrap_or(true))
 }
 
 fn read_cached_control_type(element: &IUIAutomationElement) -> String {
@@ -984,6 +1001,7 @@ pub(crate) fn format_node_line(node: &UiaNode) -> String {
         if let Some(h) = &node.help_text {
             attrs.push(format!("help=\"{}\"", h));
         }
+        attrs.extend(format_state_attrs(node));
         if !node.actions.is_empty() {
             attrs.push(format!("actions=[{}]", node.actions.join(",")));
         }
@@ -998,8 +1016,28 @@ pub(crate) fn format_node_line(node: &UiaNode) -> String {
         if let Some(v) = &node.value {
             s.push_str(&format!(" = \"{}\"", v));
         }
+        let attrs = format_state_attrs(node);
+        if !attrs.is_empty() {
+            s.push_str(&format!(" [{}]", attrs.join(" ")));
+        }
     }
     s
+}
+
+fn format_state_attrs(node: &UiaNode) -> Vec<String> {
+    let mut attrs = Vec::new();
+    if node.enabled == Some(false) {
+        attrs.push("enabled=false".into());
+    }
+    if let Some(selected) = node.selected {
+        let state = if node.control_type.eq_ignore_ascii_case("CheckBox") {
+            "checked"
+        } else {
+            "selected"
+        };
+        attrs.push(format!("{state}={selected}"));
+    }
+    attrs
 }
 
 fn render_lines(lines: &[(usize, String)]) -> String {
@@ -1054,4 +1092,98 @@ fn filter_tree(markdown: &str, query: &str) -> String {
     let mut r = output.join("\n");
     r.push('\n');
     r
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(
+        element_index: Option<usize>,
+        control_type: &str,
+        name: &str,
+        value: Option<&str>,
+        enabled: Option<bool>,
+        selected: Option<bool>,
+        actions: &[&str],
+    ) -> UiaNode {
+        UiaNode {
+            element_index,
+            control_type: control_type.into(),
+            name: Some(name.into()),
+            value: value.map(Into::into),
+            automation_id: None,
+            help_text: None,
+            actions: actions.iter().map(|action| (*action).into()).collect(),
+            enabled,
+            selected,
+            element_ptr: 0,
+            center_x: 0,
+            center_y: 0,
+            rect: None,
+            msaa_role: None,
+            depth: 0,
+            parent_element_index: None,
+            in_web_content: false,
+        }
+    }
+
+    #[test]
+    fn disabled_ancestor_overrides_enabled_and_unknown_descendants() {
+        let (parent_state, parent_is_enabled) = effective_enabled(Some(false), true);
+        assert_eq!(parent_state, Some(false));
+        assert!(!parent_is_enabled);
+
+        let (enabled_child_state, enabled_child_is_enabled) =
+            effective_enabled(Some(true), parent_is_enabled);
+        assert_eq!(enabled_child_state, Some(false));
+        assert!(!enabled_child_is_enabled);
+
+        let (unknown_grandchild_state, unknown_grandchild_is_enabled) =
+            effective_enabled(None, enabled_child_is_enabled);
+        assert_eq!(unknown_grandchild_state, Some(false));
+        assert!(!unknown_grandchild_is_enabled);
+    }
+
+    #[test]
+    fn markdown_preserves_nesting_and_explains_disabled_selection_state() {
+        let parent = node(None, "Group", "Graphics", None, Some(false), None, &[]);
+        let child = node(
+            None,
+            "ListItem",
+            "Very High",
+            None,
+            Some(false),
+            Some(true),
+            &[],
+        );
+
+        let markdown = render_lines(&[
+            (0, format_node_line(&parent)),
+            (1, format_node_line(&child)),
+        ]);
+
+        assert_eq!(
+            markdown,
+            "- Group \"Graphics\" [enabled=false]\n  - ListItem \"Very High\" [enabled=false selected=true]\n"
+        );
+    }
+
+    #[test]
+    fn markdown_labels_checkbox_toggle_state_as_checked() {
+        let checkbox = node(
+            Some(4),
+            "CheckBox",
+            "VSync",
+            None,
+            Some(true),
+            Some(false),
+            &["toggle"],
+        );
+
+        assert_eq!(
+            format_node_line(&checkbox),
+            "- [4] CheckBox \"VSync\" [checked=false actions=[toggle]]"
+        );
+    }
 }

--- a/libs/cua-driver/rust/crates/platform-windows/src/win32/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/win32/mod.rs
@@ -8,7 +8,7 @@ pub use apps::{list_descendants, list_processes, related_processes, ProcessInfo}
 pub use installed_apps::{list_installed_apps, InstalledApp};
 pub(crate) use windows::{
     capture_foreground_target, find_window_by_pid_and_handle,
-    foreground_matches_target_or_owned_window, list_windows_via_win32, resolve_uwp_app_pid,
-    window_owner_pid,
+    foreground_matches_target_or_owned_window, foreground_matches_target_owner,
+    list_windows_via_win32, resolve_uwp_app_pid, window_owner_pid,
 };
 pub use windows::{list_windows, resolve_uwp_host_window, WindowInfo};

--- a/libs/cua-driver/rust/crates/platform-windows/src/win32/windows.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/win32/windows.rs
@@ -211,6 +211,34 @@ pub(crate) fn foreground_matches_target_or_owned_window(
     })
 }
 
+/// Verify that Windows kept a live owned dialog's snapshotted same-process
+/// owner in the foreground when activation of the dialog itself was refused.
+///
+/// Owned dialogs remain above their owner in z-order, so pointer hit-testing
+/// still reaches the exact visible dialog. This is intentionally narrower than
+/// accepting any same-process sibling.
+pub(crate) fn foreground_matches_target_owner(target: ForegroundTarget, actual: u64) -> bool {
+    let target_pid = window_owner_pid(target.hwnd);
+    let actual_pid = window_owner_pid(actual);
+    target_owner_foreground_allowed(
+        target.owner == Some(actual),
+        target_pid == Some(target.pid),
+        actual_pid.is_some(),
+        unsafe { IsWindowVisible(HWND(actual as *mut _)) }.as_bool(),
+        actual_pid == Some(target.pid),
+    )
+}
+
+fn target_owner_foreground_allowed(
+    actual_is_prior_owner: bool,
+    target_identity_live: bool,
+    actual_live: bool,
+    actual_visible: bool,
+    same_pid: bool,
+) -> bool {
+    actual_is_prior_owner && target_identity_live && actual_live && actual_visible && same_pid
+}
+
 fn window_info_by_handle(hwnd: u64) -> Option<WindowInfo> {
     let native = HWND(hwnd as *mut _);
     let pid = window_owner_pid(hwnd)?;
@@ -339,7 +367,7 @@ fn get_window_bounds(hwnd: HWND) -> (i32, i32, i32, i32) {
 mod exact_window_tests {
     use super::{
         exact_window_from_probe, owner_chain_reaches_target, post_action_foreground_allowed,
-        PostActionForegroundRelation, WindowInfo,
+        target_owner_foreground_allowed, PostActionForegroundRelation, WindowInfo,
     };
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -450,6 +478,28 @@ mod exact_window_tests {
         stale.actual_visible = false;
         assert!(!post_action_foreground_allowed(stale));
         assert!(!owner_chain_reaches_target(10, 30, |_| Some(30)));
+    }
+
+    #[test]
+    fn live_owned_dialog_may_use_only_its_snapshotted_owner_for_pointer_activation() {
+        assert!(target_owner_foreground_allowed(
+            true, true, true, true, true
+        ));
+        assert!(!target_owner_foreground_allowed(
+            false, true, true, true, true
+        ));
+        assert!(!target_owner_foreground_allowed(
+            true, false, true, true, true
+        ));
+        assert!(!target_owner_foreground_allowed(
+            true, true, false, true, true
+        ));
+        assert!(!target_owner_foreground_allowed(
+            true, true, true, false, true
+        ));
+        assert!(!target_owner_foreground_allowed(
+            true, true, true, true, false
+        ));
     }
 }
 


### PR DESCRIPTION
## Problem

Windows can refuse an exact SetForegroundWindow transition for two pointer-delivery cases that are still safely recoverable:

- the verified same-process owner remains foreground while an owned dialog is visible
- the verified target can be raised but needs the requested system-routed click itself to establish foreground ownership

The current path rejects both before sending input.

## Change

- snapshot the target before activation
- accept only its live, visible, same-process snapshotted owner as the pre-action fallback
- when activation is still unavailable, temporarily raise only the verified target and let the requested click establish focus
- retain the exact/owned post-action foreground checks, so the click still fails closed if Windows routes it elsewhere
- reject unrelated same-process siblings and foreign windows

## Validation

- cargo test -p platform-windows input::mouse (6 passed)
- focused owner-chain unit test passed
- release build of cua-driver and cua-driver-uia passed
- live Windows validation: a custom-rendered game window initially rejected keyboard activation; the click-assisted path focused the verified window and the following title-screen key advanced to the main menu

## Pending

- add a deterministic integration fixture for the click-assisted transition
- investigate stale capture behavior observed in one native owned game-settings dialog

This remains a draft while those integration cases are tightened. The behavior is generic and contains no application-specific matching.