### PR TITLE
chore(cua-sandbox): synchronize bumpversion release metadata

### DIFF
--- a/libs/python/cua-sandbox/.bumpversion.cfg
+++ b/libs/python/cua-sandbox/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.2
+current_version = 0.4.3
 commit = True
 tag = True
 tag_name = sandbox-v{new_version}


### PR DESCRIPTION
Follow-up to #3325. The `cua-sandbox` package version advanced to `0.4.3`, but `.bumpversion.cfg` remained at `0.4.2`, which breaks `CI: Test Scripts` on every pull request, including the Cua Driver 0.22.0 release PR.

Validation:
- `/Users/administrator/.local/bin/python3.11 .github/scripts/tests/test_cua_sandbox_release_wiring.py`
- `git diff --check`