### PR TITLE
feat(cua-driver): add native Agent View across desktops

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -24,6 +24,7 @@
     "f@trycua.com": "f-trycua",
     "fbonacci@fbonacci-xfce-vm.b40fumexvs1ujlod2ppcyfh5qa.bx.internal.cloudapp.net": "f-trycua",
     "i@jyunko.cn": "HsiangNianian",
+    "jf-mac-mini@jf-mac-mini-4.local": "0xjohnnydev",
     "klymenko@adobe.com": "pavelklymenko",
     "m.fuechtenkoetter@posteo.de": "ai-ag2026",
     "manfred@ubuntu26.04-vm": "ai-ag2026",

--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -661,14 +661,14 @@ Caveats:
 
 ### `set_config`
 
-Update cua-driver-rs configuration. Changes to max_image_dimension take effect immediately. The experimental_pip keys are persisted to ~/.cua-driver/config.json and take effect on the next daemon restart (Agent View is initialised once at startup).
+Update cua-driver-rs configuration. Changes to max_image_dimension take effect immediately. The agent_view keys are persisted to ~/.cua-driver/config.json and take effect on the next daemon restart (Agent View is initialised once at startup).
 
 Note: capture_mode is a per-call param (on get_window_state / click), not a stored setting. Capture modality is selected by each action's target; the old capture_scope config key is retired.
 
 **Arguments:**
 
-- `experimental_pip` (boolean, optional): Enable the experimental multi-target Agent View. Exact native windows and Chrome tabs are grouped automatically by session; no target claiming is involved. Applies on next daemon restart.
-- `experimental_pip_geometry` (string, optional): Agent View size + optional position in `WxH` or `WxH+X+Y` form (e.g. `320x200+24+24`). Applies on next daemon restart.
+- `agent_view` (boolean, optional): Enable the experimental multi-target Agent View. Exact native windows and Chrome tabs are grouped automatically by session; no target claiming is involved. Applies on next daemon restart.
+- `agent_view_geometry` (string, optional): Agent View size + optional position in `WxH` or `WxH+X+Y` form (e.g. `320x200+24+24`). Applies on next daemon restart.
 - `key` (string, optional): Name of a single config field to write (&#123;key, value&#125; shape, matching the CLI `config set` and the Windows/Linux tools). Pair with `value`. Equivalent to passing the field directly.
 - `max_image_dimension` (integer, optional): Max dimension for screenshot resizing (0 = no limit).
 - `value` (unknown, optional): New value for `key`. JSON type depends on the key.

--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -661,14 +661,14 @@ Caveats:
 
 ### `set_config`
 
-Update cua-driver-rs configuration. Changes to max_image_dimension take effect immediately. The experimental_pip compatibility keys are persisted to ~/.cua-driver/config.json and take effect on the next daemon restart (Agent View is initialised once at startup).
+Update cua-driver-rs configuration. Changes to max_image_dimension take effect immediately. The experimental_pip keys are persisted to ~/.cua-driver/config.json and take effect on the next daemon restart (Agent View is initialised once at startup).
 
 Note: capture_mode is a per-call param (on get_window_state / click), not a stored setting. Capture modality is selected by each action's target; the old capture_scope config key is retired.
 
 **Arguments:**
 
-- `experimental_pip` (boolean, optional): Enable the experimental multi-target Agent View. It automatically groups exact native-window and Chrome-tab cards by the existing session; it does not claim targets. Applies on next daemon restart.
-- `experimental_pip_geometry` (string, optional): Agent View size + optional position in `WxH` or `WxH+X+Y` form (e.g. `640x420+24+24`). Applies on next daemon restart.
+- `experimental_pip` (boolean, optional): Enable the experimental multi-target Agent View. Exact native windows and Chrome tabs are grouped automatically by session; no target claiming is involved. Applies on next daemon restart.
+- `experimental_pip_geometry` (string, optional): Agent View size + optional position in `WxH` or `WxH+X+Y` form (e.g. `320x200+24+24`). Applies on next daemon restart.
 - `key` (string, optional): Name of a single config field to write (&#123;key, value&#125; shape, matching the CLI `config set` and the Windows/Linux tools). Pair with `value`. Equivalent to passing the field directly.
 - `max_image_dimension` (integer, optional): Max dimension for screenshot resizing (0 = no limit).
 - `value` (unknown, optional): New value for `key`. JSON type depends on the key.

--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -668,7 +668,7 @@ Note: capture_mode is a per-call param (on get_window_state / click), not a stor
 **Arguments:**
 
 - `agent_view` (boolean, optional): Enable the experimental multi-target Agent View. Exact native windows and Chrome tabs are grouped automatically by session; no target claiming is involved. Applies on next daemon restart.
-- `agent_view_geometry` (string, optional): Agent View size + optional position in `WxH` or `WxH+X+Y` form (e.g. `320x200+24+24`). Applies on next daemon restart.
+- `agent_view_geometry` (string, optional): Agent View size + optional position in `WxH` or `WxH+X+Y` form (e.g. `640x420+24+24`). Applies on next daemon restart.
 - `key` (string, optional): Name of a single config field to write (&#123;key, value&#125; shape, matching the CLI `config set` and the Windows/Linux tools). Pair with `value`. Equivalent to passing the field directly.
 - `max_image_dimension` (integer, optional): Max dimension for screenshot resizing (0 = no limit).
 - `value` (unknown, optional): New value for `key`. JSON type depends on the key.

--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -661,14 +661,14 @@ Caveats:
 
 ### `set_config`
 
-Update cua-driver-rs configuration. Changes to max_image_dimension take effect immediately. The experimental_pip keys are persisted to ~/.cua-driver/config.json and take effect on the next daemon restart (the PiP backend is initialised once at startup).
+Update cua-driver-rs configuration. Changes to max_image_dimension take effect immediately. The experimental_pip compatibility keys are persisted to ~/.cua-driver/config.json and take effect on the next daemon restart (Agent View is initialised once at startup).
 
 Note: capture_mode is a per-call param (on get_window_state / click), not a stored setting. Capture modality is selected by each action's target; the old capture_scope config key is retired.
 
 **Arguments:**
 
-- `experimental_pip` (boolean, optional): Enable the experimental picture-in-picture preview window. Applies on next daemon restart.
-- `experimental_pip_geometry` (string, optional): PiP window size + optional position in `WxH` or `WxH+X+Y` form (e.g. `320x200+24+24`). Applies on next daemon restart.
+- `experimental_pip` (boolean, optional): Enable the experimental multi-target Agent View. It automatically groups exact native-window and Chrome-tab cards by the existing session; it does not claim targets. Applies on next daemon restart.
+- `experimental_pip_geometry` (string, optional): Agent View size + optional position in `WxH` or `WxH+X+Y` form (e.g. `640x420+24+24`). Applies on next daemon restart.
 - `key` (string, optional): Name of a single config field to write (&#123;key, value&#125; shape, matching the CLI `config set` and the Windows/Linux tools). Pair with `value`. Equivalent to passing the field directly.
 - `max_image_dimension` (integer, optional): Max dimension for screenshot resizing (0 = no limit).
 - `value` (unknown, optional): New value for `key`. JSON type depends on the key.

--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -667,7 +667,7 @@ Note: capture_mode is a per-call param (on get_window_state / click), not a stor
 
 **Arguments:**
 
-- `agent_view` (boolean, optional): Enable the experimental multi-target Agent View. Exact native windows and Chrome tabs are grouped automatically by session; no target claiming is involved. Applies on next daemon restart.
+- `agent_view` (boolean, optional): Enable the multi-target Agent View. Exact native windows and Chrome tabs are grouped automatically by session; no target claiming is involved. Applies on next daemon restart.
 - `agent_view_geometry` (string, optional): Agent View size + optional position in `WxH` or `WxH+X+Y` form (e.g. `640x420+24+24`). Applies on next daemon restart.
 - `key` (string, optional): Name of a single config field to write (&#123;key, value&#125; shape, matching the CLI `config set` and the Windows/Linux tools). Pair with `value`. Equivalent to passing the field directly.
 - `max_image_dimension` (integer, optional): Max dimension for screenshot resizing (0 = no limit).

--- a/libs/cua-driver/README.md
+++ b/libs/cua-driver/README.md
@@ -131,6 +131,8 @@ Contributor documentation:
 
 - `docs/cursor-themes.md` documents the default semantic cursor and custom
   dotLottie authoring contract.
+- `docs/agent-view.md` documents the optional cross-platform miniature desktop,
+  its selected-session model, and exact-target membership rules.
 - `docs/test-matrix.md` maps unit and canonical harness E2E suites.
 - `docs/action-support.md` is the empirical platform behavior ledger.
 - `docs/test-harnesses-guide.md` explains fixture and runner ownership.

--- a/libs/cua-driver/README.md
+++ b/libs/cua-driver/README.md
@@ -131,8 +131,9 @@ Contributor documentation:
 
 - `docs/cursor-themes.md` documents the default semantic cursor and custom
   dotLottie authoring contract.
-- `docs/agent-view.md` documents the optional cross-platform miniature desktop,
-  its selected-session model, and exact-target membership rules.
+- `docs/agent-view.md` documents the cross-platform miniature desktop (enabled
+  by default, with an explicit opt-out), its selected-session model, and
+  exact-target membership rules.
 - `docs/test-matrix.md` maps unit and canonical harness E2E suites.
 - `docs/action-support.md` is the empirical platform behavior ledger.
 - `docs/test-harnesses-guide.md` explains fixture and runner ownership.

--- a/libs/cua-driver/docs/agent-view.md
+++ b/libs/cua-driver/docs/agent-view.md
@@ -16,6 +16,13 @@ durable config equivalent is `{"agent_view": false}` in
 Use `--agent-view-geometry WxH[+X+Y]` to override its initial size and optional
 top-left position. The default is `640x420` near the top-right of the main
 display. The view is resizable on macOS, Windows, and Linux X11/XWayland.
+Pure Wayland uses a native top-right layer surface when the compositor exposes
+`zwlr_layer_shell_v1`; its position and size are compositor-managed. GNOME
+sessions without layer-shell use the supported XWayland presentation path. A
+pure layer-shell view remains click-through and follows the most-recent session;
+local tab selection, dragging, and manual resizing require the X11/XWayland
+window path because standard Wayland does not expose those global window
+management operations to clients.
 
 ## Session model
 

--- a/libs/cua-driver/docs/agent-view.md
+++ b/libs/cua-driver/docs/agent-view.md
@@ -2,11 +2,16 @@
 
 Agent View is an optional, always-on-top miniature desktop that shows the exact
 application windows and browser tabs traversed by one Cua Driver agent session.
-Enable it when starting the daemon:
+It is enabled by default on supported interactive desktops. Disable it for one
+daemon invocation with:
 
 ```console
-cua-driver --agent-view
+cua-driver --no-agent-view
 ```
+
+`--agent-view` remains accepted as an explicit enable for compatibility. The
+durable config equivalent is `{"agent_view": false}` in
+`~/.cua-driver/config.json`.
 
 Use `--agent-view-geometry WxH[+X+Y]` to override its initial size and optional
 top-left position. The default is `640x420` near the top-right of the main
@@ -15,7 +20,8 @@ display. The view is resizable on macOS, Windows, and Linux X11/XWayland.
 ## Session model
 
 - One Agent View window belongs to one daemon and displays one selected private
-  runtime session at a time.
+  runtime session at a time. Multiple sessions appear as local tabs in that
+  same window; the tab strip is hidden when only one session has cards.
 - Until a person selects a session locally, Agent View follows the session with
   the most recent exact target activity.
 - When multiple sessions have cards, the native Agent View window exposes a

--- a/libs/cua-driver/docs/agent-view.md
+++ b/libs/cua-driver/docs/agent-view.md
@@ -1,0 +1,61 @@
+# Agent View
+
+Agent View is an optional, always-on-top miniature desktop that shows the exact
+application windows and browser tabs traversed by one Cua Driver agent session.
+Enable it when starting the daemon:
+
+```console
+cua-driver --agent-view
+```
+
+Use `--agent-view-geometry WxH[+X+Y]` to override its initial size and optional
+top-left position. The default is `640x420` near the top-right of the main
+display. The view is resizable on macOS, Windows, and Linux X11/XWayland.
+
+## Session model
+
+- One Agent View window belongs to one daemon and displays one selected private
+  runtime session at a time.
+- Until a person selects a session locally, Agent View follows the session with
+  the most recent exact target activity.
+- When multiple sessions have cards, the native Agent View window exposes a
+  local session switcher. Selecting a session pins the view there until that
+  session ends or is removed. There is no agent-facing selection tool.
+- Public session names are display labels only. The private runtime session ID
+  remains the isolation identity, so equal labels never combine sessions.
+- Ending, disconnecting, revoking, or idle-expiring a session removes its cards.
+  Reusing a revived session starts with an empty view.
+
+Agent View does not claim targets and does not add claim/release semantics to
+the CLI, MCP tools, SDKs, or target schemas. Switching the presentation never
+focuses, moves, resizes, closes, or otherwise controls an underlying target.
+
+## What becomes a card
+
+A target is added or refreshed only after Cua Driver receives exact target
+evidence through one of these paths:
+
+- `get_window_state` with both `pid` and `window_id`;
+- an exact native action carrying both `pid` and `window_id`;
+- `get_browser_state` with both `target_id` and `tab_id`; or
+- an exact browser-tab action carrying both `target_id` and `tab_id`.
+
+Broad discovery such as `list_windows`, `list_browser_tabs`, whole-desktop
+snapshots, ambient foreground activity, and actions performed outside Cua
+Driver do not populate Agent View.
+
+Browser cards use the page's stable internal CDP identity, so navigation and a
+repeated browser-window bind refresh the same card. Multiple tabs in one Chrome
+or Edge window remain distinct, while their native container window is hidden
+to avoid duplicating the browser.
+
+When a target is proven absent, only its exact card is removed. When a session
+ends, all cards belonging to that private session are removed. The underlying
+application or tab is never changed by presentation cleanup.
+
+## Public contract
+
+Agent View uses the existing daemon flag, geometry option, runtime sessions,
+and exact target arguments. This session-oriented behavior does not introduce
+new MCP tools, CLI flags, SDK types, capability IDs, claim tokens, or public
+target/session fields.

--- a/libs/cua-driver/docs/agent-view.md
+++ b/libs/cua-driver/docs/agent-view.md
@@ -29,6 +29,10 @@ display. The view is resizable on macOS, Windows, and Linux X11/XWayland.
 Agent View does not claim targets and does not add claim/release semantics to
 the CLI, MCP tools, SDKs, or target schemas. Switching the presentation never
 focuses, moves, resizes, closes, or otherwise controls an underlying target.
+During physical Cua Driver actions, the always-on-top surface temporarily
+becomes input-transparent so an overlapping Agent View cannot intercept input
+intended for the represented application. Local switching and resizing resume
+as soon as the action finishes.
 
 ## What becomes a card
 

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
@@ -414,6 +414,9 @@ pub(crate) struct BrowserTabPreview {
     pub screenshot: BrowserTabScreenshot,
     pub title: String,
     pub url: String,
+    pub cdp_target_id: String,
+    pub pid: i64,
+    pub window_id: u64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -2044,6 +2047,9 @@ impl BrowserEngine {
             screenshot,
             title: tab.title,
             url: tab.url,
+            cdp_target_id: tab.cdp_target_id,
+            pid: record.pid,
+            window_id: record.window_id,
         })
     }
 

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
@@ -410,6 +410,12 @@ pub(crate) struct BrowserTabScreenshot {
     pub pixel_to_css_scale_y: f64,
 }
 
+pub(crate) struct BrowserTabPreview {
+    pub screenshot: BrowserTabScreenshot,
+    pub title: String,
+    pub url: String,
+}
+
 #[derive(Debug, Clone, Copy)]
 struct BrowserScreenshotViewport {
     page_x: f64,
@@ -2011,6 +2017,33 @@ impl BrowserEngine {
             viewport_css_height: viewport.height,
             pixel_to_css_scale_x: viewport.width / f64::from(width),
             pixel_to_css_scale_y: viewport.height / f64::from(height),
+        })
+    }
+
+    /// Capture one exact tab for a trusted local presentation surface while
+    /// retaining the tab metadata already proved by the session-scoped store.
+    /// Like `capture_tab_screenshot`, this never activates the tab or brings
+    /// its native window to the foreground.
+    pub(crate) async fn capture_tab_preview(
+        &self,
+        session: &str,
+        target_id: &str,
+        tab_id: &str,
+    ) -> Result<BrowserTabPreview, BrowserRefusal> {
+        let record = self.store.get_target(session, target_id)?;
+        let tab = record.tabs.get(tab_id).cloned().ok_or_else(|| {
+            refuse(
+                BrowserRefusalCode::BrowserTabNotFound,
+                format!("tab {tab_id} is not known for target {target_id}"),
+            )
+        })?;
+        let screenshot = self
+            .capture_tab_screenshot(session, target_id, tab_id)
+            .await?;
+        Ok(BrowserTabPreview {
+            screenshot,
+            title: tab.title,
+            url: tab.url,
         })
     }
 

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
@@ -28,6 +28,7 @@ use super::types::BindingQuality;
 /// crates call this from their `register_all` after constructing the
 /// engine with their adapter.
 pub fn register_browser_tools(engine: &Arc<BrowserEngine>, registry: &mut ToolRegistry) {
+    registry.set_browser_engine(engine.clone());
     registry.register(Box::new(GetBrowserStateTool::new(engine.clone())));
     registry.register(Box::new(BrowserPrepareTool::new(engine.clone())));
     registry.register(Box::new(BrowserNavigateTool::new(engine.clone())));

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/pip_hook.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/pip_hook.rs
@@ -50,6 +50,9 @@ pub struct PipHookFrame {
 
 pub enum PipHookEvent {
     Upsert(PipHookFrame),
+    SetInputPassthrough {
+        passthrough: bool,
+    },
     RemoveTarget {
         workspace_id: String,
         identity_key: String,
@@ -59,12 +62,27 @@ pub enum PipHookEvent {
     },
 }
 
-type PipEventFnBox = Box<dyn Fn(PipHookEvent) + Send + Sync>;
+/// Restores Agent View interactivity even when an action exits early or
+/// unwinds. Physical desktop actions are serialized by the dispatcher, so one
+/// process-global passthrough scope is sufficient.
+pub struct PipInputPassthroughGuard;
+
+impl Drop for PipInputPassthroughGuard {
+    fn drop(&mut self) {
+        if let Some(f) = PIP_EVENT_FN.get() {
+            if let Err(error) = f(PipHookEvent::SetInputPassthrough { passthrough: false }) {
+                tracing::error!(%error, "failed to restore Agent View input handling");
+            }
+        }
+    }
+}
+
+type PipEventFnBox = Box<dyn Fn(PipHookEvent) -> Result<(), String> + Send + Sync>;
 static PIP_EVENT_FN: OnceLock<PipEventFnBox> = OnceLock::new();
 
 /// Register the platform-side push callback. `main.rs` calls this
 /// once after starting the PiP backend.
-pub fn set_pip_event_fn(f: impl Fn(PipHookEvent) + Send + Sync + 'static) {
+pub fn set_pip_event_fn(f: impl Fn(PipHookEvent) -> Result<(), String> + Send + Sync + 'static) {
     let _ = PIP_EVENT_FN.set(Box::new(f));
 }
 
@@ -75,17 +93,27 @@ pub fn pip_enabled() -> bool {
     PIP_EVENT_FN.get().is_some()
 }
 
+/// Temporarily make Agent View input-transparent. The registered backend
+/// applies the native state synchronously before this returns.
+pub fn begin_pip_input_passthrough() -> Result<Option<PipInputPassthroughGuard>, String> {
+    let Some(f) = PIP_EVENT_FN.get() else {
+        return Ok(None);
+    };
+    f(PipHookEvent::SetInputPassthrough { passthrough: true })?;
+    Ok(Some(PipInputPassthroughGuard))
+}
+
 /// Upsert one exact-target frame. No-op when no backend is registered.
 pub fn push_pip_frame(frame: PipHookFrame) {
     if let Some(f) = PIP_EVENT_FN.get() {
-        f(PipHookEvent::Upsert(frame));
+        let _ = f(PipHookEvent::Upsert(frame));
     }
 }
 
 /// Remove one exact target card. Presentation only; never closes the target.
 pub fn remove_pip_target(workspace_id: impl Into<String>, identity_key: impl Into<String>) {
     if let Some(f) = PIP_EVENT_FN.get() {
-        f(PipHookEvent::RemoveTarget {
+        let _ = f(PipHookEvent::RemoveTarget {
             workspace_id: workspace_id.into(),
             identity_key: identity_key.into(),
         });
@@ -96,7 +124,7 @@ pub fn remove_pip_target(workspace_id: impl Into<String>, identity_key: impl Int
 /// workspace's native windows or browser tabs.
 pub fn remove_pip_workspace(workspace_id: impl Into<String>) {
     if let Some(f) = PIP_EVENT_FN.get() {
-        f(PipHookEvent::RemoveWorkspace {
+        let _ = f(PipHookEvent::RemoveWorkspace {
             workspace_id: workspace_id.into(),
         });
     }

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/pip_hook.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/pip_hook.rs
@@ -1,5 +1,5 @@
-//! PiP frame-push hook — registered once by `main.rs` when the
-//! `--experimental-pip` flag is on argv.
+//! Agent View event hook, registered once by `main.rs` when the legacy
+//! `--experimental-pip` compatibility flag is enabled.
 //!
 //! The trait + factory live in the `pip-preview` crate so the platform
 //! backends can implement them without depending on `cua-driver-core`.
@@ -19,31 +19,61 @@ use std::sync::OnceLock;
 /// to `pip_preview::PipFrame` — duplicated here to keep `cua-driver-core`
 /// from importing `pip-preview` (the dependency would be circular once
 /// platform backends pull both crates in).
+#[derive(Clone, Copy)]
+pub enum PipHookTargetKind {
+    NativeWindow,
+    BrowserTab,
+}
+
+pub struct PipHookTarget {
+    pub workspace_id: String,
+    pub workspace_label: String,
+    pub target_id: String,
+    pub target_kind: PipHookTargetKind,
+    pub target_label: String,
+}
+
 pub struct PipHookFrame {
+    pub target: PipHookTarget,
     pub png_bytes: Vec<u8>,
     pub action_label: String,
     pub timestamp_ms: u64,
 }
 
-type PipPushFnBox = Box<dyn Fn(PipHookFrame) + Send + Sync>;
-static PIP_PUSH_FN: OnceLock<PipPushFnBox> = OnceLock::new();
+pub enum PipHookEvent {
+    Upsert(PipHookFrame),
+    RemoveWorkspace { workspace_id: String },
+}
+
+type PipEventFnBox = Box<dyn Fn(PipHookEvent) + Send + Sync>;
+static PIP_EVENT_FN: OnceLock<PipEventFnBox> = OnceLock::new();
 
 /// Register the platform-side push callback. `main.rs` calls this
 /// once after starting the PiP backend.
-pub fn set_pip_push_fn(f: impl Fn(PipHookFrame) + Send + Sync + 'static) {
-    let _ = PIP_PUSH_FN.set(Box::new(f));
+pub fn set_pip_event_fn(f: impl Fn(PipHookEvent) + Send + Sync + 'static) {
+    let _ = PIP_EVENT_FN.set(Box::new(f));
 }
 
 /// True when a PiP backend is wired up. Tool dispatcher uses this to
 /// skip the screenshot-bytes path when nothing would consume the
 /// frame (avoiding wasted capture work in the common --pip-off case).
 pub fn pip_enabled() -> bool {
-    PIP_PUSH_FN.get().is_some()
+    PIP_EVENT_FN.get().is_some()
 }
 
-/// Push a frame to the PiP window. No-op when no backend is registered.
+/// Upsert one exact-target frame. No-op when no backend is registered.
 pub fn push_pip_frame(frame: PipHookFrame) {
-    if let Some(f) = PIP_PUSH_FN.get() {
-        f(frame);
+    if let Some(f) = PIP_EVENT_FN.get() {
+        f(PipHookEvent::Upsert(frame));
+    }
+}
+
+/// Remove presentation state for an ended workspace. This never closes the
+/// workspace's native windows or browser tabs.
+pub fn remove_pip_workspace(workspace_id: impl Into<String>) {
+    if let Some(f) = PIP_EVENT_FN.get() {
+        f(PipHookEvent::RemoveWorkspace {
+            workspace_id: workspace_id.into(),
+        });
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/pip_hook.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/pip_hook.rs
@@ -1,5 +1,5 @@
-//! Agent View event hook, registered once by `main.rs` when the legacy
-//! `--experimental-pip` compatibility flag is enabled.
+//! Agent View event hook, registered once by `main.rs` when `--agent-view`
+//! is enabled.
 //!
 //! The trait + factory live in the `pip-preview` crate so the platform
 //! backends can implement them without depending on `cua-driver-core`.
@@ -56,7 +56,7 @@ pub fn set_pip_event_fn(f: impl Fn(PipHookEvent) + Send + Sync + 'static) {
 
 /// True when a PiP backend is wired up. Tool dispatcher uses this to
 /// skip the screenshot-bytes path when nothing would consume the
-/// frame (avoiding wasted capture work in the common --pip-off case).
+/// frame (avoiding wasted capture work when Agent View is disabled).
 pub fn pip_enabled() -> bool {
     PIP_EVENT_FN.get().is_some()
 }

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/pip_hook.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/pip_hook.rs
@@ -29,8 +29,16 @@ pub struct PipHookTarget {
     pub workspace_id: String,
     pub workspace_label: String,
     pub target_id: String,
+    pub identity_key: String,
     pub target_kind: PipHookTargetKind,
     pub target_label: String,
+    pub native_container: Option<PipHookNativeContainer>,
+}
+
+#[derive(Clone, Copy)]
+pub struct PipHookNativeContainer {
+    pub pid: i64,
+    pub window_id: u64,
 }
 
 pub struct PipHookFrame {
@@ -42,7 +50,13 @@ pub struct PipHookFrame {
 
 pub enum PipHookEvent {
     Upsert(PipHookFrame),
-    RemoveWorkspace { workspace_id: String },
+    RemoveTarget {
+        workspace_id: String,
+        identity_key: String,
+    },
+    RemoveWorkspace {
+        workspace_id: String,
+    },
 }
 
 type PipEventFnBox = Box<dyn Fn(PipHookEvent) + Send + Sync>;
@@ -65,6 +79,16 @@ pub fn pip_enabled() -> bool {
 pub fn push_pip_frame(frame: PipHookFrame) {
     if let Some(f) = PIP_EVENT_FN.get() {
         f(PipHookEvent::Upsert(frame));
+    }
+}
+
+/// Remove one exact target card. Presentation only; never closes the target.
+pub fn remove_pip_target(workspace_id: impl Into<String>, identity_key: impl Into<String>) {
+    if let Some(f) = PIP_EVENT_FN.get() {
+        f(PipHookEvent::RemoveTarget {
+            workspace_id: workspace_id.into(),
+            identity_key: identity_key.into(),
+        });
     }
 }
 

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/pip_hook.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/pip_hook.rs
@@ -46,6 +46,7 @@ pub struct PipHookFrame {
     pub png_bytes: Vec<u8>,
     pub action_label: String,
     pub timestamp_ms: u64,
+    pub cursor_position: Option<(f64, f64)>,
 }
 
 pub enum PipHookEvent {

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/recording.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/recording.rs
@@ -646,7 +646,7 @@ fn capture_turn(window_id: Option<u64>, pid: Option<i64>) -> TurnCapture {
     }
 }
 
-fn resolve_click_point(
+pub(crate) fn resolve_click_point(
     tool_name: &str,
     args: &Value,
     window_id: Option<u64>,

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -1658,6 +1658,17 @@ impl ToolRegistry {
         // so a user can inspect several targets before any mutation occurs.
         if pip_hook::pip_enabled()
             && !private_consent_turn
+            && result.is_error == Some(true)
+            && pip_result_proves_target_absent(&result)
+        {
+            if let (Some(workspace_id), Some(target)) =
+                (runtime_session.as_deref(), pip_capture_target(&args))
+            {
+                pip_hook::remove_pip_target(workspace_id, pip_target_public_key(&target));
+            }
+        }
+        if pip_hook::pip_enabled()
+            && !private_consent_turn
             && (should_record || is_exact_visual_snapshot(name, &args))
         {
             if let Some(frame) = self
@@ -1667,14 +1678,6 @@ impl ToolRegistry {
                 pip_hook::push_pip_frame(frame);
             }
         }
-        if pip_hook::pip_enabled()
-            && result.is_error != Some(true)
-            && name == "end_session"
-            && runtime_session.is_some()
-        {
-            pip_hook::remove_pip_workspace(runtime_session.as_deref().unwrap_or_default());
-        }
-
         result
     }
 
@@ -1697,10 +1700,27 @@ impl ToolRegistry {
                 .get("session")
                 .and_then(Value::as_str)
                 .or(runtime_session)?;
-            let preview = engine
+            let preview = match engine
                 .capture_tab_preview(browser_session, &target_id, &tab_id)
                 .await
-                .ok()?;
+            {
+                Ok(preview) => preview,
+                Err(error)
+                    if matches!(
+                        error.code,
+                        crate::browser::refusal::BrowserRefusalCode::BrowserTabNotFound
+                            | crate::browser::refusal::BrowserRefusalCode::BrowserBindingStale
+                            | crate::browser::refusal::BrowserRefusalCode::BrowserWrongTargetRefused
+                    ) =>
+                {
+                    pip_hook::remove_pip_target(
+                        &workspace_id,
+                        format!("browser:{target_id}:{tab_id}"),
+                    );
+                    return None;
+                }
+                Err(_) => return None,
+            };
             let png_bytes = BASE64.decode(preview.screenshot.data_base64).ok()?;
             let target_label = if preview.title.trim().is_empty() {
                 preview.url
@@ -1712,8 +1732,13 @@ impl ToolRegistry {
                     workspace_id,
                     workspace_label,
                     target_id: format!("browser:{target_id}:{tab_id}"),
+                    identity_key: format!("browser-cdp:{}", preview.cdp_target_id),
                     target_kind: pip_hook::PipHookTargetKind::BrowserTab,
                     target_label,
+                    native_container: Some(pip_hook::PipHookNativeContainer {
+                        pid: preview.pid,
+                        window_id: preview.window_id,
+                    }),
                 },
                 png_bytes,
                 action_label,
@@ -1730,8 +1755,10 @@ impl ToolRegistry {
                 workspace_id,
                 workspace_label,
                 target_id: format!("window:{pid}:{window_id}"),
+                identity_key: format!("window:{pid}:{window_id}"),
                 target_kind: pip_hook::PipHookTargetKind::NativeWindow,
                 target_label: format!("Window {window_id}"),
+                native_container: Some(pip_hook::PipHookNativeContainer { pid, window_id }),
             },
             png_bytes,
             action_label,
@@ -4824,6 +4851,33 @@ fn pip_capture_target(args: &Value) -> Option<PipCaptureTarget> {
     })
 }
 
+fn pip_target_public_key(target: &PipCaptureTarget) -> String {
+    match target {
+        PipCaptureTarget::NativeWindow { pid, window_id } => format!("window:{pid}:{window_id}"),
+        PipCaptureTarget::Browser { target_id, tab_id } => {
+            format!("browser:{target_id}:{tab_id}")
+        }
+    }
+}
+
+fn pip_result_proves_target_absent(result: &ToolResult) -> bool {
+    let code = result
+        .structured_content
+        .as_ref()
+        .and_then(|payload| payload.get("code"))
+        .and_then(Value::as_str);
+    matches!(
+        code,
+        Some(
+            "window_target_not_found"
+                | "window_not_found"
+                | "browser_tab_not_found"
+                | "browser_binding_stale"
+                | "browser_wrong_target_refused"
+        )
+    )
+}
+
 fn is_exact_visual_snapshot(tool_name: &str, args: &Value) -> bool {
     matches!(
         (tool_name, pip_capture_target(args)),
@@ -4971,6 +5025,26 @@ mod pip_routing_tests {
             pip_workspace_label(&serde_json::json!({}), "__cua_runtime_x:agent-123456"),
             "Agent 123456"
         );
+    }
+
+    #[test]
+    fn proven_absent_results_remove_only_the_exact_public_target() {
+        let absent = ToolResult::error("gone").with_structured(serde_json::json!({
+            "code": "window_target_not_found"
+        }));
+        assert!(pip_result_proves_target_absent(&absent));
+        assert_eq!(
+            pip_target_public_key(&PipCaptureTarget::NativeWindow {
+                pid: 42,
+                window_id: 7,
+            }),
+            "window:42:7"
+        );
+
+        let permission = ToolResult::error("denied").with_structured(serde_json::json!({
+            "code": "permission_denied"
+        }));
+        assert!(!pip_result_proves_target_absent(&permission));
     }
 }
 

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -1735,6 +1735,7 @@ impl ToolRegistry {
                 Err(_) => return None,
             };
             let png_bytes = BASE64.decode(preview.screenshot.data_base64).ok()?;
+            let cursor_position = pip_cursor_position(tool_name, args, &png_bytes, None, None);
             let target_label = if preview.title.trim().is_empty() {
                 preview.url
             } else {
@@ -1756,6 +1757,7 @@ impl ToolRegistry {
                 png_bytes,
                 action_label,
                 timestamp_ms,
+                cursor_position,
             });
         }
 
@@ -1763,6 +1765,8 @@ impl ToolRegistry {
             return None;
         };
         let png_bytes = screenshot_for(Some(window_id), Some(pid))?;
+        let cursor_position =
+            pip_cursor_position(tool_name, args, &png_bytes, Some(window_id), Some(pid));
         Some(pip_hook::PipHookFrame {
             target: pip_hook::PipHookTarget {
                 workspace_id,
@@ -1776,6 +1780,7 @@ impl ToolRegistry {
             png_bytes,
             action_label,
             timestamp_ms,
+            cursor_position,
         })
     }
 
@@ -4873,6 +4878,57 @@ fn pip_target_public_key(target: &PipCaptureTarget) -> String {
     }
 }
 
+fn pip_cursor_position(
+    tool_name: &str,
+    args: &Value,
+    png_bytes: &[u8],
+    window_id: Option<u64>,
+    pid: Option<i64>,
+) -> Option<(f64, f64)> {
+    use crate::tool_args::ArgsExt;
+
+    let point = if tool_name == "drag" || tool_name == "browser_drag" {
+        Some((args.opt_f64("to_x")?, args.opt_f64("to_y")?))
+    } else if matches!(
+        tool_name,
+        "click"
+            | "double_click"
+            | "right_click"
+            | "move_cursor"
+            | "browser_click"
+            | "browser_double_click"
+            | "browser_right_click"
+    ) {
+        match (args.opt_f64("x"), args.opt_f64("y")) {
+            (Some(x), Some(y)) => Some((x, y)),
+            _ => crate::recording::resolve_click_point(
+                tool_name,
+                args,
+                window_id,
+                pid,
+                args.opt_u64("element_index"),
+            ),
+        }
+    } else {
+        None
+    }?;
+    let (width, height) = pip_png_dimensions(png_bytes)?;
+    Some((
+        (point.0 / width).clamp(0.0, 1.0),
+        (point.1 / height).clamp(0.0, 1.0),
+    ))
+}
+
+fn pip_png_dimensions(bytes: &[u8]) -> Option<(f64, f64)> {
+    const PNG_SIGNATURE: &[u8; 8] = b"\x89PNG\r\n\x1a\n";
+    if bytes.len() < 24 || &bytes[..8] != PNG_SIGNATURE || &bytes[12..16] != b"IHDR" {
+        return None;
+    }
+    let width = u32::from_be_bytes(bytes[16..20].try_into().ok()?) as f64;
+    let height = u32::from_be_bytes(bytes[20..24].try_into().ok()?) as f64;
+    (width > 0.0 && height > 0.0).then_some((width, height))
+}
+
 fn pip_result_proves_target_absent(result: &ToolResult) -> bool {
     let code = result
         .structured_content
@@ -4978,6 +5034,47 @@ fn synthesize_action_label(tool_name: &str, args: &Value) -> String {
 #[cfg(test)]
 mod pip_routing_tests {
     use super::*;
+
+    fn png_header(width: u32, height: u32) -> Vec<u8> {
+        let mut bytes = b"\x89PNG\r\n\x1a\n\0\0\0\rIHDR".to_vec();
+        bytes.extend_from_slice(&width.to_be_bytes());
+        bytes.extend_from_slice(&height.to_be_bytes());
+        bytes
+    }
+
+    #[test]
+    fn pointer_coordinates_are_normalized_to_the_captured_target() {
+        assert_eq!(
+            pip_cursor_position(
+                "click",
+                &serde_json::json!({"x": 50, "y": 25}),
+                &png_header(200, 100),
+                None,
+                None,
+            ),
+            Some((0.25, 0.25))
+        );
+        assert_eq!(
+            pip_cursor_position(
+                "drag",
+                &serde_json::json!({"to_x": 180, "to_y": 90}),
+                &png_header(200, 100),
+                None,
+                None,
+            ),
+            Some((0.9, 0.9))
+        );
+        assert_eq!(
+            pip_cursor_position(
+                "type_text",
+                &serde_json::json!({"x": 50, "y": 25}),
+                &png_header(200, 100),
+                None,
+                None,
+            ),
+            None
+        );
+    }
 
     #[test]
     fn browser_tab_identity_wins_over_its_native_container_window() {

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use serde_json::Value;
 
 thread_local! {
@@ -640,6 +641,7 @@ pub struct ToolRegistry {
     approval_broker: Arc<crate::consent::ApprovalBroker>,
     protected_resource_grants: Arc<crate::consent::ProtectedResourceGrants>,
     protected_resource_ownership: Arc<crate::consent::ProtectedResourceOwnershipStore>,
+    browser_engine: Option<Arc<crate::browser::BrowserEngine>>,
 }
 
 impl ToolRegistry {
@@ -703,6 +705,7 @@ impl ToolRegistry {
             approval_broker,
             protected_resource_grants,
             protected_resource_ownership,
+            browser_engine: None,
         }
     }
 
@@ -788,6 +791,10 @@ impl ToolRegistry {
         let name = tool.def().name.clone();
         self.order.push(name.clone());
         self.tools.insert(name, tool);
+    }
+
+    pub(crate) fn set_browser_engine(&mut self, engine: Arc<crate::browser::BrowserEngine>) {
+        self.browser_engine = Some(engine);
     }
 
     pub fn retain_session_end_hook(
@@ -1646,26 +1653,90 @@ impl ToolRegistry {
             );
         }
 
-        // Experimental PiP push — only when --experimental-pip is on argv
-        // (otherwise `pip_enabled()` is false and we skip the screenshot
-        // entirely to avoid wasted capture work). We push for the same set
-        // of action tools the recording pipeline cares about (non-read-only,
-        // not the recording-control meta-tools) so the live view matches
-        // what the recorder would have captured for the turn.
-        if pip_hook::pip_enabled() && should_record && !private_consent_turn {
-            let window_id = args.opt_u64("window_id");
-            let pid = args.opt_i64("pid");
-            if let Some(png_bytes) = screenshot_for(window_id, pid) {
-                let label = synthesize_action_label(name, &public_args);
-                pip_hook::push_pip_frame(pip_hook::PipHookFrame {
-                    png_bytes,
-                    action_label: label,
-                    timestamp_ms: now_ms(),
-                });
+        // Agent View keeps one latest frame per exact native window or browser
+        // tab. Exact read-side snapshots seed cards as well as action tools,
+        // so a user can inspect several targets before any mutation occurs.
+        if pip_hook::pip_enabled()
+            && !private_consent_turn
+            && (should_record || is_exact_visual_snapshot(name, &args))
+        {
+            if let Some(frame) = self
+                .capture_pip_frame(name, &args, &public_args, runtime_session.as_deref())
+                .await
+            {
+                pip_hook::push_pip_frame(frame);
             }
+        }
+        if pip_hook::pip_enabled()
+            && result.is_error != Some(true)
+            && name == "end_session"
+            && runtime_session.is_some()
+        {
+            pip_hook::remove_pip_workspace(runtime_session.as_deref().unwrap_or_default());
         }
 
         result
+    }
+
+    async fn capture_pip_frame(
+        &self,
+        tool_name: &str,
+        args: &Value,
+        public_args: &Value,
+        runtime_session: Option<&str>,
+    ) -> Option<pip_hook::PipHookFrame> {
+        let workspace_id = runtime_session?.to_owned();
+        let workspace_label = pip_workspace_label(public_args, runtime_session?);
+        let action_label = synthesize_action_label(tool_name, public_args);
+        let timestamp_ms = now_ms();
+
+        if let (PipCaptureTarget::Browser { target_id, tab_id }, Some(engine)) =
+            (pip_capture_target(args)?, self.browser_engine.as_ref())
+        {
+            let browser_session = args
+                .get("session")
+                .and_then(Value::as_str)
+                .or(runtime_session)?;
+            let preview = engine
+                .capture_tab_preview(browser_session, &target_id, &tab_id)
+                .await
+                .ok()?;
+            let png_bytes = BASE64.decode(preview.screenshot.data_base64).ok()?;
+            let target_label = if preview.title.trim().is_empty() {
+                preview.url
+            } else {
+                preview.title
+            };
+            return Some(pip_hook::PipHookFrame {
+                target: pip_hook::PipHookTarget {
+                    workspace_id,
+                    workspace_label,
+                    target_id: format!("browser:{target_id}:{tab_id}"),
+                    target_kind: pip_hook::PipHookTargetKind::BrowserTab,
+                    target_label,
+                },
+                png_bytes,
+                action_label,
+                timestamp_ms,
+            });
+        }
+
+        let PipCaptureTarget::NativeWindow { pid, window_id } = pip_capture_target(args)? else {
+            return None;
+        };
+        let png_bytes = screenshot_for(Some(window_id), Some(pid))?;
+        Some(pip_hook::PipHookFrame {
+            target: pip_hook::PipHookTarget {
+                workspace_id,
+                workspace_label,
+                target_id: format!("window:{pid}:{window_id}"),
+                target_kind: pip_hook::PipHookTargetKind::NativeWindow,
+                target_label: format!("Window {window_id}"),
+            },
+            png_bytes,
+            action_label,
+            timestamp_ms,
+        })
     }
 
     async fn authorize_private_observation(
@@ -4731,7 +4802,66 @@ impl Default for ToolRegistry {
     }
 }
 
-/// Build a short, human-friendly label for the PiP overlay from the
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PipCaptureTarget {
+    NativeWindow { pid: i64, window_id: u64 },
+    Browser { target_id: String, tab_id: String },
+}
+
+fn pip_capture_target(args: &Value) -> Option<PipCaptureTarget> {
+    if let (Some(target_id), Some(tab_id)) = (
+        args.get("target_id").and_then(Value::as_str),
+        args.get("tab_id").and_then(Value::as_str),
+    ) {
+        return Some(PipCaptureTarget::Browser {
+            target_id: target_id.to_owned(),
+            tab_id: tab_id.to_owned(),
+        });
+    }
+    Some(PipCaptureTarget::NativeWindow {
+        pid: args.opt_i64("pid")?,
+        window_id: args.opt_u64("window_id")?,
+    })
+}
+
+fn is_exact_visual_snapshot(tool_name: &str, args: &Value) -> bool {
+    matches!(
+        (tool_name, pip_capture_target(args)),
+        (
+            "get_window_state",
+            Some(PipCaptureTarget::NativeWindow { .. })
+        ) | ("get_browser_state", Some(PipCaptureTarget::Browser { .. }))
+    )
+}
+
+fn pip_workspace_label(public_args: &Value, runtime_session: &str) -> String {
+    if let Some(label) = public_args
+        .get("session")
+        .and_then(Value::as_str)
+        .filter(|label| !label.is_empty() && *label != "default")
+    {
+        return label.to_owned();
+    }
+    let suffix = runtime_session
+        .rsplit(':')
+        .next()
+        .unwrap_or(runtime_session)
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .rev()
+        .take(6)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect::<String>();
+    if suffix.is_empty() {
+        "Agent".to_owned()
+    } else {
+        format!("Agent {suffix}")
+    }
+}
+
+/// Build a short, human-friendly label for the Agent View from the
 /// tool name + raw args. Kept under ~60 chars so the macOS NSTextField
 /// has room without truncation at default geometry.
 fn synthesize_action_label(tool_name: &str, args: &Value) -> String {
@@ -4775,6 +4905,72 @@ fn synthesize_action_label(tool_name: &str, args: &Value) -> String {
         tool_name.to_owned()
     } else {
         format!("{tool_name}: {summary}")
+    }
+}
+
+#[cfg(test)]
+mod pip_routing_tests {
+    use super::*;
+
+    #[test]
+    fn browser_tab_identity_wins_over_its_native_container_window() {
+        let target = pip_capture_target(&serde_json::json!({
+            "pid": 42,
+            "window_id": 7,
+            "target_id": "bt-one",
+            "tab_id": "tab-two",
+        }));
+        assert_eq!(
+            target,
+            Some(PipCaptureTarget::Browser {
+                target_id: "bt-one".to_owned(),
+                tab_id: "tab-two".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn native_window_identity_requires_the_exact_pair() {
+        assert_eq!(
+            pip_capture_target(&serde_json::json!({"pid": 42, "window_id": 7})),
+            Some(PipCaptureTarget::NativeWindow {
+                pid: 42,
+                window_id: 7,
+            })
+        );
+        assert!(pip_capture_target(&serde_json::json!({"pid": 42})).is_none());
+        assert!(pip_capture_target(&serde_json::json!({"window_id": 7})).is_none());
+    }
+
+    #[test]
+    fn only_exact_state_reads_seed_agent_view_cards() {
+        assert!(is_exact_visual_snapshot(
+            "get_window_state",
+            &serde_json::json!({"pid": 42, "window_id": 7})
+        ));
+        assert!(is_exact_visual_snapshot(
+            "get_browser_state",
+            &serde_json::json!({"target_id": "bt-one", "tab_id": "tab-two"})
+        ));
+        assert!(!is_exact_visual_snapshot(
+            "get_browser_state",
+            &serde_json::json!({"pid": 42, "window_id": 7})
+        ));
+    }
+
+    #[test]
+    fn public_session_label_is_preferred_for_presentation() {
+        assert_eq!(
+            pip_workspace_label(
+                &serde_json::json!({"session": "research"}),
+                "__cua_runtime_x:private"
+            ),
+            "research"
+        );
+        assert_eq!(
+            pip_workspace_label(&serde_json::json!({}), "__cua_runtime_x:agent-123456"),
+            "Agent 123456"
+        );
     }
 }
 

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -1517,6 +1517,18 @@ impl ToolRegistry {
         } else {
             None
         };
+        let pip_input_passthrough = if _desktop_action.is_some() {
+            match pip_hook::begin_pip_input_passthrough() {
+                Ok(guard) => guard,
+                Err(error) => {
+                    return ToolResult::error(format!(
+                        "Agent View could not yield pointer input before {resolved_name}: {error}"
+                    ));
+                }
+            }
+        } else {
+            None
+        };
         let pending_turn = should_record
             .then(|| {
                 if private_consent_turn {
@@ -1530,6 +1542,7 @@ impl ToolRegistry {
             .flatten();
 
         let mut result = tool.invoke(args.clone()).await;
+        drop(pip_input_passthrough);
         drop(lifecycle_dispatch);
         // The platform worker has exited, so another text operation for this
         // pid may now start even while result projection and evidence capture

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -3136,7 +3136,7 @@ mod runtime_isolation_tests {
                     "key": {"type": "string"},
                     "value": {},
                     "max_image_dimension": {"type": "integer"},
-                    "experimental_pip": {"type": "boolean"}
+                    "agent_view": {"type": "boolean"}
                 },
                 "additionalProperties": false
             })

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -641,14 +641,22 @@ pub fn parse_command() -> Command {
         );
         println!("  cua-driver history enable   Opt in and initialize encrypted local history.");
         println!("  cua-driver history status|pause|resume|flush|list|show|disable|delete");
+        println!("  --agent-view                Show an always-on-top miniature desktop for the");
+        println!("                              selected agent session. Exact native windows and");
         println!(
-            "  --agent-view                Show the always-on-top Agent View with one card per"
+            "                              Chrome tabs traversed through Cua Driver become cards."
         );
         println!(
-            "                              exact native window or Chrome tab. Existing sessions"
+            "                              Recent activity is followed until you locally select"
         );
         println!(
-            "                              group the cards; no claim/release API is involved."
+            "                              another session in Agent View; sessions never mix."
+        );
+        println!(
+            "                              Closed targets and ended sessions are removed. This is"
+        );
+        println!(
+            "                              presentation only; no claim/release API is involved."
         );
         println!(
             "                              Native presentation is available on macOS, Windows,"

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -230,10 +230,10 @@ const VALUE_FLAGS: &[&str] = &[
     "--session",
     "--profile-mode",
     "--profile-name",
-    // Experimental Agent View (legacy PiP flag) — value flag for geometry
-    // override (--experimental-pip itself is a bare flag and doesn't
+    // Experimental Agent View value flag for geometry override
+    // (`--agent-view` itself is a bare flag and doesn't
     // need to be listed here).
-    "--experimental-pip-geometry",
+    "--agent-view-geometry",
 ];
 
 /// Authorization selectors are trusted-daemon startup inputs. Direct MCP
@@ -642,7 +642,7 @@ pub fn parse_command() -> Command {
         println!("  cua-driver history enable   Opt in and initialize encrypted local history.");
         println!("  cua-driver history status|pause|resume|flush|list|show|disable|delete");
         println!(
-            "  --experimental-pip          Show the always-on-top Agent View with one card per"
+            "  --agent-view                Show the always-on-top Agent View with one card per"
         );
         println!(
             "                              exact native window or Chrome tab. Existing sessions"
@@ -651,9 +651,7 @@ pub fn parse_command() -> Command {
             "                              group the cards; no claim/release API is involved."
         );
         println!("                              macOS only today; Win/Linux print a notice.");
-        println!(
-            "  --experimental-pip-geometry WxH[+X+Y]   Override window size (and optional top-left"
-        );
+        println!("  --agent-view-geometry WxH[+X+Y]   Override window size (and optional top-left");
         println!("                                          origin). Defaults to 320x200 in the top-right");
         println!("                                          corner of the main display.");
         std::process::exit(0);

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -632,7 +632,7 @@ pub fn parse_command() -> Command {
         println!("doctor options:");
         println!("  --json                  Emit the probe report as JSON for scripting.");
         println!();
-        println!("experimental options (default: off):");
+        println!("experimental options:");
         println!(
             "  --experimental-history      Admit encrypted local Computer History for this daemon."
         );
@@ -641,8 +641,8 @@ pub fn parse_command() -> Command {
         );
         println!("  cua-driver history enable   Opt in and initialize encrypted local history.");
         println!("  cua-driver history status|pause|resume|flush|list|show|disable|delete");
-        println!("  --agent-view                Show an always-on-top miniature desktop for the");
-        println!("                              selected agent session. Exact native windows and");
+        println!("  --agent-view                Show the Agent View (enabled by default).");
+        println!("                              Exact native windows and");
         println!(
             "                              Chrome tabs traversed through Cua Driver become cards."
         );
@@ -662,6 +662,7 @@ pub fn parse_command() -> Command {
             "                              Native presentation is available on macOS, Windows,"
         );
         println!("                              and Linux (X11/XWayland).");
+        println!("  --no-agent-view             Disable Agent View for this daemon invocation.");
         println!("  --agent-view-geometry WxH[+X+Y]   Override window size (and optional top-left");
         println!("                                          origin). Defaults to 640x420 in the top-right");
         println!("                                          corner of the main display.");

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -230,7 +230,7 @@ const VALUE_FLAGS: &[&str] = &[
     "--session",
     "--profile-mode",
     "--profile-name",
-    // Experimental PiP preview — value flag for the optional geometry
+    // Experimental Agent View (legacy PiP flag) — value flag for geometry
     // override (--experimental-pip itself is a bare flag and doesn't
     // need to be listed here).
     "--experimental-pip-geometry",
@@ -641,17 +641,20 @@ pub fn parse_command() -> Command {
         );
         println!("  cua-driver history enable   Opt in and initialize encrypted local history.");
         println!("  cua-driver history status|pause|resume|flush|list|show|disable|delete");
-        println!("  --experimental-pip          Show a small always-on-top window with the latest");
         println!(
-            "                              post-action screenshot + a 1-line label. macOS only"
+            "  --experimental-pip          Show the always-on-top Agent View with one card per"
         );
         println!(
-            "                              today; Win/Linux print a not-yet-implemented notice."
+            "                              exact native window or Chrome tab. Existing sessions"
         );
+        println!(
+            "                              group the cards; no claim/release API is involved."
+        );
+        println!("                              macOS only today; Win/Linux print a notice.");
         println!(
             "  --experimental-pip-geometry WxH[+X+Y]   Override window size (and optional top-left"
         );
-        println!("                                          origin). Defaults to 480x360 in the top-right");
+        println!("                                          origin). Defaults to 320x200 in the top-right");
         println!("                                          corner of the main display.");
         std::process::exit(0);
     }

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -230,7 +230,7 @@ const VALUE_FLAGS: &[&str] = &[
     "--session",
     "--profile-mode",
     "--profile-name",
-    // Experimental Agent View value flag for geometry override
+    // Agent View value flag for the optional geometry override
     // (`--agent-view` itself is a bare flag and doesn't
     // need to be listed here).
     "--agent-view-geometry",

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -652,7 +652,7 @@ pub fn parse_command() -> Command {
         );
         println!("                              macOS only today; Win/Linux print a notice.");
         println!("  --agent-view-geometry WxH[+X+Y]   Override window size (and optional top-left");
-        println!("                                          origin). Defaults to 320x200 in the top-right");
+        println!("                                          origin). Defaults to 640x420 in the top-right");
         println!("                                          corner of the main display.");
         std::process::exit(0);
     }

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -650,7 +650,10 @@ pub fn parse_command() -> Command {
         println!(
             "                              group the cards; no claim/release API is involved."
         );
-        println!("                              macOS only today; Win/Linux print a notice.");
+        println!(
+            "                              Native presentation is available on macOS, Windows,"
+        );
+        println!("                              and Linux (X11/XWayland).");
         println!("  --agent-view-geometry WxH[+X+Y]   Override window size (and optional top-left");
         println!("                                          origin). Defaults to 640x420 in the top-right");
         println!("                                          corner of the main display.");

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -285,6 +285,13 @@ fn maybe_init_pip() {
                                     timestamp_ms: frame.timestamp_ms,
                                 });
                             }
+                            cua_driver_core::pip_hook::PipHookEvent::SetInputPassthrough {
+                                passthrough,
+                            } => {
+                                return b
+                                    .set_input_passthrough(passthrough)
+                                    .map_err(|error| error.to_string());
+                            }
                             cua_driver_core::pip_hook::PipHookEvent::RemoveWorkspace {
                                 workspace_id,
                             } => b.remove_workspace(&workspace_id),
@@ -295,6 +302,7 @@ fn maybe_init_pip() {
                         }
                     }
                 }
+                Ok(())
             });
             cua_driver_core::session::register_session_end_hook(|workspace_id| {
                 cua_driver_core::pip_hook::remove_pip_workspace(workspace_id);

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -215,7 +215,7 @@ fn run_cursor_theme_command(args: &[String]) -> ! {
     std::process::exit(status.code().unwrap_or(1));
 }
 
-/// Wire up the experimental multi-target Agent View.
+/// Wire up the multi-target Agent View.
 ///
 /// Called from every long-running entry point (Serve and Mcp on all
 /// platforms; the `Call` arm intentionally skips PiP since the

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -388,6 +388,28 @@ fn history_admission_requested(explicit: bool, persisted: bool) -> bool {
     explicit || persisted
 }
 
+#[cfg(target_os = "macos")]
+#[derive(Debug, PartialEq, Eq)]
+enum MacosMainLoopHost {
+    CursorOverlay,
+    AgentView,
+    ServeThread,
+}
+
+#[cfg(target_os = "macos")]
+fn macos_main_loop_host(cursor_enabled: bool, agent_view_enabled: bool) -> MacosMainLoopHost {
+    if cursor_enabled {
+        // The cursor host also owns NSApplication's main run loop. Agent View
+        // posts its window updates to that same queue, so both surfaces can
+        // coexist without leaving cursor animations waiting forever.
+        MacosMainLoopHost::CursorOverlay
+    } else if agent_view_enabled {
+        MacosMainLoopHost::AgentView
+    } else {
+        MacosMainLoopHost::ServeThread
+    }
+}
+
 #[cfg(test)]
 mod history_admission_tests {
     use super::history_admission_requested;
@@ -402,6 +424,31 @@ mod history_admission_tests {
         assert!(!history_admission_requested(false, false));
         assert!(history_admission_requested(true, false));
         assert!(history_admission_requested(true, true));
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod macos_main_loop_host_tests {
+    use super::{macos_main_loop_host, MacosMainLoopHost};
+
+    #[test]
+    fn cursor_overlay_hosts_the_shared_appkit_loop_when_agent_view_is_enabled() {
+        assert_eq!(
+            macos_main_loop_host(true, true),
+            MacosMainLoopHost::CursorOverlay
+        );
+    }
+
+    #[test]
+    fn agent_view_hosts_appkit_only_when_the_cursor_is_disabled() {
+        assert_eq!(
+            macos_main_loop_host(false, true),
+            MacosMainLoopHost::AgentView
+        );
+        assert_eq!(
+            macos_main_loop_host(false, false),
+            MacosMainLoopHost::ServeThread
+        );
     }
 }
 
@@ -729,24 +776,24 @@ fn main() {
 
             // Keep the main thread alive for the daemon.
             //
-            // Agent View needs the AppKit main run loop to process the
-            // dispatch_async_f calls that push frames into NSImageView;
-            // park main in NSApplication.run() when --agent-view is
-            // on. Otherwise just join the serve thread so the process
-            // stays up as long as the daemon does.
-            if pip_cfg.enabled {
-                platform_macos::pip::run_appkit_main_loop();
-            } else if cursor_cfg.enabled {
-                // Render the agent-cursor overlay: park the main thread in the
-                // AppKit run loop so the overlay NSWindow draws. `run_on_main_thread`
-                // self-guards on `has_graphic_access()` and returns immediately
-                // when the daemon has no Window Server session — fall through to
-                // join so the daemon still serves headless. The serve thread runs
-                // on its background thread regardless.
-                platform_macos::cursor::overlay::run_on_main_thread();
-                let _ = serve_handle.join();
-            } else {
-                let _ = serve_handle.join();
+            // Cursor and Agent View share one AppKit application/main queue.
+            // When both are enabled, the cursor host must drain its command
+            // receiver as well as NSApplication events; the Agent View-only
+            // loop would leave cursor-bearing actions waiting indefinitely.
+            match macos_main_loop_host(cursor_cfg.enabled, pip_cfg.enabled) {
+                MacosMainLoopHost::CursorOverlay => {
+                    // `run_on_main_thread` self-guards on graphic-session
+                    // access. If it returns, keep the daemon alive by joining
+                    // the serve thread.
+                    platform_macos::cursor::overlay::run_on_main_thread();
+                    let _ = serve_handle.join();
+                }
+                MacosMainLoopHost::AgentView => {
+                    platform_macos::pip::run_appkit_main_loop();
+                }
+                MacosMainLoopHost::ServeThread => {
+                    let _ = serve_handle.join();
+                }
             }
         }
         cli::Command::Stop { socket } => {

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -222,7 +222,6 @@ fn run_cursor_theme_command(args: &[String]) -> ! {
 /// per-call binaries don't keep an AppKit/event loop alive long
 /// enough to be useful).
 ///
-/// The legacy `--experimental-pip` flag remains the compatibility switch.
 /// On Windows / Linux
 /// the factory returns "not yet implemented" — we log and continue
 /// without a window so the rest of the daemon keeps working.
@@ -290,8 +289,7 @@ fn maybe_init_pip() {
                 }
             });
             eprintln!(
-                "⚗️  Agent View enabled via experimental PiP compatibility flag \
-                 (macOS only today; \
+                "⚗️  Agent View enabled (macOS only today; \
                  see https://github.com/trycua/cua/issues for follow-up)"
             );
         }
@@ -731,9 +729,9 @@ fn main() {
 
             // Keep the main thread alive for the daemon.
             //
-            // PiP needs the AppKit main run loop to process the
+            // Agent View needs the AppKit main run loop to process the
             // dispatch_async_f calls that push frames into NSImageView;
-            // park main in NSApplication.run() when --experimental-pip is
+            // park main in NSApplication.run() when --agent-view is
             // on. Otherwise just join the serve thread so the process
             // stays up as long as the daemon does.
             if pip_cfg.enabled {

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -222,9 +222,6 @@ fn run_cursor_theme_command(args: &[String]) -> ! {
 /// per-call binaries don't keep an AppKit/event loop alive long
 /// enough to be useful).
 ///
-/// On Windows / Linux
-/// the factory returns "not yet implemented" — we log and continue
-/// without a window so the rest of the daemon keeps working.
 fn maybe_init_pip() {
     let cfg = match pip_preview::default_config_path() {
         Some(p) => pip_preview::PipConfig::from_args_and_file(&p),
@@ -288,10 +285,7 @@ fn maybe_init_pip() {
                     }
                 }
             });
-            eprintln!(
-                "⚗️  Agent View enabled (macOS only today; \
-                 see https://github.com/trycua/cua/issues for follow-up)"
-            );
+            eprintln!("⚗️  Agent View enabled (native macOS, Windows, and Linux presentation)");
         }
         Err(e) => {
             eprintln!("⚗️  Agent View requested but unavailable: {e}");

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -215,14 +215,15 @@ fn run_cursor_theme_command(args: &[String]) -> ! {
     std::process::exit(status.code().unwrap_or(1));
 }
 
-/// Wire up the experimental picture-in-picture preview window.
+/// Wire up the experimental multi-target Agent View.
 ///
 /// Called from every long-running entry point (Serve and Mcp on all
 /// platforms; the `Call` arm intentionally skips PiP since the
 /// per-call binaries don't keep an AppKit/event loop alive long
 /// enough to be useful).
 ///
-/// No-op when `--experimental-pip` is not on argv. On Windows / Linux
+/// The legacy `--experimental-pip` flag remains the compatibility switch.
+/// On Windows / Linux
 /// the factory returns "not yet implemented" — we log and continue
 /// without a window so the rest of the daemon keeps working.
 fn maybe_init_pip() {
@@ -255,24 +256,47 @@ fn maybe_init_pip() {
                 StdMutex<Option<Box<dyn pip_preview::PipBackend>>>,
             > = std::sync::OnceLock::new();
             let _ = BACKEND.set(StdMutex::new(Some(backend)));
-            cua_driver_core::pip_hook::set_pip_push_fn(|frame| {
+            cua_driver_core::pip_hook::set_pip_event_fn(|event| {
                 if let Some(slot) = BACKEND.get() {
                     if let Some(b) = slot.lock().unwrap().as_ref() {
-                        b.push_frame(pip_preview::PipFrame {
-                            png_bytes: frame.png_bytes,
-                            action_label: frame.action_label,
-                            timestamp_ms: frame.timestamp_ms,
-                        });
+                        match event {
+                            cua_driver_core::pip_hook::PipHookEvent::Upsert(frame) => {
+                                let target_kind = match frame.target.target_kind {
+                                    cua_driver_core::pip_hook::PipHookTargetKind::NativeWindow => {
+                                        pip_preview::PipTargetKind::NativeWindow
+                                    }
+                                    cua_driver_core::pip_hook::PipHookTargetKind::BrowserTab => {
+                                        pip_preview::PipTargetKind::BrowserTab
+                                    }
+                                };
+                                b.push_frame(pip_preview::PipFrame {
+                                    target: pip_preview::PipTarget {
+                                        workspace_id: frame.target.workspace_id,
+                                        workspace_label: frame.target.workspace_label,
+                                        target_id: frame.target.target_id,
+                                        target_kind,
+                                        target_label: frame.target.target_label,
+                                    },
+                                    png_bytes: frame.png_bytes,
+                                    action_label: frame.action_label,
+                                    timestamp_ms: frame.timestamp_ms,
+                                });
+                            }
+                            cua_driver_core::pip_hook::PipHookEvent::RemoveWorkspace {
+                                workspace_id,
+                            } => b.remove_workspace(&workspace_id),
+                        }
                     }
                 }
             });
             eprintln!(
-                "⚗️  PiP preview enabled (experimental — macOS only today; \
+                "⚗️  Agent View enabled via experimental PiP compatibility flag \
+                 (macOS only today; \
                  see https://github.com/trycua/cua/issues for follow-up)"
             );
         }
         Err(e) => {
-            eprintln!("⚗️  PiP preview requested but unavailable: {e}");
+            eprintln!("⚗️  Agent View requested but unavailable: {e}");
         }
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -270,8 +270,15 @@ fn maybe_init_pip() {
                                         workspace_id: frame.target.workspace_id,
                                         workspace_label: frame.target.workspace_label,
                                         target_id: frame.target.target_id,
+                                        identity_key: frame.target.identity_key,
                                         target_kind,
                                         target_label: frame.target.target_label,
+                                        native_container: frame.target.native_container.map(
+                                            |container| pip_preview::PipNativeContainer {
+                                                pid: container.pid,
+                                                window_id: container.window_id,
+                                            },
+                                        ),
                                     },
                                     png_bytes: frame.png_bytes,
                                     action_label: frame.action_label,
@@ -281,9 +288,16 @@ fn maybe_init_pip() {
                             cua_driver_core::pip_hook::PipHookEvent::RemoveWorkspace {
                                 workspace_id,
                             } => b.remove_workspace(&workspace_id),
+                            cua_driver_core::pip_hook::PipHookEvent::RemoveTarget {
+                                workspace_id,
+                                identity_key,
+                            } => b.remove_target(&workspace_id, &identity_key),
                         }
                     }
                 }
+            });
+            cua_driver_core::session::register_session_end_hook(|workspace_id| {
+                cua_driver_core::pip_hook::remove_pip_workspace(workspace_id);
             });
             eprintln!("⚗️  Agent View enabled (native macOS, Windows, and Linux presentation)");
         }

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -283,6 +283,7 @@ fn maybe_init_pip() {
                                     png_bytes: frame.png_bytes,
                                     action_label: frame.action_label,
                                     timestamp_ms: frame.timestamp_ms,
+                                    cursor_position: frame.cursor_position,
                                 });
                             }
                             cua_driver_core::pip_hook::PipHookEvent::SetInputPassthrough {

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/lib.rs
@@ -27,10 +27,10 @@ pub use render_state::{
     SESSION_BADGE_HOLD_SECS,
 };
 pub use session_badge::{
-    paint_session_badge, sanitize_session_label, session_badge_extents, session_badge_layout,
-    BadgeExtents, BadgeLabelLayout, SessionBadgeInput, SessionBadgeLayout, BADGE_CHIP_GAP,
-    BADGE_CHIP_GROUP_GAP, BADGE_CHIP_SIZE, BADGE_CURSOR_GAP, BADGE_HEIGHT, BADGE_MAX_WIDTH,
-    MAX_SESSION_LABEL_CHARS,
+    paint_session_badge, rasterize_inter_text, sanitize_session_label, session_badge_extents,
+    session_badge_layout, BadgeExtents, BadgeLabelLayout, SessionBadgeInput, SessionBadgeLayout,
+    TextRaster, BADGE_CHIP_GAP, BADGE_CHIP_GROUP_GAP, BADGE_CHIP_SIZE, BADGE_CURSOR_GAP,
+    BADGE_HEIGHT, BADGE_MAX_WIDTH, MAX_SESSION_LABEL_CHARS,
 };
 pub use theme::{
     session_fill_hex, session_fill_rgba, CursorAction, CursorVisualState, DeliveryModifier,

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/session_badge.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/session_badge.rs
@@ -202,6 +202,56 @@ pub fn sanitize_session_label(input: &str) -> Option<String> {
     Some(result)
 }
 
+/// Tightly cropped 8-bit coverage mask for one line of rasterized text.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextRaster {
+    pub width: u32,
+    pub height: u32,
+    /// Row-major coverage, exactly `width * height` bytes.
+    pub coverage: Vec<u8>,
+}
+
+/// Rasterize one line of UI text with the bundled Inter face.
+///
+/// Renderers that do not draw through `tiny_skia` — the Windows Agent View
+/// canvas paints straight into a DIB — can compose the returned mask themselves
+/// and still share one typeface with the cursor badge, so no second font asset
+/// or drawing dependency is needed. Returns `None` for text that rasterizes to
+/// nothing, such as an empty or whitespace-only string.
+pub fn rasterize_inter_text(text: &str, font_size: f32) -> Option<TextRaster> {
+    let font = font()?;
+    let layout = text_layout(font, text, font_size.max(1.0));
+    let bounds = text_bounds(&layout)?;
+    let width = bounds.width.ceil().max(1.0) as u32;
+    let height = bounds.height.ceil().max(1.0) as u32;
+    let mut coverage = vec![0u8; width as usize * height as usize];
+    for glyph in layout.glyphs() {
+        let (metrics, bitmap) = font.rasterize_config(glyph.key);
+        if metrics.width == 0 || metrics.height == 0 {
+            continue;
+        }
+        let origin_x = (glyph.x - bounds.min_x).round() as i32;
+        let origin_y = (glyph.y - bounds.min_y).round() as i32;
+        for row in 0..metrics.height {
+            for column in 0..metrics.width {
+                let x = origin_x + column as i32;
+                let y = origin_y + row as i32;
+                if x < 0 || y < 0 || x >= width as i32 || y >= height as i32 {
+                    continue;
+                }
+                let at = y as usize * width as usize + x as usize;
+                coverage[at] = coverage[at].max(bitmap[row * metrics.width + column]);
+            }
+        }
+    }
+    let has_ink = coverage.iter().any(|&sample| sample > 0);
+    has_ink.then_some(TextRaster {
+        width,
+        height,
+        coverage,
+    })
+}
+
 fn rounded_rect(rect: Rect, radius: f32) -> Option<Path> {
     const K: f32 = 0.552_284_8;
     let x = rect.x();
@@ -582,6 +632,28 @@ mod tests {
         let long = sanitize_session_label("abcdefghijklmnopqrstuvwxyz0123456789").unwrap();
         assert_eq!(long.chars().count(), MAX_SESSION_LABEL_CHARS);
         assert!(long.ends_with('…'));
+    }
+
+    #[test]
+    fn rasterized_ui_text_is_cropped_and_reuses_the_badge_typeface() {
+        let raster = rasterize_inter_text("10:42 AM", 12.0).unwrap();
+        assert_eq!(
+            raster.coverage.len(),
+            raster.width as usize * raster.height as usize
+        );
+        assert!(raster.width > raster.height);
+        assert!(raster.coverage.iter().any(|&coverage| coverage > 128));
+        // A tight crop means the first and last columns both carry ink.
+        let column_has_ink = |column: u32| {
+            (0..raster.height)
+                .any(|row| raster.coverage[(row * raster.width + column) as usize] > 0)
+        };
+        assert!(column_has_ink(0));
+        assert!((raster.width.saturating_sub(2)..raster.width).any(column_has_ink));
+
+        let larger = rasterize_inter_text("10:42 AM", 20.0).unwrap();
+        assert!(larger.width > raster.width);
+        assert!(rasterize_inter_text("   ", 12.0).is_none());
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/pip-preview/src/desktop_layout.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/desktop_layout.rs
@@ -1,0 +1,337 @@
+//! Platform-neutral geometry for the Agent View miniature desktop.
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LayoutRect {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+impl LayoutRect {
+    #[cfg(test)]
+    fn right(self) -> f64 {
+        self.x + self.width
+    }
+
+    #[cfg(test)]
+    fn bottom(self) -> f64 {
+        self.y + self.height
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TargetSize {
+    pub width: u32,
+    pub height: u32,
+}
+
+impl TargetSize {
+    fn aspect(self) -> f64 {
+        if self.width == 0 || self.height == 0 {
+            return 16.0 / 10.0;
+        }
+        (self.width as f64 / self.height as f64).clamp(0.4, 2.8)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TargetLayout {
+    pub window: LayoutRect,
+    pub content: LayoutRect,
+    pub title_bar_height: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DesktopLayout {
+    pub menu_bar: LayoutRect,
+    pub desktop: LayoutRect,
+    pub dock: LayoutRect,
+    pub dock_icons: Vec<LayoutRect>,
+    pub targets: Vec<TargetLayout>,
+}
+
+/// Lay out a miniature desktop in top-left-origin coordinates.
+///
+/// Targets keep a stable row-major order. Columns receive widths based on the
+/// average aspect ratio of their targets, which gives landscape windows more
+/// room while keeping portrait and square windows compact. Narrow containers
+/// collapse to one column instead of shrinking previews beyond usefulness.
+pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> DesktopLayout {
+    let width = width.max(1.0);
+    let height = height.max(1.0);
+    let short_edge = width.min(height);
+    let outer_gap = (short_edge * 0.018).clamp(5.0, 11.0);
+    let menu_height = (height * 0.052).clamp(18.0, 26.0).min(height * 0.16);
+    let dock_height = (height * 0.13).clamp(36.0, 60.0).min(height * 0.24);
+    let dock_y = (height - dock_height - outer_gap).max(menu_height + outer_gap);
+    let desktop_y = menu_height + outer_gap;
+    let desktop_height = (dock_y - outer_gap - desktop_y).max(1.0);
+    let desktop = LayoutRect {
+        x: outer_gap,
+        y: desktop_y,
+        width: (width - 2.0 * outer_gap).max(1.0),
+        height: desktop_height,
+    };
+
+    let dock_gap = 6.0;
+    let icon_count = targets.len().max(1);
+    let max_icon_width = ((width - 4.0 * outer_gap - dock_gap * (icon_count - 1) as f64)
+        / icon_count as f64)
+        .max(16.0);
+    let icon_size = (dock_height - 12.0).min(max_icon_width).clamp(18.0, 46.0);
+    let dock_width = (icon_count as f64 * icon_size + (icon_count - 1) as f64 * dock_gap + 18.0)
+        .min(width - 2.0 * outer_gap)
+        .max(icon_size + 18.0);
+    let dock = LayoutRect {
+        x: (width - dock_width) / 2.0,
+        y: dock_y,
+        width: dock_width,
+        height: dock_height,
+    };
+    let icons_width = icon_count as f64 * icon_size + (icon_count - 1) as f64 * dock_gap;
+    let icon_x = dock.x + (dock.width - icons_width) / 2.0;
+    let icon_y = dock.y + (dock.height - icon_size) / 2.0 - 1.0;
+    let dock_icons = (0..targets.len())
+        .map(|index| LayoutRect {
+            x: icon_x + index as f64 * (icon_size + dock_gap),
+            y: icon_y,
+            width: icon_size,
+            height: icon_size,
+        })
+        .collect::<Vec<_>>();
+
+    if targets.is_empty() {
+        return DesktopLayout {
+            menu_bar: LayoutRect {
+                x: 0.0,
+                y: 0.0,
+                width,
+                height: menu_height,
+            },
+            desktop,
+            dock,
+            dock_icons,
+            targets: Vec::new(),
+        };
+    }
+
+    let columns = if targets.len() == 1 || desktop.width < 430.0 {
+        1
+    } else if targets.len() <= 4 || desktop.width < 760.0 {
+        2
+    } else {
+        3
+    };
+    let rows = targets.len().div_ceil(columns);
+    let cell_gap = (short_edge * 0.014).clamp(5.0, 10.0);
+    let usable_width = (desktop.width - cell_gap * (columns - 1) as f64).max(1.0);
+
+    let mut column_weights = vec![0.0; columns];
+    let mut column_counts = vec![0usize; columns];
+    for (index, target) in targets.iter().enumerate() {
+        let column = index % columns;
+        column_weights[column] += target.aspect().clamp(0.65, 2.0);
+        column_counts[column] += 1;
+    }
+    for column in 0..columns {
+        column_weights[column] = if column_counts[column] == 0 {
+            1.0
+        } else {
+            (column_weights[column] / column_counts[column] as f64).clamp(0.7, 1.8)
+        };
+    }
+    let total_column_weight = column_weights.iter().sum::<f64>().max(1.0);
+    let column_widths = column_weights
+        .iter()
+        .map(|weight| usable_width * weight / total_column_weight)
+        .collect::<Vec<_>>();
+
+    let mut row_weights = vec![1.0; rows];
+    for (row, row_weight) in row_weights.iter_mut().enumerate() {
+        let mut desired_height: f64 = 1.0;
+        for (column, column_width) in column_widths.iter().enumerate() {
+            let index = row * columns + column;
+            let Some(target) = targets.get(index) else {
+                continue;
+            };
+            desired_height = desired_height.max(column_width / target.aspect() + 22.0);
+        }
+        *row_weight = desired_height;
+    }
+    let usable_height = (desktop.height - cell_gap * (rows - 1) as f64).max(1.0);
+    let total_row_weight = row_weights.iter().sum::<f64>().max(1.0);
+    let row_heights = row_weights
+        .iter()
+        .map(|weight| usable_height * weight / total_row_weight)
+        .collect::<Vec<_>>();
+
+    let mut column_x = Vec::with_capacity(columns);
+    let mut x = desktop.x;
+    for column_width in &column_widths {
+        column_x.push(x);
+        x += column_width + cell_gap;
+    }
+    let mut row_y = Vec::with_capacity(rows);
+    let mut y = desktop.y;
+    for row_height in &row_heights {
+        row_y.push(y);
+        y += row_height + cell_gap;
+    }
+
+    let target_layouts = targets
+        .iter()
+        .enumerate()
+        .map(|(index, target)| {
+            let column = index % columns;
+            let row = index / columns;
+            fit_target(
+                LayoutRect {
+                    x: column_x[column],
+                    y: row_y[row],
+                    width: column_widths[column],
+                    height: row_heights[row],
+                },
+                target.aspect(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    DesktopLayout {
+        menu_bar: LayoutRect {
+            x: 0.0,
+            y: 0.0,
+            width,
+            height: menu_height,
+        },
+        desktop,
+        dock,
+        dock_icons,
+        targets: target_layouts,
+    }
+}
+
+fn fit_target(cell: LayoutRect, aspect: f64) -> TargetLayout {
+    let inset = 1.0;
+    let title_bar_height = (cell.height * 0.1)
+        .clamp(17.0, 23.0)
+        .min(cell.height * 0.28);
+    let available_width = (cell.width - 2.0 * inset).max(1.0);
+    let available_content_height = (cell.height - title_bar_height - 2.0 * inset).max(1.0);
+    let content_width = available_width.min(available_content_height * aspect);
+    let content_height = (content_width / aspect).min(available_content_height);
+    let window_width = content_width;
+    let window_height = content_height + title_bar_height;
+    let window = LayoutRect {
+        x: cell.x + (cell.width - window_width) / 2.0,
+        y: cell.y + (cell.height - window_height) / 2.0,
+        width: window_width,
+        height: window_height,
+    };
+    let content = LayoutRect {
+        x: window.x,
+        y: window.y + title_bar_height,
+        width: content_width,
+        height: content_height,
+    };
+    TargetLayout {
+        window,
+        content,
+        title_bar_height,
+    }
+}
+
+pub fn png_dimensions(bytes: &[u8]) -> Option<TargetSize> {
+    const PNG_SIGNATURE: &[u8; 8] = b"\x89PNG\r\n\x1a\n";
+    if bytes.len() < 24 || &bytes[..8] != PNG_SIGNATURE || &bytes[12..16] != b"IHDR" {
+        return None;
+    }
+    let width = u32::from_be_bytes(bytes[16..20].try_into().ok()?);
+    let height = u32::from_be_bytes(bytes[20..24].try_into().ok()?);
+    (width > 0 && height > 0).then_some(TargetSize { width, height })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn size(width: u32, height: u32) -> TargetSize {
+        TargetSize { width, height }
+    }
+
+    fn intersects(a: LayoutRect, b: LayoutRect) -> bool {
+        a.x < b.right() && a.right() > b.x && a.y < b.bottom() && a.bottom() > b.y
+    }
+
+    #[test]
+    fn mixed_form_factors_make_the_landscape_column_wider() {
+        let layout = layout_desktop(
+            720.0,
+            520.0,
+            &[
+                size(1600, 900),
+                size(700, 1200),
+                size(1400, 900),
+                size(900, 900),
+            ],
+        );
+        assert_eq!(layout.targets.len(), 4);
+        assert!(layout.targets[0].window.width > layout.targets[1].window.width);
+        assert!(layout.targets[2].window.width > layout.targets[3].window.width);
+    }
+
+    #[test]
+    fn narrow_desktop_reflows_to_one_column() {
+        let layout = layout_desktop(380.0, 620.0, &[size(1600, 900), size(700, 1200)]);
+        assert!(layout.targets[1].window.y > layout.targets[0].window.y);
+        assert!((layout.targets[0].window.x - layout.targets[1].window.x).abs() < 80.0);
+    }
+
+    #[test]
+    fn target_windows_stay_inside_the_desktop_and_do_not_overlap() {
+        let layout = layout_desktop(
+            840.0,
+            560.0,
+            &[
+                size(1600, 900),
+                size(700, 1200),
+                size(1400, 900),
+                size(900, 900),
+                size(1000, 700),
+                size(800, 1100),
+            ],
+        );
+        for target in &layout.targets {
+            assert!(target.window.x >= layout.desktop.x - 0.01);
+            assert!(target.window.y >= layout.desktop.y - 0.01);
+            assert!(target.window.right() <= layout.desktop.right() + 0.01);
+            assert!(target.window.bottom() <= layout.desktop.bottom() + 0.01);
+        }
+        for (index, target) in layout.targets.iter().enumerate() {
+            for other in layout.targets.iter().skip(index + 1) {
+                assert!(!intersects(target.window, other.window));
+            }
+        }
+    }
+
+    #[test]
+    fn content_preserves_the_source_aspect_ratio() {
+        let targets = [size(1600, 900), size(700, 1200), size(900, 900)];
+        let layout = layout_desktop(720.0, 520.0, &targets);
+        for (target, source) in layout.targets.iter().zip(targets) {
+            let rendered_aspect = target.content.width / target.content.height;
+            assert!((rendered_aspect - source.aspect()).abs() < 0.001);
+        }
+    }
+
+    #[test]
+    fn reads_png_ihdr_dimensions_without_decoding_the_image() {
+        let mut png = vec![0u8; 24];
+        png[..8].copy_from_slice(b"\x89PNG\r\n\x1a\n");
+        png[12..16].copy_from_slice(b"IHDR");
+        png[16..20].copy_from_slice(&1440u32.to_be_bytes());
+        png[20..24].copy_from_slice(&900u32.to_be_bytes());
+        assert_eq!(png_dimensions(&png), Some(size(1440, 900)));
+        assert_eq!(png_dimensions(b"not png"), None);
+    }
+}

--- a/libs/cua-driver/rust/crates/pip-preview/src/desktop_layout.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/desktop_layout.rs
@@ -61,7 +61,8 @@ pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> Deskto
     let short_edge = width.min(height);
     let outer_gap = (short_edge * 0.018).clamp(5.0, 11.0);
     let dock_height = (height * 0.10).clamp(30.0, 50.0).min(height * 0.22);
-    let dock_y = (height - dock_height - outer_gap * 0.7).max(outer_gap);
+    let dock_bottom_margin = (height * 0.028).clamp(10.0, 16.0);
+    let dock_y = (height - dock_height - dock_bottom_margin).max(outer_gap);
     let desktop_y = outer_gap;
     let desktop_height = (dock_y - outer_gap - desktop_y).max(1.0);
     let desktop = LayoutRect {
@@ -324,7 +325,7 @@ mod tests {
             .map(|target| target.window.bottom())
             .fold(0.0, f64::max);
         assert!(layout.dock.y >= lowest_target);
-        assert!(layout.dock.bottom() <= height);
+        assert!(layout.dock.bottom() <= height - 10.0);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/pip-preview/src/desktop_layout.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/desktop_layout.rs
@@ -60,7 +60,7 @@ pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> Deskto
     let height = height.max(1.0);
     let short_edge = width.min(height);
     let outer_gap = (short_edge * 0.018).clamp(5.0, 11.0);
-    let dock_height = (height * 0.10).clamp(30.0, 50.0).min(height * 0.22);
+    let dock_height = (height * 0.12).clamp(38.0, 58.0).min(height * 0.22);
     let dock_bottom_margin = (height * 0.028).clamp(10.0, 16.0);
     let dock_y = (height - dock_height - dock_bottom_margin).max(outer_gap);
     let desktop_y = outer_gap;
@@ -77,8 +77,8 @@ pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> Deskto
     let max_icon_width = ((width - 4.0 * outer_gap - dock_gap * (icon_count - 1) as f64)
         / icon_count as f64)
         .max(16.0);
-    let icon_size = (dock_height - 10.0).min(max_icon_width).clamp(18.0, 40.0);
-    let dock_width = (icon_count as f64 * icon_size + (icon_count - 1) as f64 * dock_gap + 20.0)
+    let icon_size = (dock_height - 16.0).min(max_icon_width).clamp(20.0, 42.0);
+    let dock_width = (icon_count as f64 * icon_size + (icon_count - 1) as f64 * dock_gap + 28.0)
         .min(width - 2.0 * outer_gap)
         .max(icon_size + 20.0);
     let dock = LayoutRect {

--- a/libs/cua-driver/rust/crates/pip-preview/src/desktop_layout.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/desktop_layout.rs
@@ -41,21 +41,69 @@ pub struct TargetLayout {
     pub content: LayoutRect,
 }
 
+/// Shell chrome idiom for the miniature desktop.
+///
+/// Only the dock band differs between styles. Target geometry is identical
+/// under every style, so a session's cards never move when the host platform
+/// swaps its shell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ShellStyle {
+    /// Centered dock floating clear of every edge (macOS and Linux).
+    #[default]
+    FloatingDock,
+    /// Full-width bar flush with the bottom screen edge (Windows).
+    EdgeTaskbar,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct DesktopLayout {
     pub desktop: LayoutRect,
     pub dock: LayoutRect,
     pub dock_icons: Vec<LayoutRect>,
     pub targets: Vec<TargetLayout>,
+    pub shell: ShellStyle,
+    /// Leading launcher slot. `EdgeTaskbar` only.
+    pub start_button: Option<LayoutRect>,
+    /// Trailing status band reserved for a clock and tray glyphs.
+    /// `EdgeTaskbar` only.
+    pub tray: Option<LayoutRect>,
+    /// Running-app marks, one per dock icon in the same order.
+    /// `EdgeTaskbar` only.
+    pub indicators: Vec<LayoutRect>,
 }
 
-/// Lay out a miniature desktop in top-left-origin coordinates.
+#[derive(Debug, Clone, PartialEq)]
+struct ShellChrome {
+    dock: LayoutRect,
+    dock_icons: Vec<LayoutRect>,
+    start_button: Option<LayoutRect>,
+    tray: Option<LayoutRect>,
+    indicators: Vec<LayoutRect>,
+}
+
+const DOCK_ICON_GAP: f64 = 8.0;
+
+/// Lay out a miniature desktop with the floating dock shell.
 ///
 /// Targets keep a stable row-major order. Columns receive widths based on the
 /// average aspect ratio of their targets, which gives landscape windows more
 /// room while keeping portrait and square windows compact. Narrow containers
 /// collapse to one column instead of shrinking previews beyond usefulness.
 pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> DesktopLayout {
+    layout_desktop_with_shell(width, height, targets, ShellStyle::FloatingDock)
+}
+
+/// Lay out a miniature desktop for one platform shell idiom.
+///
+/// The desktop band, and therefore every `TargetLayout`, is derived from the
+/// dock's top edge alone. Both shells compute that edge identically, so the
+/// shell only decides how the dock band itself is drawn.
+pub fn layout_desktop_with_shell(
+    width: f64,
+    height: f64,
+    targets: &[TargetSize],
+    shell: ShellStyle,
+) -> DesktopLayout {
     let width = width.max(1.0);
     let height = height.max(1.0);
     let short_edge = width.min(height);
@@ -74,40 +122,15 @@ pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> Deskto
         height: desktop_height,
     };
 
-    let dock_gap = 8.0;
-    let icon_count = targets.len().max(1);
-    let max_icon_width = ((width - 4.0 * outer_gap - dock_gap * (icon_count - 1) as f64)
-        / icon_count as f64)
-        .max(16.0);
-    let icon_size = (dock_height - 16.0).min(max_icon_width).clamp(20.0, 42.0);
-    let dock_width = (icon_count as f64 * icon_size + (icon_count - 1) as f64 * dock_gap + 28.0)
-        .min(width - 2.0 * outer_gap)
-        .max(icon_size + 20.0);
-    let dock = LayoutRect {
-        x: (width - dock_width) / 2.0,
-        y: dock_y,
-        width: dock_width,
-        height: dock_height,
+    let chrome = match shell {
+        ShellStyle::FloatingDock => {
+            floating_dock_chrome(width, outer_gap, dock_y, dock_height, targets.len())
+        }
+        ShellStyle::EdgeTaskbar => edge_taskbar_chrome(width, height, dock_y, targets.len()),
     };
-    let icons_width = icon_count as f64 * icon_size + (icon_count - 1) as f64 * dock_gap;
-    let icon_x = dock.x + (dock.width - icons_width) / 2.0;
-    let icon_y = dock.y + (dock.height - icon_size) / 2.0 - 1.0;
-    let dock_icons = (0..targets.len())
-        .map(|index| LayoutRect {
-            x: icon_x + index as f64 * (icon_size + dock_gap),
-            y: icon_y,
-            width: icon_size,
-            height: icon_size,
-        })
-        .collect::<Vec<_>>();
 
     if targets.is_empty() {
-        return DesktopLayout {
-            desktop,
-            dock,
-            dock_icons,
-            targets: Vec::new(),
-        };
+        return DesktopLayout::assemble(desktop, shell, chrome, Vec::new());
     }
 
     let columns = if targets.len() == 1 || desktop.width < 430.0 {
@@ -191,11 +214,139 @@ pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> Deskto
         })
         .collect::<Vec<_>>();
 
-    DesktopLayout {
-        desktop,
+    DesktopLayout::assemble(desktop, shell, chrome, target_layouts)
+}
+
+impl DesktopLayout {
+    fn assemble(
+        desktop: LayoutRect,
+        shell: ShellStyle,
+        chrome: ShellChrome,
+        targets: Vec<TargetLayout>,
+    ) -> Self {
+        Self {
+            desktop,
+            dock: chrome.dock,
+            dock_icons: chrome.dock_icons,
+            targets,
+            shell,
+            start_button: chrome.start_button,
+            tray: chrome.tray,
+            indicators: chrome.indicators,
+        }
+    }
+}
+
+fn floating_dock_chrome(
+    width: f64,
+    outer_gap: f64,
+    dock_y: f64,
+    dock_height: f64,
+    target_count: usize,
+) -> ShellChrome {
+    let icon_count = target_count.max(1);
+    let max_icon_width = ((width - 4.0 * outer_gap - DOCK_ICON_GAP * (icon_count - 1) as f64)
+        / icon_count as f64)
+        .max(16.0);
+    let icon_size = (dock_height - 16.0).min(max_icon_width).clamp(20.0, 42.0);
+    let dock_width =
+        (icon_count as f64 * icon_size + (icon_count - 1) as f64 * DOCK_ICON_GAP + 28.0)
+            .min(width - 2.0 * outer_gap)
+            .max(icon_size + 20.0);
+    let dock = LayoutRect {
+        x: (width - dock_width) / 2.0,
+        y: dock_y,
+        width: dock_width,
+        height: dock_height,
+    };
+    let icons_width = icon_count as f64 * icon_size + (icon_count - 1) as f64 * DOCK_ICON_GAP;
+    let icon_x = dock.x + (dock.width - icons_width) / 2.0;
+    let icon_y = dock.y + (dock.height - icon_size) / 2.0 - 1.0;
+    let dock_icons = (0..target_count)
+        .map(|index| LayoutRect {
+            x: icon_x + index as f64 * (icon_size + DOCK_ICON_GAP),
+            y: icon_y,
+            width: icon_size,
+            height: icon_size,
+        })
+        .collect::<Vec<_>>();
+    ShellChrome {
         dock,
         dock_icons,
-        targets: target_layouts,
+        start_button: None,
+        tray: None,
+        indicators: Vec::new(),
+    }
+}
+
+/// Windows 11-style bar: full width, flush with the bottom edge, with the
+/// launcher and app icons centered as one group and the tray trailing.
+///
+/// The bar takes its top edge from the shared `dock_y` and reaches the bottom
+/// by absorbing the floating dock's bottom margin, so it gains height without
+/// moving the desktop band above it.
+fn edge_taskbar_chrome(width: f64, height: f64, dock_y: f64, target_count: usize) -> ShellChrome {
+    let dock = LayoutRect {
+        x: 0.0,
+        y: dock_y,
+        width,
+        height: (height - dock_y).max(1.0),
+    };
+    let tray_width = (width * 0.16).clamp(56.0, 104.0).min(width * 0.34);
+    let tray = LayoutRect {
+        x: (width - tray_width).max(0.0),
+        y: dock.y,
+        width: tray_width,
+        height: dock.height,
+    };
+
+    // Reserve the tray band on both sides so the icon group stays centered on
+    // the whole bar rather than on the space left of the clock, and let icons
+    // shrink instead of sliding under the tray on a very narrow panel.
+    let slots = target_count + 1;
+    let slot_span =
+        (width - 2.0 * (tray_width + 6.0) - DOCK_ICON_GAP * (slots - 1) as f64) / slots as f64;
+    let icon_size = (dock.height * 0.55).min(slot_span).clamp(8.0, 32.0);
+    let group_width = slots as f64 * icon_size + (slots - 1) as f64 * DOCK_ICON_GAP;
+    let group_x = ((width - group_width) / 2.0).max(4.0);
+    // Sit the icons slightly high in the band to leave room for the marks.
+    let icon_y = dock.y + (dock.height - icon_size) / 2.0 - 2.0;
+    let slot_x = |index: usize| group_x + index as f64 * (icon_size + DOCK_ICON_GAP);
+
+    let start_button = LayoutRect {
+        x: slot_x(0),
+        y: icon_y,
+        width: icon_size,
+        height: icon_size,
+    };
+    let dock_icons = (0..target_count)
+        .map(|index| LayoutRect {
+            x: slot_x(index + 1),
+            y: icon_y,
+            width: icon_size,
+            height: icon_size,
+        })
+        .collect::<Vec<_>>();
+
+    let indicator_height = (icon_size * 0.1).clamp(2.0, 3.0);
+    let indicator_width = (icon_size * 0.42).max(4.0);
+    let indicator_y = (icon_y + icon_size + 3.0).min(dock.y + dock.height - indicator_height - 1.0);
+    let indicators = dock_icons
+        .iter()
+        .map(|icon| LayoutRect {
+            x: icon.x + (icon.width - indicator_width) / 2.0,
+            y: indicator_y,
+            width: indicator_width,
+            height: indicator_height,
+        })
+        .collect::<Vec<_>>();
+
+    ShellChrome {
+        dock,
+        dock_icons,
+        start_button: Some(start_button),
+        tray: Some(tray),
+        indicators,
     }
 }
 
@@ -337,6 +488,115 @@ mod tests {
             .fold(0.0, f64::max);
         assert!(layout.dock.y >= lowest_target);
         assert!(layout.dock.bottom() <= height - 10.0);
+    }
+
+    #[test]
+    fn floating_dock_is_the_default_shell_and_carries_no_taskbar_metadata() {
+        let layout = layout_desktop(720.0, 520.0, &[size(1600, 900), size(900, 900)]);
+        assert_eq!(layout.shell, ShellStyle::FloatingDock);
+        assert_eq!(layout.shell, ShellStyle::default());
+        assert!(layout.start_button.is_none());
+        assert!(layout.tray.is_none());
+        assert!(layout.indicators.is_empty());
+        assert!(layout.dock.x > 0.0);
+        assert!(layout.dock.bottom() < 520.0);
+        assert_eq!(layout.dock_icons.len(), 2);
+    }
+
+    #[test]
+    fn edge_taskbar_spans_the_full_width_and_reaches_the_bottom_edge() {
+        let width = 720.0;
+        let height = 520.0;
+        let targets = [size(1600, 900), size(900, 900), size(700, 1200)];
+        let floating = layout_desktop(width, height, &targets);
+        let taskbar = layout_desktop_with_shell(width, height, &targets, ShellStyle::EdgeTaskbar);
+
+        assert_eq!(taskbar.shell, ShellStyle::EdgeTaskbar);
+        assert_eq!(taskbar.dock.x, 0.0);
+        assert_eq!(taskbar.dock.width, width);
+        assert_eq!(taskbar.dock.bottom(), height);
+        // The bar keeps the floating dock's top edge and only absorbs the
+        // margin that used to sit below it.
+        assert_eq!(taskbar.dock.y, floating.dock.y);
+        assert!(taskbar.dock.height > floating.dock.height);
+        assert!(taskbar.dock.height - floating.dock.height <= 16.0 + f64::EPSILON);
+    }
+
+    #[test]
+    fn edge_taskbar_preserves_every_floating_dock_target_layout() {
+        let targets = [
+            size(1600, 900),
+            size(700, 1200),
+            size(1400, 900),
+            size(900, 900),
+            size(1000, 700),
+        ];
+        for (width, height) in [(720.0, 520.0), (380.0, 620.0), (360.0, 260.0)] {
+            let floating = layout_desktop(width, height, &targets);
+            let taskbar =
+                layout_desktop_with_shell(width, height, &targets, ShellStyle::EdgeTaskbar);
+            assert_eq!(floating.desktop, taskbar.desktop);
+            assert_eq!(floating.targets, taskbar.targets);
+        }
+    }
+
+    #[test]
+    fn edge_taskbar_centers_the_start_slot_with_the_app_icons() {
+        let width = 720.0;
+        let targets = [size(1600, 900), size(900, 900)];
+        let layout = layout_desktop_with_shell(width, 520.0, &targets, ShellStyle::EdgeTaskbar);
+        let start = layout.start_button.unwrap();
+        let tray = layout.tray.unwrap();
+
+        assert_eq!(layout.dock_icons.len(), targets.len());
+        assert!(start.x < layout.dock_icons[0].x);
+        assert_eq!(start.y, layout.dock_icons[0].y);
+        assert_eq!(start.width, layout.dock_icons[0].width);
+
+        let group_left = start.x;
+        let group_right = layout.dock_icons.last().unwrap().right();
+        assert!(((group_left + group_right) / 2.0 - width / 2.0).abs() < 1.0);
+        assert!(group_right <= tray.x);
+        assert_eq!(tray.right(), width);
+        assert_eq!(tray.y, layout.dock.y);
+        assert_eq!(tray.height, layout.dock.height);
+    }
+
+    #[test]
+    fn edge_taskbar_marks_every_running_icon_inside_the_bar() {
+        let targets = [size(1600, 900), size(900, 900), size(700, 1200)];
+        let layout = layout_desktop_with_shell(720.0, 520.0, &targets, ShellStyle::EdgeTaskbar);
+        assert_eq!(layout.indicators.len(), layout.dock_icons.len());
+        for (indicator, icon) in layout.indicators.iter().zip(&layout.dock_icons) {
+            assert!(indicator.width < icon.width);
+            assert!(indicator.y >= icon.bottom());
+            assert!(indicator.bottom() <= layout.dock.bottom());
+            assert!(
+                ((indicator.x + indicator.width / 2.0) - (icon.x + icon.width / 2.0)).abs() < 1.0
+            );
+        }
+    }
+
+    #[test]
+    fn edge_taskbar_keeps_the_start_slot_when_no_target_has_a_card() {
+        let layout = layout_desktop_with_shell(640.0, 420.0, &[], ShellStyle::EdgeTaskbar);
+        assert!(layout.start_button.is_some());
+        assert!(layout.tray.is_some());
+        assert!(layout.dock_icons.is_empty());
+        assert!(layout.indicators.is_empty());
+        assert!(layout.targets.is_empty());
+    }
+
+    #[test]
+    fn crowded_narrow_taskbar_shrinks_icons_instead_of_sliding_under_the_tray() {
+        let targets = vec![size(1200, 800); 12];
+        let layout = layout_desktop_with_shell(320.0, 260.0, &targets, ShellStyle::EdgeTaskbar);
+        let tray = layout.tray.unwrap();
+        assert!(layout.start_button.unwrap().x >= 0.0);
+        assert!(layout.dock_icons.last().unwrap().right() <= tray.x);
+        for icon in &layout.dock_icons {
+            assert!(icon.width >= 8.0);
+        }
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/pip-preview/src/desktop_layout.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/desktop_layout.rs
@@ -59,7 +59,9 @@ pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> Deskto
     let width = width.max(1.0);
     let height = height.max(1.0);
     let short_edge = width.min(height);
-    let outer_gap = (short_edge * 0.018).clamp(5.0, 11.0);
+    // Keep target shadows and rounded corners visibly separated from the
+    // miniature desktop frame, including at the minimum supported panel size.
+    let outer_gap = (short_edge * 0.045).clamp(16.0, 26.0);
     let dock_height = (height * 0.12).clamp(38.0, 58.0).min(height * 0.22);
     let dock_bottom_margin = (height * 0.028).clamp(10.0, 16.0);
     let dock_y = (height - dock_height - dock_bottom_margin).max(outer_gap);
@@ -305,10 +307,19 @@ mod tests {
     }
 
     #[test]
-    fn layout_reserves_no_menu_or_target_title_bars() {
+    fn layout_reserves_padding_but_no_menu_or_target_title_bars() {
         let layout = layout_desktop(720.0, 520.0, &[size(1600, 900)]);
-        assert!(layout.desktop.y < 10.0);
+        assert!((16.0..=26.0).contains(&layout.desktop.y));
         assert_eq!(layout.targets[0].window, layout.targets[0].content);
+    }
+
+    #[test]
+    fn minimum_panel_keeps_targets_away_from_the_frame() {
+        let layout = layout_desktop(360.0, 260.0, &[size(900, 700)]);
+        let target = layout.targets[0].window;
+        assert!(target.x >= 16.0);
+        assert!(target.y >= 16.0);
+        assert!(target.right() <= 344.0);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/pip-preview/src/desktop_layout.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/desktop_layout.rs
@@ -48,8 +48,10 @@ pub struct TargetLayout {
 /// swaps its shell.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ShellStyle {
-    /// Centered dock floating clear of every edge (macOS and Linux).
+    /// No permanent launcher or taskbar chrome.
     #[default]
+    None,
+    /// Centered dock floating clear of every edge (macOS and Linux).
     FloatingDock,
     /// Full-width bar flush with the bottom screen edge (Windows).
     EdgeTaskbar,
@@ -90,7 +92,7 @@ const DOCK_ICON_GAP: f64 = 8.0;
 /// room while keeping portrait and square windows compact. Narrow containers
 /// collapse to one column instead of shrinking previews beyond usefulness.
 pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> DesktopLayout {
-    layout_desktop_with_shell(width, height, targets, ShellStyle::FloatingDock)
+    layout_desktop_with_shell(width, height, targets, ShellStyle::None)
 }
 
 /// Lay out a miniature desktop for one platform shell idiom.
@@ -112,7 +114,11 @@ pub fn layout_desktop_with_shell(
     let outer_gap = (short_edge * 0.045).clamp(16.0, 26.0);
     let dock_height = (height * 0.12).clamp(38.0, 58.0).min(height * 0.22);
     let dock_bottom_margin = (height * 0.028).clamp(10.0, 16.0);
-    let dock_y = (height - dock_height - dock_bottom_margin).max(outer_gap);
+    let dock_y = if shell == ShellStyle::None {
+        height - outer_gap
+    } else {
+        (height - dock_height - dock_bottom_margin).max(outer_gap)
+    };
     let desktop_y = outer_gap;
     let desktop_height = (dock_y - outer_gap - desktop_y).max(1.0);
     let desktop = LayoutRect {
@@ -123,6 +129,18 @@ pub fn layout_desktop_with_shell(
     };
 
     let chrome = match shell {
+        ShellStyle::None => ShellChrome {
+            dock: LayoutRect {
+                x: 0.0,
+                y: height,
+                width: 0.0,
+                height: 0.0,
+            },
+            dock_icons: Vec::new(),
+            start_button: None,
+            tray: None,
+            indicators: Vec::new(),
+        },
         ShellStyle::FloatingDock => {
             floating_dock_chrome(width, outer_gap, dock_y, dock_height, targets.len())
         }
@@ -476,10 +494,11 @@ mod tests {
     #[test]
     fn dock_stays_below_targets_and_inside_the_panel() {
         let height = 520.0;
-        let layout = layout_desktop(
+        let layout = layout_desktop_with_shell(
             720.0,
             height,
             &[size(1600, 900), size(700, 1200), size(900, 900)],
+            ShellStyle::FloatingDock,
         );
         let lowest_target = layout
             .targets
@@ -491,16 +510,15 @@ mod tests {
     }
 
     #[test]
-    fn floating_dock_is_the_default_shell_and_carries_no_taskbar_metadata() {
+    fn no_shell_is_the_default_and_carries_no_launcher_metadata() {
         let layout = layout_desktop(720.0, 520.0, &[size(1600, 900), size(900, 900)]);
-        assert_eq!(layout.shell, ShellStyle::FloatingDock);
+        assert_eq!(layout.shell, ShellStyle::None);
         assert_eq!(layout.shell, ShellStyle::default());
         assert!(layout.start_button.is_none());
         assert!(layout.tray.is_none());
         assert!(layout.indicators.is_empty());
-        assert!(layout.dock.x > 0.0);
-        assert!(layout.dock.bottom() < 520.0);
-        assert_eq!(layout.dock_icons.len(), 2);
+        assert_eq!(layout.dock.width, 0.0);
+        assert!(layout.dock_icons.is_empty());
     }
 
     #[test]
@@ -508,7 +526,7 @@ mod tests {
         let width = 720.0;
         let height = 520.0;
         let targets = [size(1600, 900), size(900, 900), size(700, 1200)];
-        let floating = layout_desktop(width, height, &targets);
+        let floating = layout_desktop_with_shell(width, height, &targets, ShellStyle::FloatingDock);
         let taskbar = layout_desktop_with_shell(width, height, &targets, ShellStyle::EdgeTaskbar);
 
         assert_eq!(taskbar.shell, ShellStyle::EdgeTaskbar);
@@ -532,7 +550,8 @@ mod tests {
             size(1000, 700),
         ];
         for (width, height) in [(720.0, 520.0), (380.0, 620.0), (360.0, 260.0)] {
-            let floating = layout_desktop(width, height, &targets);
+            let floating =
+                layout_desktop_with_shell(width, height, &targets, ShellStyle::FloatingDock);
             let taskbar =
                 layout_desktop_with_shell(width, height, &targets, ShellStyle::EdgeTaskbar);
             assert_eq!(floating.desktop, taskbar.desktop);

--- a/libs/cua-driver/rust/crates/pip-preview/src/desktop_layout.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/desktop_layout.rs
@@ -39,12 +39,10 @@ impl TargetSize {
 pub struct TargetLayout {
     pub window: LayoutRect,
     pub content: LayoutRect,
-    pub title_bar_height: f64,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DesktopLayout {
-    pub menu_bar: LayoutRect,
     pub desktop: LayoutRect,
     pub dock: LayoutRect,
     pub dock_icons: Vec<LayoutRect>,
@@ -62,10 +60,9 @@ pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> Deskto
     let height = height.max(1.0);
     let short_edge = width.min(height);
     let outer_gap = (short_edge * 0.018).clamp(5.0, 11.0);
-    let menu_height = (height * 0.052).clamp(18.0, 26.0).min(height * 0.16);
-    let dock_height = (height * 0.13).clamp(36.0, 60.0).min(height * 0.24);
-    let dock_y = (height - dock_height - outer_gap).max(menu_height + outer_gap);
-    let desktop_y = menu_height + outer_gap;
+    let dock_height = (height * 0.10).clamp(30.0, 50.0).min(height * 0.22);
+    let dock_y = (height - dock_height - outer_gap * 0.7).max(outer_gap);
+    let desktop_y = outer_gap;
     let desktop_height = (dock_y - outer_gap - desktop_y).max(1.0);
     let desktop = LayoutRect {
         x: outer_gap,
@@ -74,15 +71,15 @@ pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> Deskto
         height: desktop_height,
     };
 
-    let dock_gap = 6.0;
+    let dock_gap = 8.0;
     let icon_count = targets.len().max(1);
     let max_icon_width = ((width - 4.0 * outer_gap - dock_gap * (icon_count - 1) as f64)
         / icon_count as f64)
         .max(16.0);
-    let icon_size = (dock_height - 12.0).min(max_icon_width).clamp(18.0, 46.0);
-    let dock_width = (icon_count as f64 * icon_size + (icon_count - 1) as f64 * dock_gap + 18.0)
+    let icon_size = (dock_height - 10.0).min(max_icon_width).clamp(18.0, 40.0);
+    let dock_width = (icon_count as f64 * icon_size + (icon_count - 1) as f64 * dock_gap + 20.0)
         .min(width - 2.0 * outer_gap)
-        .max(icon_size + 18.0);
+        .max(icon_size + 20.0);
     let dock = LayoutRect {
         x: (width - dock_width) / 2.0,
         y: dock_y,
@@ -103,12 +100,6 @@ pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> Deskto
 
     if targets.is_empty() {
         return DesktopLayout {
-            menu_bar: LayoutRect {
-                x: 0.0,
-                y: 0.0,
-                width,
-                height: menu_height,
-            },
             desktop,
             dock,
             dock_icons,
@@ -155,7 +146,7 @@ pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> Deskto
             let Some(target) = targets.get(index) else {
                 continue;
             };
-            desired_height = desired_height.max(column_width / target.aspect() + 22.0);
+            desired_height = desired_height.max(column_width / target.aspect());
         }
         *row_weight = desired_height;
     }
@@ -198,12 +189,6 @@ pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> Deskto
         .collect::<Vec<_>>();
 
     DesktopLayout {
-        menu_bar: LayoutRect {
-            x: 0.0,
-            y: 0.0,
-            width,
-            height: menu_height,
-        },
         desktop,
         dock,
         dock_icons,
@@ -213,15 +198,12 @@ pub fn layout_desktop(width: f64, height: f64, targets: &[TargetSize]) -> Deskto
 
 fn fit_target(cell: LayoutRect, aspect: f64) -> TargetLayout {
     let inset = 1.0;
-    let title_bar_height = (cell.height * 0.1)
-        .clamp(17.0, 23.0)
-        .min(cell.height * 0.28);
     let available_width = (cell.width - 2.0 * inset).max(1.0);
-    let available_content_height = (cell.height - title_bar_height - 2.0 * inset).max(1.0);
+    let available_content_height = (cell.height - 2.0 * inset).max(1.0);
     let content_width = available_width.min(available_content_height * aspect);
     let content_height = (content_width / aspect).min(available_content_height);
     let window_width = content_width;
-    let window_height = content_height + title_bar_height;
+    let window_height = content_height;
     let window = LayoutRect {
         x: cell.x + (cell.width - window_width) / 2.0,
         y: cell.y + (cell.height - window_height) / 2.0,
@@ -230,15 +212,11 @@ fn fit_target(cell: LayoutRect, aspect: f64) -> TargetLayout {
     };
     let content = LayoutRect {
         x: window.x,
-        y: window.y + title_bar_height,
+        y: window.y,
         width: content_width,
         height: content_height,
     };
-    TargetLayout {
-        window,
-        content,
-        title_bar_height,
-    }
+    TargetLayout { window, content }
 }
 
 pub fn png_dimensions(bytes: &[u8]) -> Option<TargetSize> {
@@ -321,7 +299,32 @@ mod tests {
         for (target, source) in layout.targets.iter().zip(targets) {
             let rendered_aspect = target.content.width / target.content.height;
             assert!((rendered_aspect - source.aspect()).abs() < 0.001);
+            assert_eq!(target.window, target.content);
         }
+    }
+
+    #[test]
+    fn layout_reserves_no_menu_or_target_title_bars() {
+        let layout = layout_desktop(720.0, 520.0, &[size(1600, 900)]);
+        assert!(layout.desktop.y < 10.0);
+        assert_eq!(layout.targets[0].window, layout.targets[0].content);
+    }
+
+    #[test]
+    fn dock_stays_below_targets_and_inside_the_panel() {
+        let height = 520.0;
+        let layout = layout_desktop(
+            720.0,
+            height,
+            &[size(1600, 900), size(700, 1200), size(900, 900)],
+        );
+        let lowest_target = layout
+            .targets
+            .iter()
+            .map(|target| target.window.bottom())
+            .fold(0.0, f64::max);
+        assert!(layout.dock.y >= lowest_target);
+        assert!(layout.dock.bottom() <= height);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
@@ -1,7 +1,6 @@
 //! Shared model and platform contract for the experimental Agent View.
 //!
-//! The existing PiP flags remain the compatibility entry point, but the
-//! surface is no longer modeled as one process-global "latest screenshot".
+//! Agent View is an opt-in surface rather than one process-global "latest screenshot".
 //! Frames carry an existing session/workspace identity and an exact native
 //! window or browser-tab identity. Platform backends can therefore keep
 //! several target cards visible without introducing target claims or leases.
@@ -43,8 +42,8 @@ pub fn read_config_value(key: &str) -> Option<serde_json::Value> {
 
 /// Merge a single `key`/`value` into `~/.cua-driver/config.json`,
 /// preserving any other keys that are already there. Used by the
-/// per-platform `set_config` tools to persist `experimental_pip` /
-/// `experimental_pip_geometry` so the next daemon restart picks them up.
+/// per-platform `set_config` tools to persist `agent_view` /
+/// `agent_view_geometry` so the next daemon restart picks them up.
 pub fn write_config_key(key: &str, value: serde_json::Value) -> Result<(), String> {
     let path = default_config_path().ok_or_else(|| "$HOME is not set".to_string())?;
     let mut json: serde_json::Value = path
@@ -62,11 +61,11 @@ pub fn write_config_key(key: &str, value: serde_json::Value) -> Result<(), Strin
     Ok(())
 }
 
-/// Read `experimental_pip` + `experimental_pip_geometry` from the
+/// Read `agent_view` + `agent_view_geometry` from the
 /// config file, falling back to defaults when missing or malformed.
 /// Surfaced by the per-platform `get_config` tools alongside the
 /// in-memory `DriverConfig` fields.
-pub fn read_pip_keys_from_file() -> (bool, Option<String>) {
+pub fn read_agent_view_keys_from_file() -> (bool, Option<String>) {
     let path = match default_config_path() {
         Some(p) => p,
         None => return (false, None),
@@ -80,11 +79,11 @@ pub fn read_pip_keys_from_file() -> (bool, Option<String>) {
         Err(_) => return (false, None),
     };
     let enabled = json
-        .get("experimental_pip")
+        .get("agent_view")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
     let geometry = json
-        .get("experimental_pip_geometry")
+        .get("agent_view_geometry")
         .and_then(|v| v.as_str())
         .map(|s| s.to_owned());
     (enabled, geometry)
@@ -92,7 +91,7 @@ pub fn read_pip_keys_from_file() -> (bool, Option<String>) {
 
 /// Geometry of the PiP window, in screen points (top-left origin).
 ///
-/// Parsed from `--experimental-pip-geometry WxH+X+Y`. `x` / `y` are
+/// Parsed from `--agent-view-geometry WxH+X+Y`. `x` / `y` are
 /// optional; when `None` the platform backend picks a sensible
 /// "top-right corner with a small inset" default so a user enabling
 /// the feature without any geometry flags still sees a window.
@@ -148,7 +147,7 @@ impl PipGeometry {
 /// flags and handed to `PipBackendFactory::start`.
 #[derive(Debug, Clone)]
 pub struct PipConfig {
-    /// `--experimental-pip` is on argv. The factory is only consulted
+    /// `--agent-view` is on argv. The factory is only consulted
     /// when this is true; the field is kept here so backends that
     /// share a `start()` path can early-return.
     pub enabled: bool,
@@ -169,12 +168,11 @@ impl Default for PipConfig {
 }
 
 impl PipConfig {
-    /// Parse the PiP-related CLI flags out of `std::env::args()`.
+    /// Parse the Agent View CLI flags out of `std::env::args()`.
     /// Recognised flags (all opt-in):
     /// ```text
-    /// --experimental-pip
-    /// --pip                        (short alias)
-    /// --experimental-pip-geometry  WxH | WxH+X+Y
+    /// --agent-view
+    /// --agent-view-geometry  WxH | WxH+X+Y
     /// ```
     /// Unknown flags are ignored so this never conflicts with the
     /// other arg-parser passes (CursorConfig, the subcommand router).
@@ -188,8 +186,8 @@ impl PipConfig {
         let mut i = 0usize;
         while i < args.len() {
             match args[i].as_str() {
-                "--experimental-pip" | "--pip" => cfg.enabled = true,
-                "--experimental-pip-geometry" => {
+                "--agent-view" => cfg.enabled = true,
+                "--agent-view-geometry" => {
                     if let Some(geom) = args.get(i + 1).and_then(|s| PipGeometry::parse(s)) {
                         cfg.geometry = geom;
                         i += 1;
@@ -205,10 +203,10 @@ impl PipConfig {
     /// Resolve the config from (in order of precedence, low → high):
     ///
     ///   defaults  →  `~/.cua-driver/config.json` keys
-    ///                  (`experimental_pip` bool, `experimental_pip_geometry` string)
+    ///                  (`agent_view` bool, `agent_view_geometry` string)
     ///              →  CLI flags
     ///
-    /// Lets users persist `--experimental-pip` across daemon restarts by
+    /// Lets users persist `--agent-view` across daemon restarts by
     /// editing `~/.cua-driver/config.json` once, instead of re-running
     /// `claude mcp add` with the flag baked into the args list.
     /// Malformed or missing file falls back to the next layer silently.
@@ -216,13 +214,10 @@ impl PipConfig {
         let mut cfg = PipConfig::default();
         if let Ok(text) = std::fs::read_to_string(config_path) {
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
-                if let Some(b) = json.get("experimental_pip").and_then(|v| v.as_bool()) {
+                if let Some(b) = json.get("agent_view").and_then(|v| v.as_bool()) {
                     cfg.enabled = b;
                 }
-                if let Some(s) = json
-                    .get("experimental_pip_geometry")
-                    .and_then(|v| v.as_str())
-                {
+                if let Some(s) = json.get("agent_view_geometry").and_then(|v| v.as_str()) {
                     if let Some(g) = PipGeometry::parse(s) {
                         cfg.geometry = g;
                     }
@@ -474,5 +469,74 @@ mod tests {
             Some("agent-a:old".to_owned())
         );
         assert_eq!(model.len(), 2);
+    }
+
+    #[test]
+    fn parses_agent_view_cli_names() {
+        let cfg = PipConfig::parse(&[
+            "--agent-view".to_owned(),
+            "--agent-view-geometry".to_owned(),
+            "640x420+24+36".to_owned(),
+        ]);
+        assert!(cfg.enabled);
+        assert_eq!(cfg.geometry.width, 640);
+        assert_eq!(cfg.geometry.height, 420);
+        assert_eq!(cfg.geometry.x, Some(24));
+        assert_eq!(cfg.geometry.y, Some(36));
+    }
+
+    #[test]
+    fn ignores_removed_pip_cli_names() {
+        let cfg = PipConfig::parse(&[
+            "--experimental-pip".to_owned(),
+            "--experimental-pip-geometry".to_owned(),
+            "640x420".to_owned(),
+            "--pip".to_owned(),
+        ]);
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.geometry.width, PipGeometry::default().width);
+        assert_eq!(cfg.geometry.height, PipGeometry::default().height);
+    }
+
+    #[test]
+    fn reads_agent_view_config_names() {
+        let path = std::env::temp_dir().join(format!(
+            "cua-agent-view-config-{}-new.json",
+            std::process::id()
+        ));
+        std::fs::write(
+            &path,
+            r#"{"agent_view":true,"agent_view_geometry":"800x600+12+24"}"#,
+        )
+        .unwrap();
+
+        let cfg = PipConfig::from_args_and_file(&path);
+        assert!(cfg.enabled);
+        assert_eq!(cfg.geometry.width, 800);
+        assert_eq!(cfg.geometry.height, 600);
+        assert_eq!(cfg.geometry.x, Some(12));
+        assert_eq!(cfg.geometry.y, Some(24));
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn ignores_removed_pip_config_names() {
+        let path = std::env::temp_dir().join(format!(
+            "cua-agent-view-config-{}-old.json",
+            std::process::id()
+        ));
+        std::fs::write(
+            &path,
+            r#"{"experimental_pip":true,"experimental_pip_geometry":"800x600"}"#,
+        )
+        .unwrap();
+
+        let cfg = PipConfig::from_args_and_file(&path);
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.geometry.width, PipGeometry::default().width);
+        assert_eq!(cfg.geometry.height, PipGeometry::default().height);
+
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
@@ -14,6 +14,12 @@ use std::sync::OnceLock;
 
 use std::collections::HashMap;
 
+mod desktop_layout;
+
+pub use desktop_layout::{
+    layout_desktop, png_dimensions, DesktopLayout, LayoutRect, TargetLayout, TargetSize,
+};
+
 /// Canonical `~/.cua-driver/config.json` path matching what the per-platform
 /// `set_config` tools write to. Resolves `$HOME` first (Unix/macOS) and falls
 /// back to `%USERPROFILE%` (Windows, where `HOME` is usually unset). Returns
@@ -106,8 +112,8 @@ pub struct PipGeometry {
 impl Default for PipGeometry {
     fn default() -> Self {
         Self {
-            width: 320,
-            height: 200,
+            width: 640,
+            height: 420,
             x: None,
             y: None,
         }

--- a/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
@@ -13,11 +13,15 @@ use std::sync::OnceLock;
 use std::collections::HashMap;
 
 mod desktop_layout;
+mod session_tabs;
 
 pub use desktop_layout::{
     layout_desktop, layout_desktop_with_shell, png_dimensions, DesktopLayout, LayoutRect,
     ShellStyle, TargetLayout, TargetSize,
 };
+pub use session_tabs::{layout_session_tabs, session_accent, SessionTab, SessionTabsLayout};
+
+pub const AGENT_VIEW_DEFAULT_ENABLED: bool = true;
 
 /// Canonical `~/.cua-driver/config.json` path matching what the per-platform
 /// `set_config` tools write to. Resolves `$HOME` first (Unix/macOS) and falls
@@ -73,20 +77,20 @@ pub fn write_config_key(key: &str, value: serde_json::Value) -> Result<(), Strin
 pub fn read_agent_view_keys_from_file() -> (bool, Option<String>) {
     let path = match default_config_path() {
         Some(p) => p,
-        None => return (false, None),
+        None => return (AGENT_VIEW_DEFAULT_ENABLED, None),
     };
     let text = match std::fs::read_to_string(&path) {
         Ok(t) => t,
-        Err(_) => return (false, None),
+        Err(_) => return (AGENT_VIEW_DEFAULT_ENABLED, None),
     };
     let json: serde_json::Value = match serde_json::from_str(&text) {
         Ok(v) => v,
-        Err(_) => return (false, None),
+        Err(_) => return (AGENT_VIEW_DEFAULT_ENABLED, None),
     };
     let enabled = json
         .get("agent_view")
         .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+        .unwrap_or(AGENT_VIEW_DEFAULT_ENABLED);
     let geometry = json
         .get("agent_view_geometry")
         .and_then(|v| v.as_str())
@@ -164,7 +168,7 @@ pub struct PipConfig {
 impl Default for PipConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: AGENT_VIEW_DEFAULT_ENABLED,
             geometry: PipGeometry::default(),
             title: "Cua Agent View".to_owned(),
         }
@@ -173,9 +177,10 @@ impl Default for PipConfig {
 
 impl PipConfig {
     /// Parse the Agent View CLI flags out of `std::env::args()`.
-    /// Recognised flags (all opt-in):
+    /// Recognised flags:
     /// ```text
     /// --agent-view
+    /// --no-agent-view
     /// --agent-view-geometry  WxH | WxH+X+Y
     /// ```
     /// Unknown flags are ignored so this never conflicts with the
@@ -187,13 +192,27 @@ impl PipConfig {
 
     pub fn parse(args: &[String]) -> Self {
         let mut cfg = PipConfig::default();
+        let (enabled, geometry) = Self::parse_overrides(args);
+        if let Some(enabled) = enabled {
+            cfg.enabled = enabled;
+        }
+        if let Some(geometry) = geometry {
+            cfg.geometry = geometry;
+        }
+        cfg
+    }
+
+    fn parse_overrides(args: &[String]) -> (Option<bool>, Option<PipGeometry>) {
+        let mut enabled = None;
+        let mut geometry = None;
         let mut i = 0usize;
         while i < args.len() {
             match args[i].as_str() {
-                "--agent-view" => cfg.enabled = true,
+                "--agent-view" => enabled = Some(true),
+                "--no-agent-view" => enabled = Some(false),
                 "--agent-view-geometry" => {
                     if let Some(geom) = args.get(i + 1).and_then(|s| PipGeometry::parse(s)) {
-                        cfg.geometry = geom;
+                        geometry = Some(geom);
                         i += 1;
                     }
                 }
@@ -201,7 +220,7 @@ impl PipConfig {
             }
             i += 1;
         }
-        cfg
+        (enabled, geometry)
     }
 
     /// Resolve the config from (in order of precedence, low → high):
@@ -215,6 +234,11 @@ impl PipConfig {
     /// `claude mcp add` with the flag baked into the args list.
     /// Malformed or missing file falls back to the next layer silently.
     pub fn from_args_and_file(config_path: &std::path::Path) -> Self {
+        let args: Vec<String> = std::env::args().skip(1).collect();
+        Self::from_file_and_args(config_path, &args)
+    }
+
+    fn from_file_and_args(config_path: &std::path::Path, args: &[String]) -> Self {
         let mut cfg = PipConfig::default();
         if let Ok(text) = std::fs::read_to_string(config_path) {
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
@@ -229,20 +253,12 @@ impl PipConfig {
             }
         }
         // CLI args override anything in the file.
-        let args: Vec<String> = std::env::args().collect();
-        let cli = PipConfig::parse(&args[1..]);
-        if cli.enabled {
-            cfg.enabled = true;
+        let (enabled, geometry) = PipConfig::parse_overrides(args);
+        if let Some(enabled) = enabled {
+            cfg.enabled = enabled;
         }
-        // CLI geometry only overrides when explicitly passed — detect by
-        // diffing against PipGeometry::default() (the parse() entry point
-        // returns the default when no flag is present).
-        if cli.geometry.width != PipGeometry::default().width
-            || cli.geometry.height != PipGeometry::default().height
-            || cli.geometry.x.is_some()
-            || cli.geometry.y.is_some()
-        {
-            cfg.geometry = cli.geometry;
+        if let Some(geometry) = geometry {
+            cfg.geometry = geometry;
         }
         cfg
     }
@@ -332,6 +348,7 @@ pub struct PipViewModel {
     max_targets: usize,
     frames: HashMap<String, PipFrame>,
     workspace_activity_ms: HashMap<String, u64>,
+    active_targets: HashMap<String, String>,
     selected_workspace_id: Option<String>,
     selection_pinned: bool,
 }
@@ -350,6 +367,7 @@ impl PipViewModel {
             max_targets: max_targets.max(1),
             frames: HashMap::new(),
             workspace_activity_ms: HashMap::new(),
+            active_targets: HashMap::new(),
             selected_workspace_id: None,
             selection_pinned: false,
         }
@@ -393,6 +411,8 @@ impl PipViewModel {
                 .and_then(|previous| previous.cursor_position);
         }
         self.frames.insert(view_id.clone(), frame);
+        self.active_targets
+            .insert(workspace_id.clone(), view_id.clone());
         if self.frames.len() <= self.max_targets {
             return None;
         }
@@ -425,7 +445,15 @@ impl PipViewModel {
             })
             .map(|(id, _)| id.clone());
         if let Some(id) = evicted.as_ref() {
+            let workspace_id = self
+                .frames
+                .get(id)
+                .map(|frame| frame.target.workspace_id.clone());
             self.frames.remove(id);
+            self.clear_active_view(id);
+            if let Some(workspace_id) = workspace_id.as_deref() {
+                self.reconcile_active_target(workspace_id);
+            }
         }
         self.prune_empty_workspace_activity();
         self.reconcile_selection();
@@ -451,6 +479,10 @@ impl PipViewModel {
             .as_ref()
             .is_some_and(|view_id| self.frames.remove(view_id).is_some());
         if removed {
+            if let Some(view_id) = view_id.as_deref() {
+                self.clear_active_view(view_id);
+            }
+            self.reconcile_active_target(workspace_id);
             self.prune_empty_workspace_activity();
             self.reconcile_selection();
         }
@@ -468,6 +500,7 @@ impl PipViewModel {
             self.frames.remove(id);
         }
         self.workspace_activity_ms.remove(workspace_id);
+        self.active_targets.remove(workspace_id);
         if self.selected_workspace_id.as_deref() == Some(workspace_id) {
             self.selection_pinned = false;
         }
@@ -506,6 +539,11 @@ impl PipViewModel {
                 .then_with(|| a.target.identity_key.cmp(&b.target.identity_key))
         });
         frames
+    }
+
+    pub fn active_view_id(&self) -> Option<&str> {
+        let workspace_id = self.selected_workspace_id()?;
+        self.active_targets.get(workspace_id).map(String::as_str)
     }
 
     pub fn workspaces(&self) -> Vec<PipWorkspaceSummary> {
@@ -591,6 +629,36 @@ impl PipViewModel {
                 .values()
                 .any(|frame| frame.target.workspace_id == *workspace_id)
         });
+    }
+
+    fn clear_active_view(&mut self, view_id: &str) {
+        self.active_targets.retain(|_, active| active != view_id);
+    }
+
+    fn reconcile_active_target(&mut self, workspace_id: &str) {
+        if self
+            .active_targets
+            .get(workspace_id)
+            .is_some_and(|active| self.frames.contains_key(active))
+        {
+            return;
+        }
+        let fallback = self
+            .frames
+            .iter()
+            .filter(|(_, frame)| frame.target.workspace_id == workspace_id)
+            .max_by(|(left_id, left), (right_id, right)| {
+                left.timestamp_ms
+                    .cmp(&right.timestamp_ms)
+                    .then_with(|| right_id.cmp(left_id))
+            })
+            .map(|(id, _)| id.clone());
+        if let Some(fallback) = fallback {
+            self.active_targets
+                .insert(workspace_id.to_owned(), fallback);
+        } else {
+            self.active_targets.remove(workspace_id);
+        }
     }
 
     pub fn len(&self) -> usize {
@@ -797,6 +865,65 @@ mod tests {
     }
 
     #[test]
+    fn active_target_is_scoped_to_the_selected_workspace() {
+        let mut model = PipViewModel::new(6);
+        model.upsert(frame("agent-a", "a-old", 1));
+        model.upsert(frame("agent-a", "a-active", 2));
+        model.upsert(frame("agent-b", "b-old", 3));
+        model.upsert(frame("agent-b", "b-active", 4));
+
+        assert_eq!(
+            model.active_view_id(),
+            Some(view_id("agent-b", "b-active").as_str())
+        );
+        assert!(model.select_workspace("agent-a"));
+        assert_eq!(
+            model.active_view_id(),
+            Some(view_id("agent-a", "a-active").as_str())
+        );
+        assert!(model.select_workspace("agent-b"));
+        assert_eq!(
+            model.active_view_id(),
+            Some(view_id("agent-b", "b-active").as_str())
+        );
+    }
+
+    #[test]
+    fn removing_an_active_target_falls_back_within_its_workspace() {
+        let mut model = PipViewModel::new(6);
+        model.upsert(frame("agent-a", "older", 1));
+        model.upsert(frame("agent-a", "newer", 2));
+        model.upsert(frame("agent-b", "other", 3));
+        assert!(model.select_workspace("agent-a"));
+
+        assert!(model.remove_target("agent-a", "newer"));
+
+        assert_eq!(
+            model.active_view_id(),
+            Some(view_id("agent-a", "older").as_str())
+        );
+        assert_eq!(model.selected_workspace_id(), Some("agent-a"));
+    }
+
+    #[test]
+    fn evicting_an_active_target_falls_back_within_its_workspace() {
+        let mut model = PipViewModel::new(3);
+        model.upsert(frame("agent-a", "fallback", 10));
+        model.upsert(frame("agent-a", "active", 1));
+        model.upsert(frame("agent-b", "other", 20));
+        assert!(model.select_workspace("agent-a"));
+
+        assert_eq!(
+            model.upsert(frame("agent-c", "new", 30)),
+            Some(view_id("agent-a", "active"))
+        );
+        assert_eq!(
+            model.active_view_id(),
+            Some(view_id("agent-a", "fallback").as_str())
+        );
+    }
+
+    #[test]
     fn removing_the_selected_workspace_falls_back_to_the_most_recent() {
         let mut model = PipViewModel::new(4);
         model.upsert(frame("agent-a", "a", 1));
@@ -977,6 +1104,13 @@ mod tests {
     }
 
     #[test]
+    fn explicit_no_agent_view_overrides_the_default() {
+        let cfg = PipConfig::parse(&["--no-agent-view".to_owned()]);
+        assert!(!cfg.enabled);
+        assert!(PipConfig::default().enabled);
+    }
+
+    #[test]
     fn ignores_removed_pip_cli_names() {
         let cfg = PipConfig::parse(&[
             "--experimental-pip".to_owned(),
@@ -984,7 +1118,7 @@ mod tests {
             "640x420".to_owned(),
             "--pip".to_owned(),
         ]);
-        assert!(!cfg.enabled);
+        assert!(cfg.enabled);
         assert_eq!(cfg.geometry.width, PipGeometry::default().width);
         assert_eq!(cfg.geometry.height, PipGeometry::default().height);
     }
@@ -1012,6 +1146,57 @@ mod tests {
     }
 
     #[test]
+    fn config_file_overrides_defaults_without_cli_flags() {
+        let path = std::env::temp_dir().join(format!(
+            "cua-agent-view-config-{}-file-precedence.json",
+            std::process::id()
+        ));
+        std::fs::write(
+            &path,
+            r#"{"agent_view":false,"agent_view_geometry":"800x600+12+24"}"#,
+        )
+        .unwrap();
+
+        let cfg = PipConfig::from_file_and_args(&path, &[]);
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.geometry.width, 800);
+        assert_eq!(cfg.geometry.height, 600);
+        assert_eq!(cfg.geometry.x, Some(12));
+        assert_eq!(cfg.geometry.y, Some(24));
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cli_flags_override_config_file_values() {
+        let path = std::env::temp_dir().join(format!(
+            "cua-agent-view-config-{}-cli-precedence.json",
+            std::process::id()
+        ));
+        std::fs::write(
+            &path,
+            r#"{"agent_view":true,"agent_view_geometry":"800x600+12+24"}"#,
+        )
+        .unwrap();
+
+        let cfg = PipConfig::from_file_and_args(
+            &path,
+            &[
+                "--no-agent-view".to_owned(),
+                "--agent-view-geometry".to_owned(),
+                "720x480+30+40".to_owned(),
+            ],
+        );
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.geometry.width, 720);
+        assert_eq!(cfg.geometry.height, 480);
+        assert_eq!(cfg.geometry.x, Some(30));
+        assert_eq!(cfg.geometry.y, Some(40));
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn ignores_removed_pip_config_names() {
         let path = std::env::temp_dir().join(format!(
             "cua-agent-view-config-{}-old.json",
@@ -1024,7 +1209,7 @@ mod tests {
         .unwrap();
 
         let cfg = PipConfig::from_args_and_file(&path);
-        assert!(!cfg.enabled);
+        assert!(cfg.enabled);
         assert_eq!(cfg.geometry.width, PipGeometry::default().width);
         assert_eq!(cfg.geometry.height, PipGeometry::default().height);
 

--- a/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
@@ -1,14 +1,12 @@
-//! Shared model and platform contract for the experimental Agent View.
+//! Shared model and platform contract for Agent View.
 //!
 //! Agent View is an opt-in surface rather than one process-global "latest screenshot".
 //! Frames carry an existing session/workspace identity and an exact native
 //! window or browser-tab identity. Platform backends can therefore keep
 //! several target cards visible without introducing target claims or leases.
 //!
-//! macOS is the first working implementation (NSWindow + NSImageView).
-//! Windows + Linux ship as compile-clean stubs whose `start()` returns
-//! a clear "not yet implemented" error so the rest of the daemon
-//! continues without a PiP window.
+//! Native backends render the shared model on macOS, Windows, and Linux
+//! X11/XWayland while keeping platform-specific window-system code isolated.
 
 use std::sync::OnceLock;
 
@@ -158,8 +156,7 @@ pub struct PipConfig {
     /// share a `start()` path can early-return.
     pub enabled: bool,
     pub geometry: PipGeometry,
-    /// Window title — kept here so the "experimental" label stays in
-    /// one place. Defaults to "cua-driver — agent view (experimental)".
+    /// Native window title shared by all platform backends.
     pub title: String,
 }
 
@@ -168,7 +165,7 @@ impl Default for PipConfig {
         Self {
             enabled: false,
             geometry: PipGeometry::default(),
-            title: "Cua Agent View (experimental)".to_owned(),
+            title: "Cua Agent View".to_owned(),
         }
     }
 }

--- a/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
@@ -276,14 +276,33 @@ pub struct PipTarget {
     pub workspace_label: String,
     /// Stable exact-target key within the workspace.
     pub target_id: String,
+    /// Process-local identity used to de-duplicate equivalent bindings. This
+    /// may be more stable than the public target reference (for example a CDP
+    /// page target across repeated browser-window binds).
+    pub identity_key: String,
     pub target_kind: PipTargetKind,
     pub target_label: String,
+    /// Native window containing this target, when proven. Browser tabs use it
+    /// to avoid a duplicate native Chrome/Edge window card.
+    pub native_container: Option<PipNativeContainer>,
 }
 
 impl PipTarget {
     pub fn view_id(&self) -> String {
-        format!("{}:{}", self.workspace_id, self.target_id)
+        view_id(&self.workspace_id, &self.identity_key)
     }
+}
+
+fn view_id(workspace_id: &str, identity_key: &str) -> String {
+    // Both identities may contain `:`. Prefixing the workspace byte length
+    // prevents cross-session concatenation aliases.
+    format!("{}:{workspace_id}{identity_key}", workspace_id.len())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PipNativeContainer {
+    pub pid: i64,
+    pub window_id: u64,
 }
 
 /// A single exact-target frame pushed into the Agent View after a tool call.
@@ -312,6 +331,16 @@ pub struct PipFrame {
 pub struct PipViewModel {
     max_targets: usize,
     frames: HashMap<String, PipFrame>,
+    selected_workspace_id: Option<String>,
+    selection_pinned: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PipWorkspaceSummary {
+    pub workspace_id: String,
+    pub workspace_label: String,
+    pub target_count: usize,
+    pub updated_ms: u64,
 }
 
 impl PipViewModel {
@@ -319,25 +348,98 @@ impl PipViewModel {
         Self {
             max_targets: max_targets.max(1),
             frames: HashMap::new(),
+            selected_workspace_id: None,
+            selection_pinned: false,
         }
     }
 
     pub fn upsert(&mut self, frame: PipFrame) -> Option<String> {
+        let workspace_id = frame.target.workspace_id.clone();
+        if frame.target.target_kind == PipTargetKind::NativeWindow
+            && frame.target.native_container.is_some_and(|container| {
+                self.frames.values().any(|existing| {
+                    existing.target.workspace_id == workspace_id
+                        && existing.target.target_kind == PipTargetKind::BrowserTab
+                        && existing.target.native_container == Some(container)
+                })
+            })
+        {
+            return None;
+        }
+        if frame.target.target_kind == PipTargetKind::BrowserTab {
+            if let Some(container) = frame.target.native_container {
+                self.frames.retain(|_, existing| {
+                    existing.target.workspace_id != workspace_id
+                        || existing.target.target_kind != PipTargetKind::NativeWindow
+                        || existing.target.native_container != Some(container)
+                });
+            }
+        }
         let view_id = frame.target.view_id();
         self.frames.insert(view_id.clone(), frame);
+        if self.selected_workspace_id.is_none() || !self.selection_pinned {
+            self.selected_workspace_id = Some(workspace_id.clone());
+        }
         if self.frames.len() <= self.max_targets {
             return None;
         }
+        let counts = self
+            .frames
+            .values()
+            .fold(HashMap::new(), |mut counts, frame| {
+                *counts
+                    .entry(frame.target.workspace_id.as_str())
+                    .or_insert(0usize) += 1;
+                counts
+            });
+        let largest_workspace = counts
+            .iter()
+            .max_by(|(left_id, left_count), (right_id, right_count)| {
+                left_count
+                    .cmp(right_count)
+                    .then_with(|| right_id.cmp(left_id))
+            })
+            .map(|(id, _)| *id);
         let evicted = self
             .frames
             .iter()
             .filter(|(id, _)| *id != &view_id)
-            .min_by_key(|(_, frame)| frame.timestamp_ms)
+            .min_by_key(|(_, candidate)| {
+                (
+                    candidate.target.workspace_id.as_str() != largest_workspace.unwrap_or(""),
+                    candidate.timestamp_ms,
+                )
+            })
             .map(|(id, _)| id.clone());
         if let Some(id) = evicted.as_ref() {
             self.frames.remove(id);
         }
+        self.reconcile_selection();
         evicted
+    }
+
+    pub fn remove_target(&mut self, workspace_id: &str, identity_key: &str) -> bool {
+        let direct = view_id(workspace_id, identity_key);
+        let view_id = self
+            .frames
+            .contains_key(&direct)
+            .then_some(direct)
+            .or_else(|| {
+                self.frames
+                    .iter()
+                    .find(|(_, frame)| {
+                        frame.target.workspace_id == workspace_id
+                            && frame.target.target_id == identity_key
+                    })
+                    .map(|(id, _)| id.clone())
+            });
+        let removed = view_id
+            .as_ref()
+            .is_some_and(|view_id| self.frames.remove(view_id).is_some());
+        if removed {
+            self.reconcile_selection();
+        }
+        removed
     }
 
     pub fn remove_workspace(&mut self, workspace_id: &str) -> Vec<String> {
@@ -350,6 +452,10 @@ impl PipViewModel {
         for id in &removed {
             self.frames.remove(id);
         }
+        if self.selected_workspace_id.as_deref() == Some(workspace_id) {
+            self.selection_pinned = false;
+        }
+        self.reconcile_selection();
         removed
     }
 
@@ -365,6 +471,101 @@ impl PipViewModel {
         frames
     }
 
+    pub fn selected_workspace_id(&self) -> Option<&str> {
+        self.selected_workspace_id.as_deref()
+    }
+
+    pub fn selected_frames(&self) -> Vec<&PipFrame> {
+        let Some(selected) = self.selected_workspace_id() else {
+            return Vec::new();
+        };
+        let mut frames = self
+            .frames
+            .values()
+            .filter(|frame| frame.target.workspace_id == selected)
+            .collect::<Vec<_>>();
+        frames.sort_by(|a, b| {
+            b.timestamp_ms
+                .cmp(&a.timestamp_ms)
+                .then_with(|| a.target.identity_key.cmp(&b.target.identity_key))
+        });
+        frames
+    }
+
+    pub fn workspaces(&self) -> Vec<PipWorkspaceSummary> {
+        let mut summaries = HashMap::<&str, PipWorkspaceSummary>::new();
+        for frame in self.frames.values() {
+            let entry = summaries
+                .entry(&frame.target.workspace_id)
+                .or_insert_with(|| PipWorkspaceSummary {
+                    workspace_id: frame.target.workspace_id.clone(),
+                    workspace_label: sanitize_label(&frame.target.workspace_label, 48),
+                    target_count: 0,
+                    updated_ms: 0,
+                });
+            entry.target_count += 1;
+            entry.updated_ms = entry.updated_ms.max(frame.timestamp_ms);
+        }
+        let mut summaries = summaries.into_values().collect::<Vec<_>>();
+        summaries.sort_by(|a, b| {
+            b.updated_ms
+                .cmp(&a.updated_ms)
+                .then_with(|| a.workspace_label.cmp(&b.workspace_label))
+                .then_with(|| a.workspace_id.cmp(&b.workspace_id))
+        });
+        summaries
+    }
+
+    pub fn select_workspace(&mut self, workspace_id: &str) -> bool {
+        if !self
+            .frames
+            .values()
+            .any(|frame| frame.target.workspace_id == workspace_id)
+        {
+            return false;
+        }
+        self.selected_workspace_id = Some(workspace_id.to_owned());
+        self.selection_pinned = true;
+        true
+    }
+
+    pub fn select_next_workspace(&mut self) -> bool {
+        let workspaces = self.workspaces();
+        if workspaces.len() <= 1 {
+            return false;
+        }
+        let selected = self.selected_workspace_id();
+        let index = workspaces
+            .iter()
+            .position(|workspace| Some(workspace.workspace_id.as_str()) == selected)
+            .unwrap_or(0);
+        self.select_workspace(&workspaces[(index + 1) % workspaces.len()].workspace_id)
+    }
+
+    pub fn selection_is_pinned(&self) -> bool {
+        self.selection_pinned
+    }
+
+    fn reconcile_selection(&mut self) {
+        let selected_exists = self
+            .selected_workspace_id
+            .as_deref()
+            .is_some_and(|selected| {
+                self.frames
+                    .values()
+                    .any(|frame| frame.target.workspace_id == selected)
+            });
+        if selected_exists {
+            return;
+        }
+        self.selection_pinned = false;
+        self.selected_workspace_id = self
+            .frames
+            .values()
+            .max_by_key(|frame| frame.timestamp_ms)
+            .map(|frame| frame.target.workspace_id.clone());
+    }
+
     pub fn len(&self) -> usize {
         self.frames.len()
     }
@@ -372,6 +573,18 @@ impl PipViewModel {
     pub fn is_empty(&self) -> bool {
         self.frames.is_empty()
     }
+}
+
+fn sanitize_label(value: &str, max_chars: usize) -> String {
+    let mut label = value
+        .chars()
+        .filter(|character| !character.is_control())
+        .take(max_chars)
+        .collect::<String>();
+    if label.trim().is_empty() {
+        label = "Agent".to_owned();
+    }
+    label
 }
 
 /// A live PiP window. Owned by `main.rs` for the lifetime of the
@@ -386,6 +599,10 @@ pub trait PipBackend: Send + Sync {
     /// Remove every card associated with an ended session/workspace. This
     /// changes only Agent View presentation; it does not close applications.
     fn remove_workspace(&self, workspace_id: &str);
+
+    /// Remove one exact target from presentation. This never closes or
+    /// otherwise mutates the underlying native window or browser tab.
+    fn remove_target(&self, _workspace_id: &str, _identity_key: &str) {}
 
     /// Close the window and release native resources. Called from
     /// `main.rs` on shutdown.
@@ -428,13 +645,49 @@ mod tests {
                 workspace_id: workspace.to_owned(),
                 workspace_label: workspace.to_owned(),
                 target_id: target.to_owned(),
+                identity_key: target.to_owned(),
                 target_kind: PipTargetKind::NativeWindow,
                 target_label: target.to_owned(),
+                native_container: None,
             },
             png_bytes: vec![1],
             action_label: "click".to_owned(),
             timestamp_ms,
         }
+    }
+
+    fn browser_frame(
+        workspace: &str,
+        target: &str,
+        identity: &str,
+        container: PipNativeContainer,
+        timestamp_ms: u64,
+    ) -> PipFrame {
+        PipFrame {
+            target: PipTarget {
+                workspace_id: workspace.to_owned(),
+                workspace_label: workspace.to_owned(),
+                target_id: target.to_owned(),
+                identity_key: identity.to_owned(),
+                target_kind: PipTargetKind::BrowserTab,
+                target_label: target.to_owned(),
+                native_container: Some(container),
+            },
+            png_bytes: vec![1],
+            action_label: "get_browser_state".to_owned(),
+            timestamp_ms,
+        }
+    }
+
+    fn native_frame(
+        workspace: &str,
+        target: &str,
+        container: PipNativeContainer,
+        timestamp_ms: u64,
+    ) -> PipFrame {
+        let mut frame = frame(workspace, target, timestamp_ms);
+        frame.target.native_container = Some(container);
+        frame
     }
 
     #[test]
@@ -472,9 +725,151 @@ mod tests {
         model.upsert(frame("agent-a", "newer", 2));
         assert_eq!(
             model.upsert(frame("agent-b", "newest", 3)),
-            Some("agent-a:old".to_owned())
+            Some(view_id("agent-a", "old"))
         );
         assert_eq!(model.len(), 2);
+    }
+
+    #[test]
+    fn follows_recent_activity_until_the_user_pins_a_workspace() {
+        let mut model = PipViewModel::new(4);
+        model.upsert(frame("agent-a", "a", 1));
+        model.upsert(frame("agent-b", "b", 2));
+        assert_eq!(model.selected_workspace_id(), Some("agent-b"));
+
+        assert!(model.select_workspace("agent-a"));
+        model.upsert(frame("agent-b", "b", 3));
+        assert_eq!(model.selected_workspace_id(), Some("agent-a"));
+        assert!(model.selection_is_pinned());
+        assert_eq!(model.selected_frames().len(), 1);
+    }
+
+    #[test]
+    fn removing_the_selected_workspace_falls_back_to_the_most_recent() {
+        let mut model = PipViewModel::new(4);
+        model.upsert(frame("agent-a", "a", 1));
+        model.upsert(frame("agent-b", "b", 2));
+        assert!(model.select_workspace("agent-a"));
+        model.remove_workspace("agent-a");
+        assert_eq!(model.selected_workspace_id(), Some("agent-b"));
+        assert!(!model.selection_is_pinned());
+    }
+
+    #[test]
+    fn exact_target_removal_uses_the_internal_identity_key() {
+        let mut model = PipViewModel::new(4);
+        model.upsert(frame("agent-a", "window:1:2", 1));
+        assert!(model.remove_target("agent-a", "window:1:2"));
+        assert!(model.is_empty());
+        assert_eq!(model.selected_workspace_id(), None);
+    }
+
+    #[test]
+    fn equal_public_labels_do_not_merge_private_workspaces() {
+        let mut model = PipViewModel::new(4);
+        let mut first = frame("private-a", "one", 1);
+        first.target.workspace_label = "research".to_owned();
+        let mut second = frame("private-b", "two", 2);
+        second.target.workspace_label = "research".to_owned();
+        model.upsert(first);
+        model.upsert(second);
+
+        let workspaces = model.workspaces();
+        assert_eq!(workspaces.len(), 2);
+        assert!(workspaces
+            .iter()
+            .all(|workspace| workspace.workspace_label == "research"));
+        assert_eq!(model.selected_workspace_id(), Some("private-b"));
+    }
+
+    #[test]
+    fn stable_browser_identity_updates_across_repeated_bindings() {
+        let mut model = PipViewModel::new(4);
+        let container = PipNativeContainer {
+            pid: 42,
+            window_id: 7,
+        };
+        model.upsert(browser_frame(
+            "agent-a",
+            "browser:first:tab-a",
+            "browser-cdp:page-1",
+            container,
+            1,
+        ));
+        model.upsert(browser_frame(
+            "agent-a",
+            "browser:second:tab-b",
+            "browser-cdp:page-1",
+            container,
+            2,
+        ));
+
+        assert_eq!(model.len(), 1);
+        assert_eq!(
+            model.selected_frames()[0].target.target_id,
+            "browser:second:tab-b"
+        );
+        assert_eq!(model.selected_frames()[0].timestamp_ms, 2);
+    }
+
+    #[test]
+    fn browser_tabs_replace_and_suppress_their_native_container_card() {
+        let mut model = PipViewModel::new(6);
+        let container = PipNativeContainer {
+            pid: 42,
+            window_id: 7,
+        };
+        model.upsert(native_frame("agent-a", "window:42:7", container, 1));
+        model.upsert(browser_frame(
+            "agent-a",
+            "browser:binding:tab-a",
+            "browser-cdp:page-a",
+            container,
+            2,
+        ));
+        model.upsert(browser_frame(
+            "agent-a",
+            "browser:binding:tab-b",
+            "browser-cdp:page-b",
+            container,
+            3,
+        ));
+        model.upsert(native_frame("agent-a", "window:42:7", container, 4));
+
+        let frames = model.selected_frames();
+        assert_eq!(frames.len(), 2);
+        assert!(frames
+            .iter()
+            .all(|frame| frame.target.target_kind == PipTargetKind::BrowserTab));
+    }
+
+    #[test]
+    fn private_session_and_target_delimiters_cannot_alias() {
+        let mut model = PipViewModel::new(4);
+        model.upsert(frame("private:a", "b", 1));
+        model.upsert(frame("private", "a:b", 2));
+
+        assert_eq!(model.len(), 2);
+        assert!(model.select_workspace("private:a"));
+        assert_eq!(model.selected_frames()[0].target.target_id, "b");
+        assert!(model.select_workspace("private"));
+        assert_eq!(model.selected_frames()[0].target.target_id, "a:b");
+    }
+
+    #[test]
+    fn eviction_prefers_the_most_populated_workspace() {
+        let mut model = PipViewModel::new(3);
+        model.upsert(frame("agent-a", "old-a", 1));
+        model.upsert(frame("agent-a", "new-a", 2));
+        model.upsert(frame("agent-b", "only-b", 3));
+        assert_eq!(
+            model.upsert(frame("agent-c", "only-c", 4)),
+            Some(view_id("agent-a", "old-a"))
+        );
+        assert!(model
+            .ordered_frames()
+            .iter()
+            .any(|frame| frame.target.workspace_id == "agent-b"));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
@@ -318,6 +318,8 @@ pub struct PipFrame {
     /// Wall-clock timestamp (ms since Unix epoch) — used by backends
     /// that want to show "last update Xs ago" in the title bar.
     pub timestamp_ms: u64,
+    /// Normalized location of the synthetic agent pointer within the target image.
+    pub cursor_position: Option<(f64, f64)>,
 }
 
 /// Platform-neutral latest-frame model with bounded target retention.
@@ -353,6 +355,7 @@ impl PipViewModel {
     }
 
     pub fn upsert(&mut self, frame: PipFrame) -> Option<String> {
+        let mut frame = frame;
         let workspace_id = frame.target.workspace_id.clone();
         self.workspace_activity_ms
             .entry(workspace_id.clone())
@@ -382,6 +385,12 @@ impl PipViewModel {
             }
         }
         let view_id = frame.target.view_id();
+        if frame.cursor_position.is_none() {
+            frame.cursor_position = self
+                .frames
+                .get(&view_id)
+                .and_then(|previous| previous.cursor_position);
+        }
         self.frames.insert(view_id.clone(), frame);
         if self.frames.len() <= self.max_targets {
             return None;
@@ -680,6 +689,7 @@ mod tests {
             png_bytes: vec![1],
             action_label: "click".to_owned(),
             timestamp_ms,
+            cursor_position: None,
         }
     }
 
@@ -703,6 +713,7 @@ mod tests {
             png_bytes: vec![1],
             action_label: "get_browser_state".to_owned(),
             timestamp_ms,
+            cursor_position: None,
         }
     }
 
@@ -723,6 +734,19 @@ mod tests {
         model.upsert(frame("agent-a", "window:1:2", 1));
         model.upsert(frame("agent-a", "browser:bt:tab", 2));
         assert_eq!(model.len(), 2);
+    }
+
+    #[test]
+    fn non_pointer_updates_preserve_the_last_cursor_position() {
+        let mut model = PipViewModel::new(4);
+        let mut clicked = frame("agent-a", "window:1:2", 1);
+        clicked.cursor_position = Some((0.25, 0.75));
+        model.upsert(clicked);
+        model.upsert(frame("agent-a", "window:1:2", 2));
+        assert_eq!(
+            model.selected_frames()[0].cursor_position,
+            Some((0.25, 0.75))
+        );
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
@@ -1,13 +1,10 @@
-//! pip-preview — shared types + trait for the experimental
-//! picture-in-picture agent preview window.
+//! Shared model and platform contract for the experimental Agent View.
 //!
-//! The PiP window is an opt-in, always-on-top floating window that
-//! shows what the cua-driver agent just did: a post-action screenshot
-//! of the target window plus a one-line label summarising the tool
-//! call. It mirrors the architecture used by `cursor-overlay` (shared
-//! config/types here, platform-specific renderer in each `platform-*`
-//! crate) and the registration pattern used by `cua_driver_core::video`
-//! (a `OnceLock` factory set once at startup by `main.rs`).
+//! The existing PiP flags remain the compatibility entry point, but the
+//! surface is no longer modeled as one process-global "latest screenshot".
+//! Frames carry an existing session/workspace identity and an exact native
+//! window or browser-tab identity. Platform backends can therefore keep
+//! several target cards visible without introducing target claims or leases.
 //!
 //! macOS is the first working implementation (NSWindow + NSImageView).
 //! Windows + Linux ship as compile-clean stubs whose `start()` returns
@@ -15,6 +12,8 @@
 //! continues without a PiP window.
 
 use std::sync::OnceLock;
+
+use std::collections::HashMap;
 
 /// Canonical `~/.cua-driver/config.json` path matching what the per-platform
 /// `set_config` tools write to. Resolves `$HOME` first (Unix/macOS) and falls
@@ -164,7 +163,7 @@ impl Default for PipConfig {
         Self {
             enabled: false,
             geometry: PipGeometry::default(),
-            title: "cua-driver — agent view (experimental)".to_owned(),
+            title: "Cua Agent View (experimental)".to_owned(),
         }
     }
 }
@@ -250,7 +249,43 @@ impl PipConfig {
     }
 }
 
-/// A single frame pushed into the PiP window after a tool call lands.
+/// The exact surface represented by an Agent View card.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PipTargetKind {
+    NativeWindow,
+    BrowserTab,
+}
+
+impl PipTargetKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NativeWindow => "native_window",
+            Self::BrowserTab => "browser_tab",
+        }
+    }
+}
+
+/// Stable target metadata used to group frames in the Agent View.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PipTarget {
+    /// Runtime-unique session key. This is grouping metadata, not an ownership
+    /// or authorization claim.
+    pub workspace_id: String,
+    /// Short public session label shown to the user.
+    pub workspace_label: String,
+    /// Stable exact-target key within the workspace.
+    pub target_id: String,
+    pub target_kind: PipTargetKind,
+    pub target_label: String,
+}
+
+impl PipTarget {
+    pub fn view_id(&self) -> String {
+        format!("{}:{}", self.workspace_id, self.target_id)
+    }
+}
+
+/// A single exact-target frame pushed into the Agent View after a tool call.
 ///
 /// `png_bytes` are the raw PNG bytes produced by the platform
 /// screenshot callback — the same path that powers `screenshot.png`
@@ -258,6 +293,7 @@ impl PipConfig {
 /// sees.
 #[derive(Debug, Clone)]
 pub struct PipFrame {
+    pub target: PipTarget,
     pub png_bytes: Vec<u8>,
     /// One-line summary shown overlayed on the frame, e.g.
     /// `click element_index=2` or `type_text "hello world"`.
@@ -265,6 +301,76 @@ pub struct PipFrame {
     /// Wall-clock timestamp (ms since Unix epoch) — used by backends
     /// that want to show "last update Xs ago" in the title bar.
     pub timestamp_ms: u64,
+}
+
+/// Platform-neutral latest-frame model with bounded target retention.
+///
+/// Backends use this to keep one card per exact target. The oldest-updated
+/// card is evicted when the configured limit is reached; ending a workspace
+/// removes all of its cards without closing the underlying applications.
+pub struct PipViewModel {
+    max_targets: usize,
+    frames: HashMap<String, PipFrame>,
+}
+
+impl PipViewModel {
+    pub fn new(max_targets: usize) -> Self {
+        Self {
+            max_targets: max_targets.max(1),
+            frames: HashMap::new(),
+        }
+    }
+
+    pub fn upsert(&mut self, frame: PipFrame) -> Option<String> {
+        let view_id = frame.target.view_id();
+        self.frames.insert(view_id.clone(), frame);
+        if self.frames.len() <= self.max_targets {
+            return None;
+        }
+        let evicted = self
+            .frames
+            .iter()
+            .filter(|(id, _)| *id != &view_id)
+            .min_by_key(|(_, frame)| frame.timestamp_ms)
+            .map(|(id, _)| id.clone());
+        if let Some(id) = evicted.as_ref() {
+            self.frames.remove(id);
+        }
+        evicted
+    }
+
+    pub fn remove_workspace(&mut self, workspace_id: &str) -> Vec<String> {
+        let removed = self
+            .frames
+            .iter()
+            .filter(|(_, frame)| frame.target.workspace_id == workspace_id)
+            .map(|(id, _)| id.clone())
+            .collect::<Vec<_>>();
+        for id in &removed {
+            self.frames.remove(id);
+        }
+        removed
+    }
+
+    pub fn ordered_frames(&self) -> Vec<&PipFrame> {
+        let mut frames = self.frames.values().collect::<Vec<_>>();
+        frames.sort_by(|a, b| {
+            a.target
+                .workspace_label
+                .cmp(&b.target.workspace_label)
+                .then_with(|| b.timestamp_ms.cmp(&a.timestamp_ms))
+                .then_with(|| a.target.target_id.cmp(&b.target.target_id))
+        });
+        frames
+    }
+
+    pub fn len(&self) -> usize {
+        self.frames.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
 }
 
 /// A live PiP window. Owned by `main.rs` for the lifetime of the
@@ -275,6 +381,10 @@ pub trait PipBackend: Send + Sync {
     /// its UI toolkit requires (the macOS impl dispatches to the main
     /// queue via `dispatch_async`).
     fn push_frame(&self, frame: PipFrame);
+
+    /// Remove every card associated with an ended session/workspace. This
+    /// changes only Agent View presentation; it does not close applications.
+    fn remove_workspace(&self, workspace_id: &str);
 
     /// Close the window and release native resources. Called from
     /// `main.rs` on shutdown.
@@ -305,4 +415,64 @@ pub fn start_pip(cfg: &PipConfig) -> anyhow::Result<Box<dyn PipBackend>> {
         .get()
         .ok_or_else(|| anyhow::anyhow!("no PiP backend registered for this platform"))?;
     factory.start(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frame(workspace: &str, target: &str, timestamp_ms: u64) -> PipFrame {
+        PipFrame {
+            target: PipTarget {
+                workspace_id: workspace.to_owned(),
+                workspace_label: workspace.to_owned(),
+                target_id: target.to_owned(),
+                target_kind: PipTargetKind::NativeWindow,
+                target_label: target.to_owned(),
+            },
+            png_bytes: vec![1],
+            action_label: "click".to_owned(),
+            timestamp_ms,
+        }
+    }
+
+    #[test]
+    fn keeps_distinct_targets_in_the_same_workspace() {
+        let mut model = PipViewModel::new(4);
+        model.upsert(frame("agent-a", "window:1:2", 1));
+        model.upsert(frame("agent-a", "browser:bt:tab", 2));
+        assert_eq!(model.len(), 2);
+    }
+
+    #[test]
+    fn updating_one_target_does_not_replace_another() {
+        let mut model = PipViewModel::new(4);
+        model.upsert(frame("agent-a", "window:1:2", 1));
+        model.upsert(frame("agent-a", "browser:bt:tab", 2));
+        model.upsert(frame("agent-a", "window:1:2", 3));
+        assert_eq!(model.len(), 2);
+        assert_eq!(model.ordered_frames()[0].target.target_id, "window:1:2");
+    }
+
+    #[test]
+    fn ending_a_workspace_removes_only_its_cards() {
+        let mut model = PipViewModel::new(4);
+        model.upsert(frame("agent-a", "window:1:2", 1));
+        model.upsert(frame("agent-b", "window:3:4", 2));
+        assert_eq!(model.remove_workspace("agent-a").len(), 1);
+        assert_eq!(model.len(), 1);
+        assert_eq!(model.ordered_frames()[0].target.workspace_id, "agent-b");
+    }
+
+    #[test]
+    fn evicts_the_oldest_other_target_at_capacity() {
+        let mut model = PipViewModel::new(2);
+        model.upsert(frame("agent-a", "old", 1));
+        model.upsert(frame("agent-a", "newer", 2));
+        assert_eq!(
+            model.upsert(frame("agent-b", "newest", 3)),
+            Some("agent-a:old".to_owned())
+        );
+        assert_eq!(model.len(), 2);
+    }
 }

--- a/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
@@ -331,6 +331,7 @@ pub struct PipFrame {
 pub struct PipViewModel {
     max_targets: usize,
     frames: HashMap<String, PipFrame>,
+    workspace_activity_ms: HashMap<String, u64>,
     selected_workspace_id: Option<String>,
     selection_pinned: bool,
 }
@@ -348,6 +349,7 @@ impl PipViewModel {
         Self {
             max_targets: max_targets.max(1),
             frames: HashMap::new(),
+            workspace_activity_ms: HashMap::new(),
             selected_workspace_id: None,
             selection_pinned: false,
         }
@@ -355,6 +357,13 @@ impl PipViewModel {
 
     pub fn upsert(&mut self, frame: PipFrame) -> Option<String> {
         let workspace_id = frame.target.workspace_id.clone();
+        self.workspace_activity_ms
+            .entry(workspace_id.clone())
+            .and_modify(|timestamp| *timestamp = (*timestamp).max(frame.timestamp_ms))
+            .or_insert(frame.timestamp_ms);
+        if self.selected_workspace_id.is_none() || !self.selection_pinned {
+            self.selected_workspace_id = Some(workspace_id.clone());
+        }
         if frame.target.target_kind == PipTargetKind::NativeWindow
             && frame.target.native_container.is_some_and(|container| {
                 self.frames.values().any(|existing| {
@@ -377,9 +386,6 @@ impl PipViewModel {
         }
         let view_id = frame.target.view_id();
         self.frames.insert(view_id.clone(), frame);
-        if self.selected_workspace_id.is_none() || !self.selection_pinned {
-            self.selected_workspace_id = Some(workspace_id.clone());
-        }
         if self.frames.len() <= self.max_targets {
             return None;
         }
@@ -414,6 +420,7 @@ impl PipViewModel {
         if let Some(id) = evicted.as_ref() {
             self.frames.remove(id);
         }
+        self.prune_empty_workspace_activity();
         self.reconcile_selection();
         evicted
     }
@@ -437,6 +444,7 @@ impl PipViewModel {
             .as_ref()
             .is_some_and(|view_id| self.frames.remove(view_id).is_some());
         if removed {
+            self.prune_empty_workspace_activity();
             self.reconcile_selection();
         }
         removed
@@ -452,6 +460,7 @@ impl PipViewModel {
         for id in &removed {
             self.frames.remove(id);
         }
+        self.workspace_activity_ms.remove(workspace_id);
         if self.selected_workspace_id.as_deref() == Some(workspace_id) {
             self.selection_pinned = false;
         }
@@ -501,10 +510,13 @@ impl PipViewModel {
                     workspace_id: frame.target.workspace_id.clone(),
                     workspace_label: sanitize_label(&frame.target.workspace_label, 48),
                     target_count: 0,
-                    updated_ms: 0,
+                    updated_ms: self
+                        .workspace_activity_ms
+                        .get(&frame.target.workspace_id)
+                        .copied()
+                        .unwrap_or(frame.timestamp_ms),
                 });
             entry.target_count += 1;
-            entry.updated_ms = entry.updated_ms.max(frame.timestamp_ms);
         }
         let mut summaries = summaries.into_values().collect::<Vec<_>>();
         summaries.sort_by(|a, b| {
@@ -560,10 +572,18 @@ impl PipViewModel {
         }
         self.selection_pinned = false;
         self.selected_workspace_id = self
-            .frames
-            .values()
-            .max_by_key(|frame| frame.timestamp_ms)
-            .map(|frame| frame.target.workspace_id.clone());
+            .workspaces()
+            .into_iter()
+            .next()
+            .map(|workspace| workspace.workspace_id);
+    }
+
+    fn prune_empty_workspace_activity(&mut self) {
+        self.workspace_activity_ms.retain(|workspace_id, _| {
+            self.frames
+                .values()
+                .any(|frame| frame.target.workspace_id == *workspace_id)
+        });
     }
 
     pub fn len(&self) -> usize {
@@ -839,6 +859,44 @@ mod tests {
         let frames = model.selected_frames();
         assert_eq!(frames.len(), 2);
         assert!(frames
+            .iter()
+            .all(|frame| frame.target.target_kind == PipTargetKind::BrowserTab));
+    }
+
+    #[test]
+    fn suppressed_native_container_activity_still_drives_auto_follow() {
+        let mut model = PipViewModel::new(6);
+        let first_container = PipNativeContainer {
+            pid: 42,
+            window_id: 7,
+        };
+        let second_container = PipNativeContainer {
+            pid: 84,
+            window_id: 9,
+        };
+        model.upsert(browser_frame(
+            "agent-a",
+            "browser:first:tab-a",
+            "browser-cdp:page-a",
+            first_container,
+            1,
+        ));
+        model.upsert(browser_frame(
+            "agent-b",
+            "browser:second:tab-b",
+            "browser-cdp:page-b",
+            second_container,
+            2,
+        ));
+        assert_eq!(model.selected_workspace_id(), Some("agent-b"));
+
+        model.upsert(native_frame("agent-a", "window:42:7", first_container, 3));
+
+        assert_eq!(model.selected_workspace_id(), Some("agent-a"));
+        assert_eq!(model.workspaces()[0].workspace_id, "agent-a");
+        assert_eq!(model.workspaces()[0].updated_ms, 3);
+        assert!(model
+            .selected_frames()
             .iter()
             .all(|frame| frame.target.target_kind == PipTargetKind::BrowserTab));
     }

--- a/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
@@ -621,6 +621,16 @@ pub trait PipBackend: Send + Sync {
     /// otherwise mutates the underlying native window or browser tab.
     fn remove_target(&self, _workspace_id: &str, _identity_key: &str) {}
 
+    /// Make the floating surface ignore or resume native pointer input.
+    ///
+    /// Implementations must not return until the native window-system state is
+    /// applied. Cua Driver uses this around physical desktop actions so an
+    /// overlapping always-on-top Agent View cannot intercept the action meant
+    /// for an underlying target.
+    fn set_input_passthrough(&self, _passthrough: bool) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     /// Close the window and release native resources. Called from
     /// `main.rs` on shutdown.
     fn shutdown(self: Box<Self>);

--- a/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
@@ -15,7 +15,8 @@ use std::collections::HashMap;
 mod desktop_layout;
 
 pub use desktop_layout::{
-    layout_desktop, png_dimensions, DesktopLayout, LayoutRect, TargetLayout, TargetSize,
+    layout_desktop, layout_desktop_with_shell, png_dimensions, DesktopLayout, LayoutRect,
+    ShellStyle, TargetLayout, TargetSize,
 };
 
 /// Canonical `~/.cua-driver/config.json` path matching what the per-platform

--- a/libs/cua-driver/rust/crates/pip-preview/src/session_tabs.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/session_tabs.rs
@@ -1,0 +1,136 @@
+use crate::{LayoutRect, PipWorkspaceSummary};
+
+const MAX_VISIBLE_TABS: usize = 6;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionTab {
+    pub workspace_id: String,
+    pub label: String,
+    pub rect: LayoutRect,
+    pub selected: bool,
+    pub accent: (u8, u8, u8),
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct SessionTabsLayout {
+    pub tabs: Vec<SessionTab>,
+    pub overflow: usize,
+}
+
+impl SessionTabsLayout {
+    pub fn hit_test(&self, x: f64, y: f64) -> Option<&str> {
+        self.tabs
+            .iter()
+            .find(|tab| {
+                x >= tab.rect.x
+                    && x <= tab.rect.x + tab.rect.width
+                    && y >= tab.rect.y
+                    && y <= tab.rect.y + tab.rect.height
+            })
+            .map(|tab| tab.workspace_id.as_str())
+    }
+}
+
+pub fn layout_session_tabs(
+    panel: LayoutRect,
+    workspaces: &[PipWorkspaceSummary],
+    selected_workspace_id: Option<&str>,
+) -> SessionTabsLayout {
+    if workspaces.len() <= 1 {
+        return SessionTabsLayout::default();
+    }
+    let visible = workspaces.len().min(MAX_VISIBLE_TABS);
+    let gap = 6.0;
+    let height = (panel.height * 0.09).clamp(28.0, 42.0);
+    let width = ((panel.width - gap * (visible.saturating_sub(1)) as f64) / visible as f64)
+        .clamp(90.0, 190.0);
+    let tabs = workspaces
+        .iter()
+        .take(visible)
+        .enumerate()
+        .map(|(index, workspace)| SessionTab {
+            workspace_id: workspace.workspace_id.clone(),
+            label: workspace.workspace_label.clone(),
+            rect: LayoutRect {
+                x: panel.x + index as f64 * (width + gap),
+                y: panel.y,
+                width,
+                height,
+            },
+            selected: selected_workspace_id == Some(workspace.workspace_id.as_str()),
+            accent: session_accent(&workspace.workspace_id),
+        })
+        .collect();
+    SessionTabsLayout {
+        tabs,
+        overflow: workspaces.len().saturating_sub(visible),
+    }
+}
+
+pub fn session_accent(workspace_id: &str) -> (u8, u8, u8) {
+    let hash = workspace_id
+        .bytes()
+        .fold(0u32, |hash, byte| hash.wrapping_mul(16777619) ^ byte as u32);
+    const COLORS: [(u8, u8, u8); 6] = [
+        (55, 148, 255),
+        (255, 166, 54),
+        (54, 190, 160),
+        (228, 96, 135),
+        (139, 112, 246),
+        (66, 181, 225),
+    ];
+    COLORS[hash as usize % COLORS.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace(id: &str, updated_ms: u64) -> PipWorkspaceSummary {
+        PipWorkspaceSummary {
+            workspace_id: id.into(),
+            workspace_label: id.into(),
+            target_count: 1,
+            updated_ms,
+        }
+    }
+
+    #[test]
+    fn hides_single_session_and_directly_hit_tests_tabs() {
+        let panel = LayoutRect {
+            x: 10.0,
+            y: 12.0,
+            width: 600.0,
+            height: 400.0,
+        };
+        assert!(layout_session_tabs(panel, &[workspace("a", 1)], Some("a"))
+            .tabs
+            .is_empty());
+        let layout = layout_session_tabs(panel, &[workspace("b", 2), workspace("a", 1)], Some("a"));
+        assert_eq!(
+            layout.hit_test(layout.tabs[0].rect.x + 2.0, layout.tabs[0].rect.y + 2.0),
+            Some("b")
+        );
+        assert!(layout.tabs[1].selected);
+    }
+
+    #[test]
+    fn caps_visible_tabs_and_reports_overflow() {
+        let workspaces = (0..8)
+            .map(|i| workspace(&format!("agent-{i}"), i))
+            .collect::<Vec<_>>();
+        let layout = layout_session_tabs(
+            LayoutRect {
+                x: 0.0,
+                y: 0.0,
+                width: 900.0,
+                height: 500.0,
+            },
+            &workspaces,
+            None,
+        );
+        assert_eq!(layout.tabs.len(), 6);
+        assert_eq!(layout.overflow, 2);
+        assert_eq!(session_accent("stable"), session_accent("stable"));
+    }
+}

--- a/libs/cua-driver/rust/crates/platform-linux/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/pip/mod.rs
@@ -1304,6 +1304,7 @@ mod tests {
                 png_bytes: png(width, height, base),
                 action_label: "observe".to_owned(),
                 timestamp_ms: index as u64,
+                cursor_position: None,
             });
         }
         let seconds = std::env::var("CUA_AGENT_VIEW_SMOKE_SECONDS")

--- a/libs/cua-driver/rust/crates/platform-linux/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/pip/mod.rs
@@ -1,23 +1,927 @@
-//! Linux picture-in-picture preview stub.
+//! Linux multi-target Agent View.
 //!
-//! The Linux implementation is a follow-up to the experimental macOS
-//! drop. Plan: GTK4 always-on-top utility window under X11/XWayland,
-//! with a Wayland-native fallback via `wlr-layer-shell` where
-//! supported. Tracking issue linked in the docs.
-//!
-//! Until that lands, `start()` returns a clear error so `main.rs`
-//! can log "PiP unavailable on this platform" and continue without
-//! the window.
+//! The backend uses a regular, resizable X11 utility window (and therefore
+//! also works through XWayland) with a software-rendered GNOME-like overview.
+//! It only presents frames supplied by the shared Agent View model; it never
+//! moves, resizes, focuses, or closes the represented applications.
 
-use pip_preview::{PipBackend, PipBackendFactory, PipConfig};
+use std::sync::mpsc::{self, Receiver, Sender};
+#[cfg(target_os = "linux")]
+use std::time::Duration;
+
+#[cfg(target_os = "linux")]
+use image::imageops::FilterType;
+use pip_preview::{
+    layout_desktop, png_dimensions, LayoutRect, PipBackend, PipBackendFactory, PipConfig, PipFrame,
+    PipTargetKind, PipViewModel, TargetSize,
+};
+
+const MIN_WIDTH: u16 = 360;
+const MIN_HEIGHT: u16 = 260;
+
+enum UiMessage {
+    Frame(PipFrame),
+    RemoveWorkspace(String),
+    Shutdown,
+}
+
+pub struct LinuxPipBackend {
+    tx: Sender<UiMessage>,
+}
+
+impl PipBackend for LinuxPipBackend {
+    fn push_frame(&self, frame: PipFrame) {
+        tracing::debug!(
+            target: "pip",
+            view_id = %frame.target.view_id(),
+            "queueing Linux Agent View frame"
+        );
+        let _ = self.tx.send(UiMessage::Frame(frame));
+    }
+
+    fn remove_workspace(&self, workspace_id: &str) {
+        let _ = self
+            .tx
+            .send(UiMessage::RemoveWorkspace(workspace_id.to_owned()));
+    }
+
+    fn shutdown(self: Box<Self>) {
+        let _ = self.tx.send(UiMessage::Shutdown);
+    }
+}
 
 pub struct LinuxPipBackendFactory;
 
 impl PipBackendFactory for LinuxPipBackendFactory {
-    fn start(&self, _cfg: &PipConfig) -> anyhow::Result<Box<dyn PipBackend>> {
-        Err(anyhow::anyhow!(
-            "PiP preview is not yet implemented on Linux — track \
-             trycua/cua follow-up issue for status"
+    fn start(&self, cfg: &PipConfig) -> anyhow::Result<Box<dyn PipBackend>> {
+        let (tx, rx) = mpsc::channel();
+        let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+        let cfg = cfg.clone();
+        std::thread::Builder::new()
+            .name("cua-agent-view-linux".to_owned())
+            .spawn(move || run_x11_window(cfg, rx, ready_tx))?;
+
+        ready_rx
+            .recv()
+            .map_err(|_| anyhow::anyhow!("Agent View X11 thread exited during startup"))??;
+        Ok(Box::new(LinuxPipBackend { tx }))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn run_x11_window(
+    cfg: PipConfig,
+    rx: Receiver<UiMessage>,
+    ready: mpsc::SyncSender<anyhow::Result<()>>,
+) {
+    use x11rb::connection::Connection;
+    use x11rb::protocol::xproto::{
+        AtomEnum, ConnectionExt as _, CreateGCAux, CreateWindowAux, EventMask, PropMode,
+        WindowClass,
+    };
+    use x11rb::protocol::Event;
+    use x11rb::wrapper::ConnectionExt as _;
+
+    let setup = (|| -> anyhow::Result<_> {
+        let (conn, screen_num) = x11rb::connect(None)?;
+        let screen = &conn.setup().roots[screen_num];
+        let root = screen.root;
+        let root_depth = screen.root_depth;
+        let root_visual = screen.root_visual;
+        let screen_width = screen.width_in_pixels;
+        let width = cfg
+            .geometry
+            .width
+            .clamp(u32::from(MIN_WIDTH), u32::from(u16::MAX)) as u16;
+        let height = cfg
+            .geometry
+            .height
+            .clamp(u32::from(MIN_HEIGHT), u32::from(u16::MAX)) as u16;
+        let inset = 24i16;
+        let x = cfg.geometry.x.map(clamp_i16).unwrap_or_else(|| {
+            clamp_i16(i32::from(screen_width) - i32::from(width) - i32::from(inset))
+        });
+        let y = cfg.geometry.y.map(clamp_i16).unwrap_or(inset);
+        let window = conn.generate_id()?;
+        conn.create_window(
+            root_depth,
+            window,
+            root,
+            x,
+            y,
+            width,
+            height,
+            0,
+            WindowClass::INPUT_OUTPUT,
+            root_visual,
+            &CreateWindowAux::new()
+                .background_pixel(0x1820_27)
+                .border_pixel(0)
+                .event_mask(
+                    EventMask::EXPOSURE | EventMask::STRUCTURE_NOTIFY | EventMask::PROPERTY_CHANGE,
+                ),
+        )?
+        .check()?;
+
+        let gc = conn.generate_id()?;
+        conn.create_gc(gc, window, &CreateGCAux::new())?.check()?;
+        conn.change_property8(
+            PropMode::REPLACE,
+            window,
+            AtomEnum::WM_NAME,
+            AtomEnum::STRING,
+            cfg.title.as_bytes(),
+        )?;
+        conn.change_property8(
+            PropMode::REPLACE,
+            window,
+            AtomEnum::WM_CLASS,
+            AtomEnum::STRING,
+            b"cua-agent-view\0CuaAgentView\0",
+        )?;
+        let net_wm_pid = conn.intern_atom(false, b"_NET_WM_PID")?.reply()?.atom;
+        conn.change_property32(
+            PropMode::REPLACE,
+            window,
+            net_wm_pid,
+            AtomEnum::CARDINAL,
+            &[std::process::id()],
+        )?;
+
+        let wm_protocols = conn.intern_atom(false, b"WM_PROTOCOLS")?.reply()?.atom;
+        let wm_delete = conn.intern_atom(false, b"WM_DELETE_WINDOW")?.reply()?.atom;
+        conn.change_property32(
+            PropMode::REPLACE,
+            window,
+            wm_protocols,
+            AtomEnum::ATOM,
+            &[wm_delete],
+        )?;
+        let net_wm_state = conn.intern_atom(false, b"_NET_WM_STATE")?.reply()?.atom;
+        let net_wm_state_above = conn
+            .intern_atom(false, b"_NET_WM_STATE_ABOVE")?
+            .reply()?
+            .atom;
+        conn.change_property32(
+            PropMode::REPLACE,
+            window,
+            net_wm_state,
+            AtomEnum::ATOM,
+            &[net_wm_state_above],
+        )?;
+        let net_wm_window_type = conn
+            .intern_atom(false, b"_NET_WM_WINDOW_TYPE")?
+            .reply()?
+            .atom;
+        let net_wm_window_type_utility = conn
+            .intern_atom(false, b"_NET_WM_WINDOW_TYPE_UTILITY")?
+            .reply()?
+            .atom;
+        conn.change_property32(
+            PropMode::REPLACE,
+            window,
+            net_wm_window_type,
+            AtomEnum::ATOM,
+            &[net_wm_window_type_utility],
+        )?;
+        conn.map_window(window)?.check()?;
+        conn.flush()?;
+        Ok((
+            conn,
+            window,
+            gc,
+            root_depth,
+            wm_protocols,
+            wm_delete,
+            width,
+            height,
         ))
+    })();
+
+    let (conn, window, gc, depth, wm_protocols, wm_delete, mut width, mut height) = match setup {
+        Ok(values) => {
+            let _ = ready.send(Ok(()));
+            values
+        }
+        Err(error) => {
+            let _ = ready.send(Err(error));
+            return;
+        }
+    };
+
+    let mut model = PipViewModel::new(12);
+    let mut dirty = true;
+    let mut running = true;
+    while running {
+        while let Ok(message) = rx.try_recv() {
+            handle_message(message, &mut model, &mut dirty, &mut running);
+        }
+
+        loop {
+            match conn.poll_for_event() {
+                Ok(Some(Event::Expose(_))) => dirty = true,
+                Ok(Some(Event::ConfigureNotify(event))) => {
+                    let next_width = event.width.max(1);
+                    let next_height = event.height.max(1);
+                    if next_width != width || next_height != height {
+                        width = next_width;
+                        height = next_height;
+                        dirty = true;
+                    }
+                }
+                Ok(Some(Event::ClientMessage(event)))
+                    if is_delete_message(&event, wm_protocols, wm_delete) =>
+                {
+                    running = false;
+                }
+                Ok(Some(_)) => {}
+                Ok(None) => break,
+                Err(error) => {
+                    tracing::warn!(target: "pip", "Agent View X11 event error: {error}");
+                    running = false;
+                    break;
+                }
+            }
+        }
+
+        if dirty && running {
+            let frames = model.ordered_frames();
+            let pixels = render_agent_view(width, height, &frames);
+            if let Err(error) = upload_image(&conn, window, gc, depth, width, height, &pixels) {
+                tracing::warn!(target: "pip", "Agent View X11 paint failed: {error}");
+                running = false;
+            }
+            dirty = false;
+        }
+
+        if running {
+            match rx.recv_timeout(Duration::from_millis(16)) {
+                Ok(message) => handle_message(message, &mut model, &mut dirty, &mut running),
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(mpsc::RecvTimeoutError::Disconnected) => running = false,
+            }
+        }
+    }
+
+    let _ = conn.free_gc(gc);
+    let _ = conn.destroy_window(window);
+    let _ = conn.flush();
+}
+
+#[cfg(target_os = "linux")]
+fn upload_image(
+    conn: &impl x11rb::connection::Connection,
+    window: u32,
+    gc: u32,
+    depth: u8,
+    width: u16,
+    height: u16,
+    pixels: &[u8],
+) -> anyhow::Result<()> {
+    use x11rb::protocol::xproto::{ConnectionExt as _, ImageFormat};
+
+    let stride = usize::from(width) * 4;
+    // Keep each PutImage below the common 256 KiB X11 request limit.
+    let rows_per_request = (200_000usize / stride.max(1)).max(1);
+    for start_row in (0..usize::from(height)).step_by(rows_per_request) {
+        let rows = rows_per_request.min(usize::from(height) - start_row);
+        let start = start_row * stride;
+        let end = start + rows * stride;
+        conn.put_image(
+            ImageFormat::Z_PIXMAP,
+            window,
+            gc,
+            width,
+            rows as u16,
+            0,
+            start_row as i16,
+            0,
+            depth,
+            &pixels[start..end],
+        )?
+        .check()?;
+    }
+    conn.flush()?;
+    Ok(())
+}
+
+fn handle_message(
+    message: UiMessage,
+    model: &mut PipViewModel,
+    dirty: &mut bool,
+    running: &mut bool,
+) {
+    match message {
+        UiMessage::Frame(frame) => {
+            tracing::debug!(
+                target: "pip",
+                view_id = %frame.target.view_id(),
+                "rendering Linux Agent View frame"
+            );
+            model.upsert(frame);
+            *dirty = true;
+        }
+        UiMessage::RemoveWorkspace(workspace_id) => {
+            model.remove_workspace(&workspace_id);
+            *dirty = true;
+        }
+        UiMessage::Shutdown => *running = false,
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn run_x11_window(
+    _cfg: PipConfig,
+    _rx: Receiver<UiMessage>,
+    ready: mpsc::SyncSender<anyhow::Result<()>>,
+) {
+    let _ = ready.send(Err(anyhow::anyhow!(
+        "Linux Agent View can only start on Linux"
+    )));
+}
+
+#[cfg(target_os = "linux")]
+fn is_delete_message(
+    event: &x11rb::protocol::xproto::ClientMessageEvent,
+    wm_protocols: u32,
+    wm_delete: u32,
+) -> bool {
+    event.type_ == wm_protocols && event.data.as_data32()[0] == wm_delete
+}
+
+fn clamp_i16(value: i32) -> i16 {
+    value.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16
+}
+
+fn render_agent_view(width: u16, height: u16, frames: &[&PipFrame]) -> Vec<u8> {
+    let mut canvas = Canvas::new(width, height);
+    canvas.vertical_gradient(Color::rgb(45, 57, 66), Color::rgb(24, 29, 34));
+    canvas.radial_glow(
+        width as f64 * 0.18,
+        height as f64 * 0.02,
+        width as f64 * 0.72,
+        Color::rgba(93, 129, 145, 70),
+    );
+    canvas.radial_glow(
+        width as f64 * 0.88,
+        height as f64 * 0.72,
+        width as f64 * 0.55,
+        Color::rgba(113, 90, 72, 42),
+    );
+    canvas.rounded_rect(
+        Rect::new(1.0, 1.0, width as f64 - 2.0, height as f64 - 2.0),
+        15.0,
+        Color::rgba(15, 18, 21, 142),
+    );
+    canvas.stroke_rounded_rect(
+        Rect::new(1.5, 1.5, width as f64 - 3.0, height as f64 - 3.0),
+        14.5,
+        1.0,
+        Color::rgba(210, 221, 226, 92),
+    );
+
+    let sizes = frames
+        .iter()
+        .map(|frame| {
+            png_dimensions(&frame.png_bytes).unwrap_or(TargetSize {
+                width: 16,
+                height: 10,
+            })
+        })
+        .collect::<Vec<_>>();
+    let layout = layout_desktop(width.into(), height.into(), &sizes);
+    if frames.is_empty() {
+        render_waiting_state(&mut canvas, layout.desktop);
+    } else {
+        for (frame, target) in frames.iter().zip(&layout.targets) {
+            render_target(&mut canvas, frame, target.window);
+        }
+        render_dash(&mut canvas, frames, &layout.dock, &layout.dock_icons);
+    }
+    render_resize_affordance(&mut canvas, width, height);
+    canvas.into_bgrx()
+}
+
+fn render_waiting_state(canvas: &mut Canvas, desktop: LayoutRect) {
+    let center_x = desktop.x + desktop.width / 2.0;
+    let center_y = desktop.y + desktop.height / 2.0;
+    canvas.circle(center_x, center_y - 7.0, 22.0, Color::rgba(48, 59, 67, 220));
+    canvas.stroke_circle(
+        center_x,
+        center_y - 7.0,
+        22.0,
+        1.0,
+        Color::rgba(223, 230, 233, 88),
+    );
+    for offset in [-8.0, 0.0, 8.0] {
+        canvas.circle(
+            center_x + offset,
+            center_y - 7.0,
+            2.1,
+            Color::rgba(235, 239, 241, 170),
+        );
+    }
+    canvas.rounded_rect(
+        Rect::new(center_x - 58.0, center_y + 25.0, 116.0, 3.0),
+        1.5,
+        Color::rgba(224, 230, 232, 45),
+    );
+}
+
+fn render_target(canvas: &mut Canvas, frame: &PipFrame, rect: LayoutRect) {
+    let rect = Rect::from_layout(rect);
+    canvas.shadow(rect, 9.0, 6.0, Color::rgba(0, 0, 0, 118));
+    canvas.rounded_rect(rect.expand(1.0), 8.0, Color::rgba(220, 225, 227, 68));
+    canvas.rounded_rect(rect, 7.0, Color::rgb(21, 25, 28));
+    if !draw_frame_image(canvas, frame, rect) {
+        canvas.vertical_gradient_in(rect, Color::rgb(47, 55, 61), Color::rgb(27, 31, 35));
+        let accent = target_accent(frame.target.target_kind);
+        canvas.circle(
+            rect.x + rect.width / 2.0,
+            rect.y + rect.height / 2.0,
+            12.0,
+            accent,
+        );
+    }
+    canvas.stroke_rounded_rect(rect, 7.0, 1.0, Color::rgba(225, 230, 232, 76));
+}
+
+#[cfg(target_os = "linux")]
+fn draw_frame_image(canvas: &mut Canvas, frame: &PipFrame, rect: Rect) -> bool {
+    let Ok(image) = image::load_from_memory(&frame.png_bytes) else {
+        return false;
+    };
+    canvas.draw_image_cover(&image.to_rgba8(), rect, 6.5);
+    true
+}
+
+#[cfg(not(target_os = "linux"))]
+fn draw_frame_image(_canvas: &mut Canvas, _frame: &PipFrame, _rect: Rect) -> bool {
+    false
+}
+
+fn render_dash(canvas: &mut Canvas, frames: &[&PipFrame], dock: &LayoutRect, icons: &[LayoutRect]) {
+    let dock = Rect::from_layout(*dock);
+    canvas.shadow(dock, 12.0, 5.0, Color::rgba(0, 0, 0, 100));
+    canvas.rounded_rect(dock, dock.height * 0.27, Color::rgba(67, 70, 72, 195));
+    canvas.stroke_rounded_rect(
+        dock,
+        dock.height * 0.27,
+        1.0,
+        Color::rgba(231, 235, 236, 66),
+    );
+    for (frame, icon) in frames.iter().zip(icons) {
+        let icon = Rect::from_layout(*icon);
+        let accent = target_accent(frame.target.target_kind);
+        canvas.rounded_rect(icon, icon.width * 0.23, accent);
+        let glyph = icon.inset(icon.width * 0.23);
+        match frame.target.target_kind {
+            PipTargetKind::BrowserTab => {
+                canvas.stroke_circle(
+                    glyph.x + glyph.width / 2.0,
+                    glyph.y + glyph.height / 2.0,
+                    glyph.width * 0.44,
+                    (glyph.width * 0.08).max(1.0),
+                    Color::rgba(250, 252, 253, 235),
+                );
+                canvas.line(
+                    glyph.x + glyph.width / 2.0,
+                    glyph.y,
+                    glyph.x + glyph.width / 2.0,
+                    glyph.y + glyph.height,
+                    (glyph.width * 0.07).max(1.0),
+                    Color::rgba(250, 252, 253, 215),
+                );
+            }
+            PipTargetKind::NativeWindow => {
+                canvas.rounded_rect(glyph, glyph.width * 0.12, Color::rgba(250, 252, 253, 228));
+                canvas.rect(
+                    Rect::new(
+                        glyph.x + glyph.width * 0.12,
+                        glyph.y + glyph.height * 0.25,
+                        glyph.width * 0.76,
+                        (glyph.height * 0.09).max(1.0),
+                    ),
+                    accent,
+                );
+            }
+        }
+        canvas.circle(
+            icon.x + icon.width / 2.0,
+            dock.y + dock.height - 4.0,
+            1.6,
+            Color::rgba(242, 245, 246, 225),
+        );
+    }
+}
+
+fn render_resize_affordance(canvas: &mut Canvas, width: u16, height: u16) {
+    let x = f64::from(width) - 15.0;
+    let y = f64::from(height) - 8.0;
+    let color = Color::rgba(226, 231, 233, 116);
+    canvas.line(x, y, x + 7.0, y - 7.0, 1.2, color);
+    canvas.line(x + 5.0, y, x + 9.0, y - 4.0, 1.2, color);
+}
+
+fn target_accent(kind: PipTargetKind) -> Color {
+    match kind {
+        PipTargetKind::BrowserTab => Color::rgb(53, 154, 220),
+        PipTargetKind::NativeWindow => Color::rgb(239, 112, 54),
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Rect {
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+}
+
+impl Rect {
+    fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
+        Self {
+            x,
+            y,
+            width: width.max(0.0),
+            height: height.max(0.0),
+        }
+    }
+
+    fn from_layout(rect: LayoutRect) -> Self {
+        Self::new(rect.x, rect.y, rect.width, rect.height)
+    }
+
+    fn inset(self, amount: f64) -> Self {
+        Self::new(
+            self.x + amount,
+            self.y + amount,
+            self.width - amount * 2.0,
+            self.height - amount * 2.0,
+        )
+    }
+
+    fn expand(self, amount: f64) -> Self {
+        Self::new(
+            self.x - amount,
+            self.y - amount,
+            self.width + amount * 2.0,
+            self.height + amount * 2.0,
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Color {
+    r: u8,
+    g: u8,
+    b: u8,
+    a: u8,
+}
+
+impl Color {
+    const fn rgb(r: u8, g: u8, b: u8) -> Self {
+        Self { r, g, b, a: 255 }
+    }
+
+    const fn rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
+        Self { r, g, b, a }
+    }
+}
+
+struct Canvas {
+    width: usize,
+    height: usize,
+    rgba: Vec<u8>,
+}
+
+impl Canvas {
+    fn new(width: u16, height: u16) -> Self {
+        Self {
+            width: usize::from(width),
+            height: usize::from(height),
+            rgba: vec![0; usize::from(width) * usize::from(height) * 4],
+        }
+    }
+
+    fn into_bgrx(mut self) -> Vec<u8> {
+        for pixel in self.rgba.chunks_exact_mut(4) {
+            pixel.swap(0, 2);
+            pixel[3] = 0;
+        }
+        self.rgba
+    }
+
+    fn blend(&mut self, x: i32, y: i32, color: Color) {
+        if x < 0 || y < 0 || x >= self.width as i32 || y >= self.height as i32 {
+            return;
+        }
+        let index = (y as usize * self.width + x as usize) * 4;
+        let alpha = u32::from(color.a);
+        let inverse = 255 - alpha;
+        self.rgba[index] =
+            ((u32::from(color.r) * alpha + u32::from(self.rgba[index]) * inverse) / 255) as u8;
+        self.rgba[index + 1] =
+            ((u32::from(color.g) * alpha + u32::from(self.rgba[index + 1]) * inverse) / 255) as u8;
+        self.rgba[index + 2] =
+            ((u32::from(color.b) * alpha + u32::from(self.rgba[index + 2]) * inverse) / 255) as u8;
+        self.rgba[index + 3] = 255;
+    }
+
+    fn vertical_gradient(&mut self, top: Color, bottom: Color) {
+        self.vertical_gradient_in(
+            Rect::new(0.0, 0.0, self.width as f64, self.height as f64),
+            top,
+            bottom,
+        );
+    }
+
+    fn vertical_gradient_in(&mut self, rect: Rect, top: Color, bottom: Color) {
+        let (x0, y0, x1, y1) = self.bounds(rect);
+        let height = (y1 - y0).max(1) as f64;
+        for y in y0..y1 {
+            let t = f64::from(y - y0) / height;
+            let color = lerp_color(top, bottom, t);
+            for x in x0..x1 {
+                self.blend(x, y, color);
+            }
+        }
+    }
+
+    fn radial_glow(&mut self, cx: f64, cy: f64, radius: f64, color: Color) {
+        let rect = Rect::new(cx - radius, cy - radius, radius * 2.0, radius * 2.0);
+        let (x0, y0, x1, y1) = self.bounds(rect);
+        for y in y0..y1 {
+            for x in x0..x1 {
+                let distance = ((f64::from(x) - cx).powi(2) + (f64::from(y) - cy).powi(2)).sqrt();
+                if distance < radius {
+                    let mut glow = color;
+                    glow.a = (f64::from(color.a) * (1.0 - distance / radius).powi(2)) as u8;
+                    self.blend(x, y, glow);
+                }
+            }
+        }
+    }
+
+    fn rect(&mut self, rect: Rect, color: Color) {
+        let (x0, y0, x1, y1) = self.bounds(rect);
+        for y in y0..y1 {
+            for x in x0..x1 {
+                self.blend(x, y, color);
+            }
+        }
+    }
+
+    fn rounded_rect(&mut self, rect: Rect, radius: f64, color: Color) {
+        let (x0, y0, x1, y1) = self.bounds(rect);
+        for y in y0..y1 {
+            for x in x0..x1 {
+                if rounded_contains(rect, radius, f64::from(x) + 0.5, f64::from(y) + 0.5) {
+                    self.blend(x, y, color);
+                }
+            }
+        }
+    }
+
+    fn stroke_rounded_rect(&mut self, rect: Rect, radius: f64, width: f64, color: Color) {
+        let inner = rect.inset(width);
+        let (x0, y0, x1, y1) = self.bounds(rect);
+        for y in y0..y1 {
+            for x in x0..x1 {
+                let px = f64::from(x) + 0.5;
+                let py = f64::from(y) + 0.5;
+                if rounded_contains(rect, radius, px, py)
+                    && !rounded_contains(inner, (radius - width).max(0.0), px, py)
+                {
+                    self.blend(x, y, color);
+                }
+            }
+        }
+    }
+
+    fn shadow(&mut self, rect: Rect, radius: f64, y_offset: f64, color: Color) {
+        let steps = 6;
+        for step in (1..=steps).rev() {
+            let spread = radius * f64::from(step) / f64::from(steps);
+            let mut layer = color;
+            layer.a = color.a / (steps as u8 + 1);
+            self.rounded_rect(
+                Rect::new(
+                    rect.x - spread,
+                    rect.y - spread + y_offset,
+                    rect.width + spread * 2.0,
+                    rect.height + spread * 2.0,
+                ),
+                7.0 + spread,
+                layer,
+            );
+        }
+    }
+
+    fn circle(&mut self, cx: f64, cy: f64, radius: f64, color: Color) {
+        let (x0, y0, x1, y1) = self.bounds(Rect::new(
+            cx - radius,
+            cy - radius,
+            radius * 2.0,
+            radius * 2.0,
+        ));
+        let radius_squared = radius * radius;
+        for y in y0..y1 {
+            for x in x0..x1 {
+                if (f64::from(x) + 0.5 - cx).powi(2) + (f64::from(y) + 0.5 - cy).powi(2)
+                    <= radius_squared
+                {
+                    self.blend(x, y, color);
+                }
+            }
+        }
+    }
+
+    fn stroke_circle(&mut self, cx: f64, cy: f64, radius: f64, width: f64, color: Color) {
+        let inner = (radius - width).max(0.0);
+        let (x0, y0, x1, y1) = self.bounds(Rect::new(
+            cx - radius,
+            cy - radius,
+            radius * 2.0,
+            radius * 2.0,
+        ));
+        for y in y0..y1 {
+            for x in x0..x1 {
+                let distance =
+                    ((f64::from(x) + 0.5 - cx).powi(2) + (f64::from(y) + 0.5 - cy).powi(2)).sqrt();
+                if distance >= inner && distance <= radius {
+                    self.blend(x, y, color);
+                }
+            }
+        }
+    }
+
+    fn line(&mut self, x0: f64, y0: f64, x1: f64, y1: f64, width: f64, color: Color) {
+        let steps = ((x1 - x0).abs().max((y1 - y0).abs()).ceil() as usize).max(1);
+        for step in 0..=steps {
+            let t = step as f64 / steps as f64;
+            self.circle(x0 + (x1 - x0) * t, y0 + (y1 - y0) * t, width / 2.0, color);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn draw_image_cover(&mut self, image: &image::RgbaImage, rect: Rect, radius: f64) {
+        let target_width = rect.width.ceil().max(1.0) as u32;
+        let target_height = rect.height.ceil().max(1.0) as u32;
+        let scale = (target_width as f64 / image.width() as f64)
+            .max(target_height as f64 / image.height() as f64);
+        let scaled_width = (image.width() as f64 * scale).ceil().max(1.0) as u32;
+        let scaled_height = (image.height() as f64 * scale).ceil().max(1.0) as u32;
+        let scaled =
+            image::imageops::resize(image, scaled_width, scaled_height, FilterType::Triangle);
+        let crop_x = scaled_width.saturating_sub(target_width) / 2;
+        let crop_y = scaled_height.saturating_sub(target_height) / 2;
+        let (x0, y0, x1, y1) = self.bounds(rect);
+        for y in y0..y1 {
+            for x in x0..x1 {
+                let px = f64::from(x) + 0.5;
+                let py = f64::from(y) + 0.5;
+                if !rounded_contains(rect, radius, px, py) {
+                    continue;
+                }
+                let source_x = (x - x0) as u32 + crop_x;
+                let source_y = (y - y0) as u32 + crop_y;
+                if source_x < scaled.width() && source_y < scaled.height() {
+                    let pixel = scaled.get_pixel(source_x, source_y);
+                    self.blend(x, y, Color::rgba(pixel[0], pixel[1], pixel[2], pixel[3]));
+                }
+            }
+        }
+    }
+
+    fn bounds(&self, rect: Rect) -> (i32, i32, i32, i32) {
+        (
+            rect.x.floor().max(0.0) as i32,
+            rect.y.floor().max(0.0) as i32,
+            (rect.x + rect.width).ceil().min(self.width as f64) as i32,
+            (rect.y + rect.height).ceil().min(self.height as f64) as i32,
+        )
+    }
+}
+
+fn rounded_contains(rect: Rect, radius: f64, x: f64, y: f64) -> bool {
+    if x < rect.x || y < rect.y || x >= rect.x + rect.width || y >= rect.y + rect.height {
+        return false;
+    }
+    let radius = radius.min(rect.width / 2.0).min(rect.height / 2.0).max(0.0);
+    let nearest_x = x.clamp(rect.x + radius, rect.x + rect.width - radius);
+    let nearest_y = y.clamp(rect.y + radius, rect.y + rect.height - radius);
+    (x - nearest_x).powi(2) + (y - nearest_y).powi(2) <= radius * radius
+}
+
+fn lerp_color(from: Color, to: Color, t: f64) -> Color {
+    let channel = |a: u8, b: u8| (f64::from(a) + (f64::from(b) - f64::from(a)) * t) as u8;
+    Color::rgba(
+        channel(from.r, to.r),
+        channel(from.g, to.g),
+        channel(from.b, to.b),
+        channel(from.a, to.a),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renderer_emits_x11_bgrx_at_the_requested_size() {
+        let rendered = render_agent_view(360, 260, &[]);
+        assert_eq!(rendered.len(), 360 * 260 * 4);
+        assert!(rendered.chunks_exact(4).all(|pixel| pixel[3] == 0));
+    }
+
+    #[test]
+    fn target_kind_uses_distinct_gnome_dash_accents() {
+        assert_ne!(
+            target_accent(PipTargetKind::NativeWindow),
+            target_accent(PipTargetKind::BrowserTab)
+        );
+    }
+
+    #[test]
+    fn rounded_rect_clips_its_corner() {
+        let rect = Rect::new(10.0, 10.0, 40.0, 30.0);
+        assert!(!rounded_contains(rect, 8.0, 10.0, 10.0));
+        assert!(rounded_contains(rect, 8.0, 18.0, 10.5));
+        assert!(rounded_contains(rect, 8.0, 30.0, 25.0));
+    }
+
+    #[test]
+    fn default_position_clamps_to_x11_coordinates() {
+        assert_eq!(clamp_i16(i32::MAX), i16::MAX);
+        assert_eq!(clamp_i16(i32::MIN), i16::MIN);
+        assert_eq!(clamp_i16(24), 24);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[ignore = "requires an interactive X11 display"]
+    fn x11_visual_smoke_presents_multiple_targets() {
+        use std::io::Cursor;
+
+        use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
+        use pip_preview::{PipGeometry, PipTarget};
+
+        fn png(width: u32, height: u32, base: [u8; 3]) -> Vec<u8> {
+            let mut image = RgbaImage::new(width, height);
+            for (x, y, pixel) in image.enumerate_pixels_mut() {
+                let shade = ((x * 31 / width.max(1) + y * 23 / height.max(1)) % 44) as u8;
+                *pixel = Rgba([
+                    base[0].saturating_add(shade),
+                    base[1].saturating_add(shade),
+                    base[2].saturating_add(shade),
+                    255,
+                ]);
+            }
+            let mut bytes = Cursor::new(Vec::new());
+            DynamicImage::ImageRgba8(image)
+                .write_to(&mut bytes, ImageFormat::Png)
+                .unwrap();
+            bytes.into_inner()
+        }
+
+        let config = PipConfig {
+            enabled: true,
+            geometry: PipGeometry {
+                width: 720,
+                height: 520,
+                x: Some(1080),
+                y: Some(80),
+            },
+            title: "Cua Agent View Linux visual smoke".to_owned(),
+        };
+        let backend = LinuxPipBackendFactory.start(&config).unwrap();
+        for (index, (width, height, base, kind)) in [
+            (1280, 760, [20, 72, 92], PipTargetKind::BrowserTab),
+            (840, 1060, [47, 58, 65], PipTargetKind::NativeWindow),
+            (760, 760, [91, 59, 34], PipTargetKind::NativeWindow),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            backend.push_frame(PipFrame {
+                target: PipTarget {
+                    workspace_id: "linux-smoke".to_owned(),
+                    workspace_label: "Linux smoke".to_owned(),
+                    target_id: format!("target-{index}"),
+                    target_kind: kind,
+                    target_label: format!("Target {index}"),
+                },
+                png_bytes: png(width, height, base),
+                action_label: "observe".to_owned(),
+                timestamp_ms: index as u64,
+            });
+        }
+        let seconds = std::env::var("CUA_AGENT_VIEW_SMOKE_SECONDS")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(3);
+        std::thread::sleep(Duration::from_secs(seconds));
+        backend.shutdown();
     }
 }

--- a/libs/cua-driver/rust/crates/platform-linux/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/pip/mod.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use image::imageops::FilterType;
 use pip_preview::{
     layout_desktop, png_dimensions, LayoutRect, PipBackend, PipBackendFactory, PipConfig, PipFrame,
-    PipTargetKind, PipViewModel, TargetSize,
+    PipTargetKind, PipViewModel, PipWorkspaceSummary, TargetSize,
 };
 
 const MIN_WIDTH: u16 = 360;
@@ -21,6 +21,7 @@ const MIN_HEIGHT: u16 = 260;
 
 enum UiMessage {
     Frame(PipFrame),
+    RemoveTarget(String, String),
     RemoveWorkspace(String),
     Shutdown,
 }
@@ -43,6 +44,13 @@ impl PipBackend for LinuxPipBackend {
         let _ = self
             .tx
             .send(UiMessage::RemoveWorkspace(workspace_id.to_owned()));
+    }
+
+    fn remove_target(&self, workspace_id: &str, identity_key: &str) {
+        let _ = self.tx.send(UiMessage::RemoveTarget(
+            workspace_id.to_owned(),
+            identity_key.to_owned(),
+        ));
     }
 
     fn shutdown(self: Box<Self>) {
@@ -118,7 +126,10 @@ fn run_x11_window(
                 .background_pixel(0x1820_27)
                 .border_pixel(0)
                 .event_mask(
-                    EventMask::EXPOSURE | EventMask::STRUCTURE_NOTIFY | EventMask::PROPERTY_CHANGE,
+                    EventMask::EXPOSURE
+                        | EventMask::STRUCTURE_NOTIFY
+                        | EventMask::PROPERTY_CHANGE
+                        | EventMask::BUTTON_PRESS,
                 ),
         )?
         .check()?;
@@ -229,6 +240,18 @@ fn run_x11_window(
                         dirty = true;
                     }
                 }
+                Ok(Some(Event::ButtonPress(event))) => {
+                    let workspaces = model.workspaces();
+                    if let Some(index) = session_selector_hit_test(
+                        width,
+                        height,
+                        workspaces.len(),
+                        f64::from(event.event_x),
+                        f64::from(event.event_y),
+                    ) {
+                        dirty |= model.select_workspace(&workspaces[index].workspace_id);
+                    }
+                }
                 Ok(Some(Event::ClientMessage(event)))
                     if is_delete_message(&event, wm_protocols, wm_delete) =>
                 {
@@ -245,8 +268,15 @@ fn run_x11_window(
         }
 
         if dirty && running {
-            let frames = model.ordered_frames();
-            let pixels = render_agent_view(width, height, &frames);
+            let frames = model.selected_frames();
+            let workspaces = model.workspaces();
+            let pixels = render_agent_view(
+                width,
+                height,
+                &frames,
+                &workspaces,
+                model.selected_workspace_id(),
+            );
             if let Err(error) = upload_image(&conn, window, gc, depth, width, height, &pixels) {
                 tracing::warn!(target: "pip", "Agent View X11 paint failed: {error}");
                 running = false;
@@ -321,9 +351,11 @@ fn handle_message(
             model.upsert(frame);
             *dirty = true;
         }
+        UiMessage::RemoveTarget(workspace_id, identity_key) => {
+            *dirty |= model.remove_target(&workspace_id, &identity_key);
+        }
         UiMessage::RemoveWorkspace(workspace_id) => {
-            model.remove_workspace(&workspace_id);
-            *dirty = true;
+            *dirty |= !model.remove_workspace(&workspace_id).is_empty();
         }
         UiMessage::Shutdown => *running = false,
     }
@@ -353,7 +385,13 @@ fn clamp_i16(value: i32) -> i16 {
     value.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16
 }
 
-fn render_agent_view(width: u16, height: u16, frames: &[&PipFrame]) -> Vec<u8> {
+fn render_agent_view(
+    width: u16,
+    height: u16,
+    frames: &[&PipFrame],
+    workspaces: &[PipWorkspaceSummary],
+    selected_workspace_id: Option<&str>,
+) -> Vec<u8> {
     let mut canvas = Canvas::new(width, height);
     canvas.vertical_gradient(Color::rgb(45, 57, 66), Color::rgb(24, 29, 34));
     canvas.radial_glow(
@@ -389,7 +427,13 @@ fn render_agent_view(width: u16, height: u16, frames: &[&PipFrame]) -> Vec<u8> {
             })
         })
         .collect::<Vec<_>>();
-    let layout = layout_desktop(width.into(), height.into(), &sizes);
+    let selector_height = if workspaces.len() > 1 { 34.0 } else { 0.0 };
+    let mut layout = layout_desktop(
+        width.into(),
+        (f64::from(height) - selector_height).max(1.0),
+        &sizes,
+    );
+    offset_layout_y(&mut layout, selector_height);
     if frames.is_empty() {
         render_waiting_state(&mut canvas, layout.desktop);
     } else {
@@ -398,6 +442,13 @@ fn render_agent_view(width: u16, height: u16, frames: &[&PipFrame]) -> Vec<u8> {
         }
         render_dash(&mut canvas, frames, &layout.dock, &layout.dock_icons);
     }
+    render_session_selector(
+        &mut canvas,
+        width,
+        height,
+        workspaces,
+        selected_workspace_id,
+    );
     render_resize_affordance(&mut canvas, width, height);
     canvas.into_bgrx()
 }
@@ -451,13 +502,122 @@ fn draw_frame_image(canvas: &mut Canvas, frame: &PipFrame, rect: Rect) -> bool {
     let Ok(image) = image::load_from_memory(&frame.png_bytes) else {
         return false;
     };
-    canvas.draw_image_cover(&image.to_rgba8(), rect, 6.5);
+    canvas.draw_image_contain(&image.to_rgba8(), rect, 6.5);
     true
 }
 
 #[cfg(not(target_os = "linux"))]
 fn draw_frame_image(_canvas: &mut Canvas, _frame: &PipFrame, _rect: Rect) -> bool {
     false
+}
+
+fn session_selector_layout(width: u16, height: u16, count: usize) -> Option<(Rect, Vec<Rect>)> {
+    if count <= 1 {
+        return None;
+    }
+    let visible = count;
+    let icon = 22.0;
+    let gap = 5.0;
+    let padding = 6.0;
+    let selector_width = padding * 2.0 + visible as f64 * icon + (visible - 1) as f64 * gap;
+    let selector = Rect::new(
+        (f64::from(width) - selector_width) / 2.0,
+        4.0_f64.min(f64::from(height).max(0.0)),
+        selector_width,
+        28.0,
+    );
+    let icons = (0..visible)
+        .map(|index| {
+            Rect::new(
+                selector.x + padding + index as f64 * (icon + gap),
+                selector.y + 3.0,
+                icon,
+                icon,
+            )
+        })
+        .collect();
+    Some((selector, icons))
+}
+
+fn session_selector_hit_test(
+    width: u16,
+    height: u16,
+    count: usize,
+    x: f64,
+    y: f64,
+) -> Option<usize> {
+    let (_, icons) = session_selector_layout(width, height, count)?;
+    icons.iter().position(|icon| icon.contains(x, y))
+}
+
+fn render_session_selector(
+    canvas: &mut Canvas,
+    width: u16,
+    height: u16,
+    workspaces: &[PipWorkspaceSummary],
+    selected_workspace_id: Option<&str>,
+) {
+    let Some((dock, icons)) = session_selector_layout(width, height, workspaces.len()) else {
+        return;
+    };
+    canvas.shadow(dock, 12.0, 5.0, Color::rgba(0, 0, 0, 100));
+    canvas.rounded_rect(dock, dock.height * 0.27, Color::rgba(67, 70, 72, 195));
+    canvas.stroke_rounded_rect(
+        dock,
+        dock.height * 0.27,
+        1.0,
+        Color::rgba(231, 235, 236, 66),
+    );
+    for (workspace, icon) in workspaces.iter().zip(icons) {
+        let selected = selected_workspace_id == Some(workspace.workspace_id.as_str());
+        let accent = workspace_accent(&workspace.workspace_id);
+        if selected {
+            canvas.rounded_rect(
+                icon.expand(2.0),
+                icon.width * 0.27,
+                Color::rgba(245, 248, 249, 220),
+            );
+        }
+        canvas.rounded_rect(icon, icon.width * 0.23, accent);
+        let glyph = icon.inset(icon.width * 0.23);
+        canvas.circle(
+            glyph.x + glyph.width / 2.0,
+            glyph.y + glyph.height * 0.36,
+            glyph.width * 0.22,
+            Color::rgba(250, 252, 253, 235),
+        );
+        canvas.rounded_rect(
+            Rect::new(
+                glyph.x + glyph.width * 0.16,
+                glyph.y + glyph.height * 0.62,
+                glyph.width * 0.68,
+                glyph.height * 0.28,
+            ),
+            glyph.width * 0.14,
+            Color::rgba(250, 252, 253, 225),
+        );
+        let indicators = workspace.target_count.min(3);
+        for index in 0..indicators {
+            canvas.circle(
+                icon.x + icon.width / 2.0 + (index as f64 - (indicators - 1) as f64 / 2.0) * 5.0,
+                dock.y + dock.height - 4.0,
+                1.4,
+                Color::rgba(242, 245, 246, if selected { 245 } else { 145 }),
+            );
+        }
+    }
+}
+
+fn offset_layout_y(layout: &mut pip_preview::DesktopLayout, offset: f64) {
+    layout.desktop.y += offset;
+    layout.dock.y += offset;
+    for icon in &mut layout.dock_icons {
+        icon.y += offset;
+    }
+    for target in &mut layout.targets {
+        target.window.y += offset;
+        target.content.y += offset;
+    }
 }
 
 fn render_dash(canvas: &mut Canvas, frames: &[&PipFrame], dock: &LayoutRect, icons: &[LayoutRect]) {
@@ -515,6 +675,20 @@ fn render_dash(canvas: &mut Canvas, frames: &[&PipFrame], dock: &LayoutRect, ico
     }
 }
 
+fn workspace_accent(workspace_id: &str) -> Color {
+    let hash = workspace_id.bytes().fold(0u32, |hash, byte| {
+        hash.wrapping_mul(31).wrapping_add(u32::from(byte))
+    });
+    const COLORS: [Color; 5] = [
+        Color::rgb(53, 154, 220),
+        Color::rgb(239, 112, 54),
+        Color::rgb(72, 178, 123),
+        Color::rgb(214, 151, 48),
+        Color::rgb(104, 136, 196),
+    ];
+    COLORS[hash as usize % COLORS.len()]
+}
+
 fn render_resize_affordance(canvas: &mut Canvas, width: u16, height: u16) {
     let x = f64::from(width) - 15.0;
     let y = f64::from(height) - 8.0;
@@ -568,6 +742,10 @@ impl Rect {
             self.width + amount * 2.0,
             self.height + amount * 2.0,
         )
+    }
+
+    fn contains(self, x: f64, y: f64) -> bool {
+        x >= self.x && y >= self.y && x < self.x + self.width && y < self.y + self.height
     }
 }
 
@@ -765,18 +943,22 @@ impl Canvas {
     }
 
     #[cfg(target_os = "linux")]
-    fn draw_image_cover(&mut self, image: &image::RgbaImage, rect: Rect, radius: f64) {
+    fn draw_image_contain(&mut self, image: &image::RgbaImage, rect: Rect, radius: f64) {
         let target_width = rect.width.ceil().max(1.0) as u32;
         let target_height = rect.height.ceil().max(1.0) as u32;
         let scale = (target_width as f64 / image.width() as f64)
-            .max(target_height as f64 / image.height() as f64);
-        let scaled_width = (image.width() as f64 * scale).ceil().max(1.0) as u32;
-        let scaled_height = (image.height() as f64 * scale).ceil().max(1.0) as u32;
+            .min(target_height as f64 / image.height() as f64);
+        let scaled_width = (image.width() as f64 * scale).floor().max(1.0) as u32;
+        let scaled_height = (image.height() as f64 * scale).floor().max(1.0) as u32;
         let scaled =
             image::imageops::resize(image, scaled_width, scaled_height, FilterType::Triangle);
-        let crop_x = scaled_width.saturating_sub(target_width) / 2;
-        let crop_y = scaled_height.saturating_sub(target_height) / 2;
-        let (x0, y0, x1, y1) = self.bounds(rect);
+        let image_rect = Rect::new(
+            rect.x + (rect.width - f64::from(scaled_width)) / 2.0,
+            rect.y + (rect.height - f64::from(scaled_height)) / 2.0,
+            f64::from(scaled_width),
+            f64::from(scaled_height),
+        );
+        let (x0, y0, x1, y1) = self.bounds(image_rect);
         for y in y0..y1 {
             for x in x0..x1 {
                 let px = f64::from(x) + 0.5;
@@ -784,8 +966,8 @@ impl Canvas {
                 if !rounded_contains(rect, radius, px, py) {
                     continue;
                 }
-                let source_x = (x - x0) as u32 + crop_x;
-                let source_y = (y - y0) as u32 + crop_y;
+                let source_x = (f64::from(x) + 0.5 - image_rect.x).floor().max(0.0) as u32;
+                let source_y = (f64::from(y) + 0.5 - image_rect.y).floor().max(0.0) as u32;
                 if source_x < scaled.width() && source_y < scaled.height() {
                     let pixel = scaled.get_pixel(source_x, source_y);
                     self.blend(x, y, Color::rgba(pixel[0], pixel[1], pixel[2], pixel[3]));
@@ -809,8 +991,10 @@ fn rounded_contains(rect: Rect, radius: f64, x: f64, y: f64) -> bool {
         return false;
     }
     let radius = radius.min(rect.width / 2.0).min(rect.height / 2.0).max(0.0);
-    let nearest_x = x.clamp(rect.x + radius, rect.x + rect.width - radius);
-    let nearest_y = y.clamp(rect.y + radius, rect.y + rect.height - radius);
+    // Equivalent half-width bounds can differ by a sub-ULP after arithmetic;
+    // max/min preserves the rounded geometry without f64::clamp panicking.
+    let nearest_x = x.max(rect.x + radius).min(rect.x + rect.width - radius);
+    let nearest_y = y.max(rect.y + radius).min(rect.y + rect.height - radius);
     (x - nearest_x).powi(2) + (y - nearest_y).powi(2) <= radius * radius
 }
 
@@ -830,9 +1014,36 @@ mod tests {
 
     #[test]
     fn renderer_emits_x11_bgrx_at_the_requested_size() {
-        let rendered = render_agent_view(360, 260, &[]);
+        let rendered = render_agent_view(360, 260, &[], &[], None);
         assert_eq!(rendered.len(), 360 * 260 * 4);
         assert!(rendered.chunks_exact(4).all(|pixel| pixel[3] == 0));
+    }
+
+    #[test]
+    fn session_selector_is_hidden_for_zero_or_one_workspace() {
+        assert!(session_selector_layout(720, 520, 0).is_none());
+        assert!(session_selector_layout(720, 520, 1).is_none());
+        assert!(session_selector_layout(720, 520, 2).is_some());
+    }
+
+    #[test]
+    fn session_selector_hit_testing_only_accepts_session_icons() {
+        let (dock, icons) = session_selector_layout(720, 520, 3).unwrap();
+        let first = icons[0];
+        assert_eq!(
+            session_selector_hit_test(
+                720,
+                520,
+                3,
+                first.x + first.width / 2.0,
+                first.y + first.height / 2.0,
+            ),
+            Some(0)
+        );
+        assert_eq!(
+            session_selector_hit_test(720, 520, 3, dock.x + 2.0, dock.y + 2.0),
+            None
+        );
     }
 
     #[test]
@@ -896,21 +1107,52 @@ mod tests {
             title: "Cua Agent View Linux visual smoke".to_owned(),
         };
         let backend = LinuxPipBackendFactory.start(&config).unwrap();
-        for (index, (width, height, base, kind)) in [
-            (1280, 760, [20, 72, 92], PipTargetKind::BrowserTab),
-            (840, 1060, [47, 58, 65], PipTargetKind::NativeWindow),
-            (760, 760, [91, 59, 34], PipTargetKind::NativeWindow),
+        for (index, (workspace_id, workspace_label, width, height, base, kind)) in [
+            (
+                "linux-browser",
+                "Browser session",
+                1280,
+                760,
+                [20, 72, 92],
+                PipTargetKind::BrowserTab,
+            ),
+            (
+                "linux-browser",
+                "Browser session",
+                760,
+                760,
+                [25, 91, 67],
+                PipTargetKind::BrowserTab,
+            ),
+            (
+                "linux-native",
+                "Native session",
+                840,
+                1060,
+                [47, 58, 65],
+                PipTargetKind::NativeWindow,
+            ),
+            (
+                "linux-native",
+                "Native session",
+                1440,
+                800,
+                [91, 59, 34],
+                PipTargetKind::NativeWindow,
+            ),
         ]
         .into_iter()
         .enumerate()
         {
             backend.push_frame(PipFrame {
                 target: PipTarget {
-                    workspace_id: "linux-smoke".to_owned(),
-                    workspace_label: "Linux smoke".to_owned(),
+                    workspace_id: workspace_id.to_owned(),
+                    workspace_label: workspace_label.to_owned(),
                     target_id: format!("target-{index}"),
+                    identity_key: format!("target-{index}"),
                     target_kind: kind,
                     target_label: format!("Target {index}"),
+                    native_container: None,
                 },
                 png_bytes: png(width, height, base),
                 action_label: "observe".to_owned(),

--- a/libs/cua-driver/rust/crates/platform-linux/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/pip/mod.rs
@@ -11,8 +11,9 @@ use std::time::Duration;
 #[cfg(target_os = "linux")]
 use image::imageops::FilterType;
 use pip_preview::{
-    layout_desktop, png_dimensions, LayoutRect, PipBackend, PipBackendFactory, PipConfig, PipFrame,
-    PipTargetKind, PipViewModel, PipWorkspaceSummary, TargetSize,
+    layout_desktop, layout_session_tabs, png_dimensions, LayoutRect, PipBackend, PipBackendFactory,
+    PipConfig, PipFrame, PipTargetKind, PipViewModel, PipWorkspaceSummary, SessionTabsLayout,
+    TargetSize,
 };
 
 const MIN_WIDTH: u16 = 360;
@@ -38,9 +39,13 @@ impl LinuxPipBackend {
     /// change prevents an always-on-top Agent View from intercepting the action.
     pub fn set_input_transparent(&self, transparent: bool) -> anyhow::Result<()> {
         let (reply_tx, reply_rx) = mpsc::sync_channel(1);
-        self.tx
+        if self
+            .tx
             .send(UiMessage::SetInputTransparent(transparent, reply_tx))
-            .map_err(|_| anyhow::anyhow!("Agent View X11 thread is not running"))?;
+            .is_err()
+        {
+            return Ok(());
+        }
         reply_rx
             .recv_timeout(Duration::from_secs(2))
             .map_err(|error| {
@@ -274,14 +279,16 @@ fn run_x11_window(
                 }
                 Ok(Some(Event::ButtonPress(event))) => {
                     let workspaces = model.workspaces();
-                    if let Some(index) = session_selector_hit_test(
+                    let tabs = session_tabs_for_bounds(
                         width,
                         height,
-                        workspaces.len(),
-                        f64::from(event.event_x),
-                        f64::from(event.event_y),
-                    ) {
-                        dirty |= model.select_workspace(&workspaces[index].workspace_id);
+                        &workspaces,
+                        model.selected_workspace_id(),
+                    );
+                    if let Some(workspace_id) =
+                        tabs.hit_test(f64::from(event.event_x), f64::from(event.event_y))
+                    {
+                        dirty |= model.select_workspace(workspace_id);
                     }
                 }
                 Ok(Some(Event::ClientMessage(event)))
@@ -308,6 +315,7 @@ fn run_x11_window(
                 &frames,
                 &workspaces,
                 model.selected_workspace_id(),
+                model.active_view_id(),
             );
             if let Err(error) = upload_image(&conn, window, gc, depth, width, height, &pixels) {
                 tracing::warn!(target: "pip", "Agent View X11 paint failed: {error}");
@@ -493,6 +501,7 @@ fn render_agent_view(
     frames: &[&PipFrame],
     workspaces: &[PipWorkspaceSummary],
     selected_workspace_id: Option<&str>,
+    active_view_id: Option<&str>,
 ) -> Vec<u8> {
     let mut canvas = Canvas::new(width, height);
     canvas.vertical_gradient(Color::rgb(45, 57, 66), Color::rgb(24, 29, 34));
@@ -541,8 +550,17 @@ fn render_agent_view(
     } else {
         for (frame, target) in frames.iter().zip(&layout.targets) {
             render_target(&mut canvas, frame, target.window);
+            if active_view_id == Some(frame.target.view_id().as_str()) {
+                canvas.stroke_rounded_rect(
+                    Rect::from_layout(target.window).expand(3.0),
+                    13.0,
+                    2.0,
+                    Color::rgba(55, 148, 255, 242),
+                );
+            }
         }
-        render_dash(&mut canvas, frames, &layout.dock, &layout.dock_icons);
+        // Agent View has no permanent launcher; session tabs remain the only
+        // presentation-level navigation surface.
     }
     render_session_selector(
         &mut canvas,
@@ -613,43 +631,25 @@ fn draw_frame_image(_canvas: &mut Canvas, _frame: &PipFrame, _rect: Rect) -> boo
     false
 }
 
-fn session_selector_layout(width: u16, height: u16, count: usize) -> Option<(Rect, Vec<Rect>)> {
-    if count <= 1 {
-        return None;
-    }
-    let visible = count;
-    let icon = 22.0;
-    let gap = 5.0;
-    let padding = 6.0;
-    let selector_width = padding * 2.0 + visible as f64 * icon + (visible - 1) as f64 * gap;
-    let selector = Rect::new(
-        (f64::from(width) - selector_width) / 2.0,
-        4.0_f64.min(f64::from(height).max(0.0)),
-        selector_width,
-        28.0,
-    );
-    let icons = (0..visible)
-        .map(|index| {
-            Rect::new(
-                selector.x + padding + index as f64 * (icon + gap),
-                selector.y + 3.0,
-                icon,
-                icon,
-            )
-        })
-        .collect();
-    Some((selector, icons))
-}
-
-fn session_selector_hit_test(
+fn session_tabs_for_bounds(
     width: u16,
     height: u16,
-    count: usize,
-    x: f64,
-    y: f64,
-) -> Option<usize> {
-    let (_, icons) = session_selector_layout(width, height, count)?;
-    icons.iter().position(|icon| icon.contains(x, y))
+    workspaces: &[PipWorkspaceSummary],
+    selected_workspace_id: Option<&str>,
+) -> SessionTabsLayout {
+    let visible = workspaces.len().min(6);
+    let desired_width = visible as f64 * 190.0 + visible.saturating_sub(1) as f64 * 6.0;
+    let panel_width = desired_width.min((f64::from(width) - 16.0).max(1.0));
+    layout_session_tabs(
+        LayoutRect {
+            x: ((f64::from(width) - panel_width) / 2.0).max(0.0),
+            y: 4.0_f64.min(f64::from(height).max(0.0)),
+            width: panel_width,
+            height: 34.0,
+        },
+        workspaces,
+        selected_workspace_id,
+    )
 }
 
 fn render_session_selector(
@@ -659,9 +659,17 @@ fn render_session_selector(
     workspaces: &[PipWorkspaceSummary],
     selected_workspace_id: Option<&str>,
 ) {
-    let Some((dock, icons)) = session_selector_layout(width, height, workspaces.len()) else {
+    let tabs = session_tabs_for_bounds(width, height, workspaces, selected_workspace_id);
+    let Some(first) = tabs.tabs.first() else {
         return;
     };
+    let last = tabs.tabs.last().expect("session tabs are non-empty");
+    let dock = Rect::new(
+        first.rect.x - 6.0,
+        first.rect.y - 3.0,
+        last.rect.x + last.rect.width - first.rect.x + 12.0,
+        first.rect.height + 6.0,
+    );
     canvas.shadow(dock, 12.0, 5.0, Color::rgba(0, 0, 0, 100));
     canvas.rounded_rect(dock, dock.height * 0.27, Color::rgba(67, 70, 72, 195));
     canvas.stroke_rounded_rect(
@@ -670,10 +678,10 @@ fn render_session_selector(
         1.0,
         Color::rgba(231, 235, 236, 66),
     );
-    for (workspace, icon) in workspaces.iter().zip(icons) {
-        let selected = selected_workspace_id == Some(workspace.workspace_id.as_str());
-        let accent = workspace_accent(&workspace.workspace_id);
-        if selected {
+    for (workspace, tab) in workspaces.iter().zip(&tabs.tabs) {
+        let icon = Rect::from_layout(tab.rect);
+        let accent = Color::rgb(tab.accent.0, tab.accent.1, tab.accent.2);
+        if tab.selected {
             canvas.rounded_rect(
                 icon.expand(2.0),
                 icon.width * 0.27,
@@ -704,7 +712,7 @@ fn render_session_selector(
                 icon.x + icon.width / 2.0 + (index as f64 - (indicators - 1) as f64 / 2.0) * 5.0,
                 dock.y + dock.height - 4.0,
                 1.4,
-                Color::rgba(242, 245, 246, if selected { 245 } else { 145 }),
+                Color::rgba(242, 245, 246, if tab.selected { 245 } else { 145 }),
             );
         }
     }
@@ -777,20 +785,6 @@ fn render_dash(canvas: &mut Canvas, frames: &[&PipFrame], dock: &LayoutRect, ico
     }
 }
 
-fn workspace_accent(workspace_id: &str) -> Color {
-    let hash = workspace_id.bytes().fold(0u32, |hash, byte| {
-        hash.wrapping_mul(31).wrapping_add(u32::from(byte))
-    });
-    const COLORS: [Color; 5] = [
-        Color::rgb(53, 154, 220),
-        Color::rgb(239, 112, 54),
-        Color::rgb(72, 178, 123),
-        Color::rgb(214, 151, 48),
-        Color::rgb(104, 136, 196),
-    ];
-    COLORS[hash as usize % COLORS.len()]
-}
-
 fn render_resize_affordance(canvas: &mut Canvas, width: u16, height: u16) {
     let x = f64::from(width) - 15.0;
     let y = f64::from(height) - 8.0;
@@ -844,10 +838,6 @@ impl Rect {
             self.width + amount * 2.0,
             self.height + amount * 2.0,
         )
-    }
-
-    fn contains(self, x: f64, y: f64) -> bool {
-        x >= self.x && y >= self.y && x < self.x + self.width && y < self.y + self.height
     }
 }
 
@@ -1114,36 +1104,49 @@ fn lerp_color(from: Color, to: Color, t: f64) -> Color {
 mod tests {
     use super::*;
 
+    fn workspace(id: &str) -> PipWorkspaceSummary {
+        PipWorkspaceSummary {
+            workspace_id: id.to_owned(),
+            workspace_label: id.to_owned(),
+            target_count: 1,
+            updated_ms: 0,
+        }
+    }
+
     #[test]
     fn renderer_emits_x11_bgrx_at_the_requested_size() {
-        let rendered = render_agent_view(360, 260, &[], &[], None);
+        let rendered = render_agent_view(360, 260, &[], &[], None, None);
         assert_eq!(rendered.len(), 360 * 260 * 4);
         assert!(rendered.chunks_exact(4).all(|pixel| pixel[3] == 0));
     }
 
     #[test]
     fn session_selector_is_hidden_for_zero_or_one_workspace() {
-        assert!(session_selector_layout(720, 520, 0).is_none());
-        assert!(session_selector_layout(720, 520, 1).is_none());
-        assert!(session_selector_layout(720, 520, 2).is_some());
+        assert!(session_tabs_for_bounds(720, 520, &[], None).tabs.is_empty());
+        assert!(
+            session_tabs_for_bounds(720, 520, &[workspace("one")], Some("one"))
+                .tabs
+                .is_empty()
+        );
+        assert_eq!(
+            session_tabs_for_bounds(720, 520, &[workspace("one"), workspace("two")], Some("one"),)
+                .tabs
+                .len(),
+            2
+        );
     }
 
     #[test]
-    fn session_selector_hit_testing_only_accepts_session_icons() {
-        let (dock, icons) = session_selector_layout(720, 520, 3).unwrap();
-        let first = icons[0];
+    fn session_selector_hit_testing_only_accepts_session_tabs() {
+        let workspaces = [workspace("one"), workspace("two"), workspace("three")];
+        let tabs = session_tabs_for_bounds(720, 520, &workspaces, Some("one"));
+        let first = tabs.tabs[0].rect;
         assert_eq!(
-            session_selector_hit_test(
-                720,
-                520,
-                3,
-                first.x + first.width / 2.0,
-                first.y + first.height / 2.0,
-            ),
-            Some(0)
+            tabs.hit_test(first.x + first.width / 2.0, first.y + first.height / 2.0),
+            Some("one")
         );
         assert_eq!(
-            session_selector_hit_test(720, 520, 3, dock.x + 2.0, dock.y + 2.0),
+            tabs.hit_test(first.x - 2.0, first.y + first.height / 2.0),
             None
         );
     }

--- a/libs/cua-driver/rust/crates/platform-linux/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/pip/mod.rs
@@ -6,7 +6,6 @@
 //! moves, resizes, focuses, or closes the represented applications.
 
 use std::sync::mpsc::{self, Receiver, Sender};
-#[cfg(target_os = "linux")]
 use std::time::Duration;
 
 #[cfg(target_os = "linux")]
@@ -23,11 +22,31 @@ enum UiMessage {
     Frame(PipFrame),
     RemoveTarget(String, String),
     RemoveWorkspace(String),
+    SetInputTransparent(bool, mpsc::SyncSender<anyhow::Result<()>>),
     Shutdown,
 }
 
 pub struct LinuxPipBackend {
     tx: Sender<UiMessage>,
+}
+
+impl LinuxPipBackend {
+    /// Synchronously include or exclude Agent View from X11 pointer hit-testing.
+    ///
+    /// Cua actions should enable transparency before injecting input and restore
+    /// interaction afterward. Waiting for the X11 thread to flush the shape
+    /// change prevents an always-on-top Agent View from intercepting the action.
+    pub fn set_input_transparent(&self, transparent: bool) -> anyhow::Result<()> {
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        self.tx
+            .send(UiMessage::SetInputTransparent(transparent, reply_tx))
+            .map_err(|_| anyhow::anyhow!("Agent View X11 thread is not running"))?;
+        reply_rx
+            .recv_timeout(Duration::from_secs(2))
+            .map_err(|error| {
+                anyhow::anyhow!("timed out updating Agent View input shape: {error}")
+            })?
+    }
 }
 
 impl PipBackend for LinuxPipBackend {
@@ -44,6 +63,10 @@ impl PipBackend for LinuxPipBackend {
         let _ = self
             .tx
             .send(UiMessage::RemoveWorkspace(workspace_id.to_owned()));
+    }
+
+    fn set_input_passthrough(&self, passthrough: bool) -> anyhow::Result<()> {
+        self.set_input_transparent(passthrough)
     }
 
     fn remove_target(&self, workspace_id: &str, identity_key: &str) {
@@ -225,7 +248,16 @@ fn run_x11_window(
     let mut running = true;
     while running {
         while let Ok(message) = rx.try_recv() {
-            handle_message(message, &mut model, &mut dirty, &mut running);
+            handle_x11_message(
+                &conn,
+                window,
+                width,
+                height,
+                message,
+                &mut model,
+                &mut dirty,
+                &mut running,
+            );
         }
 
         loop {
@@ -286,7 +318,16 @@ fn run_x11_window(
 
         if running {
             match rx.recv_timeout(Duration::from_millis(16)) {
-                Ok(message) => handle_message(message, &mut model, &mut dirty, &mut running),
+                Ok(message) => handle_x11_message(
+                    &conn,
+                    window,
+                    width,
+                    height,
+                    message,
+                    &mut model,
+                    &mut dirty,
+                    &mut running,
+                ),
                 Err(mpsc::RecvTimeoutError::Timeout) => {}
                 Err(mpsc::RecvTimeoutError::Disconnected) => running = false,
             }
@@ -296,6 +337,62 @@ fn run_x11_window(
     let _ = conn.free_gc(gc);
     let _ = conn.destroy_window(window);
     let _ = conn.flush();
+}
+
+#[cfg(target_os = "linux")]
+fn handle_x11_message(
+    conn: &impl x11rb::connection::Connection,
+    window: u32,
+    width: u16,
+    height: u16,
+    message: UiMessage,
+    model: &mut PipViewModel,
+    dirty: &mut bool,
+    running: &mut bool,
+) {
+    match message {
+        UiMessage::SetInputTransparent(transparent, reply) => {
+            let result = set_x11_input_transparent(conn, window, width, height, transparent);
+            let _ = reply.send(result);
+        }
+        message => handle_message(message, model, dirty, running),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn set_x11_input_transparent(
+    conn: &impl x11rb::connection::Connection,
+    window: u32,
+    width: u16,
+    height: u16,
+    transparent: bool,
+) -> anyhow::Result<()> {
+    use x11rb::protocol::shape::{ConnectionExt as ShapeConnectionExt, SK, SO};
+    use x11rb::protocol::xproto::{ClipOrdering, Rectangle};
+
+    let interactive_region = [Rectangle {
+        x: 0,
+        y: 0,
+        width,
+        height,
+    }];
+    let rectangles = if transparent {
+        &[][..]
+    } else {
+        &interactive_region[..]
+    };
+    conn.shape_rectangles(
+        SO::SET,
+        SK::INPUT,
+        ClipOrdering::UNSORTED,
+        window,
+        0,
+        0,
+        rectangles,
+    )?
+    .check()?;
+    conn.flush()?;
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
@@ -356,6 +453,11 @@ fn handle_message(
         }
         UiMessage::RemoveWorkspace(workspace_id) => {
             *dirty |= !model.remove_workspace(&workspace_id).is_empty();
+        }
+        UiMessage::SetInputTransparent(_, reply) => {
+            let _ = reply.send(Err(anyhow::anyhow!(
+                "Agent View input shape update reached a non-X11 handler"
+            )));
         }
         UiMessage::Shutdown => *running = false,
     }
@@ -1067,6 +1169,51 @@ mod tests {
         assert_eq!(clamp_i16(i32::MAX), i16::MAX);
         assert_eq!(clamp_i16(i32::MIN), i16::MIN);
         assert_eq!(clamp_i16(24), 24);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[ignore = "requires a live X11 server (run under xvfb-run)"]
+    fn x11_input_transparency_toggle_changes_input_shape() -> anyhow::Result<()> {
+        use x11rb::connection::Connection;
+        use x11rb::protocol::shape::{ConnectionExt as ShapeConnectionExt, SK};
+        use x11rb::protocol::xproto::{ConnectionExt as _, CreateWindowAux, WindowClass};
+
+        let (conn, screen_num) = x11rb::connect(None)?;
+        let screen = &conn.setup().roots[screen_num];
+        let window = conn.generate_id()?;
+        let width = 320;
+        let height = 240;
+        conn.create_window(
+            screen.root_depth,
+            window,
+            screen.root,
+            0,
+            0,
+            width,
+            height,
+            0,
+            WindowClass::INPUT_OUTPUT,
+            screen.root_visual,
+            &CreateWindowAux::new(),
+        )?
+        .check()?;
+        conn.map_window(window)?.check()?;
+        conn.flush()?;
+
+        set_x11_input_transparent(&conn, window, width, height, true)?;
+        let transparent = conn.shape_get_rectangles(window, SK::INPUT)?.reply()?;
+        assert!(transparent.rectangles.is_empty());
+
+        set_x11_input_transparent(&conn, window, width, height, false)?;
+        let interactive = conn.shape_get_rectangles(window, SK::INPUT)?.reply()?;
+        assert_eq!(interactive.rectangles.len(), 1);
+        assert_eq!(interactive.rectangles[0].width, width);
+        assert_eq!(interactive.rectangles[0].height, height);
+
+        conn.destroy_window(window)?.check()?;
+        conn.flush()?;
+        Ok(())
     }
 
     #[cfg(target_os = "linux")]

--- a/libs/cua-driver/rust/crates/platform-linux/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/pip/mod.rs
@@ -9,6 +9,9 @@ use std::sync::mpsc::{self, Receiver, Sender};
 use std::time::Duration;
 
 #[cfg(target_os = "linux")]
+mod wayland;
+
+#[cfg(target_os = "linux")]
 use image::imageops::FilterType;
 use pip_preview::{
     layout_desktop, layout_session_tabs, png_dimensions, LayoutRect, PipBackend, PipBackendFactory,
@@ -19,7 +22,7 @@ use pip_preview::{
 const MIN_WIDTH: u16 = 360;
 const MIN_HEIGHT: u16 = 260;
 
-enum UiMessage {
+pub(super) enum UiMessage {
     Frame(PipFrame),
     RemoveTarget(String, String),
     RemoveWorkspace(String),
@@ -95,13 +98,26 @@ impl PipBackendFactory for LinuxPipBackendFactory {
         let cfg = cfg.clone();
         std::thread::Builder::new()
             .name("cua-agent-view-linux".to_owned())
-            .spawn(move || run_x11_window(cfg, rx, ready_tx))?;
+            .spawn(move || {
+                #[cfg(target_os = "linux")]
+                if should_use_native_wayland() {
+                    wayland::run_window(cfg, rx, ready_tx);
+                    return;
+                }
+                run_x11_window(cfg, rx, ready_tx)
+            })?;
 
         ready_rx
             .recv()
             .map_err(|_| anyhow::anyhow!("Agent View X11 thread exited during startup"))??;
         Ok(Box::new(LinuxPipBackend { tx }))
     }
+}
+
+#[cfg(target_os = "linux")]
+fn should_use_native_wayland() -> bool {
+    std::env::var_os("WAYLAND_DISPLAY").is_some()
+        && (crate::wayland::is_wayland() || std::env::var_os("DISPLAY").is_none())
 }
 
 #[cfg(target_os = "linux")]
@@ -495,7 +511,7 @@ fn clamp_i16(value: i32) -> i16 {
     value.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16
 }
 
-fn render_agent_view(
+pub(super) fn render_agent_view(
     width: u16,
     height: u16,
     frames: &[&PipFrame],
@@ -1149,6 +1165,18 @@ mod tests {
             tabs.hit_test(first.x - 2.0, first.y + first.height / 2.0),
             None
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[ignore = "requires a live pure-Wayland compositor with layer-shell"]
+    fn native_wayland_agent_view_starts_and_stops() {
+        assert!(std::env::var_os("WAYLAND_DISPLAY").is_some());
+        assert!(std::env::var_os("DISPLAY").is_none());
+        let backend = LinuxPipBackendFactory
+            .start(&PipConfig::default())
+            .expect("native Wayland Agent View should start");
+        backend.shutdown();
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/pip/wayland.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/pip/wayland.rs
@@ -1,0 +1,307 @@
+//! Native Wayland Agent View for compositors exposing layer-shell.
+
+use std::collections::HashMap;
+use std::sync::mpsc::{Receiver, SyncSender};
+use std::time::Duration;
+
+use pip_preview::{PipConfig, PipViewModel};
+use wayland_client::{
+    protocol::{
+        wl_buffer::{self, WlBuffer},
+        wl_compositor::WlCompositor,
+        wl_region::WlRegion,
+        wl_registry,
+        wl_shm::{Format, WlShm},
+        wl_shm_pool::WlShmPool,
+        wl_surface::WlSurface,
+    },
+    Connection, Dispatch, Proxy, QueueHandle,
+};
+use wayland_protocols_wlr::layer_shell::v1::client::{
+    zwlr_layer_shell_v1::{Layer, ZwlrLayerShellV1},
+    zwlr_layer_surface_v1::{self, Anchor, KeyboardInteractivity, ZwlrLayerSurfaceV1},
+};
+
+use super::{render_agent_view, UiMessage};
+
+struct State {
+    compositor: Option<WlCompositor>,
+    shm: Option<WlShm>,
+    layer_shell: Option<ZwlrLayerShellV1>,
+    surface: Option<WlSurface>,
+    layer_surface: Option<ZwlrLayerSurfaceV1>,
+    configured: bool,
+    width: u32,
+    height: u32,
+    pending_buffers: HashMap<u32, (*mut libc::c_void, usize, i32)>,
+}
+
+unsafe impl Send for State {}
+
+impl State {
+    fn new(width: u32, height: u32) -> Self {
+        Self {
+            compositor: None,
+            shm: None,
+            layer_shell: None,
+            surface: None,
+            layer_surface: None,
+            configured: false,
+            width,
+            height,
+            pending_buffers: HashMap::new(),
+        }
+    }
+}
+
+pub(super) fn run_window(
+    cfg: PipConfig,
+    rx: Receiver<UiMessage>,
+    ready: SyncSender<anyhow::Result<()>>,
+) {
+    if let Err(error) = run(cfg, rx, &ready) {
+        let _ = ready.send(Err(error));
+    }
+}
+
+fn run(
+    cfg: PipConfig,
+    rx: Receiver<UiMessage>,
+    ready: &SyncSender<anyhow::Result<()>>,
+) -> anyhow::Result<()> {
+    let connection = Connection::connect_to_env()?;
+    let mut queue = connection.new_event_queue::<State>();
+    let qh = queue.handle();
+    let _registry = connection.display().get_registry(&qh, ());
+    let mut state = State::new(cfg.geometry.width.max(360), cfg.geometry.height.max(260));
+    queue.roundtrip(&mut state)?;
+
+    let compositor = state
+        .compositor
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("Wayland compositor does not expose wl_compositor"))?;
+    let layer_shell = state.layer_shell.clone().ok_or_else(|| {
+        anyhow::anyhow!(
+            "native Wayland Agent View requires zwlr_layer_shell_v1; use XWayland on this compositor"
+        )
+    })?;
+    let surface = compositor.create_surface(&qh, ());
+    let layer_surface = layer_shell.get_layer_surface(
+        &surface,
+        None,
+        Layer::Overlay,
+        "cua-agent-view".to_owned(),
+        &qh,
+        (),
+    );
+    layer_surface.set_anchor(Anchor::Top | Anchor::Right);
+    layer_surface.set_size(state.width, state.height);
+    layer_surface.set_margin(24, 24, 24, 24);
+    layer_surface.set_exclusive_zone(-1);
+    layer_surface.set_keyboard_interactivity(KeyboardInteractivity::None);
+    // Layer-shell cannot provide a normal draggable/resizable window contract.
+    // Keep the presentation click-through so it can never block automation;
+    // session selection continues to follow MRU on this native-only path.
+    let input_region = compositor.create_region(&qh, ());
+    surface.set_input_region(Some(&input_region));
+    input_region.destroy();
+    surface.commit();
+    state.surface = Some(surface);
+    state.layer_surface = Some(layer_surface);
+
+    for _ in 0..8 {
+        queue.roundtrip(&mut state)?;
+        if state.configured {
+            break;
+        }
+    }
+    anyhow::ensure!(state.configured, "Wayland Agent View was never configured");
+    ready
+        .send(Ok(()))
+        .map_err(|_| anyhow::anyhow!("Agent View startup receiver was dropped"))?;
+
+    let mut model = PipViewModel::new(12);
+    let mut running = true;
+    let mut dirty = true;
+    while running {
+        match rx.recv_timeout(Duration::from_millis(16)) {
+            Ok(UiMessage::Frame(frame)) => {
+                model.upsert(frame);
+                dirty = true;
+            }
+            Ok(UiMessage::RemoveTarget(workspace, target)) => {
+                dirty |= model.remove_target(&workspace, &target);
+            }
+            Ok(UiMessage::RemoveWorkspace(workspace)) => {
+                dirty |= !model.remove_workspace(&workspace).is_empty();
+            }
+            Ok(UiMessage::SetInputTransparent(_, reply)) => {
+                // Layer-shell presentation does not cover the automated target
+                // at its top-right inset, so no compositor input-region swap is
+                // required for injected actions.
+                let _ = reply.send(Ok(()));
+            }
+            Ok(UiMessage::Shutdown) => running = false,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+        if dirty && running {
+            redraw(&mut state, &model, &qh)?;
+            dirty = false;
+        }
+        queue.roundtrip(&mut state)?;
+    }
+    Ok(())
+}
+
+fn redraw(state: &mut State, model: &PipViewModel, qh: &QueueHandle<State>) -> anyhow::Result<()> {
+    let surface = state
+        .surface
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Wayland Agent View surface is unavailable"))?;
+    let shm = state
+        .shm
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Wayland compositor does not expose wl_shm"))?;
+    let width = state.width.max(1).min(u16::MAX as u32) as u16;
+    let height = state.height.max(1).min(u16::MAX as u32) as u16;
+    let frames = model.selected_frames();
+    let workspaces = model.workspaces();
+    let pixels = render_agent_view(
+        width,
+        height,
+        &frames,
+        &workspaces,
+        model.selected_workspace_id(),
+        model.active_view_id(),
+    );
+    let stride = i32::from(width) * 4;
+    let size = pixels.len();
+    let (fd, ptr) = crate::wayland::anon_shm(size)?;
+    unsafe { std::ptr::copy_nonoverlapping(pixels.as_ptr(), ptr.cast::<u8>(), size) };
+    use std::os::fd::AsFd as _;
+    let pool_fd = unsafe { crate::wayland::borrowed_fd(fd) };
+    let pool = shm.create_pool(pool_fd.as_fd(), size as i32, qh, ());
+    let buffer = pool.create_buffer(
+        0,
+        i32::from(width),
+        i32::from(height),
+        stride,
+        Format::Xrgb8888,
+        qh,
+        (),
+    );
+    pool.destroy();
+    state
+        .pending_buffers
+        .insert(buffer.id().protocol_id(), (ptr, size, fd));
+    surface.attach(Some(&buffer), 0, 0);
+    surface.damage_buffer(0, 0, i32::from(width), i32::from(height));
+    surface.commit();
+    Ok(())
+}
+
+impl Dispatch<wl_registry::WlRegistry, ()> for State {
+    fn event(
+        state: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global {
+            name,
+            interface,
+            version,
+        } = event
+        {
+            match interface.as_str() {
+                "wl_compositor" => {
+                    state.compositor =
+                        Some(registry.bind::<WlCompositor, _, _>(name, version.min(6), qh, ()))
+                }
+                "wl_shm" => {
+                    state.shm = Some(registry.bind::<WlShm, _, _>(name, version.min(1), qh, ()))
+                }
+                "zwlr_layer_shell_v1" => {
+                    state.layer_shell =
+                        Some(registry.bind::<ZwlrLayerShellV1, _, _>(name, version.min(4), qh, ()))
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl Dispatch<ZwlrLayerSurfaceV1, ()> for State {
+    fn event(
+        state: &mut Self,
+        layer: &ZwlrLayerSurfaceV1,
+        event: zwlr_layer_surface_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match event {
+            zwlr_layer_surface_v1::Event::Configure {
+                serial,
+                width,
+                height,
+            } => {
+                layer.ack_configure(serial);
+                if width > 0 {
+                    state.width = width;
+                }
+                if height > 0 {
+                    state.height = height;
+                }
+                state.configured = true;
+            }
+            zwlr_layer_surface_v1::Event::Closed => state.surface = None,
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<WlBuffer, ()> for State {
+    fn event(
+        state: &mut Self,
+        buffer: &WlBuffer,
+        event: wl_buffer::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if matches!(event, wl_buffer::Event::Release) {
+            if let Some((ptr, size, fd)) = state.pending_buffers.remove(&buffer.id().protocol_id())
+            {
+                crate::wayland::cleanup_mmap(ptr, size, fd);
+            }
+            buffer.destroy();
+        }
+    }
+}
+
+macro_rules! empty_dispatch {
+    ($ty:ty) => {
+        impl Dispatch<$ty, ()> for State {
+            fn event(
+                _: &mut Self,
+                _: &$ty,
+                _: <$ty as Proxy>::Event,
+                _: &(),
+                _: &Connection,
+                _: &QueueHandle<Self>,
+            ) {
+            }
+        }
+    };
+}
+
+empty_dispatch!(WlCompositor);
+empty_dispatch!(WlShm);
+empty_dispatch!(WlShmPool);
+empty_dispatch!(WlSurface);
+empty_dispatch!(WlRegion);
+empty_dispatch!(ZwlrLayerShellV1);

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -6895,15 +6895,16 @@ impl Tool for GetConfigTool {
     }
     async fn invoke(&self, _args: Value) -> ToolResult {
         let cfg = self.state.config.read().unwrap();
-        let (pip_enabled, pip_geometry) = pip_preview::read_pip_keys_from_file();
+        let (agent_view_enabled, agent_view_geometry) =
+            pip_preview::read_agent_view_keys_from_file();
         ToolResult::text("cua-driver-rs configuration").with_structured(json!({
             "version": env!("CARGO_PKG_VERSION"),
             "source_sha": option_env!("CUA_DRIVER_SOURCE_SHA"),
             "platform": "linux",
             "capture_mode": cfg.capture_mode,
             "max_image_dimension": cfg.max_image_dimension,
-            "experimental_pip": pip_enabled,
-            "experimental_pip_geometry": pip_geometry
+            "agent_view": agent_view_enabled,
+            "agent_view_geometry": agent_view_geometry
         }))
     }
 }
@@ -6926,7 +6927,7 @@ impl Tool for SetConfigTool {
                 - **{key, value}** (preferred): `{\"key\": \"max_image_dimension\", \"value\": 800}` \
                   — single leaf write.\n\
                 - **Legacy per-field**: `{\"capture_mode\": \"som\", \"max_image_dimension\": 0}`.\n\n\
-                The experimental_pip keys persist to ~/.cua-driver/config.json and apply on next \
+                The agent_view keys persist to ~/.cua-driver/config.json and apply on next \
                 daemon restart (Agent View is initialised once at startup; \
                 Linux ships only the trait stub today — see issue #1729).".into(),
             input_schema: json!({"type":"object","properties":{
@@ -6934,8 +6935,8 @@ impl Tool for SetConfigTool {
                 "value":{"description":"New value for `key`. JSON type depends on the key."},
                 "capture_mode":{"type":"string","enum":["ax","vision"],"description":"Legacy per-field shape. Default capture mode for get_window_state. (\"som\"/\"screenshot\" still decode as deprecated aliases.)"},
                 "max_image_dimension":{"type":"integer","description":"Legacy per-field shape. Max dimension for screenshot resizing (0 = no limit)."},
-                "experimental_pip":{"type":"boolean","description":"Enable the experimental multi-target Agent View (applies next restart; Linux backend stubbed)."},
-                "experimental_pip_geometry":{"type":"string","description":"Agent View size + optional position in `WxH` or `WxH+X+Y` form."}
+                "agent_view":{"type":"boolean","description":"Enable the experimental multi-target Agent View (applies next restart; Linux backend stubbed)."},
+                "agent_view_geometry":{"type":"string","description":"Agent View size + optional position in `WxH` or `WxH+X+Y` form."}
             },"additionalProperties":false}),
             read_only: false, destructive: false, idempotent: true, open_world: false,
         })
@@ -6984,31 +6985,31 @@ impl Tool for SetConfigTool {
                     }
                     None => return ToolResult::error(format!("`max_image_dimension` must be an integer, got {val}.")),
                 },
-                "experimental_pip" => match val.as_bool() {
+                "agent_view" => match val.as_bool() {
                     Some(b) => {
-                        if let Err(e) = pip_preview::write_config_key("experimental_pip", Value::Bool(b)) {
-                            return ToolResult::error(format!("failed to persist experimental_pip: {e}"));
+                        if let Err(e) = pip_preview::write_config_key("agent_view", Value::Bool(b)) {
+                            return ToolResult::error(format!("failed to persist agent_view: {e}"));
                         }
-                        parts.push(format!("experimental_pip={b} (next restart)"));
+                        parts.push(format!("agent_view={b} (next restart)"));
                     }
-                    None => return ToolResult::error(format!("`experimental_pip` must be a boolean, got {val}.")),
+                    None => return ToolResult::error(format!("`agent_view` must be a boolean, got {val}.")),
                 },
-                "experimental_pip_geometry" => match val.as_str() {
+                "agent_view_geometry" => match val.as_str() {
                     Some(s) => {
                         if pip_preview::PipGeometry::parse(s).is_none() {
                             return ToolResult::error(format!(
-                                "experimental_pip_geometry `{s}` is not a valid WxH or WxH+X+Y string"
+                                "agent_view_geometry `{s}` is not a valid WxH or WxH+X+Y string"
                             ));
                         }
-                        if let Err(e) = pip_preview::write_config_key("experimental_pip_geometry", Value::String(s.to_owned())) {
-                            return ToolResult::error(format!("failed to persist experimental_pip_geometry: {e}"));
+                        if let Err(e) = pip_preview::write_config_key("agent_view_geometry", Value::String(s.to_owned())) {
+                            return ToolResult::error(format!("failed to persist agent_view_geometry: {e}"));
                         }
-                        parts.push(format!("experimental_pip_geometry={s} (next restart)"));
+                        parts.push(format!("agent_view_geometry={s} (next restart)"));
                     }
-                    None => return ToolResult::error(format!("`experimental_pip_geometry` must be a string, got {val}.")),
+                    None => return ToolResult::error(format!("`agent_view_geometry` must be a string, got {val}.")),
                 },
                 other => return ToolResult::error(format!(
-                    "Unknown config key `{other}`. Known: capture_mode, max_image_dimension, experimental_pip, experimental_pip_geometry."
+                    "Unknown config key `{other}`. Known: capture_mode, max_image_dimension, agent_view, agent_view_geometry."
                 )),
             }
         }
@@ -7029,40 +7030,37 @@ impl Tool for SetConfigTool {
             }
             parts.push(format!("max_image_dimension={dim}"));
         }
-        if let Some(enabled) = args.get("experimental_pip").and_then(|v| v.as_bool()) {
-            if let Err(e) = pip_preview::write_config_key("experimental_pip", Value::Bool(enabled))
-            {
-                return ToolResult::error(format!("failed to persist experimental_pip: {e}"));
+        if let Some(enabled) = args.get("agent_view").and_then(|v| v.as_bool()) {
+            if let Err(e) = pip_preview::write_config_key("agent_view", Value::Bool(enabled)) {
+                return ToolResult::error(format!("failed to persist agent_view: {e}"));
             }
-            parts.push(format!("experimental_pip={enabled} (next restart)"));
+            parts.push(format!("agent_view={enabled} (next restart)"));
         }
-        if let Some(geom) = args.opt_str("experimental_pip_geometry") {
+        if let Some(geom) = args.opt_str("agent_view_geometry") {
             if pip_preview::PipGeometry::parse(&geom).is_none() {
                 return ToolResult::error(format!(
-                    "experimental_pip_geometry `{geom}` is not a valid WxH or WxH+X+Y string"
+                    "agent_view_geometry `{geom}` is not a valid WxH or WxH+X+Y string"
                 ));
             }
-            if let Err(e) = pip_preview::write_config_key(
-                "experimental_pip_geometry",
-                Value::String(geom.clone()),
-            ) {
-                return ToolResult::error(format!(
-                    "failed to persist experimental_pip_geometry: {e}"
-                ));
+            if let Err(e) =
+                pip_preview::write_config_key("agent_view_geometry", Value::String(geom.clone()))
+            {
+                return ToolResult::error(format!("failed to persist agent_view_geometry: {e}"));
             }
-            parts.push(format!("experimental_pip_geometry={geom} (next restart)"));
+            parts.push(format!("agent_view_geometry={geom} (next restart)"));
         }
         let msg = if parts.is_empty() {
             "Config unchanged (no known parameters).".to_owned()
         } else {
             format!("Config updated: {}", parts.join(", "))
         };
-        let (pip_enabled, pip_geometry) = pip_preview::read_pip_keys_from_file();
+        let (agent_view_enabled, agent_view_geometry) =
+            pip_preview::read_agent_view_keys_from_file();
         ToolResult::text(msg).with_structured(json!({
             "capture_mode": cfg.capture_mode,
             "max_image_dimension": cfg.max_image_dimension,
-            "experimental_pip": pip_enabled,
-            "experimental_pip_geometry": pip_geometry
+            "agent_view": agent_view_enabled,
+            "agent_view_geometry": agent_view_geometry
         }))
     }
 }

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -6927,15 +6927,15 @@ impl Tool for SetConfigTool {
                   — single leaf write.\n\
                 - **Legacy per-field**: `{\"capture_mode\": \"som\", \"max_image_dimension\": 0}`.\n\n\
                 The experimental_pip keys persist to ~/.cua-driver/config.json and apply on next \
-                daemon restart (the PiP backend is initialised once at startup; \
+                daemon restart (Agent View is initialised once at startup; \
                 Linux ships only the trait stub today — see issue #1729).".into(),
             input_schema: json!({"type":"object","properties":{
                 "key":{"type":"string","description":"Name of a single config field to write ({key, value} shape). Pair with `value`."},
                 "value":{"description":"New value for `key`. JSON type depends on the key."},
                 "capture_mode":{"type":"string","enum":["ax","vision"],"description":"Legacy per-field shape. Default capture mode for get_window_state. (\"som\"/\"screenshot\" still decode as deprecated aliases.)"},
                 "max_image_dimension":{"type":"integer","description":"Legacy per-field shape. Max dimension for screenshot resizing (0 = no limit)."},
-                "experimental_pip":{"type":"boolean","description":"Enable the experimental PiP preview window (applies next restart; Linux backend stubbed)."},
-                "experimental_pip_geometry":{"type":"string","description":"PiP window size + optional position in `WxH` or `WxH+X+Y` form."}
+                "experimental_pip":{"type":"boolean","description":"Enable the experimental multi-target Agent View (applies next restart; Linux backend stubbed)."},
+                "experimental_pip_geometry":{"type":"string","description":"Agent View size + optional position in `WxH` or `WxH+X+Y` form."}
             },"additionalProperties":false}),
             read_only: false, destructive: false, idempotent: true, open_world: false,
         })

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -6934,7 +6934,7 @@ impl Tool for SetConfigTool {
                 "value":{"description":"New value for `key`. JSON type depends on the key."},
                 "capture_mode":{"type":"string","enum":["ax","vision"],"description":"Legacy per-field shape. Default capture mode for get_window_state. (\"som\"/\"screenshot\" still decode as deprecated aliases.)"},
                 "max_image_dimension":{"type":"integer","description":"Legacy per-field shape. Max dimension for screenshot resizing (0 = no limit)."},
-                "agent_view":{"type":"boolean","description":"Enable the experimental multi-target Agent View (applies next restart)."},
+                "agent_view":{"type":"boolean","description":"Enable the multi-target Agent View (applies next restart)."},
                 "agent_view_geometry":{"type":"string","description":"Agent View size + optional position in `WxH` or `WxH+X+Y` form."}
             },"additionalProperties":false}),
             read_only: false, destructive: false, idempotent: true, open_world: false,

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -6928,14 +6928,13 @@ impl Tool for SetConfigTool {
                   — single leaf write.\n\
                 - **Legacy per-field**: `{\"capture_mode\": \"som\", \"max_image_dimension\": 0}`.\n\n\
                 The agent_view keys persist to ~/.cua-driver/config.json and apply on next \
-                daemon restart (Agent View is initialised once at startup; \
-                Linux ships only the trait stub today — see issue #1729).".into(),
+                daemon restart (Agent View is initialised once at startup).".into(),
             input_schema: json!({"type":"object","properties":{
                 "key":{"type":"string","description":"Name of a single config field to write ({key, value} shape). Pair with `value`."},
                 "value":{"description":"New value for `key`. JSON type depends on the key."},
                 "capture_mode":{"type":"string","enum":["ax","vision"],"description":"Legacy per-field shape. Default capture mode for get_window_state. (\"som\"/\"screenshot\" still decode as deprecated aliases.)"},
                 "max_image_dimension":{"type":"integer","description":"Legacy per-field shape. Max dimension for screenshot resizing (0 = no limit)."},
-                "agent_view":{"type":"boolean","description":"Enable the experimental multi-target Agent View (applies next restart; Linux backend stubbed)."},
+                "agent_view":{"type":"boolean","description":"Enable the experimental multi-target Agent View (applies next restart)."},
                 "agent_view_geometry":{"type":"string","description":"Agent View size + optional position in `WxH` or `WxH+X+Y` form."}
             },"additionalProperties":false}),
             read_only: false, destructive: false, idempotent: true, open_world: false,

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -1278,8 +1278,12 @@ unsafe fn install_wallpaper(
     // covered by a sharp inset copy while the outer copy is blurred and tinted.
     let glass_frame = rounded_view(
         bounds,
-        CONTAINER_RADIUS,
-        color(0.18, 0.21, 0.25, 0.16),
+        if SHOW_SHELL_BORDER {
+            CONTAINER_RADIUS
+        } else {
+            0.0
+        },
+        color(0.18, 0.21, 0.25, if SHOW_SHELL_BORDER { 0.16 } else { 0.0 }),
         true,
     );
     let _: () = msg_send![glass_frame, setAutoresizingMask: 18u64];
@@ -1358,7 +1362,7 @@ unsafe fn install_wallpaper(
     }
 
     let container_frame = desktop_frame(bounds);
-    let container_radius = 8.5;
+    let container_radius = if SHOW_SHELL_BORDER { 8.5 } else { 0.0 };
     let wallpaper_shadow = rounded_view(
         container_frame,
         container_radius,
@@ -1549,7 +1553,7 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     let clear: *mut AnyObject = msg_send![class!(NSColor), clearColor];
     let _: () = msg_send![window, setBackgroundColor: clear];
     let _: () = msg_send![window, setOpaque: false];
-    let _: () = msg_send![window, setHasShadow: true];
+    let _: () = msg_send![window, setHasShadow: SHOW_SHELL_BORDER];
     // Screen sharing and recordings should include Agent View itself.
     let _: () = msg_send![window, setSharingType: 1u64];
     let _: () = msg_send![window, setMovableByWindowBackground: true];
@@ -1566,7 +1570,14 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     let content_view: *mut AnyObject = msg_send![window, contentView];
     let _: () = msg_send![content_view, setWantsLayer: true];
     let content_layer: *mut AnyObject = msg_send![content_view, layer];
-    let _: () = msg_send![content_layer, setCornerRadius: CONTAINER_RADIUS];
+    let _: () = msg_send![
+        content_layer,
+        setCornerRadius: if SHOW_SHELL_BORDER {
+            CONTAINER_RADIUS
+        } else {
+            0.0
+        }
+    ];
     set_continuous_corners(content_layer);
     // The chrome view clips its own children. Masking here too would clip the
     // chrome's own outer rim stroke in half and flatten the frame.
@@ -1586,7 +1597,10 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     // the container silhouette.
     let _: () = msg_send![canvas, setWantsLayer: true];
     let canvas_layer: *mut AnyObject = msg_send![canvas, layer];
-    let _: () = msg_send![canvas_layer, setCornerRadius: 8.5_f64];
+    let _: () = msg_send![
+        canvas_layer,
+        setCornerRadius: if SHOW_SHELL_BORDER { 8.5_f64 } else { 0.0 }
+    ];
     set_continuous_corners(canvas_layer);
     let _: () = msg_send![canvas_layer, setMasksToBounds: true];
     let _: () = msg_send![content_view, addSubview: canvas];

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -758,15 +758,13 @@ unsafe fn install_wallpaper(
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
 
-    // Outer container chrome. A deterministic layer keeps the rim free of the
-    // saturated wallpaper cast an NSVisualEffectView material picks up at this
-    // scale. This base is a low-alpha graphite tint; the gradient body below
-    // supplies the lit-to-dark falloff, so the bright outer rim reads as a
-    // highlight on a translucent glass body rather than as the whole frame.
+    // The shell clips a real behind-window visual effect. The miniature
+    // desktop covers its centre, leaving the blurred host desktop or app
+    // visible only through the top, side, and bottom rails.
     let glass_frame = rounded_view(
         bounds,
         CONTAINER_RADIUS,
-        color(0.26, 0.29, 0.34, 0.62),
+        color(0.18, 0.21, 0.25, 0.16),
         true,
     );
     let _: () = msg_send![glass_frame, setAutoresizingMask: 18u64];
@@ -775,13 +773,30 @@ unsafe fn install_wallpaper(
     set_layer_border(glass_layer, 0.8, color(1.0, 1.0, 1.0, 0.50));
     let _: () = msg_send![content_view, addSubview: glass_frame];
 
-    // Vertical falloff across the chrome body. Lit at the top, graphite at the
-    // bottom, translucent enough to pick up depth from whatever sits behind.
+    let backdrop: *mut AnyObject = {
+        let allocated: *mut AnyObject = msg_send![class!(NSVisualEffectView), alloc];
+        msg_send![
+            allocated,
+            initWithFrame: objc2_foundation::NSRect::new(
+                objc2_foundation::NSPoint::new(0.0, 0.0),
+                bounds.size,
+            )
+        ]
+    };
+    let _: () = msg_send![backdrop, setAutoresizingMask: 18u64];
+    let _: () = msg_send![backdrop, setMaterial: 13i64]; // HUD window material.
+    let _: () = msg_send![backdrop, setBlendingMode: 0i64]; // Behind the Agent View window.
+    let _: () = msg_send![backdrop, setState: 1i64]; // Keep the blur active while non-key.
+    let _: () = msg_send![backdrop, setEmphasized: true];
+    let _: () = msg_send![glass_frame, addSubview: backdrop];
+
+    // A restrained silver-to-graphite tint keeps the blurred backdrop legible
+    // as a shell instead of exposing raw, high-contrast shapes behind it.
     let body = gradient_view(
         objc2_foundation::NSRect::new(objc2_foundation::NSPoint::new(0.0, 0.0), bounds.size),
         CONTAINER_RADIUS,
-        color(0.58, 0.61, 0.66, 0.88),
-        color(0.19, 0.22, 0.27, 0.92),
+        color(0.68, 0.71, 0.76, 0.34),
+        color(0.15, 0.18, 0.22, 0.52),
     );
     let _: () = msg_send![body, setAutoresizingMask: 18u64];
     let body_layer: *mut AnyObject = msg_send![body, layer];

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -1,8 +1,7 @@
-//! macOS picture-in-picture preview window.
+//! macOS multi-target Agent View.
 //!
-//! Floating NSWindow with an NSImageView showing the most recent
-//! post-action screenshot and an NSTextField with a one-line label
-//! describing the action that produced it.
+//! Floating NSWindow containing a bounded grid of exact native-window and
+//! browser-tab cards, grouped by the existing lifecycle session.
 //!
 //! ## Threading model
 //!
@@ -44,7 +43,7 @@
 use std::ffi::c_void;
 use std::sync::Mutex;
 
-use pip_preview::{PipBackend, PipBackendFactory, PipConfig, PipFrame};
+use pip_preview::{PipBackend, PipBackendFactory, PipConfig, PipFrame, PipViewModel};
 
 // ── CGColor objc2 encoding shim ────────────────────────────────────────────
 //
@@ -78,11 +77,11 @@ unsafe impl objc2::RefEncode for CGColor {
 
 struct NativeHandles {
     window: usize,
-    image_view: usize,
-    label: usize,
+    content_view: usize,
 }
 
 static HANDLES: Mutex<Option<NativeHandles>> = Mutex::new(None);
+static VIEW_MODEL: Mutex<Option<PipViewModel>> = Mutex::new(None);
 
 // ── libdispatch glue — same shape as cursor::overlay ──────────────────────
 
@@ -119,58 +118,235 @@ impl PipBackend for MacosPipBackend {
         dispatch_to_main(frame, push_frame_cb);
     }
 
+    fn remove_workspace(&self, workspace_id: &str) {
+        dispatch_to_main(workspace_id.to_owned(), remove_workspace_cb);
+    }
+
     fn shutdown(self: Box<Self>) {
         dispatch_to_main((), shutdown_cb);
     }
 }
 
 unsafe extern "C" fn push_frame_cb(ctx: *mut c_void) {
+    let frame: PipFrame = *Box::from_raw(ctx as *mut PipFrame);
+    let frames = {
+        let mut model = VIEW_MODEL.lock().unwrap();
+        let model = model.get_or_insert_with(|| PipViewModel::new(12));
+        model.upsert(frame);
+        model
+            .ordered_frames()
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>()
+    };
+    render_frames(&frames);
+}
+
+unsafe extern "C" fn remove_workspace_cb(ctx: *mut c_void) {
+    let workspace_id: String = *Box::from_raw(ctx as *mut String);
+    let frames = {
+        let mut model = VIEW_MODEL.lock().unwrap();
+        let model = model.get_or_insert_with(|| PipViewModel::new(12));
+        model.remove_workspace(&workspace_id);
+        model
+            .ordered_frames()
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>()
+    };
+    render_frames(&frames);
+}
+
+unsafe fn ns_string(value: &str) -> *mut objc2::runtime::AnyObject {
+    use objc2::{class, msg_send};
+
+    let sanitized = value.replace('\0', " ");
+    let Ok(cstr) = std::ffi::CString::new(sanitized) else {
+        return std::ptr::null_mut();
+    };
+    msg_send![
+        class!(NSString),
+        stringWithUTF8String: cstr.as_ptr() as *const u8
+    ]
+}
+
+unsafe fn add_text_label(
+    parent: *mut objc2::runtime::AnyObject,
+    frame: objc2_foundation::NSRect,
+    text: &str,
+    font_size: f64,
+    bold: bool,
+    secondary: bool,
+) {
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
 
-    let frame: PipFrame = *Box::from_raw(ctx as *mut PipFrame);
+    let label: *mut AnyObject = {
+        let alloc: *mut AnyObject = msg_send![class!(NSTextField), alloc];
+        msg_send![alloc, initWithFrame: frame]
+    };
+    let _: () = msg_send![label, setBezeled: false];
+    let _: () = msg_send![label, setDrawsBackground: false];
+    let _: () = msg_send![label, setEditable: false];
+    let _: () = msg_send![label, setSelectable: false];
+    let color: *mut AnyObject = if secondary {
+        msg_send![
+            class!(NSColor),
+            colorWithCalibratedWhite: 0.78_f64
+            alpha: 1.0_f64
+        ]
+    } else {
+        msg_send![class!(NSColor), whiteColor]
+    };
+    let _: () = msg_send![label, setTextColor: color];
+    let font: *mut AnyObject = if bold {
+        msg_send![class!(NSFont), boldSystemFontOfSize: font_size]
+    } else {
+        msg_send![class!(NSFont), systemFontOfSize: font_size]
+    };
+    let _: () = msg_send![label, setFont: font];
+    let value = ns_string(text);
+    if !value.is_null() {
+        let _: () = msg_send![label, setStringValue: value];
+    }
+    let _: () = msg_send![parent, addSubview: label];
+}
 
-    let (image_view_ptr, label_ptr) = {
+unsafe fn render_frames(frames: &[PipFrame]) {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    let content_view = {
         let guard = HANDLES.lock().unwrap();
         match guard.as_ref() {
-            Some(h) => (h.image_view, h.label),
+            Some(handles) => handles.content_view as *mut AnyObject,
             None => return,
         }
     };
+    let empty: *mut AnyObject = msg_send![class!(NSArray), array];
+    let _: () = msg_send![content_view, setSubviews: empty];
 
-    // Construct NSData from the PNG bytes, then NSImage from NSData.
-    // `dataWithBytes:length:` copies into a fresh NSData so the input
-    // `Vec<u8>` can be freed at the end of this block.
-    let png_ptr = frame.png_bytes.as_ptr() as *const c_void;
-    let png_len = frame.png_bytes.len();
-    let ns_data: *mut AnyObject = msg_send![
-        class!(NSData),
-        dataWithBytes: png_ptr
-        length: png_len
-    ];
-    if ns_data.is_null() {
+    let bounds: NSRect = msg_send![content_view, bounds];
+    if frames.is_empty() {
+        add_text_label(
+            content_view,
+            NSRect::new(
+                NSPoint::new(16.0, (bounds.size.height - 24.0) / 2.0),
+                NSSize::new((bounds.size.width - 32.0).max(40.0), 24.0),
+            ),
+            "Waiting for an exact window or browser tab...",
+            12.0,
+            false,
+            true,
+        );
         return;
     }
-    let img: *mut AnyObject = {
-        let alloc: *mut AnyObject = msg_send![class!(NSImage), alloc];
-        msg_send![alloc, initWithData: ns_data]
-    };
-    if !img.is_null() {
-        let image_view = image_view_ptr as *mut AnyObject;
-        let _: () = msg_send![image_view, setImage: img];
-    }
 
-    // Update the label. NSString::stringWithUTF8String requires NUL
-    // termination; copy into a CString so we hand a clean buffer.
-    if let Ok(cstr) = std::ffi::CString::new(frame.action_label) {
-        let ns_str: *mut AnyObject = msg_send![
-            class!(NSString),
-            stringWithUTF8String: cstr.as_ptr() as *const u8
+    let count = frames.len();
+    let cols = match count {
+        1 => 1,
+        2..=4 => 2,
+        _ => 3,
+    };
+    let rows = count.div_ceil(cols);
+    let gap = 6.0_f64;
+    let card_width = ((bounds.size.width - gap * (cols as f64 + 1.0)) / cols as f64).max(40.0);
+    let card_height = ((bounds.size.height - gap * (rows as f64 + 1.0)) / rows as f64).max(40.0);
+    let header_height = 20.0_f64.min(card_height * 0.22);
+    let footer_height = 19.0_f64.min(card_height * 0.20);
+
+    for (index, frame) in frames.iter().enumerate() {
+        let col = index % cols;
+        let row = index / cols;
+        let x = gap + col as f64 * (card_width + gap);
+        let y = bounds.size.height - gap - (row as f64 + 1.0) * card_height - row as f64 * gap;
+        let card_rect = NSRect::new(NSPoint::new(x, y), NSSize::new(card_width, card_height));
+        let card: *mut AnyObject = {
+            let alloc: *mut AnyObject = msg_send![class!(NSView), alloc];
+            msg_send![alloc, initWithFrame: card_rect]
+        };
+        let _: () = msg_send![card, setWantsLayer: true];
+        let layer: *mut AnyObject = msg_send![card, layer];
+        let _: () = msg_send![layer, setCornerRadius: 9.0_f64];
+        let _: () = msg_send![layer, setMasksToBounds: true];
+        let bg: *mut AnyObject = msg_send![
+            class!(NSColor),
+            colorWithCalibratedRed: 0.055_f64
+            green: 0.065_f64
+            blue: 0.075_f64
+            alpha: 1.0_f64
         ];
-        if !ns_str.is_null() {
-            let label = label_ptr as *mut AnyObject;
-            let _: () = msg_send![label, setStringValue: ns_str];
+        let bg_cg: *mut CGColor = msg_send![bg, CGColor];
+        let _: () = msg_send![layer, setBackgroundColor: bg_cg];
+        let accent: *mut AnyObject = match frame.target.target_kind {
+            pip_preview::PipTargetKind::BrowserTab => msg_send![
+                class!(NSColor),
+                colorWithCalibratedRed: 0.15_f64
+                green: 0.78_f64
+                blue: 0.65_f64
+                alpha: 0.95_f64
+            ],
+            pip_preview::PipTargetKind::NativeWindow => msg_send![
+                class!(NSColor),
+                colorWithCalibratedRed: 0.98_f64
+                green: 0.52_f64
+                blue: 0.20_f64
+                alpha: 0.95_f64
+            ],
+        };
+        let accent_cg: *mut CGColor = msg_send![accent, CGColor];
+        let _: () = msg_send![layer, setBorderColor: accent_cg];
+        let _: () = msg_send![layer, setBorderWidth: 1.5_f64];
+
+        let image_height = (card_height - header_height - footer_height).max(1.0);
+        let image_rect = NSRect::new(
+            NSPoint::new(0.0, footer_height),
+            NSSize::new(card_width, image_height),
+        );
+        let image_view: *mut AnyObject = {
+            let alloc: *mut AnyObject = msg_send![class!(NSImageView), alloc];
+            msg_send![alloc, initWithFrame: image_rect]
+        };
+        let _: () = msg_send![image_view, setImageScaling: 3u64];
+        let ns_data: *mut AnyObject = msg_send![
+            class!(NSData),
+            dataWithBytes: frame.png_bytes.as_ptr() as *const c_void
+            length: frame.png_bytes.len()
+        ];
+        if !ns_data.is_null() {
+            let alloc: *mut AnyObject = msg_send![class!(NSImage), alloc];
+            let image: *mut AnyObject = msg_send![alloc, initWithData: ns_data];
+            if !image.is_null() {
+                let _: () = msg_send![image_view, setImage: image];
+            }
         }
+        let _: () = msg_send![card, addSubview: image_view];
+
+        add_text_label(
+            card,
+            NSRect::new(
+                NSPoint::new(8.0, card_height - header_height),
+                NSSize::new((card_width - 16.0).max(20.0), header_height),
+            ),
+            &frame.target.workspace_label,
+            10.5,
+            true,
+            false,
+        );
+        let footer = format!("{} · {}", frame.target.target_label, frame.action_label);
+        add_text_label(
+            card,
+            NSRect::new(
+                NSPoint::new(8.0, 0.0),
+                NSSize::new((card_width - 16.0).max(20.0), footer_height),
+            ),
+            &footer,
+            9.5,
+            false,
+            true,
+        );
+        let _: () = msg_send![content_view, addSubview: card];
     }
 }
 
@@ -179,6 +355,7 @@ unsafe extern "C" fn shutdown_cb(_ctx: *mut c_void) {
     use objc2::runtime::AnyObject;
 
     let handles = HANDLES.lock().unwrap().take();
+    VIEW_MODEL.lock().unwrap().take();
     if let Some(h) = handles {
         let win = h.window as *mut AnyObject;
         if !win.is_null() {
@@ -337,89 +514,15 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     let black_cg: *mut CGColor = msg_send![black, CGColor];
     let _: () = msg_send![content_layer, setBackgroundColor: black_cg];
 
-    // ── NSImageView: fills the entire content view ──
-    let image_rect = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(w, h));
-    let image_view: *mut AnyObject = {
-        let alloc: *mut AnyObject = msg_send![class!(NSImageView), alloc];
-        msg_send![alloc, initWithFrame: image_rect]
-    };
-    // NSImageScaleProportionallyUpOrDown = 3 (preserve aspect ratio).
-    // AppKit types this as NSUInteger — passing signed i64 triggers
-    // an objc2 type-encoding panic on macOS 26+.
-    let _: () = msg_send![image_view, setImageScaling: 3u64];
-
-    // ── Label overlay: pill at bottom-center ──
-    // Container NSView with semi-transparent black backing + rounded
-    // corners (half its height for a fully rounded pill). NSTextField
-    // sits inside, centered, white text on the dark backing.
-    let pill_height = 22.0_f64;
-    let pill_inset_x = 16.0_f64;
-    let pill_inset_bottom = 10.0_f64;
-    let pill_w = (w - pill_inset_x * 2.0).max(60.0);
-    let pill_rect = NSRect::new(
-        NSPoint::new(pill_inset_x, pill_inset_bottom),
-        NSSize::new(pill_w, pill_height),
-    );
-    let pill: *mut AnyObject = {
-        let alloc: *mut AnyObject = msg_send![class!(NSView), alloc];
-        msg_send![alloc, initWithFrame: pill_rect]
-    };
-    let _: () = msg_send![pill, setWantsLayer: true];
-    let pill_layer: *mut AnyObject = msg_send![pill, layer];
-    let _: () = msg_send![pill_layer, setCornerRadius: pill_height / 2.0];
-    let _: () = msg_send![pill_layer, setMasksToBounds: true];
-    let pill_bg: *mut AnyObject = msg_send![
-        class!(NSColor),
-        colorWithCalibratedRed: 0.0_f64
-        green: 0.0_f64
-        blue: 0.0_f64
-        alpha: 0.62_f64
-    ];
-    let pill_bg_cg: *mut CGColor = msg_send![pill_bg, CGColor];
-    let _: () = msg_send![pill_layer, setBackgroundColor: pill_bg_cg];
-
-    // NSTextField inside the pill — horizontal padding via frame inset.
-    let label_rect = NSRect::new(
-        NSPoint::new(10.0, 0.0),
-        NSSize::new(pill_w - 20.0, pill_height),
-    );
-    let label: *mut AnyObject = {
-        let alloc: *mut AnyObject = msg_send![class!(NSTextField), alloc];
-        msg_send![alloc, initWithFrame: label_rect]
-    };
-    let _: () = msg_send![label, setBezeled: false];
-    let _: () = msg_send![label, setDrawsBackground: false];
-    let _: () = msg_send![label, setEditable: false];
-    let _: () = msg_send![label, setSelectable: false];
-    // NSTextAlignment.center = 2 (NSInteger).
-    let _: () = msg_send![label, setAlignment: 2i64];
-    let white: *mut AnyObject = msg_send![class!(NSColor), whiteColor];
-    let _: () = msg_send![label, setTextColor: white];
-    let font: *mut AnyObject = msg_send![class!(NSFont), systemFontOfSize: 11.0_f64];
-    let _: () = msg_send![label, setFont: font];
-    // Initial placeholder text — overwritten on the first frame.
-    if let Ok(cstr) = std::ffi::CString::new("waiting for first action…") {
-        let ns_str: *mut AnyObject = msg_send![
-            class!(NSString),
-            stringWithUTF8String: cstr.as_ptr() as *const u8
-        ];
-        if !ns_str.is_null() {
-            let _: () = msg_send![label, setStringValue: ns_str];
-        }
-    }
-
-    let _: () = msg_send![content_view, addSubview: image_view];
-    let _: () = msg_send![pill, addSubview: label];
-    let _: () = msg_send![content_view, addSubview: pill];
-
     // Show the window without making it key or activating the app.
     let _: () = msg_send![win, orderFrontRegardless];
 
     *HANDLES.lock().unwrap() = Some(NativeHandles {
         window: win as usize,
-        image_view: image_view as usize,
-        label: label as usize,
+        content_view: content_view as usize,
     });
+    *VIEW_MODEL.lock().unwrap() = Some(PipViewModel::new(12));
+    render_frames(&[]);
 
-    tracing::info!(target: "pip", "PiP window initialised ({}x{})", cfg.geometry.width, cfg.geometry.height);
+    tracing::info!(target: "pip", "Agent View initialised ({}x{})", cfg.geometry.width, cfg.geometry.height);
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -233,6 +233,30 @@ unsafe fn rounded_view(
     view
 }
 
+unsafe fn visual_effect_view(
+    frame: objc2_foundation::NSRect,
+    radius: f64,
+    material: isize,
+    blending_mode: isize,
+    clips: bool,
+) -> *mut objc2::runtime::AnyObject {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+
+    let view: *mut AnyObject = {
+        let alloc: *mut AnyObject = msg_send![class!(NSVisualEffectView), alloc];
+        msg_send![alloc, initWithFrame: frame]
+    };
+    let _: () = msg_send![view, setMaterial: material];
+    let _: () = msg_send![view, setBlendingMode: blending_mode];
+    let _: () = msg_send![view, setState: 1isize];
+    let _: () = msg_send![view, setWantsLayer: true];
+    let layer: *mut AnyObject = msg_send![view, layer];
+    let _: () = msg_send![layer, setCornerRadius: radius];
+    let _: () = msg_send![layer, setMasksToBounds: clips];
+    view
+}
+
 unsafe fn add_circle(
     parent: *mut objc2::runtime::AnyObject,
     x: f64,
@@ -344,7 +368,7 @@ unsafe fn render_target_window(
 
     let window_frame = appkit_rect(layout.window, bounds_height);
     let radius = (window_frame.size.width.min(window_frame.size.height) * 0.035).clamp(5.0, 9.0);
-    let shadow = rounded_view(window_frame, radius, color(0.96, 0.96, 0.97, 1.0), false);
+    let shadow = rounded_view(window_frame, radius, color(0.0, 0.0, 0.0, 0.0), false);
     let shadow_layer: *mut AnyObject = msg_send![shadow, layer];
     let _: () = msg_send![shadow_layer, setShadowOpacity: 0.30_f32];
     let _: () = msg_send![shadow_layer, setShadowRadius: 16.0_f64];
@@ -359,11 +383,11 @@ unsafe fn render_target_window(
             NSSize::new(window_frame.size.width, window_frame.size.height),
         ),
         radius,
-        color(0.96, 0.96, 0.97, 1.0),
+        color(0.0, 0.0, 0.0, 0.0),
         true,
     );
     let window_layer: *mut AnyObject = msg_send![window, layer];
-    set_layer_border(window_layer, 0.6, color(1.0, 1.0, 1.0, 0.24));
+    set_layer_border(window_layer, 0.55, color(0.0, 0.0, 0.0, 0.22));
     let image_view: *mut AnyObject = {
         let alloc: *mut AnyObject = msg_send![class!(NSImageView), alloc];
         msg_send![
@@ -395,17 +419,13 @@ unsafe fn render_dock(
     use objc2_foundation::{NSPoint, NSRect, NSSize};
 
     let dock_frame = appkit_rect(layout.dock, bounds_height);
-    let dock = rounded_view(
-        dock_frame,
-        dock_frame.size.height * 0.28,
-        color(0.82, 0.84, 0.87, 0.62),
-        false,
-    );
+    let dock = visual_effect_view(dock_frame, dock_frame.size.height * 0.30, 6, 1, false);
     let dock_layer: *mut AnyObject = msg_send![dock, layer];
-    set_layer_border(dock_layer, 0.6, color(1.0, 1.0, 1.0, 0.36));
-    let _: () = msg_send![dock_layer, setShadowOpacity: 0.22_f32];
-    let _: () = msg_send![dock_layer, setShadowRadius: 10.0_f64];
-    let _: () = msg_send![dock_layer, setShadowOffset: NSSize::new(0.0, -4.0)];
+    set_layer_background(dock_layer, color(0.72, 0.74, 0.77, 0.16));
+    set_layer_border(dock_layer, 0.65, color(1.0, 1.0, 1.0, 0.34));
+    let _: () = msg_send![dock_layer, setShadowOpacity: 0.26_f32];
+    let _: () = msg_send![dock_layer, setShadowRadius: 12.0_f64];
+    let _: () = msg_send![dock_layer, setShadowOffset: NSSize::new(0.0, -5.0)];
     let dock_shadow = color(0.0, 0.0, 0.0, 0.75);
     let dock_shadow_cg: *mut CGColor = msg_send![dock_shadow, CGColor];
     let _: () = msg_send![dock_layer, setShadowColor: dock_shadow_cg];
@@ -630,7 +650,14 @@ unsafe fn install_wallpaper(
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
 
-    let inset = 3.0;
+    let glass_frame = visual_effect_view(bounds, 12.5, 13, 0, true);
+    let _: () = msg_send![glass_frame, setAutoresizingMask: 18u64];
+    let glass_layer: *mut AnyObject = msg_send![glass_frame, layer];
+    set_layer_background(glass_layer, color(0.20, 0.24, 0.27, 0.20));
+    set_layer_border(glass_layer, 0.9, color(1.0, 1.0, 1.0, 0.30));
+    let _: () = msg_send![content_view, addSubview: glass_frame];
+
+    let inset = 6.0;
     let container_frame = objc2_foundation::NSRect::new(
         objc2_foundation::NSPoint::new(inset, inset),
         objc2_foundation::NSSize::new(
@@ -639,10 +666,10 @@ unsafe fn install_wallpaper(
         ),
     );
     let wallpaper_container =
-        rounded_view(container_frame, 9.5, color(0.02, 0.03, 0.04, 1.0), true);
+        rounded_view(container_frame, 8.5, color(0.02, 0.03, 0.04, 0.72), true);
     let _: () = msg_send![wallpaper_container, setAutoresizingMask: 18u64];
     let container_layer: *mut AnyObject = msg_send![wallpaper_container, layer];
-    set_layer_border(container_layer, 0.5, color(1.0, 1.0, 1.0, 0.12));
+    set_layer_border(container_layer, 0.65, color(1.0, 1.0, 1.0, 0.18));
     let container_bounds: objc2_foundation::NSRect = msg_send![wallpaper_container, bounds];
     let wallpaper_view: *mut AnyObject = {
         let allocated: *mut AnyObject = msg_send![class!(NSImageView), alloc];
@@ -774,10 +801,9 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     let content_view: *mut AnyObject = msg_send![window, contentView];
     let _: () = msg_send![content_view, setWantsLayer: true];
     let content_layer: *mut AnyObject = msg_send![content_view, layer];
-    let _: () = msg_send![content_layer, setCornerRadius: 11.5_f64];
+    let _: () = msg_send![content_layer, setCornerRadius: 12.5_f64];
     let _: () = msg_send![content_layer, setMasksToBounds: true];
-    set_layer_background(content_layer, color(0.08, 0.09, 0.11, 0.94));
-    set_layer_border(content_layer, 1.0, color(1.0, 1.0, 1.0, 0.18));
+    set_layer_background(content_layer, color(0.0, 0.0, 0.0, 0.0));
     let bounds: NSRect = msg_send![content_view, bounds];
     let (wallpaper_container, wallpaper_view) = install_wallpaper(content_view, screen, bounds);
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -10,8 +10,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use pip_preview::{
-    layout_desktop, png_dimensions, PipBackend, PipBackendFactory, PipConfig, PipFrame,
-    PipTargetKind, PipViewModel, PipWorkspaceSummary, TargetSize,
+    layout_desktop, layout_session_tabs, png_dimensions, LayoutRect, PipBackend, PipBackendFactory,
+    PipConfig, PipFrame, PipTargetKind, PipViewModel, PipWorkspaceSummary, SessionTabsLayout,
+    TargetSize,
 };
 
 #[repr(C)]
@@ -125,9 +126,9 @@ impl PipBackend for MacosPipBackend {
             },
             set_input_passthrough_cb,
         );
-        if !applied.load(Ordering::Acquire) {
-            anyhow::bail!("Agent View window is not running");
-        }
+        // The user may close the optional presentation window while the
+        // daemon continues serving tools; that must never break input.
+        let _ = applied.load(Ordering::Acquire);
         Ok(())
     }
 
@@ -187,6 +188,7 @@ struct ViewSnapshot {
     frames: Vec<PipFrame>,
     workspaces: Vec<PipWorkspaceSummary>,
     selected_workspace_id: Option<String>,
+    active_view_id: Option<String>,
 }
 
 fn clone_snapshot(model: &PipViewModel) -> ViewSnapshot {
@@ -194,6 +196,7 @@ fn clone_snapshot(model: &PipViewModel) -> ViewSnapshot {
         frames: model.selected_frames().into_iter().cloned().collect(),
         workspaces: model.workspaces(),
         selected_workspace_id: model.selected_workspace_id().map(str::to_owned),
+        active_view_id: model.active_view_id().map(str::to_owned),
     }
 }
 
@@ -207,6 +210,7 @@ fn current_snapshot() -> ViewSnapshot {
             frames: Vec::new(),
             workspaces: Vec::new(),
             selected_workspace_id: None,
+            active_view_id: None,
         })
 }
 
@@ -520,6 +524,7 @@ unsafe fn render_target_window(
     frame: &PipFrame,
     layout: pip_preview::TargetLayout,
     bounds_height: f64,
+    active: bool,
 ) {
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
@@ -546,7 +551,9 @@ unsafe fn render_target_window(
         true,
     );
     let window_layer: *mut AnyObject = msg_send![window, layer];
-    if SHOW_SHELL_BORDER {
+    if active {
+        set_layer_border(window_layer, 2.2, color(0.25, 0.65, 1.0, 0.96));
+    } else if SHOW_SHELL_BORDER {
         set_layer_border(window_layer, 0.55, color(0.0, 0.0, 0.0, 0.22));
     }
     let image_view: *mut AnyObject = {
@@ -680,48 +687,22 @@ unsafe fn render_dock(
     let _: () = msg_send![canvas, addSubview: dock];
 }
 
-fn session_selector_layout(
+fn session_tabs_layout(
     width: f64,
     height: f64,
-    count: usize,
-) -> Option<(objc2_foundation::NSRect, Vec<objc2_foundation::NSRect>)> {
-    use objc2_foundation::{NSPoint, NSRect, NSSize};
-
-    if count <= 1 {
-        return None;
-    }
-    let visible = count;
-    let icon = 22.0;
-    let gap = 5.0;
-    let padding = 6.0;
-    let selector_width = padding * 2.0 + visible as f64 * icon + (visible - 1) as f64 * gap;
-    let selector = NSRect::new(
-        NSPoint::new((width - selector_width) / 2.0, height - 29.0),
-        NSSize::new(selector_width, 28.0),
-    );
-    let icons = (0..visible)
-        .map(|index| {
-            NSRect::new(
-                NSPoint::new(padding + index as f64 * (icon + gap), 3.0),
-                NSSize::new(icon, icon),
-            )
-        })
-        .collect();
-    Some((selector, icons))
-}
-
-fn workspace_accent(workspace_id: &str) -> (f64, f64, f64) {
-    let hash = workspace_id.bytes().fold(2_166_136_261u32, |value, byte| {
-        (value ^ u32::from(byte)).wrapping_mul(16_777_619)
-    });
-    let palette = [
-        (0.29, 0.64, 0.96),
-        (0.30, 0.78, 0.56),
-        (0.96, 0.58, 0.27),
-        (0.91, 0.39, 0.49),
-        (0.46, 0.72, 0.86),
-    ];
-    palette[hash as usize % palette.len()]
+    workspaces: &[PipWorkspaceSummary],
+    selected_workspace_id: Option<&str>,
+) -> SessionTabsLayout {
+    layout_session_tabs(
+        LayoutRect {
+            x: (width - 600.0).max(0.0) / 2.0,
+            y: (height - SESSION_SELECTOR_HEIGHT).max(0.0),
+            width: width.min(600.0),
+            height: SESSION_SELECTOR_HEIGHT,
+        },
+        workspaces,
+        selected_workspace_id,
+    )
 }
 
 unsafe fn render_session_selector(
@@ -733,11 +714,23 @@ unsafe fn render_session_selector(
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
 
-    let Some((selector_frame, icons)) =
-        session_selector_layout(bounds.size.width, bounds.size.height, workspaces.len())
-    else {
+    let tabs = session_tabs_layout(
+        bounds.size.width,
+        bounds.size.height,
+        workspaces,
+        selected_workspace_id,
+    );
+    let Some(first) = tabs.tabs.first() else {
         return;
     };
+    let last = tabs.tabs.last().expect("tabs are non-empty");
+    let selector_frame = objc2_foundation::NSRect::new(
+        objc2_foundation::NSPoint::new(first.rect.x - 6.0, first.rect.y - 3.0),
+        objc2_foundation::NSSize::new(
+            last.rect.x + last.rect.width - first.rect.x + 12.0,
+            first.rect.height + 6.0,
+        ),
+    );
     let selector = visual_effect_view(selector_frame, 14.0, 6, 1, true);
     let selector_layer: *mut AnyObject = msg_send![selector, layer];
     set_layer_background(selector_layer, color(0.10, 0.12, 0.15, 0.30));
@@ -749,9 +742,18 @@ unsafe fn render_session_selector(
         .as_ref()
         .map(|handles| handles.delegate as *mut AnyObject)
         .unwrap_or(std::ptr::null_mut());
-    for (index, (workspace, icon_frame)) in workspaces.iter().zip(icons).enumerate() {
-        let selected = selected_workspace_id == Some(workspace.workspace_id.as_str());
-        let (red, green, blue) = workspace_accent(&workspace.workspace_id);
+    for (index, tab) in tabs.tabs.iter().enumerate() {
+        let workspace = &workspaces[index];
+        let selected = tab.selected;
+        let (red, green, blue) = (
+            f64::from(tab.accent.0) / 255.0,
+            f64::from(tab.accent.1) / 255.0,
+            f64::from(tab.accent.2) / 255.0,
+        );
+        let icon_frame = objc2_foundation::NSRect::new(
+            objc2_foundation::NSPoint::new(tab.rect.x, tab.rect.y),
+            objc2_foundation::NSSize::new(tab.rect.width, tab.rect.height),
+        );
         let button: *mut AnyObject = {
             let allocated: *mut AnyObject = msg_send![class!(NSButton), alloc];
             msg_send![allocated, initWithFrame: icon_frame]
@@ -1138,9 +1140,15 @@ unsafe fn render_snapshot(snapshot: &ViewSnapshot) {
         );
     } else {
         for (frame, target_layout) in snapshot.frames.iter().zip(layout.targets.iter().copied()) {
-            render_target_window(canvas, frame, target_layout, content_height);
+            render_target_window(
+                canvas,
+                frame,
+                target_layout,
+                content_height,
+                snapshot.active_view_id.as_deref() == Some(frame.target.view_id().as_str()),
+            );
         }
-        render_dock(canvas, &snapshot.frames, &layout, content_height);
+        // Keep the resting Agent View free of a redundant internal Dock.
     }
     render_session_selector(
         canvas,
@@ -1633,6 +1641,7 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
         frames: Vec::new(),
         workspaces: Vec::new(),
         selected_workspace_id: None,
+        active_view_id: None,
     });
     let _: () = msg_send![window, orderFrontRegardless];
 
@@ -1647,6 +1656,15 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn workspace(id: &str, target_count: usize, updated_ms: u64) -> PipWorkspaceSummary {
+        PipWorkspaceSummary {
+            workspace_id: id.to_owned(),
+            workspace_label: id.to_owned(),
+            target_count,
+            updated_ms,
+        }
+    }
 
     #[test]
     fn parses_native_pid_from_exact_window_target() {
@@ -1684,29 +1702,33 @@ mod tests {
     }
 
     #[test]
-    fn desktop_frame_preserves_asymmetric_shell_rails() {
+    fn desktop_frame_uses_full_bounds_when_shell_border_is_hidden() {
         use objc2_foundation::{NSPoint, NSRect, NSSize};
 
         let outer = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(620.0, 420.0));
         let inner = desktop_frame(outer);
 
-        assert_eq!(inner.origin, NSPoint::new(9.0, 10.0));
-        assert_eq!(inner.size, NSSize::new(602.0, 390.0));
-        assert_eq!(outer.size.height - inner.origin.y - inner.size.height, 20.0);
+        assert_eq!(inner, outer);
     }
 
     #[test]
     fn session_selector_is_local_compact_and_hidden_for_one_session() {
-        assert!(session_selector_layout(602.0, 390.0, 1).is_none());
-        let (selector, icons) = session_selector_layout(602.0, 390.0, 3).unwrap();
-        assert_eq!(icons.len(), 3);
-        assert!(selector.origin.x > 0.0);
-        assert!(selector.origin.y + selector.size.height <= 390.0);
-        assert!(icons.iter().all(|icon| {
-            icon.origin.x >= 0.0
-                && icon.origin.y >= 0.0
-                && icon.origin.x + icon.size.width <= selector.size.width
-                && icon.origin.y + icon.size.height <= selector.size.height
+        let one = [workspace("one", 1, 1)];
+        assert!(session_tabs_layout(602.0, 390.0, &one, Some("one"))
+            .tabs
+            .is_empty());
+        let workspaces = [
+            workspace("one", 1, 1),
+            workspace("two", 1, 1),
+            workspace("three", 1, 1),
+        ];
+        let tabs = session_tabs_layout(602.0, 390.0, &workspaces, Some("one"));
+        assert_eq!(tabs.tabs.len(), 3);
+        assert!(tabs.tabs.iter().all(|tab| {
+            tab.rect.x >= 0.0
+                && tab.rect.y >= 0.0
+                && tab.rect.x + tab.rect.width <= 602.0
+                && tab.rect.y + tab.rect.height <= 390.0
         }));
     }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -26,6 +26,8 @@ unsafe impl objc2::RefEncode for CGColor {
 struct NativeHandles {
     window: usize,
     canvas_view: usize,
+    shell_wallpaper_container: usize,
+    shell_wallpaper_view: usize,
     wallpaper_container: usize,
     wallpaper_view: usize,
     delegate: usize,
@@ -754,13 +756,14 @@ unsafe fn install_wallpaper(
 ) -> (
     *mut objc2::runtime::AnyObject,
     *mut objc2::runtime::AnyObject,
+    *mut objc2::runtime::AnyObject,
+    *mut objc2::runtime::AnyObject,
 ) {
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
 
-    // The shell clips a real behind-window visual effect. The miniature
-    // desktop covers its centre, leaving the blurred host desktop or app
-    // visible only through the top, side, and bottom rails.
+    // The same wallpaper continues beneath the shell rails. The centre is
+    // covered by a sharp inset copy while the outer copy is blurred and tinted.
     let glass_frame = rounded_view(
         bounds,
         CONTAINER_RADIUS,
@@ -772,6 +775,14 @@ unsafe fn install_wallpaper(
     set_continuous_corners(glass_layer);
     set_layer_border(glass_layer, 0.8, color(1.0, 1.0, 1.0, 0.50));
     let _: () = msg_send![content_view, addSubview: glass_frame];
+
+    let glass_bounds: objc2_foundation::NSRect = msg_send![glass_frame, bounds];
+    let shell_wallpaper_view: *mut AnyObject = {
+        let allocated: *mut AnyObject = msg_send![class!(NSImageView), alloc];
+        msg_send![allocated, initWithFrame: glass_bounds]
+    };
+    let _: () = msg_send![shell_wallpaper_view, setImageScaling: 2u64];
+    let _: () = msg_send![glass_frame, addSubview: shell_wallpaper_view];
 
     let backdrop: *mut AnyObject = {
         let allocated: *mut AnyObject = msg_send![class!(NSVisualEffectView), alloc];
@@ -785,7 +796,7 @@ unsafe fn install_wallpaper(
     };
     let _: () = msg_send![backdrop, setAutoresizingMask: 18u64];
     let _: () = msg_send![backdrop, setMaterial: 13i64]; // HUD window material.
-    let _: () = msg_send![backdrop, setBlendingMode: 0i64]; // Behind the Agent View window.
+    let _: () = msg_send![backdrop, setBlendingMode: 1i64]; // Blur the wallpaper within the shell.
     let _: () = msg_send![backdrop, setState: 1i64]; // Keep the blur active while non-key.
     let _: () = msg_send![backdrop, setEmphasized: true];
     let _: () = msg_send![glass_frame, addSubview: backdrop];
@@ -893,13 +904,19 @@ unsafe fn install_wallpaper(
         let allocated: *mut AnyObject = msg_send![class!(NSImage), alloc];
         let wallpaper: *mut AnyObject = msg_send![allocated, initWithContentsOfURL: url];
         if !wallpaper.is_null() {
+            let _: () = msg_send![shell_wallpaper_view, setImage: wallpaper];
             let _: () = msg_send![wallpaper_view, setImage: wallpaper];
         }
     }
     let _: () = msg_send![wallpaper_container, addSubview: wallpaper_view];
     let _: () = msg_send![content_view, addSubview: wallpaper_container];
 
-    (wallpaper_container, wallpaper_view)
+    (
+        glass_frame,
+        shell_wallpaper_view,
+        wallpaper_container,
+        wallpaper_view,
+    )
 }
 
 fn aspect_fill_frame(
@@ -928,25 +945,32 @@ unsafe fn update_wallpaper_frame() {
     use objc2::runtime::AnyObject;
     use objc2_foundation::{NSRect, NSSize};
 
-    let (wallpaper_container, wallpaper_view) = {
+    let (shell_container, shell_view, wallpaper_container, wallpaper_view) = {
         let guard = HANDLES.lock().unwrap();
         let Some(handles) = guard.as_ref() else {
             return;
         };
         (
+            handles.shell_wallpaper_container as *mut AnyObject,
+            handles.shell_wallpaper_view as *mut AnyObject,
             handles.wallpaper_container as *mut AnyObject,
             handles.wallpaper_view as *mut AnyObject,
         )
     };
-    let bounds: NSRect = msg_send![wallpaper_container, bounds];
-    let image: *mut AnyObject = msg_send![wallpaper_view, image];
-    let image_size = if image.is_null() {
-        NSSize::new(0.0, 0.0)
-    } else {
-        msg_send![image, size]
-    };
-    let frame = aspect_fill_frame(bounds, image_size);
-    let _: () = msg_send![wallpaper_view, setFrame: frame];
+    for (container, view) in [
+        (shell_container, shell_view),
+        (wallpaper_container, wallpaper_view),
+    ] {
+        let bounds: NSRect = msg_send![container, bounds];
+        let image: *mut AnyObject = msg_send![view, image];
+        let image_size = if image.is_null() {
+            NSSize::new(0.0, 0.0)
+        } else {
+            msg_send![image, size]
+        };
+        let frame = aspect_fill_frame(bounds, image_size);
+        let _: () = msg_send![view, setFrame: frame];
+    }
 }
 
 unsafe extern "C" fn init_cb(ctx: *mut c_void) {
@@ -1019,7 +1043,8 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     let _: () = msg_send![content_layer, setMasksToBounds: false];
     set_layer_background(content_layer, color(0.0, 0.0, 0.0, 0.0));
     let bounds: NSRect = msg_send![content_view, bounds];
-    let (wallpaper_container, wallpaper_view) = install_wallpaper(content_view, screen, bounds);
+    let (shell_wallpaper_container, shell_wallpaper_view, wallpaper_container, wallpaper_view) =
+        install_wallpaper(content_view, screen, bounds);
     let inner_frame = desktop_frame(bounds);
 
     let canvas: *mut AnyObject = {
@@ -1042,6 +1067,8 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     *HANDLES.lock().unwrap() = Some(NativeHandles {
         window: window as usize,
         canvas_view: canvas as usize,
+        shell_wallpaper_container: shell_wallpaper_container as usize,
+        shell_wallpaper_view: shell_wallpaper_view as usize,
         wallpaper_container: wallpaper_container as usize,
         wallpaper_view: wallpaper_view as usize,
         delegate: delegate as usize,

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -31,6 +31,12 @@ struct NativeHandles {
     delegate: usize,
 }
 
+/// Outer corner radius of the Agent View container chrome.
+const CONTAINER_RADIUS: f64 = 12.5;
+/// Thickness of the chrome between the panel edge and the miniature desktop.
+/// Kept thin so the container reads as macOS glass rather than as a bezel.
+const FRAME_INSET: f64 = 4.0;
+
 static HANDLES: Mutex<Option<NativeHandles>> = Mutex::new(None);
 static VIEW_MODEL: Mutex<Option<PipViewModel>> = Mutex::new(None);
 
@@ -159,6 +165,22 @@ unsafe fn set_layer_background(
 
     let cg_color: *mut CGColor = msg_send![background, CGColor];
     let _: () = msg_send![layer, setBackgroundColor: cg_color];
+}
+
+/// Opt a container layer into the macOS squircle corner curve so the chrome
+/// reads as continuous rather than as a circular-arc rectangle.
+unsafe fn set_continuous_corners(layer: *mut objc2::runtime::AnyObject) {
+    use objc2::msg_send;
+
+    let responds: bool = msg_send![layer, respondsToSelector: objc2::sel!(setCornerCurve:)];
+    if !responds {
+        return;
+    }
+    let curve = ns_string("continuous");
+    if curve.is_null() {
+        return;
+    }
+    let _: () = msg_send![layer, setCornerCurve: curve];
 }
 
 unsafe fn set_layer_border(
@@ -655,16 +677,40 @@ unsafe fn install_wallpaper(
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
 
-    let glass_frame = rounded_view(bounds, 13.5, color(0.012, 0.016, 0.020, 0.92), true);
+    // Outer container chrome. A deterministic neutral layer keeps the rim free
+    // of the saturated wallpaper cast an NSVisualEffectView material picks up at
+    // this scale; the bright outer rim, the top specular, the dark inner
+    // hairline and a tight inset shadow supply the dimensionality instead.
+    let glass_frame = rounded_view(
+        bounds,
+        CONTAINER_RADIUS,
+        color(0.58, 0.60, 0.64, 0.82),
+        true,
+    );
     let _: () = msg_send![glass_frame, setAutoresizingMask: 18u64];
     let glass_layer: *mut AnyObject = msg_send![glass_frame, layer];
-    // A visual-effect material inherits saturated wallpaper colors too
-    // aggressively at this scale. Use a translucent neutral rim instead, then
-    // rely on the inset highlight and native panel shadow for glass-like depth.
-    set_layer_border(glass_layer, 0.7, color(0.90, 0.93, 0.95, 0.16));
+    set_continuous_corners(glass_layer);
+    set_layer_border(glass_layer, 0.8, color(1.0, 1.0, 1.0, 0.52));
     let _: () = msg_send![content_view, addSubview: glass_frame];
 
-    let inset = 7.0;
+    // Light-from-above specular along the top edge of the chrome.
+    let highlight = rounded_view(
+        objc2_foundation::NSRect::new(
+            objc2_foundation::NSPoint::new(CONTAINER_RADIUS, bounds.size.height - 1.7),
+            objc2_foundation::NSSize::new(
+                (bounds.size.width - 2.0 * CONTAINER_RADIUS).max(1.0),
+                1.0,
+            ),
+        ),
+        0.5,
+        color(1.0, 1.0, 1.0, 0.32),
+        true,
+    );
+    let _: () = msg_send![highlight, setAutoresizingMask: 10u64];
+    let _: () = msg_send![glass_frame, addSubview: highlight];
+
+    let inset = FRAME_INSET;
+    let container_radius = CONTAINER_RADIUS - inset;
     let container_frame = objc2_foundation::NSRect::new(
         objc2_foundation::NSPoint::new(inset, inset),
         objc2_foundation::NSSize::new(
@@ -672,22 +718,36 @@ unsafe fn install_wallpaper(
             (bounds.size.height - 2.0 * inset).max(1.0),
         ),
     );
-    let wallpaper_shadow = rounded_view(container_frame, 9.5, color(0.0, 0.0, 0.0, 0.01), false);
+    let wallpaper_shadow = rounded_view(
+        container_frame,
+        container_radius,
+        color(0.0, 0.0, 0.0, 0.01),
+        false,
+    );
     let _: () = msg_send![wallpaper_shadow, setAutoresizingMask: 18u64];
     let shadow_layer: *mut AnyObject = msg_send![wallpaper_shadow, layer];
-    let _: () = msg_send![shadow_layer, setShadowOpacity: 0.52_f32];
-    let _: () = msg_send![shadow_layer, setShadowRadius: 9.0_f64];
-    let _: () = msg_send![shadow_layer, setShadowOffset: objc2_foundation::NSSize::new(0.0, -2.0)];
-    let shadow_color = color(0.0, 0.0, 0.0, 0.88);
+    set_continuous_corners(shadow_layer);
+    // Tight and close, so the desktop reads as sunk into a thin frame instead
+    // of sitting behind a black halo that swallows the chrome.
+    let _: () = msg_send![shadow_layer, setShadowOpacity: 0.55_f32];
+    let _: () = msg_send![shadow_layer, setShadowRadius: 3.0_f64];
+    let _: () = msg_send![shadow_layer, setShadowOffset: objc2_foundation::NSSize::new(0.0, -1.0)];
+    let shadow_color = color(0.0, 0.0, 0.0, 0.85);
     let shadow_cg: *mut CGColor = msg_send![shadow_color, CGColor];
     let _: () = msg_send![shadow_layer, setShadowColor: shadow_cg];
     let _: () = msg_send![content_view, addSubview: wallpaper_shadow];
 
-    let wallpaper_container =
-        rounded_view(container_frame, 9.5, color(0.02, 0.03, 0.04, 0.68), true);
+    let wallpaper_container = rounded_view(
+        container_frame,
+        container_radius,
+        color(0.02, 0.03, 0.04, 0.68),
+        true,
+    );
     let _: () = msg_send![wallpaper_container, setAutoresizingMask: 18u64];
     let container_layer: *mut AnyObject = msg_send![wallpaper_container, layer];
-    set_layer_border(container_layer, 0.6, color(0.86, 0.94, 0.98, 0.09));
+    set_continuous_corners(container_layer);
+    // Dark hairline where the miniature desktop meets the chrome.
+    set_layer_border(container_layer, 0.8, color(0.0, 0.0, 0.0, 0.42));
     let container_bounds: objc2_foundation::NSRect = msg_send![wallpaper_container, bounds];
     let wallpaper_view: *mut AnyObject = {
         let allocated: *mut AnyObject = msg_send![class!(NSImageView), alloc];
@@ -819,8 +879,11 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     let content_view: *mut AnyObject = msg_send![window, contentView];
     let _: () = msg_send![content_view, setWantsLayer: true];
     let content_layer: *mut AnyObject = msg_send![content_view, layer];
-    let _: () = msg_send![content_layer, setCornerRadius: 12.5_f64];
-    let _: () = msg_send![content_layer, setMasksToBounds: true];
+    let _: () = msg_send![content_layer, setCornerRadius: CONTAINER_RADIUS];
+    set_continuous_corners(content_layer);
+    // The chrome view clips its own children. Masking here too would clip the
+    // chrome's own outer rim stroke in half and flatten the frame.
+    let _: () = msg_send![content_layer, setMasksToBounds: false];
     set_layer_background(content_layer, color(0.0, 0.0, 0.0, 0.0));
     let bounds: NSRect = msg_send![content_view, bounds];
     let (wallpaper_container, wallpaper_view) = install_wallpaper(content_view, screen, bounds);
@@ -830,6 +893,13 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
         msg_send![allocated, initWithFrame: bounds]
     };
     let _: () = msg_send![canvas, setAutoresizingMask: 18u64];
+    // The content view no longer masks, so the canvas clips its own contents to
+    // the container silhouette.
+    let _: () = msg_send![canvas, setWantsLayer: true];
+    let canvas_layer: *mut AnyObject = msg_send![canvas, layer];
+    let _: () = msg_send![canvas_layer, setCornerRadius: CONTAINER_RADIUS];
+    set_continuous_corners(canvas_layer);
+    let _: () = msg_send![canvas_layer, setMasksToBounds: true];
     let _: () = msg_send![content_view, addSubview: canvas];
 
     let delegate = agent_view_delegate_instance();

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -89,9 +89,8 @@ struct InputPassthroughRequest {
 
 impl PipBackend for MacosPipBackend {
     fn push_frame(&self, frame: PipFrame) {
-        if HANDLES.lock().unwrap().is_none() {
-            return;
-        }
+        // init_cb was queued first on the serial main queue, so retaining the
+        // frame here avoids dropping exact activity during daemon startup.
         dispatch_to_main(frame, push_frame_cb);
     }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -419,13 +419,19 @@ unsafe fn render_dock(
     use objc2_foundation::{NSPoint, NSRect, NSSize};
 
     let dock_frame = appkit_rect(layout.dock, bounds_height);
-    let dock = visual_effect_view(dock_frame, dock_frame.size.height * 0.30, 6, 1, false);
+    let dock = visual_effect_view(dock_frame, dock_frame.size.height * 0.27, 13, 1, false);
+    let appearance_name = ns_string("NSAppearanceNameVibrantDark");
+    let dark_appearance: *mut AnyObject =
+        msg_send![class!(NSAppearance), appearanceNamed: appearance_name];
+    if !dark_appearance.is_null() {
+        let _: () = msg_send![dock, setAppearance: dark_appearance];
+    }
     let dock_layer: *mut AnyObject = msg_send![dock, layer];
-    set_layer_background(dock_layer, color(0.72, 0.74, 0.77, 0.16));
-    set_layer_border(dock_layer, 0.65, color(1.0, 1.0, 1.0, 0.34));
-    let _: () = msg_send![dock_layer, setShadowOpacity: 0.26_f32];
-    let _: () = msg_send![dock_layer, setShadowRadius: 12.0_f64];
-    let _: () = msg_send![dock_layer, setShadowOffset: NSSize::new(0.0, -5.0)];
+    set_layer_background(dock_layer, color(0.13, 0.15, 0.17, 0.30));
+    set_layer_border(dock_layer, 0.7, color(1.0, 1.0, 1.0, 0.22));
+    let _: () = msg_send![dock_layer, setShadowOpacity: 0.34_f32];
+    let _: () = msg_send![dock_layer, setShadowRadius: 14.0_f64];
+    let _: () = msg_send![dock_layer, setShadowOffset: NSSize::new(0.0, -6.0)];
     let dock_shadow = color(0.0, 0.0, 0.0, 0.75);
     let dock_shadow_cg: *mut CGColor = msg_send![dock_shadow, CGColor];
     let _: () = msg_send![dock_layer, setShadowColor: dock_shadow_cg];
@@ -659,11 +665,11 @@ unsafe fn install_wallpaper(
         let _: () = msg_send![glass_frame, setAppearance: dark_appearance];
     }
     let glass_layer: *mut AnyObject = msg_send![glass_frame, layer];
-    set_layer_background(glass_layer, color(0.05, 0.08, 0.11, 0.24));
-    set_layer_border(glass_layer, 0.8, color(1.0, 1.0, 1.0, 0.32));
+    set_layer_background(glass_layer, color(0.025, 0.055, 0.075, 0.58));
+    set_layer_border(glass_layer, 0.7, color(0.78, 0.90, 0.96, 0.20));
     let _: () = msg_send![content_view, addSubview: glass_frame];
 
-    let inset = 7.5;
+    let inset = 7.0;
     let container_frame = objc2_foundation::NSRect::new(
         objc2_foundation::NSPoint::new(inset, inset),
         objc2_foundation::NSSize::new(
@@ -674,8 +680,8 @@ unsafe fn install_wallpaper(
     let wallpaper_shadow = rounded_view(container_frame, 9.5, color(0.0, 0.0, 0.0, 0.01), false);
     let _: () = msg_send![wallpaper_shadow, setAutoresizingMask: 18u64];
     let shadow_layer: *mut AnyObject = msg_send![wallpaper_shadow, layer];
-    let _: () = msg_send![shadow_layer, setShadowOpacity: 0.42_f32];
-    let _: () = msg_send![shadow_layer, setShadowRadius: 8.0_f64];
+    let _: () = msg_send![shadow_layer, setShadowOpacity: 0.52_f32];
+    let _: () = msg_send![shadow_layer, setShadowRadius: 9.0_f64];
     let _: () = msg_send![shadow_layer, setShadowOffset: objc2_foundation::NSSize::new(0.0, -2.0)];
     let shadow_color = color(0.0, 0.0, 0.0, 0.88);
     let shadow_cg: *mut CGColor = msg_send![shadow_color, CGColor];
@@ -686,7 +692,7 @@ unsafe fn install_wallpaper(
         rounded_view(container_frame, 9.5, color(0.02, 0.03, 0.04, 0.68), true);
     let _: () = msg_send![wallpaper_container, setAutoresizingMask: 18u64];
     let container_layer: *mut AnyObject = msg_send![wallpaper_container, layer];
-    set_layer_border(container_layer, 0.75, color(1.0, 1.0, 1.0, 0.26));
+    set_layer_border(container_layer, 0.65, color(0.86, 0.94, 0.98, 0.16));
     let container_bounds: objc2_foundation::NSRect = msg_send![wallpaper_container, bounds];
     let wallpaper_view: *mut AnyObject = {
         let allocated: *mut AnyObject = msg_send![class!(NSImageView), alloc];

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -800,6 +800,10 @@ unsafe fn render_session_selector(
 fn desktop_frame(bounds: objc2_foundation::NSRect) -> objc2_foundation::NSRect {
     use objc2_foundation::{NSPoint, NSRect, NSSize};
 
+    if !SHOW_SHELL_BORDER {
+        return bounds;
+    }
+
     NSRect::new(
         NSPoint::new(SHELL_SIDE_INSET, SHELL_BOTTOM_INSET),
         NSSize::new(
@@ -815,6 +819,10 @@ unsafe fn install_shell_details(
 ) {
     use objc2::msg_send;
     use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    if !SHOW_SHELL_BORDER {
+        return;
+    }
 
     let grip_width = 24.0;
     let grip = rounded_view(
@@ -1288,7 +1296,9 @@ unsafe fn install_wallpaper(
         msg_send![allocated, initWithFrame: glass_bounds]
     };
     let _: () = msg_send![shell_wallpaper_view, setImageScaling: 2u64];
-    let _: () = msg_send![glass_frame, addSubview: shell_wallpaper_view];
+    if SHOW_SHELL_BORDER {
+        let _: () = msg_send![glass_frame, addSubview: shell_wallpaper_view];
+    }
 
     let backdrop: *mut AnyObject = {
         let allocated: *mut AnyObject = msg_send![class!(NSVisualEffectView), alloc];
@@ -1305,7 +1315,9 @@ unsafe fn install_wallpaper(
     let _: () = msg_send![backdrop, setBlendingMode: 1i64]; // Blur the wallpaper within the shell.
     let _: () = msg_send![backdrop, setState: 1i64]; // Keep the blur active while non-key.
     let _: () = msg_send![backdrop, setEmphasized: true];
-    let _: () = msg_send![glass_frame, addSubview: backdrop];
+    if SHOW_SHELL_BORDER {
+        let _: () = msg_send![glass_frame, addSubview: backdrop];
+    }
 
     // A restrained silver-to-graphite tint keeps the blurred backdrop legible
     // as a shell instead of exposing raw, high-contrast shapes behind it.
@@ -1323,7 +1335,9 @@ unsafe fn install_wallpaper(
         // hairlines are sub-point.
         let _: () = msg_send![body_layer, setContentsScale: scale];
     }
-    let _: () = msg_send![glass_frame, addSubview: body];
+    if SHOW_SHELL_BORDER {
+        let _: () = msg_send![glass_frame, addSubview: body];
+    }
 
     // Light-from-above specular along the top edge of the chrome.
     let highlight = rounded_view(
@@ -1395,7 +1409,7 @@ unsafe fn install_wallpaper(
     let wallpaper_container = rounded_view(
         container_frame,
         container_radius,
-        color(0.02, 0.03, 0.04, 0.68),
+        color(0.02, 0.03, 0.04, if SHOW_SHELL_BORDER { 0.68 } else { 0.0 }),
         true,
     );
     let _: () = msg_send![wallpaper_container, setAutoresizingMask: 18u64];

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -656,18 +656,12 @@ unsafe fn install_wallpaper(
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
 
-    let glass_frame = visual_effect_view(bounds, 13.5, 13, 0, true);
+    let glass_frame = rounded_view(bounds, 13.5, color(0.012, 0.016, 0.020, 0.92), true);
     let _: () = msg_send![glass_frame, setAutoresizingMask: 18u64];
-    let appearance_name = ns_string("NSAppearanceNameVibrantDark");
-    let dark_appearance: *mut AnyObject =
-        msg_send![class!(NSAppearance), appearanceNamed: appearance_name];
-    if !dark_appearance.is_null() {
-        let _: () = msg_send![glass_frame, setAppearance: dark_appearance];
-    }
     let glass_layer: *mut AnyObject = msg_send![glass_frame, layer];
-    // Keep the rim neutral even over a saturated wallpaper. The material still
-    // supplies depth, while the graphite wash prevents a bright cyan halo.
-    set_layer_background(glass_layer, color(0.012, 0.016, 0.020, 0.92));
+    // A visual-effect material inherits saturated wallpaper colors too
+    // aggressively at this scale. Use a translucent neutral rim instead, then
+    // rely on the inset highlight and native panel shadow for glass-like depth.
     set_layer_border(glass_layer, 0.7, color(0.90, 0.93, 0.95, 0.16));
     let _: () = msg_send![content_view, addSubview: glass_frame];
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -41,6 +41,12 @@ const SHELL_SIDE_INSET: f64 = 9.0;
 const SHELL_TOP_INSET: f64 = 20.0;
 const SHELL_BOTTOM_INSET: f64 = 10.0;
 const SESSION_SELECTOR_HEIGHT: f64 = 34.0;
+const RESIZE_HIT_INSET: f64 = 7.0;
+
+const RESIZE_LEFT: isize = 1;
+const RESIZE_RIGHT: isize = 2;
+const RESIZE_BOTTOM: isize = 4;
+const RESIZE_TOP: isize = 8;
 
 static HANDLES: Mutex<Option<NativeHandles>> = Mutex::new(None);
 static VIEW_MODEL: Mutex<Option<PipViewModel>> = Mutex::new(None);
@@ -552,6 +558,36 @@ unsafe fn render_target_window(
         let _: () = msg_send![image_view, setImage: image];
     }
     let _: () = msg_send![window, addSubview: image_view];
+    if let Some((normalized_x, normalized_y)) = frame.cursor_position {
+        let pointer_size = NSSize::new(18.0, 22.0);
+        let x = (normalized_x.clamp(0.0, 1.0) * window_frame.size.width)
+            .clamp(0.0, (window_frame.size.width - pointer_size.width).max(0.0));
+        let y_from_top = normalized_y.clamp(0.0, 1.0) * window_frame.size.height;
+        let y = (window_frame.size.height - y_from_top - pointer_size.height).clamp(
+            0.0,
+            (window_frame.size.height - pointer_size.height).max(0.0),
+        );
+        let pointer: *mut AnyObject = {
+            let alloc: *mut AnyObject = msg_send![class!(NSImageView), alloc];
+            msg_send![
+                alloc,
+                initWithFrame: NSRect::new(NSPoint::new(x, y), pointer_size)
+            ]
+        };
+        let arrow_cursor: *mut AnyObject = msg_send![class!(NSCursor), arrowCursor];
+        let arrow_image: *mut AnyObject = msg_send![arrow_cursor, image];
+        let _: () = msg_send![pointer, setImage: arrow_image];
+        let _: () = msg_send![pointer, setImageScaling: 0u64];
+        let _: () = msg_send![pointer, setWantsLayer: true];
+        let pointer_layer: *mut AnyObject = msg_send![pointer, layer];
+        let _: () = msg_send![pointer_layer, setShadowOpacity: 0.72_f32];
+        let _: () = msg_send![pointer_layer, setShadowRadius: 2.5_f64];
+        let _: () = msg_send![pointer_layer, setShadowOffset: NSSize::new(0.0, -1.0)];
+        let shadow_color = color(0.0, 0.0, 0.0, 0.92);
+        let shadow_cg: *mut CGColor = msg_send![shadow_color, CGColor];
+        let _: () = msg_send![pointer_layer, setShadowColor: shadow_cg];
+        let _: () = msg_send![window, addSubview: pointer];
+    }
     let _: () = msg_send![shadow, addSubview: window];
     let _: () = msg_send![canvas, addSubview: shadow];
 }
@@ -814,6 +850,225 @@ unsafe fn install_shell_details(
         let _: () = msg_send![bar, setAutoresizingMask: 1u64];
         let _: () = msg_send![content_view, addSubview: bar];
     }
+}
+
+fn resized_window_frame(
+    start: objc2_foundation::NSRect,
+    delta_x: f64,
+    delta_y: f64,
+    direction: isize,
+    minimum: objc2_foundation::NSSize,
+) -> objc2_foundation::NSRect {
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    let mut x = start.origin.x;
+    let mut y = start.origin.y;
+    let mut width = start.size.width;
+    let mut height = start.size.height;
+    if direction & RESIZE_LEFT != 0 {
+        let applied = delta_x.min(width - minimum.width);
+        x += applied;
+        width -= applied;
+    }
+    if direction & RESIZE_RIGHT != 0 {
+        width = (width + delta_x).max(minimum.width);
+    }
+    if direction & RESIZE_BOTTOM != 0 {
+        let applied = delta_y.min(height - minimum.height);
+        y += applied;
+        height -= applied;
+    }
+    if direction & RESIZE_TOP != 0 {
+        height = (height + delta_y).max(minimum.height);
+    }
+    NSRect::new(NSPoint::new(x, y), NSSize::new(width, height))
+}
+
+fn agent_view_shell_hit_class() -> &'static objc2::runtime::AnyClass {
+    use objc2::class;
+    use objc2::declare::ClassBuilder;
+
+    static CLASS: OnceLock<&'static objc2::runtime::AnyClass> = OnceLock::new();
+    CLASS.get_or_init(|| {
+        let mut builder = ClassBuilder::new("CuaDriverAgentViewShellHitView", class!(NSView))
+            .expect("CuaDriverAgentViewShellHitView already registered");
+        unsafe {
+            builder.add_method(
+                objc2::sel!(acceptsFirstMouse:),
+                shell_accepts_first_mouse as extern "C" fn(_, _, _) -> objc2::runtime::Bool,
+            );
+            builder.add_method(
+                objc2::sel!(mouseDown:),
+                shell_mouse_down as extern "C" fn(_, _, _),
+            );
+        }
+        builder.register()
+    })
+}
+
+extern "C" fn shell_accepts_first_mouse(
+    _view: *mut objc2::runtime::AnyObject,
+    _selector: objc2::runtime::Sel,
+    _event: *mut objc2::runtime::AnyObject,
+) -> objc2::runtime::Bool {
+    objc2::runtime::Bool::YES
+}
+
+extern "C" fn shell_mouse_down(
+    view: *mut objc2::runtime::AnyObject,
+    _selector: objc2::runtime::Sel,
+    event: *mut objc2::runtime::AnyObject,
+) {
+    use objc2::msg_send;
+    use objc2::runtime::AnyObject;
+
+    if view.is_null() || event.is_null() {
+        return;
+    }
+    unsafe {
+        let window: *mut AnyObject = msg_send![view, window];
+        if window.is_null() {
+            return;
+        }
+        let direction = rust_string(msg_send![view, toolTip])
+            .and_then(|value| value.parse::<isize>().ok())
+            .unwrap_or(0);
+        if direction == 0 {
+            let _: () = msg_send![window, performWindowDragWithEvent: event];
+            return;
+        }
+
+        let start_frame: objc2_foundation::NSRect = msg_send![window, frame];
+        let minimum: objc2_foundation::NSSize = msg_send![window, minSize];
+        let start_mouse: objc2_foundation::NSPoint =
+            msg_send![objc2::class!(NSEvent), mouseLocation];
+        let event_mask: u64 = (1 << 2) | (1 << 6);
+        let distant_future: *mut AnyObject = msg_send![objc2::class!(NSDate), distantFuture];
+        let default_mode = ns_string("kCFRunLoopDefaultMode");
+        loop {
+            let next: *mut AnyObject = msg_send![
+                window,
+                nextEventMatchingMask: event_mask
+                untilDate: distant_future
+                inMode: default_mode
+                dequeue: true
+            ];
+            if next.is_null() {
+                break;
+            }
+            let event_type: usize = msg_send![next, type];
+            if event_type == 2 {
+                break;
+            }
+            let mouse: objc2_foundation::NSPoint = msg_send![objc2::class!(NSEvent), mouseLocation];
+            let frame = resized_window_frame(
+                start_frame,
+                mouse.x - start_mouse.x,
+                mouse.y - start_mouse.y,
+                direction,
+                minimum,
+            );
+            let _: () = msg_send![window, setFrame: frame display: true];
+        }
+    }
+}
+
+unsafe fn add_shell_hit_view(
+    parent: *mut objc2::runtime::AnyObject,
+    frame: objc2_foundation::NSRect,
+    direction: isize,
+    autoresizing_mask: u64,
+) {
+    use objc2::msg_send;
+    use objc2::runtime::AnyObject;
+
+    let allocated: *mut AnyObject = msg_send![agent_view_shell_hit_class(), alloc];
+    let view: *mut AnyObject = msg_send![allocated, initWithFrame: frame];
+    let direction_string = ns_string(&direction.to_string());
+    let _: () = msg_send![view, setToolTip: direction_string];
+    let _: () = msg_send![view, setAutoresizingMask: autoresizing_mask];
+    let _: () = msg_send![parent, addSubview: view];
+}
+
+unsafe fn install_shell_interaction(
+    content_view: *mut objc2::runtime::AnyObject,
+    bounds: objc2_foundation::NSRect,
+) {
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    let edge = RESIZE_HIT_INSET;
+    let width = bounds.size.width;
+    let height = bounds.size.height;
+    add_shell_hit_view(
+        content_view,
+        NSRect::new(
+            NSPoint::new(edge, height - edge),
+            NSSize::new(width - 2.0 * edge, edge),
+        ),
+        RESIZE_TOP,
+        10,
+    );
+    add_shell_hit_view(
+        content_view,
+        NSRect::new(
+            NSPoint::new(edge, 0.0),
+            NSSize::new(width - 2.0 * edge, edge),
+        ),
+        RESIZE_BOTTOM,
+        10,
+    );
+    add_shell_hit_view(
+        content_view,
+        NSRect::new(
+            NSPoint::new(0.0, edge),
+            NSSize::new(edge, height - 2.0 * edge),
+        ),
+        RESIZE_LEFT,
+        20,
+    );
+    add_shell_hit_view(
+        content_view,
+        NSRect::new(
+            NSPoint::new(width - edge, edge),
+            NSSize::new(edge, height - 2.0 * edge),
+        ),
+        RESIZE_RIGHT,
+        17,
+    );
+    for (origin, direction, mask) in [
+        (NSPoint::new(0.0, 0.0), RESIZE_LEFT | RESIZE_BOTTOM, 4),
+        (
+            NSPoint::new(width - edge, 0.0),
+            RESIZE_RIGHT | RESIZE_BOTTOM,
+            1,
+        ),
+        (
+            NSPoint::new(0.0, height - edge),
+            RESIZE_LEFT | RESIZE_TOP,
+            8,
+        ),
+        (
+            NSPoint::new(width - edge, height - edge),
+            RESIZE_RIGHT | RESIZE_TOP,
+            2,
+        ),
+    ] {
+        add_shell_hit_view(
+            content_view,
+            NSRect::new(origin, NSSize::new(edge, edge)),
+            direction,
+            mask,
+        );
+    }
+    add_shell_hit_view(
+        content_view,
+        NSRect::new(
+            NSPoint::new(edge, height - SHELL_TOP_INSET),
+            NSSize::new(width - 2.0 * edge, SHELL_TOP_INSET - edge),
+        ),
+        0,
+        10,
+    );
 }
 
 unsafe fn render_snapshot(snapshot: &ViewSnapshot) {
@@ -1265,6 +1520,8 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     let _: () = msg_send![window, setBackgroundColor: clear];
     let _: () = msg_send![window, setOpaque: false];
     let _: () = msg_send![window, setHasShadow: true];
+    // Screen sharing and recordings should include Agent View itself.
+    let _: () = msg_send![window, setSharingType: 1u64];
     let _: () = msg_send![window, setMovableByWindowBackground: true];
     let _: () = msg_send![window, setIgnoresMouseEvents: false];
     let _: () = msg_send![window, setBecomesKeyOnlyIfNeeded: true];
@@ -1304,6 +1561,7 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     let _: () = msg_send![canvas_layer, setMasksToBounds: true];
     let _: () = msg_send![content_view, addSubview: canvas];
     install_shell_details(content_view, bounds);
+    install_shell_interaction(content_view, bounds);
 
     let delegate = agent_view_delegate_instance();
     let _: () = msg_send![window, setDelegate: delegate];
@@ -1397,5 +1655,39 @@ mod tests {
                 && icon.origin.x + icon.size.width <= selector.size.width
                 && icon.origin.y + icon.size.height <= selector.size.height
         }));
+    }
+
+    #[test]
+    fn every_resize_direction_keeps_the_opposite_edges_anchored() {
+        use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+        let start = NSRect::new(NSPoint::new(100.0, 100.0), NSSize::new(600.0, 400.0));
+        let minimum = NSSize::new(360.0, 260.0);
+        let left = resized_window_frame(start, 40.0, 0.0, RESIZE_LEFT, minimum);
+        assert_eq!(left.origin.x, 140.0);
+        assert_eq!(left.size.width, 560.0);
+        let right = resized_window_frame(start, 40.0, 0.0, RESIZE_RIGHT, minimum);
+        assert_eq!(right.origin.x, 100.0);
+        assert_eq!(right.size.width, 640.0);
+        let bottom = resized_window_frame(start, 0.0, 30.0, RESIZE_BOTTOM, minimum);
+        assert_eq!(bottom.origin.y, 130.0);
+        assert_eq!(bottom.size.height, 370.0);
+        let top = resized_window_frame(start, 0.0, 30.0, RESIZE_TOP, minimum);
+        assert_eq!(top.origin.y, 100.0);
+        assert_eq!(top.size.height, 430.0);
+        let corner = resized_window_frame(start, -25.0, 35.0, RESIZE_LEFT | RESIZE_TOP, minimum);
+        assert_eq!(corner.origin, NSPoint::new(75.0, 100.0));
+        assert_eq!(corner.size, NSSize::new(625.0, 435.0));
+    }
+
+    #[test]
+    fn resize_geometry_enforces_the_minimum_without_moving_far_edges() {
+        use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+        let start = NSRect::new(NSPoint::new(100.0, 100.0), NSSize::new(600.0, 400.0));
+        let minimum = NSSize::new(360.0, 260.0);
+        let frame = resized_window_frame(start, 500.0, 500.0, RESIZE_LEFT | RESIZE_BOTTOM, minimum);
+        assert_eq!(frame.origin, NSPoint::new(340.0, 240.0));
+        assert_eq!(frame.size, minimum);
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -32,10 +32,11 @@ struct NativeHandles {
 }
 
 /// Outer corner radius of the Agent View container chrome.
-const CONTAINER_RADIUS: f64 = 12.5;
-/// Thickness of the chrome between the panel edge and the miniature desktop.
-/// Kept thin so the container reads as macOS glass rather than as a bezel.
-const FRAME_INSET: f64 = 4.0;
+const CONTAINER_RADIUS: f64 = 15.0;
+/// The miniature desktop sits inside an asymmetric hardware-like glass shell.
+const SHELL_SIDE_INSET: f64 = 9.0;
+const SHELL_TOP_INSET: f64 = 20.0;
+const SHELL_BOTTOM_INSET: f64 = 10.0;
 
 static HANDLES: Mutex<Option<NativeHandles>> = Mutex::new(None);
 static VIEW_MODEL: Mutex<Option<PipViewModel>> = Mutex::new(None);
@@ -554,17 +555,53 @@ unsafe fn render_dock(
     let _: () = msg_send![canvas, addSubview: dock];
 }
 
-unsafe fn render_resize_affordance(canvas: *mut objc2::runtime::AnyObject, width: f64) {
+fn desktop_frame(bounds: objc2_foundation::NSRect) -> objc2_foundation::NSRect {
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    NSRect::new(
+        NSPoint::new(SHELL_SIDE_INSET, SHELL_BOTTOM_INSET),
+        NSSize::new(
+            (bounds.size.width - 2.0 * SHELL_SIDE_INSET).max(1.0),
+            (bounds.size.height - SHELL_TOP_INSET - SHELL_BOTTOM_INSET).max(1.0),
+        ),
+    )
+}
+
+unsafe fn install_shell_details(
+    content_view: *mut objc2::runtime::AnyObject,
+    bounds: objc2_foundation::NSRect,
+) {
     use objc2::msg_send;
     use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    let grip_width = 24.0;
+    let grip = rounded_view(
+        NSRect::new(
+            NSPoint::new(
+                (bounds.size.width - grip_width) / 2.0,
+                bounds.size.height - 9.0,
+            ),
+            NSSize::new(grip_width, 3.0),
+        ),
+        1.5,
+        color(0.08, 0.10, 0.13, 0.52),
+        true,
+    );
+    // Keep the grip centred and pinned to the shell's top edge while resizing.
+    let _: () = msg_send![grip, setAutoresizingMask: 13u64];
+    let grip_layer: *mut objc2::runtime::AnyObject = msg_send![grip, layer];
+    let _: () = msg_send![grip_layer, setShadowOpacity: 0.32_f32];
+    let _: () = msg_send![grip_layer, setShadowRadius: 0.8_f64];
+    let _: () = msg_send![grip_layer, setShadowOffset: NSSize::new(0.0, 1.0)];
+    let _: () = msg_send![content_view, addSubview: grip];
 
     let marker = color(1.0, 1.0, 1.0, 0.48);
     for (index, length) in [10.0_f64, 6.0].into_iter().enumerate() {
         let bar = rounded_view(
             NSRect::new(
                 NSPoint::new(
-                    (width - 15.0 + index as f64 * 4.0).max(0.0),
-                    6.0 + index as f64 * 2.0,
+                    (bounds.size.width - 16.0 + index as f64 * 4.0).max(0.0),
+                    4.5 + index as f64 * 2.0,
                 ),
                 NSSize::new(length, 1.2),
             ),
@@ -573,7 +610,9 @@ unsafe fn render_resize_affordance(canvas: *mut objc2::runtime::AnyObject, width
             false,
         );
         let _: () = msg_send![bar, setFrameCenterRotation: -45.0_f64];
-        let _: () = msg_send![canvas, addSubview: bar];
+        // Move with the right edge while remaining in the bottom shell rail.
+        let _: () = msg_send![bar, setAutoresizingMask: 1u64];
+        let _: () = msg_send![content_view, addSubview: bar];
     }
 }
 
@@ -626,7 +665,6 @@ unsafe fn render_frames(frames: &[PipFrame]) {
         }
         render_dock(canvas, frames, &layout, bounds.size.height);
     }
-    render_resize_affordance(canvas, bounds.size.width);
 }
 
 unsafe extern "C" fn shutdown_cb(_ctx: *mut c_void) {
@@ -771,15 +809,8 @@ unsafe fn install_wallpaper(
     let _: () = msg_send![highlight, setAutoresizingMask: 10u64];
     let _: () = msg_send![glass_frame, addSubview: highlight];
 
-    let inset = FRAME_INSET;
-    let container_radius = CONTAINER_RADIUS - inset;
-    let container_frame = objc2_foundation::NSRect::new(
-        objc2_foundation::NSPoint::new(inset, inset),
-        objc2_foundation::NSSize::new(
-            (bounds.size.width - 2.0 * inset).max(1.0),
-            (bounds.size.height - 2.0 * inset).max(1.0),
-        ),
-    );
+    let container_frame = desktop_frame(bounds);
+    let container_radius = 8.5;
     let wallpaper_shadow = rounded_view(
         container_frame,
         container_radius,
@@ -789,11 +820,10 @@ unsafe fn install_wallpaper(
     let _: () = msg_send![wallpaper_shadow, setAutoresizingMask: 18u64];
     let shadow_layer: *mut AnyObject = msg_send![wallpaper_shadow, layer];
     set_continuous_corners(shadow_layer);
-    // Tight and close, so the desktop reads as sunk into a thin frame instead
-    // of sitting behind a black halo that swallows the chrome.
-    let _: () = msg_send![shadow_layer, setShadowOpacity: 0.55_f32];
-    let _: () = msg_send![shadow_layer, setShadowRadius: 3.0_f64];
-    let _: () = msg_send![shadow_layer, setShadowOffset: objc2_foundation::NSSize::new(0.0, -1.0)];
+    // The inset shadow separates the desktop from the thicker shell rails.
+    let _: () = msg_send![shadow_layer, setShadowOpacity: 0.62_f32];
+    let _: () = msg_send![shadow_layer, setShadowRadius: 4.0_f64];
+    let _: () = msg_send![shadow_layer, setShadowOffset: objc2_foundation::NSSize::new(0.0, -1.5)];
     let shadow_color = color(0.0, 0.0, 0.0, 0.85);
     let shadow_cg: *mut CGColor = msg_send![shadow_color, CGColor];
     let _: () = msg_send![shadow_layer, setShadowColor: shadow_cg];
@@ -805,7 +835,10 @@ unsafe fn install_wallpaper(
     let seam_outset = 0.75;
     let seam = rounded_view(
         objc2_foundation::NSRect::new(
-            objc2_foundation::NSPoint::new(inset - seam_outset, inset - seam_outset),
+            objc2_foundation::NSPoint::new(
+                container_frame.origin.x - seam_outset,
+                container_frame.origin.y - seam_outset,
+            ),
             objc2_foundation::NSSize::new(
                 container_frame.size.width + 2.0 * seam_outset,
                 container_frame.size.height + 2.0 * seam_outset,
@@ -972,20 +1005,22 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     set_layer_background(content_layer, color(0.0, 0.0, 0.0, 0.0));
     let bounds: NSRect = msg_send![content_view, bounds];
     let (wallpaper_container, wallpaper_view) = install_wallpaper(content_view, screen, bounds);
+    let inner_frame = desktop_frame(bounds);
 
     let canvas: *mut AnyObject = {
         let allocated: *mut AnyObject = msg_send![class!(NSView), alloc];
-        msg_send![allocated, initWithFrame: bounds]
+        msg_send![allocated, initWithFrame: inner_frame]
     };
     let _: () = msg_send![canvas, setAutoresizingMask: 18u64];
     // The content view no longer masks, so the canvas clips its own contents to
     // the container silhouette.
     let _: () = msg_send![canvas, setWantsLayer: true];
     let canvas_layer: *mut AnyObject = msg_send![canvas, layer];
-    let _: () = msg_send![canvas_layer, setCornerRadius: CONTAINER_RADIUS];
+    let _: () = msg_send![canvas_layer, setCornerRadius: 8.5_f64];
     set_continuous_corners(canvas_layer);
     let _: () = msg_send![canvas_layer, setMasksToBounds: true];
     let _: () = msg_send![content_view, addSubview: canvas];
+    install_shell_details(content_view, bounds);
 
     let delegate = agent_view_delegate_instance();
     let _: () = msg_send![window, setDelegate: delegate];
@@ -1046,5 +1081,17 @@ mod tests {
         );
         assert_eq!(tall.size, NSSize::new(1056.0, 660.0));
         assert_eq!(tall.origin, NSPoint::new(-338.0, 0.0));
+    }
+
+    #[test]
+    fn desktop_frame_preserves_asymmetric_shell_rails() {
+        use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+        let outer = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(620.0, 420.0));
+        let inner = desktop_frame(outer);
+
+        assert_eq!(inner.origin, NSPoint::new(9.0, 10.0));
+        assert_eq!(inner.size, NSSize::new(602.0, 390.0));
+        assert_eq!(outer.size.height - inner.origin.y - inner.size.height, 20.0);
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -43,6 +43,10 @@ const SHELL_BOTTOM_INSET: f64 = 10.0;
 const SESSION_SELECTOR_HEIGHT: f64 = 34.0;
 const RESIZE_HIT_INSET: f64 = 7.0;
 
+// Keep the PiP shell visually clean for now; invisible hit zones still provide
+// dragging and resizing without exposing a native or custom frame.
+const SHOW_SHELL_BORDER: bool = false;
+
 const RESIZE_LEFT: isize = 1;
 const RESIZE_RIGHT: isize = 2;
 const RESIZE_BOTTOM: isize = 4;
@@ -541,7 +545,9 @@ unsafe fn render_target_window(
         true,
     );
     let window_layer: *mut AnyObject = msg_send![window, layer];
-    set_layer_border(window_layer, 0.55, color(0.0, 0.0, 0.0, 0.22));
+    if SHOW_SHELL_BORDER {
+        set_layer_border(window_layer, 0.55, color(0.0, 0.0, 0.0, 0.22));
+    }
     let image_view: *mut AnyObject = {
         let alloc: *mut AnyObject = msg_send![class!(NSImageView), alloc];
         msg_send![
@@ -1271,7 +1277,9 @@ unsafe fn install_wallpaper(
     let _: () = msg_send![glass_frame, setAutoresizingMask: 18u64];
     let glass_layer: *mut AnyObject = msg_send![glass_frame, layer];
     set_continuous_corners(glass_layer);
-    set_layer_border(glass_layer, 0.8, color(1.0, 1.0, 1.0, 0.50));
+    if SHOW_SHELL_BORDER {
+        set_layer_border(glass_layer, 0.8, color(1.0, 1.0, 1.0, 0.50));
+    }
     let _: () = msg_send![content_view, addSubview: glass_frame];
 
     let glass_bounds: objc2_foundation::NSRect = msg_send![glass_frame, bounds];
@@ -1331,7 +1339,9 @@ unsafe fn install_wallpaper(
         true,
     );
     let _: () = msg_send![highlight, setAutoresizingMask: 10u64];
-    let _: () = msg_send![glass_frame, addSubview: highlight];
+    if SHOW_SHELL_BORDER {
+        let _: () = msg_send![glass_frame, addSubview: highlight];
+    }
 
     let container_frame = desktop_frame(bounds);
     let container_radius = 8.5;
@@ -1351,7 +1361,9 @@ unsafe fn install_wallpaper(
     let shadow_color = color(0.0, 0.0, 0.0, 0.85);
     let shadow_cg: *mut CGColor = msg_send![shadow_color, CGColor];
     let _: () = msg_send![shadow_layer, setShadowColor: shadow_cg];
-    let _: () = msg_send![content_view, addSubview: wallpaper_shadow];
+    if SHOW_SHELL_BORDER {
+        let _: () = msg_send![content_view, addSubview: wallpaper_shadow];
+    }
 
     // Machined inner edge. It hugs the seam from the chrome side, so the
     // miniature desktop stays separated from the graphite body whether the
@@ -1375,7 +1387,9 @@ unsafe fn install_wallpaper(
     let _: () = msg_send![seam, setAutoresizingMask: 18u64];
     let seam_layer: *mut AnyObject = msg_send![seam, layer];
     set_continuous_corners(seam_layer);
-    set_layer_border(seam_layer, seam_outset, color(1.0, 1.0, 1.0, 0.20));
+    if SHOW_SHELL_BORDER {
+        set_layer_border(seam_layer, seam_outset, color(1.0, 1.0, 1.0, 0.20));
+    }
     let _: () = msg_send![content_view, addSubview: seam];
 
     let wallpaper_container = rounded_view(
@@ -1389,7 +1403,9 @@ unsafe fn install_wallpaper(
     set_continuous_corners(container_layer);
     // Dark hairline where the miniature desktop meets the chrome. Softer than
     // the flat-outline pass, because the graphite body now carries the seam.
-    set_layer_border(container_layer, 0.8, color(0.0, 0.0, 0.0, 0.30));
+    if SHOW_SHELL_BORDER {
+        set_layer_border(container_layer, 0.8, color(0.0, 0.0, 0.0, 0.30));
+    }
     let container_bounds: objc2_foundation::NSRect = msg_send![wallpaper_container, bounds];
     let wallpaper_view: *mut AnyObject = {
         let allocated: *mut AnyObject = msg_send![class!(NSImageView), alloc];

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -36,6 +36,7 @@ struct NativeHandles {
 
 /// Outer corner radius of the Agent View container chrome.
 const CONTAINER_RADIUS: f64 = 15.0;
+const PIP_CORNER_RADIUS: f64 = 12.0;
 /// The miniature desktop sits inside an asymmetric hardware-like glass shell.
 const SHELL_SIDE_INSET: f64 = 9.0;
 const SHELL_TOP_INSET: f64 = 20.0;
@@ -1281,7 +1282,7 @@ unsafe fn install_wallpaper(
         if SHOW_SHELL_BORDER {
             CONTAINER_RADIUS
         } else {
-            0.0
+            PIP_CORNER_RADIUS
         },
         color(0.18, 0.21, 0.25, if SHOW_SHELL_BORDER { 0.16 } else { 0.0 }),
         true,
@@ -1362,7 +1363,11 @@ unsafe fn install_wallpaper(
     }
 
     let container_frame = desktop_frame(bounds);
-    let container_radius = if SHOW_SHELL_BORDER { 8.5 } else { 0.0 };
+    let container_radius = if SHOW_SHELL_BORDER {
+        8.5
+    } else {
+        PIP_CORNER_RADIUS
+    };
     let wallpaper_shadow = rounded_view(
         container_frame,
         container_radius,
@@ -1575,7 +1580,7 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
         setCornerRadius: if SHOW_SHELL_BORDER {
             CONTAINER_RADIUS
         } else {
-            0.0
+            PIP_CORNER_RADIUS
         }
     ];
     set_continuous_corners(content_layer);
@@ -1599,7 +1604,11 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     let canvas_layer: *mut AnyObject = msg_send![canvas, layer];
     let _: () = msg_send![
         canvas_layer,
-        setCornerRadius: if SHOW_SHELL_BORDER { 8.5_f64 } else { 0.0 }
+        setCornerRadius: if SHOW_SHELL_BORDER {
+            8.5_f64
+        } else {
+            PIP_CORNER_RADIUS
+        }
     ];
     set_continuous_corners(canvas_layer);
     let _: () = msg_send![canvas_layer, setMasksToBounds: true];

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -766,7 +766,7 @@ unsafe fn install_wallpaper(
     let glass_frame = rounded_view(
         bounds,
         CONTAINER_RADIUS,
-        color(0.26, 0.29, 0.34, 0.35),
+        color(0.26, 0.29, 0.34, 0.62),
         true,
     );
     let _: () = msg_send![glass_frame, setAutoresizingMask: 18u64];
@@ -780,8 +780,8 @@ unsafe fn install_wallpaper(
     let body = gradient_view(
         objc2_foundation::NSRect::new(objc2_foundation::NSPoint::new(0.0, 0.0), bounds.size),
         CONTAINER_RADIUS,
-        color(0.58, 0.61, 0.66, 0.72),
-        color(0.19, 0.22, 0.27, 0.82),
+        color(0.58, 0.61, 0.66, 0.88),
+        color(0.19, 0.22, 0.27, 0.92),
     );
     let _: () = msg_send![body, setAutoresizingMask: 18u64];
     let body_layer: *mut AnyObject = msg_send![body, layer];

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -419,7 +419,7 @@ unsafe fn render_dock(
     use objc2_foundation::{NSPoint, NSRect, NSSize};
 
     let dock_frame = appkit_rect(layout.dock, bounds_height);
-    let dock = visual_effect_view(dock_frame, dock_frame.size.height * 0.27, 13, 1, false);
+    let dock = visual_effect_view(dock_frame, dock_frame.size.height * 0.27, 6, 1, false);
     let appearance_name = ns_string("NSAppearanceNameVibrantDark");
     let dark_appearance: *mut AnyObject =
         msg_send![class!(NSAppearance), appearanceNamed: appearance_name];
@@ -427,8 +427,8 @@ unsafe fn render_dock(
         let _: () = msg_send![dock, setAppearance: dark_appearance];
     }
     let dock_layer: *mut AnyObject = msg_send![dock, layer];
-    set_layer_background(dock_layer, color(0.13, 0.15, 0.17, 0.30));
-    set_layer_border(dock_layer, 0.7, color(1.0, 1.0, 1.0, 0.22));
+    set_layer_background(dock_layer, color(0.30, 0.32, 0.34, 0.22));
+    set_layer_border(dock_layer, 0.65, color(1.0, 1.0, 1.0, 0.20));
     let _: () = msg_send![dock_layer, setShadowOpacity: 0.34_f32];
     let _: () = msg_send![dock_layer, setShadowRadius: 14.0_f64];
     let _: () = msg_send![dock_layer, setShadowOffset: NSSize::new(0.0, -6.0)];
@@ -665,8 +665,8 @@ unsafe fn install_wallpaper(
         let _: () = msg_send![glass_frame, setAppearance: dark_appearance];
     }
     let glass_layer: *mut AnyObject = msg_send![glass_frame, layer];
-    set_layer_background(glass_layer, color(0.025, 0.055, 0.075, 0.58));
-    set_layer_border(glass_layer, 0.7, color(0.78, 0.90, 0.96, 0.20));
+    set_layer_background(glass_layer, color(0.015, 0.03, 0.045, 0.78));
+    set_layer_border(glass_layer, 0.65, color(0.78, 0.90, 0.96, 0.10));
     let _: () = msg_send![content_view, addSubview: glass_frame];
 
     let inset = 7.0;
@@ -692,7 +692,7 @@ unsafe fn install_wallpaper(
         rounded_view(container_frame, 9.5, color(0.02, 0.03, 0.04, 0.68), true);
     let _: () = msg_send![wallpaper_container, setAutoresizingMask: 18u64];
     let container_layer: *mut AnyObject = msg_send![wallpaper_container, layer];
-    set_layer_border(container_layer, 0.65, color(0.86, 0.94, 0.98, 0.16));
+    set_layer_border(container_layer, 0.6, color(0.86, 0.94, 0.98, 0.09));
     let container_bounds: objc2_foundation::NSRect = msg_send![wallpaper_container, bounds];
     let wallpaper_view: *mut AnyObject = {
         let allocated: *mut AnyObject = msg_send![class!(NSImageView), alloc];

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -419,7 +419,7 @@ unsafe fn render_dock(
     use objc2_foundation::{NSPoint, NSRect, NSSize};
 
     let dock_frame = appkit_rect(layout.dock, bounds_height);
-    let dock = visual_effect_view(dock_frame, dock_frame.size.height * 0.27, 6, 1, false);
+    let dock = visual_effect_view(dock_frame, dock_frame.size.height * 0.30, 6, 1, true);
     let appearance_name = ns_string("NSAppearanceNameVibrantDark");
     let dark_appearance: *mut AnyObject =
         msg_send![class!(NSAppearance), appearanceNamed: appearance_name];
@@ -483,8 +483,7 @@ unsafe fn render_dock(
         }
 
         let dot_size = 3.2_f64.min(icon_frame.size.width * 0.10);
-        let dot_x =
-            icon_frame.origin.x - dock_frame.origin.x + (icon_frame.size.width - dot_size) / 2.0;
+        let dot_x = icon_frame.origin.x + (icon_frame.size.width - dot_size) / 2.0;
         add_circle(dock, dot_x, 2.2, dot_size, color(0.20, 0.72, 0.38, 0.92));
     }
     let _: () = msg_send![canvas, addSubview: dock];

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -650,7 +650,7 @@ unsafe fn install_wallpaper(
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
 
-    let glass_frame = visual_effect_view(bounds, 12.5, 13, 0, true);
+    let glass_frame = visual_effect_view(bounds, 13.5, 13, 0, true);
     let _: () = msg_send![glass_frame, setAutoresizingMask: 18u64];
     let appearance_name = ns_string("NSAppearanceNameVibrantDark");
     let dark_appearance: *mut AnyObject =
@@ -659,11 +659,11 @@ unsafe fn install_wallpaper(
         let _: () = msg_send![glass_frame, setAppearance: dark_appearance];
     }
     let glass_layer: *mut AnyObject = msg_send![glass_frame, layer];
-    set_layer_background(glass_layer, color(0.06, 0.09, 0.12, 0.30));
-    set_layer_border(glass_layer, 0.7, color(1.0, 1.0, 1.0, 0.28));
+    set_layer_background(glass_layer, color(0.05, 0.08, 0.11, 0.24));
+    set_layer_border(glass_layer, 0.8, color(1.0, 1.0, 1.0, 0.32));
     let _: () = msg_send![content_view, addSubview: glass_frame];
 
-    let inset = 6.0;
+    let inset = 7.5;
     let container_frame = objc2_foundation::NSRect::new(
         objc2_foundation::NSPoint::new(inset, inset),
         objc2_foundation::NSSize::new(
@@ -671,11 +671,22 @@ unsafe fn install_wallpaper(
             (bounds.size.height - 2.0 * inset).max(1.0),
         ),
     );
+    let wallpaper_shadow = rounded_view(container_frame, 9.5, color(0.0, 0.0, 0.0, 0.01), false);
+    let _: () = msg_send![wallpaper_shadow, setAutoresizingMask: 18u64];
+    let shadow_layer: *mut AnyObject = msg_send![wallpaper_shadow, layer];
+    let _: () = msg_send![shadow_layer, setShadowOpacity: 0.42_f32];
+    let _: () = msg_send![shadow_layer, setShadowRadius: 8.0_f64];
+    let _: () = msg_send![shadow_layer, setShadowOffset: objc2_foundation::NSSize::new(0.0, -2.0)];
+    let shadow_color = color(0.0, 0.0, 0.0, 0.88);
+    let shadow_cg: *mut CGColor = msg_send![shadow_color, CGColor];
+    let _: () = msg_send![shadow_layer, setShadowColor: shadow_cg];
+    let _: () = msg_send![content_view, addSubview: wallpaper_shadow];
+
     let wallpaper_container =
-        rounded_view(container_frame, 8.5, color(0.02, 0.03, 0.04, 0.72), true);
+        rounded_view(container_frame, 9.5, color(0.02, 0.03, 0.04, 0.68), true);
     let _: () = msg_send![wallpaper_container, setAutoresizingMask: 18u64];
     let container_layer: *mut AnyObject = msg_send![wallpaper_container, layer];
-    set_layer_border(container_layer, 0.65, color(1.0, 1.0, 1.0, 0.18));
+    set_layer_border(container_layer, 0.75, color(1.0, 1.0, 1.0, 0.26));
     let container_bounds: objc2_foundation::NSRect = msg_send![wallpaper_container, bounds];
     let wallpaper_view: *mut AnyObject = {
         let allocated: *mut AnyObject = msg_send![class!(NSImageView), alloc];

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -180,7 +180,7 @@ unsafe fn add_text_label(
     font_size: f64,
     bold: bool,
     tone: LabelTone,
-    alignment: u64,
+    alignment: isize,
 ) {
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -52,6 +52,11 @@ extern "C" {
         context: *mut c_void,
         work: unsafe extern "C" fn(*mut c_void),
     );
+    fn dispatch_sync_f(
+        queue: *const c_void,
+        context: *mut c_void,
+        work: unsafe extern "C" fn(*mut c_void),
+    );
 }
 
 fn dispatch_to_main<T: Send + 'static>(payload: T, cb: unsafe extern "C" fn(*mut c_void)) {
@@ -59,6 +64,18 @@ fn dispatch_to_main<T: Send + 'static>(payload: T, cb: unsafe extern "C" fn(*mut
     unsafe {
         let main_queue = &raw const _dispatch_main_q as *const c_void;
         dispatch_async_f(main_queue, Box::into_raw(boxed) as *mut c_void, cb);
+    }
+}
+
+fn dispatch_to_main_sync<T>(payload: T, cb: unsafe extern "C" fn(*mut c_void)) {
+    let context = Box::into_raw(Box::new(payload)) as *mut c_void;
+    unsafe {
+        if libc::pthread_main_np() != 0 {
+            cb(context);
+        } else {
+            let main_queue = &raw const _dispatch_main_q as *const c_void;
+            dispatch_sync_f(main_queue, context, cb);
+        }
     }
 }
 
@@ -83,8 +100,25 @@ impl PipBackend for MacosPipBackend {
         );
     }
 
+    fn set_input_passthrough(&self, passthrough: bool) -> anyhow::Result<()> {
+        dispatch_to_main_sync(passthrough, set_input_passthrough_cb);
+        Ok(())
+    }
+
     fn shutdown(self: Box<Self>) {
         dispatch_to_main((), shutdown_cb);
+    }
+}
+
+unsafe extern "C" fn set_input_passthrough_cb(ctx: *mut c_void) {
+    use objc2::msg_send;
+    use objc2::runtime::AnyObject;
+
+    let passthrough: bool = *Box::from_raw(ctx as *mut bool);
+    let handles = HANDLES.lock().unwrap();
+    if let Some(handles) = handles.as_ref() {
+        let window = handles.window as *mut AnyObject;
+        let _: () = msg_send![window, setIgnoresMouseEvents: passthrough];
     }
 }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -665,8 +665,10 @@ unsafe fn install_wallpaper(
         let _: () = msg_send![glass_frame, setAppearance: dark_appearance];
     }
     let glass_layer: *mut AnyObject = msg_send![glass_frame, layer];
-    set_layer_background(glass_layer, color(0.015, 0.03, 0.045, 0.78));
-    set_layer_border(glass_layer, 0.65, color(0.78, 0.90, 0.96, 0.10));
+    // Keep the rim neutral even over a saturated wallpaper. The material still
+    // supplies depth, while the graphite wash prevents a bright cyan halo.
+    set_layer_background(glass_layer, color(0.012, 0.016, 0.020, 0.92));
+    set_layer_border(glass_layer, 0.7, color(0.90, 0.93, 0.95, 0.16));
     let _: () = msg_send![content_view, addSubview: glass_frame];
 
     let inset = 7.0;

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -652,9 +652,15 @@ unsafe fn install_wallpaper(
 
     let glass_frame = visual_effect_view(bounds, 12.5, 13, 0, true);
     let _: () = msg_send![glass_frame, setAutoresizingMask: 18u64];
+    let appearance_name = ns_string("NSAppearanceNameVibrantDark");
+    let dark_appearance: *mut AnyObject =
+        msg_send![class!(NSAppearance), appearanceNamed: appearance_name];
+    if !dark_appearance.is_null() {
+        let _: () = msg_send![glass_frame, setAppearance: dark_appearance];
+    }
     let glass_layer: *mut AnyObject = msg_send![glass_frame, layer];
-    set_layer_background(glass_layer, color(0.20, 0.24, 0.27, 0.20));
-    set_layer_border(glass_layer, 0.9, color(1.0, 1.0, 1.0, 0.30));
+    set_layer_background(glass_layer, color(0.06, 0.09, 0.12, 0.30));
+    set_layer_border(glass_layer, 0.7, color(1.0, 1.0, 1.0, 0.28));
     let _: () = msg_send![content_view, addSubview: glass_frame];
 
     let inset = 6.0;

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -26,6 +26,7 @@ unsafe impl objc2::RefEncode for CGColor {
 struct NativeHandles {
     window: usize,
     canvas_view: usize,
+    wallpaper_container: usize,
     wallpaper_view: usize,
     delegate: usize,
 }
@@ -134,7 +135,6 @@ unsafe fn rust_string(value: *mut objc2::runtime::AnyObject) -> Option<String> {
 
 #[derive(Clone, Copy)]
 enum LabelTone {
-    Light,
     Muted,
     Dark,
 }
@@ -161,6 +161,18 @@ unsafe fn set_layer_background(
     let _: () = msg_send![layer, setBackgroundColor: cg_color];
 }
 
+unsafe fn set_layer_border(
+    layer: *mut objc2::runtime::AnyObject,
+    width: f64,
+    border: *mut objc2::runtime::AnyObject,
+) {
+    use objc2::msg_send;
+
+    let cg_color: *mut CGColor = msg_send![border, CGColor];
+    let _: () = msg_send![layer, setBorderWidth: width];
+    let _: () = msg_send![layer, setBorderColor: cg_color];
+}
+
 unsafe fn add_text_label(
     parent: *mut objc2::runtime::AnyObject,
     frame: objc2_foundation::NSRect,
@@ -183,7 +195,6 @@ unsafe fn add_text_label(
     let _: () = msg_send![label, setSelectable: false];
     let _: () = msg_send![label, setAlignment: alignment];
     let text_color = match tone {
-        LabelTone::Light => color(1.0, 1.0, 1.0, 0.95),
         LabelTone::Muted => color(1.0, 1.0, 1.0, 0.66),
         LabelTone::Dark => color(0.12, 0.13, 0.15, 0.94),
     };
@@ -321,53 +332,6 @@ unsafe fn image_from_png(bytes: &[u8]) -> *mut objc2::runtime::AnyObject {
     msg_send![alloc, initWithData: data]
 }
 
-fn current_time_label() -> String {
-    unsafe {
-        let timestamp = libc::time(std::ptr::null_mut());
-        let mut local: libc::tm = std::mem::zeroed();
-        if libc::localtime_r(&timestamp, &mut local).is_null() {
-            return "--:--".to_owned();
-        }
-        format!("{:02}:{:02}", local.tm_hour, local.tm_min)
-    }
-}
-
-unsafe fn render_menu_bar(canvas: *mut objc2::runtime::AnyObject, frame: objc2_foundation::NSRect) {
-    use objc2::msg_send;
-    use objc2_foundation::{NSPoint, NSRect, NSSize};
-
-    let bar = rounded_view(frame, 0.0, color(0.03, 0.05, 0.08, 0.68), false);
-    let text_height = frame.size.height.min(22.0);
-    add_text_label(
-        bar,
-        NSRect::new(
-            NSPoint::new(10.0, (frame.size.height - text_height) / 2.0 - 1.0),
-            NSSize::new((frame.size.width - 90.0).max(20.0), text_height),
-        ),
-        "Cua   File   View   Window",
-        9.5,
-        true,
-        LabelTone::Light,
-        0,
-    );
-    add_text_label(
-        bar,
-        NSRect::new(
-            NSPoint::new(
-                (frame.size.width - 68.0).max(0.0),
-                (frame.size.height - text_height) / 2.0 - 1.0,
-            ),
-            NSSize::new(58.0, text_height),
-        ),
-        &current_time_label(),
-        9.5,
-        false,
-        LabelTone::Light,
-        2,
-    );
-    let _: () = msg_send![canvas, addSubview: bar];
-}
-
 unsafe fn render_target_window(
     canvas: *mut objc2::runtime::AnyObject,
     frame: &PipFrame,
@@ -379,16 +343,13 @@ unsafe fn render_target_window(
     use objc2_foundation::{NSPoint, NSRect, NSSize};
 
     let window_frame = appkit_rect(layout.window, bounds_height);
-    let shadow: *mut AnyObject = {
-        let alloc: *mut AnyObject = msg_send![class!(NSView), alloc];
-        msg_send![alloc, initWithFrame: window_frame]
-    };
-    let _: () = msg_send![shadow, setWantsLayer: true];
+    let radius = (window_frame.size.width.min(window_frame.size.height) * 0.035).clamp(5.0, 9.0);
+    let shadow = rounded_view(window_frame, radius, color(0.96, 0.96, 0.97, 1.0), false);
     let shadow_layer: *mut AnyObject = msg_send![shadow, layer];
-    let _: () = msg_send![shadow_layer, setShadowOpacity: 0.34_f32];
-    let _: () = msg_send![shadow_layer, setShadowRadius: 8.0_f64];
-    let _: () = msg_send![shadow_layer, setShadowOffset: NSSize::new(0.0, -3.0)];
-    let black = color(0.0, 0.0, 0.0, 0.75);
+    let _: () = msg_send![shadow_layer, setShadowOpacity: 0.30_f32];
+    let _: () = msg_send![shadow_layer, setShadowRadius: 16.0_f64];
+    let _: () = msg_send![shadow_layer, setShadowOffset: NSSize::new(0.0, -6.0)];
+    let black = color(0.0, 0.0, 0.0, 0.90);
     let black_cg: *mut CGColor = msg_send![black, CGColor];
     let _: () = msg_send![shadow_layer, setShadowColor: black_cg];
 
@@ -397,70 +358,19 @@ unsafe fn render_target_window(
             NSPoint::new(0.0, 0.0),
             NSSize::new(window_frame.size.width, window_frame.size.height),
         ),
-        7.0,
+        radius,
         color(0.96, 0.96, 0.97, 1.0),
         true,
     );
-    let title_height = layout.title_bar_height.min(window_frame.size.height);
-    let title_bar = rounded_view(
-        NSRect::new(
-            NSPoint::new(0.0, window_frame.size.height - title_height),
-            NSSize::new(window_frame.size.width, title_height),
-        ),
-        0.0,
-        color(0.94, 0.94, 0.95, 0.98),
-        false,
-    );
-    let separator = rounded_view(
-        NSRect::new(
-            NSPoint::new(0.0, window_frame.size.height - title_height),
-            NSSize::new(window_frame.size.width, 0.7),
-        ),
-        0.0,
-        color(1.0, 1.0, 1.0, 0.18),
-        false,
-    );
-    let traffic_size = title_height.clamp(5.5, 8.5) * 0.72;
-    let traffic_y = (title_height - traffic_size) / 2.0;
-    for (index, fill) in [
-        color(1.0, 0.32, 0.28, 1.0),
-        color(1.0, 0.72, 0.18, 1.0),
-        color(0.18, 0.76, 0.31, 1.0),
-    ]
-    .into_iter()
-    .enumerate()
-    {
-        add_circle(
-            title_bar,
-            8.0 + index as f64 * (traffic_size + 4.0),
-            traffic_y,
-            traffic_size,
-            fill,
-        );
-    }
-
-    let (title, _, _) = target_identity(frame);
-    add_text_label(
-        title_bar,
-        NSRect::new(
-            NSPoint::new(38.0, (title_height - 16.0) / 2.0 - 1.0),
-            NSSize::new((window_frame.size.width - 76.0).max(20.0), 16.0),
-        ),
-        &title,
-        title_height.clamp(8.0, 11.0) * 0.88,
-        false,
-        LabelTone::Dark,
-        1,
-    );
-
-    let content_height = (window_frame.size.height - title_height).max(1.0);
+    let window_layer: *mut AnyObject = msg_send![window, layer];
+    set_layer_border(window_layer, 0.6, color(1.0, 1.0, 1.0, 0.24));
     let image_view: *mut AnyObject = {
         let alloc: *mut AnyObject = msg_send![class!(NSImageView), alloc];
         msg_send![
             alloc,
             initWithFrame: NSRect::new(
                 NSPoint::new(0.0, 0.0),
-                NSSize::new(window_frame.size.width, content_height),
+                NSSize::new(window_frame.size.width, window_frame.size.height),
             )
         ]
     };
@@ -470,8 +380,6 @@ unsafe fn render_target_window(
         let _: () = msg_send![image_view, setImage: image];
     }
     let _: () = msg_send![window, addSubview: image_view];
-    let _: () = msg_send![window, addSubview: title_bar];
-    let _: () = msg_send![window, addSubview: separator];
     let _: () = msg_send![shadow, addSubview: window];
     let _: () = msg_send![canvas, addSubview: shadow];
 }
@@ -489,10 +397,18 @@ unsafe fn render_dock(
     let dock_frame = appkit_rect(layout.dock, bounds_height);
     let dock = rounded_view(
         dock_frame,
-        dock_frame.size.height * 0.24,
-        color(0.04, 0.06, 0.08, 0.66),
-        true,
+        dock_frame.size.height * 0.28,
+        color(0.82, 0.84, 0.87, 0.62),
+        false,
     );
+    let dock_layer: *mut AnyObject = msg_send![dock, layer];
+    set_layer_border(dock_layer, 0.6, color(1.0, 1.0, 1.0, 0.36));
+    let _: () = msg_send![dock_layer, setShadowOpacity: 0.22_f32];
+    let _: () = msg_send![dock_layer, setShadowRadius: 10.0_f64];
+    let _: () = msg_send![dock_layer, setShadowOffset: NSSize::new(0.0, -4.0)];
+    let dock_shadow = color(0.0, 0.0, 0.0, 0.75);
+    let dock_shadow_cg: *mut CGColor = msg_send![dock_shadow, CGColor];
+    let _: () = msg_send![dock_layer, setShadowColor: dock_shadow_cg];
 
     for (frame, icon_layout) in frames.iter().zip(layout.dock_icons.iter()) {
         let icon_global = appkit_rect(*icon_layout, bounds_height);
@@ -503,14 +419,14 @@ unsafe fn render_dock(
             ),
             icon_global.size,
         );
-        let tile = rounded_view(
-            icon_frame,
-            icon_frame.size.width * 0.22,
-            color(0.98, 0.98, 0.99, 0.92),
-            true,
-        );
         let (_, icon, fallback) = target_identity(frame);
         if icon.is_null() {
+            let tile = rounded_view(
+                icon_frame,
+                icon_frame.size.width * 0.22,
+                color(0.98, 0.98, 0.99, 0.86),
+                true,
+            );
             add_text_label(
                 tile,
                 NSRect::new(
@@ -523,30 +439,27 @@ unsafe fn render_dock(
                 LabelTone::Dark,
                 1,
             );
+            let _: () = msg_send![dock, addSubview: tile];
         } else {
             let image_view: *mut AnyObject = {
                 let alloc: *mut AnyObject = msg_send![class!(NSImageView), alloc];
                 msg_send![
                     alloc,
                     initWithFrame: NSRect::new(
-                        NSPoint::new(3.0, 3.0),
-                        NSSize::new(
-                            (icon_frame.size.width - 6.0).max(1.0),
-                            (icon_frame.size.height - 6.0).max(1.0),
-                        ),
+                        icon_frame.origin,
+                        icon_frame.size,
                     )
                 ]
             };
             let _: () = msg_send![image_view, setImageScaling: 3u64];
             let _: () = msg_send![image_view, setImage: icon];
-            let _: () = msg_send![tile, addSubview: image_view];
+            let _: () = msg_send![dock, addSubview: image_view];
         }
-        let _: () = msg_send![dock, addSubview: tile];
 
-        let dot_size = 4.0_f64.min(icon_frame.size.width * 0.12);
+        let dot_size = 3.2_f64.min(icon_frame.size.width * 0.10);
         let dot_x =
             icon_frame.origin.x - dock_frame.origin.x + (icon_frame.size.width - dot_size) / 2.0;
-        add_circle(dock, dot_x, 2.0, dot_size, color(0.20, 0.87, 0.42, 1.0));
+        add_circle(dock, dot_x, 2.2, dot_size, color(0.20, 0.72, 0.38, 0.92));
     }
     let _: () = msg_send![canvas, addSubview: dock];
 }
@@ -555,27 +468,23 @@ unsafe fn render_resize_affordance(canvas: *mut objc2::runtime::AnyObject, width
     use objc2::msg_send;
     use objc2_foundation::{NSPoint, NSRect, NSSize};
 
-    let marker = color(1.0, 1.0, 1.0, 0.55);
-    let horizontal = rounded_view(
-        NSRect::new(
-            NSPoint::new((width - 14.0).max(0.0), 4.0),
-            NSSize::new(9.0, 1.5),
-        ),
-        0.75,
-        marker,
-        false,
-    );
-    let vertical = rounded_view(
-        NSRect::new(
-            NSPoint::new((width - 5.5).max(0.0), 4.0),
-            NSSize::new(1.5, 9.0),
-        ),
-        0.75,
-        marker,
-        false,
-    );
-    let _: () = msg_send![canvas, addSubview: horizontal];
-    let _: () = msg_send![canvas, addSubview: vertical];
+    let marker = color(1.0, 1.0, 1.0, 0.48);
+    for (index, length) in [10.0_f64, 6.0].into_iter().enumerate() {
+        let bar = rounded_view(
+            NSRect::new(
+                NSPoint::new(
+                    (width - 15.0 + index as f64 * 4.0).max(0.0),
+                    6.0 + index as f64 * 2.0,
+                ),
+                NSSize::new(length, 1.2),
+            ),
+            0.6,
+            marker,
+            false,
+        );
+        let _: () = msg_send![bar, setFrameCenterRotation: -45.0_f64];
+        let _: () = msg_send![canvas, addSubview: bar];
+    }
 }
 
 unsafe fn render_frames(frames: &[PipFrame]) {
@@ -604,8 +513,6 @@ unsafe fn render_frames(frames: &[PipFrame]) {
         })
         .collect::<Vec<_>>();
     let layout = layout_desktop(bounds.size.width, bounds.size.height, &target_sizes);
-    render_menu_bar(canvas, appkit_rect(layout.menu_bar, bounds.size.height));
-
     if frames.is_empty() {
         let waiting = appkit_rect(layout.desktop, bounds.size.height);
         add_text_label(
@@ -716,13 +623,30 @@ unsafe fn install_wallpaper(
     content_view: *mut objc2::runtime::AnyObject,
     screen: *mut objc2::runtime::AnyObject,
     bounds: objc2_foundation::NSRect,
-) -> *mut objc2::runtime::AnyObject {
+) -> (
+    *mut objc2::runtime::AnyObject,
+    *mut objc2::runtime::AnyObject,
+) {
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
 
+    let inset = 3.0;
+    let container_frame = objc2_foundation::NSRect::new(
+        objc2_foundation::NSPoint::new(inset, inset),
+        objc2_foundation::NSSize::new(
+            (bounds.size.width - 2.0 * inset).max(1.0),
+            (bounds.size.height - 2.0 * inset).max(1.0),
+        ),
+    );
+    let wallpaper_container =
+        rounded_view(container_frame, 9.5, color(0.02, 0.03, 0.04, 1.0), true);
+    let _: () = msg_send![wallpaper_container, setAutoresizingMask: 18u64];
+    let container_layer: *mut AnyObject = msg_send![wallpaper_container, layer];
+    set_layer_border(container_layer, 0.5, color(1.0, 1.0, 1.0, 0.12));
+    let container_bounds: objc2_foundation::NSRect = msg_send![wallpaper_container, bounds];
     let wallpaper_view: *mut AnyObject = {
         let allocated: *mut AnyObject = msg_send![class!(NSImageView), alloc];
-        msg_send![allocated, initWithFrame: bounds]
+        msg_send![allocated, initWithFrame: container_bounds]
     };
     let _: () = msg_send![wallpaper_view, setImageScaling: 2u64];
     let workspace: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
@@ -734,13 +658,10 @@ unsafe fn install_wallpaper(
             let _: () = msg_send![wallpaper_view, setImage: wallpaper];
         }
     }
-    let _: () = msg_send![content_view, addSubview: wallpaper_view];
+    let _: () = msg_send![wallpaper_container, addSubview: wallpaper_view];
+    let _: () = msg_send![content_view, addSubview: wallpaper_container];
 
-    let tint = rounded_view(bounds, 0.0, color(0.01, 0.03, 0.05, 0.10), false);
-    let _: () = msg_send![tint, setAutoresizingMask: 18u64];
-    let _: () = msg_send![content_view, addSubview: tint];
-
-    wallpaper_view
+    (wallpaper_container, wallpaper_view)
 }
 
 fn aspect_fill_frame(
@@ -769,17 +690,17 @@ unsafe fn update_wallpaper_frame() {
     use objc2::runtime::AnyObject;
     use objc2_foundation::{NSRect, NSSize};
 
-    let (canvas, wallpaper_view) = {
+    let (wallpaper_container, wallpaper_view) = {
         let guard = HANDLES.lock().unwrap();
         let Some(handles) = guard.as_ref() else {
             return;
         };
         (
-            handles.canvas_view as *mut AnyObject,
+            handles.wallpaper_container as *mut AnyObject,
             handles.wallpaper_view as *mut AnyObject,
         )
     };
-    let bounds: NSRect = msg_send![canvas, bounds];
+    let bounds: NSRect = msg_send![wallpaper_container, bounds];
     let image: *mut AnyObject = msg_send![wallpaper_view, image];
     let image_size = if image.is_null() {
         NSSize::new(0.0, 0.0)
@@ -853,11 +774,12 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     let content_view: *mut AnyObject = msg_send![window, contentView];
     let _: () = msg_send![content_view, setWantsLayer: true];
     let content_layer: *mut AnyObject = msg_send![content_view, layer];
-    let _: () = msg_send![content_layer, setCornerRadius: 13.0_f64];
+    let _: () = msg_send![content_layer, setCornerRadius: 11.5_f64];
     let _: () = msg_send![content_layer, setMasksToBounds: true];
-    set_layer_background(content_layer, color(0.02, 0.04, 0.06, 1.0));
+    set_layer_background(content_layer, color(0.08, 0.09, 0.11, 0.94));
+    set_layer_border(content_layer, 1.0, color(1.0, 1.0, 1.0, 0.18));
     let bounds: NSRect = msg_send![content_view, bounds];
-    let wallpaper_view = install_wallpaper(content_view, screen, bounds);
+    let (wallpaper_container, wallpaper_view) = install_wallpaper(content_view, screen, bounds);
 
     let canvas: *mut AnyObject = {
         let allocated: *mut AnyObject = msg_send![class!(NSView), alloc];
@@ -871,6 +793,7 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     *HANDLES.lock().unwrap() = Some(NativeHandles {
         window: window as usize,
         canvas_view: canvas as usize,
+        wallpaper_container: wallpaper_container as usize,
         wallpaper_view: wallpaper_view as usize,
         delegate: delegate as usize,
     });

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -10,7 +10,7 @@ use std::sync::{Mutex, OnceLock};
 
 use pip_preview::{
     layout_desktop, png_dimensions, PipBackend, PipBackendFactory, PipConfig, PipFrame,
-    PipTargetKind, PipViewModel, TargetSize,
+    PipTargetKind, PipViewModel, PipWorkspaceSummary, TargetSize,
 };
 
 #[repr(C)]
@@ -39,6 +39,7 @@ const CONTAINER_RADIUS: f64 = 15.0;
 const SHELL_SIDE_INSET: f64 = 9.0;
 const SHELL_TOP_INSET: f64 = 20.0;
 const SHELL_BOTTOM_INSET: f64 = 10.0;
+const SESSION_SELECTOR_HEIGHT: f64 = 34.0;
 
 static HANDLES: Mutex<Option<NativeHandles>> = Mutex::new(None);
 static VIEW_MODEL: Mutex<Option<PipViewModel>> = Mutex::new(None);
@@ -75,6 +76,13 @@ impl PipBackend for MacosPipBackend {
         dispatch_to_main(workspace_id.to_owned(), remove_workspace_cb);
     }
 
+    fn remove_target(&self, workspace_id: &str, identity_key: &str) {
+        dispatch_to_main(
+            (workspace_id.to_owned(), identity_key.to_owned()),
+            remove_target_cb,
+        );
+    }
+
     fn shutdown(self: Box<Self>) {
         dispatch_to_main((), shutdown_cb);
     }
@@ -82,41 +90,63 @@ impl PipBackend for MacosPipBackend {
 
 unsafe extern "C" fn push_frame_cb(ctx: *mut c_void) {
     let frame: PipFrame = *Box::from_raw(ctx as *mut PipFrame);
-    let frames = {
+    let snapshot = {
         let mut model = VIEW_MODEL.lock().unwrap();
         let model = model.get_or_insert_with(|| PipViewModel::new(12));
         model.upsert(frame);
-        clone_ordered_frames(model)
+        clone_snapshot(model)
     };
-    render_frames(&frames);
+    render_snapshot(&snapshot);
 }
 
 unsafe extern "C" fn remove_workspace_cb(ctx: *mut c_void) {
     let workspace_id: String = *Box::from_raw(ctx as *mut String);
-    let frames = {
+    let snapshot = {
         let mut model = VIEW_MODEL.lock().unwrap();
         let model = model.get_or_insert_with(|| PipViewModel::new(12));
         model.remove_workspace(&workspace_id);
-        clone_ordered_frames(model)
+        clone_snapshot(model)
     };
-    render_frames(&frames);
+    render_snapshot(&snapshot);
 }
 
-fn clone_ordered_frames(model: &PipViewModel) -> Vec<PipFrame> {
-    model
-        .ordered_frames()
-        .into_iter()
-        .cloned()
-        .collect::<Vec<_>>()
+unsafe extern "C" fn remove_target_cb(ctx: *mut c_void) {
+    let (workspace_id, identity_key): (String, String) =
+        *Box::from_raw(ctx as *mut (String, String));
+    let snapshot = {
+        let mut model = VIEW_MODEL.lock().unwrap();
+        let model = model.get_or_insert_with(|| PipViewModel::new(12));
+        model.remove_target(&workspace_id, &identity_key);
+        clone_snapshot(model)
+    };
+    render_snapshot(&snapshot);
 }
 
-fn current_frames() -> Vec<PipFrame> {
+struct ViewSnapshot {
+    frames: Vec<PipFrame>,
+    workspaces: Vec<PipWorkspaceSummary>,
+    selected_workspace_id: Option<String>,
+}
+
+fn clone_snapshot(model: &PipViewModel) -> ViewSnapshot {
+    ViewSnapshot {
+        frames: model.selected_frames().into_iter().cloned().collect(),
+        workspaces: model.workspaces(),
+        selected_workspace_id: model.selected_workspace_id().map(str::to_owned),
+    }
+}
+
+fn current_snapshot() -> ViewSnapshot {
     VIEW_MODEL
         .lock()
         .unwrap()
         .as_ref()
-        .map(clone_ordered_frames)
-        .unwrap_or_default()
+        .map(clone_snapshot)
+        .unwrap_or_else(|| ViewSnapshot {
+            frames: Vec::new(),
+            workspaces: Vec::new(),
+            selected_workspace_id: None,
+        })
 }
 
 unsafe fn ns_string(value: &str) -> *mut objc2::runtime::AnyObject {
@@ -557,6 +587,124 @@ unsafe fn render_dock(
     let _: () = msg_send![canvas, addSubview: dock];
 }
 
+fn session_selector_layout(
+    width: f64,
+    height: f64,
+    count: usize,
+) -> Option<(objc2_foundation::NSRect, Vec<objc2_foundation::NSRect>)> {
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    if count <= 1 {
+        return None;
+    }
+    let visible = count;
+    let icon = 22.0;
+    let gap = 5.0;
+    let padding = 6.0;
+    let selector_width = padding * 2.0 + visible as f64 * icon + (visible - 1) as f64 * gap;
+    let selector = NSRect::new(
+        NSPoint::new((width - selector_width) / 2.0, height - 29.0),
+        NSSize::new(selector_width, 28.0),
+    );
+    let icons = (0..visible)
+        .map(|index| {
+            NSRect::new(
+                NSPoint::new(padding + index as f64 * (icon + gap), 3.0),
+                NSSize::new(icon, icon),
+            )
+        })
+        .collect();
+    Some((selector, icons))
+}
+
+fn workspace_accent(workspace_id: &str) -> (f64, f64, f64) {
+    let hash = workspace_id.bytes().fold(2_166_136_261u32, |value, byte| {
+        (value ^ u32::from(byte)).wrapping_mul(16_777_619)
+    });
+    let palette = [
+        (0.29, 0.64, 0.96),
+        (0.30, 0.78, 0.56),
+        (0.96, 0.58, 0.27),
+        (0.91, 0.39, 0.49),
+        (0.46, 0.72, 0.86),
+    ];
+    palette[hash as usize % palette.len()]
+}
+
+unsafe fn render_session_selector(
+    canvas: *mut objc2::runtime::AnyObject,
+    bounds: objc2_foundation::NSRect,
+    workspaces: &[PipWorkspaceSummary],
+    selected_workspace_id: Option<&str>,
+) {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+
+    let Some((selector_frame, icons)) =
+        session_selector_layout(bounds.size.width, bounds.size.height, workspaces.len())
+    else {
+        return;
+    };
+    let selector = visual_effect_view(selector_frame, 14.0, 6, 1, true);
+    let selector_layer: *mut AnyObject = msg_send![selector, layer];
+    set_layer_background(selector_layer, color(0.10, 0.12, 0.15, 0.30));
+    set_layer_border(selector_layer, 0.6, color(1.0, 1.0, 1.0, 0.26));
+
+    let delegate = HANDLES
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(|handles| handles.delegate as *mut AnyObject)
+        .unwrap_or(std::ptr::null_mut());
+    for (index, (workspace, icon_frame)) in workspaces.iter().zip(icons).enumerate() {
+        let selected = selected_workspace_id == Some(workspace.workspace_id.as_str());
+        let (red, green, blue) = workspace_accent(&workspace.workspace_id);
+        let button: *mut AnyObject = {
+            let allocated: *mut AnyObject = msg_send![class!(NSButton), alloc];
+            msg_send![allocated, initWithFrame: icon_frame]
+        };
+        let _: () = msg_send![button, setBordered: false];
+        let _: () = msg_send![button, setRefusesFirstResponder: true];
+        let _: () = msg_send![button, setWantsLayer: true];
+        let layer: *mut AnyObject = msg_send![button, layer];
+        let _: () = msg_send![layer, setCornerRadius: 11.0_f64];
+        set_continuous_corners(layer);
+        set_layer_background(
+            layer,
+            color(red, green, blue, if selected { 0.96 } else { 0.62 }),
+        );
+        set_layer_border(
+            layer,
+            if selected { 1.4 } else { 0.5 },
+            color(1.0, 1.0, 1.0, if selected { 0.94 } else { 0.38 }),
+        );
+        let initial = workspace
+            .workspace_label
+            .chars()
+            .find(|character| character.is_alphanumeric())
+            .unwrap_or('A')
+            .to_uppercase()
+            .collect::<String>();
+        let title = ns_string(&initial);
+        let tooltip = ns_string(&workspace.workspace_label);
+        if !title.is_null() {
+            let _: () = msg_send![button, setTitle: title];
+        }
+        if !tooltip.is_null() {
+            let _: () = msg_send![button, setToolTip: tooltip];
+        }
+        let font: *mut AnyObject = msg_send![class!(NSFont), boldSystemFontOfSize: 10.0_f64];
+        let _: () = msg_send![button, setFont: font];
+        let _: () = msg_send![button, setTag: index as isize];
+        if !delegate.is_null() {
+            let _: () = msg_send![button, setTarget: delegate];
+            let _: () = msg_send![button, setAction: objc2::sel!(selectWorkspace:)];
+        }
+        let _: () = msg_send![selector, addSubview: button];
+    }
+    let _: () = msg_send![canvas, addSubview: selector];
+}
+
 fn desktop_frame(bounds: objc2_foundation::NSRect) -> objc2_foundation::NSRect {
     use objc2_foundation::{NSPoint, NSRect, NSSize};
 
@@ -618,7 +766,7 @@ unsafe fn install_shell_details(
     }
 }
 
-unsafe fn render_frames(frames: &[PipFrame]) {
+unsafe fn render_snapshot(snapshot: &ViewSnapshot) {
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
     use objc2_foundation::{NSPoint, NSRect, NSSize};
@@ -634,7 +782,14 @@ unsafe fn render_frames(frames: &[PipFrame]) {
     let _: () = msg_send![canvas, setSubviews: empty];
 
     let bounds: NSRect = msg_send![canvas, bounds];
-    let target_sizes = frames
+    let selector_height = if snapshot.workspaces.len() > 1 {
+        SESSION_SELECTOR_HEIGHT
+    } else {
+        0.0
+    };
+    let content_height = (bounds.size.height - selector_height).max(1.0);
+    let target_sizes = snapshot
+        .frames
         .iter()
         .map(|frame| {
             png_dimensions(&frame.png_bytes).unwrap_or(TargetSize {
@@ -643,9 +798,9 @@ unsafe fn render_frames(frames: &[PipFrame]) {
             })
         })
         .collect::<Vec<_>>();
-    let layout = layout_desktop(bounds.size.width, bounds.size.height, &target_sizes);
-    if frames.is_empty() {
-        let waiting = appkit_rect(layout.desktop, bounds.size.height);
+    let layout = layout_desktop(bounds.size.width, content_height, &target_sizes);
+    if snapshot.frames.is_empty() {
+        let waiting = appkit_rect(layout.desktop, content_height);
         add_text_label(
             canvas,
             NSRect::new(
@@ -662,11 +817,17 @@ unsafe fn render_frames(frames: &[PipFrame]) {
             1,
         );
     } else {
-        for (frame, target_layout) in frames.iter().zip(layout.targets.iter().copied()) {
-            render_target_window(canvas, frame, target_layout, bounds.size.height);
+        for (frame, target_layout) in snapshot.frames.iter().zip(layout.targets.iter().copied()) {
+            render_target_window(canvas, frame, target_layout, content_height);
         }
-        render_dock(canvas, frames, &layout, bounds.size.height);
+        render_dock(canvas, &snapshot.frames, &layout, content_height);
     }
+    render_session_selector(
+        canvas,
+        bounds,
+        &snapshot.workspaces,
+        snapshot.selected_workspace_id.as_deref(),
+    );
 }
 
 unsafe extern "C" fn shutdown_cb(_ctx: *mut c_void) {
@@ -698,6 +859,10 @@ fn agent_view_delegate_class() -> &'static objc2::runtime::AnyClass {
                 objc2::sel!(windowDidResize:),
                 on_window_did_resize as extern "C" fn(_, _, _),
             );
+            builder.add_method(
+                objc2::sel!(selectWorkspace:),
+                on_select_workspace as extern "C" fn(_, _, _),
+            );
         }
         builder.register()
     })
@@ -717,11 +882,39 @@ extern "C" fn on_window_did_resize(
     _selector: objc2::runtime::Sel,
     _notification: *mut objc2::runtime::AnyObject,
 ) {
-    let frames = current_frames();
+    let snapshot = current_snapshot();
     unsafe {
         update_wallpaper_frame();
-        render_frames(&frames);
+        render_snapshot(&snapshot);
     };
+}
+
+extern "C" fn on_select_workspace(
+    _delegate: *mut objc2::runtime::AnyObject,
+    _selector: objc2::runtime::Sel,
+    sender: *mut objc2::runtime::AnyObject,
+) {
+    if sender.is_null() {
+        return;
+    }
+    let index: isize = unsafe { objc2::msg_send![sender, tag] };
+    if index < 0 {
+        return;
+    }
+    let snapshot = {
+        let mut model = VIEW_MODEL.lock().unwrap();
+        let Some(model) = model.as_mut() else {
+            return;
+        };
+        let workspaces = model.workspaces();
+        let Some(workspace) = workspaces.get(index as usize) else {
+            return;
+        };
+        let workspace_id = workspace.workspace_id.clone();
+        model.select_workspace(&workspace_id);
+        clone_snapshot(model)
+    };
+    unsafe { render_snapshot(&snapshot) };
 }
 
 /// Park the main thread in `NSApplication.run()` for the main-queue AppKit
@@ -1075,7 +1268,11 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     });
     *VIEW_MODEL.lock().unwrap() = Some(PipViewModel::new(12));
     update_wallpaper_frame();
-    render_frames(&[]);
+    render_snapshot(&ViewSnapshot {
+        frames: Vec::new(),
+        workspaces: Vec::new(),
+        selected_workspace_id: None,
+    });
     let _: () = msg_send![window, orderFrontRegardless];
 
     tracing::info!(
@@ -1135,5 +1332,20 @@ mod tests {
         assert_eq!(inner.origin, NSPoint::new(9.0, 10.0));
         assert_eq!(inner.size, NSSize::new(602.0, 390.0));
         assert_eq!(outer.size.height - inner.origin.y - inner.size.height, 20.0);
+    }
+
+    #[test]
+    fn session_selector_is_local_compact_and_hidden_for_one_session() {
+        assert!(session_selector_layout(602.0, 390.0, 1).is_none());
+        let (selector, icons) = session_selector_layout(602.0, 390.0, 3).unwrap();
+        assert_eq!(icons.len(), 3);
+        assert!(selector.origin.x > 0.0);
+        assert!(selector.origin.y + selector.size.height <= 390.0);
+        assert!(icons.iter().all(|icon| {
+            icon.origin.x >= 0.0
+                && icon.origin.y >= 0.0
+                && icon.origin.x + icon.size.width <= selector.size.width
+                && icon.origin.y + icon.size.height <= selector.size.height
+        }));
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -1,89 +1,37 @@
 //! macOS multi-target Agent View.
 //!
-//! Floating NSWindow containing a bounded grid of exact native-window and
-//! browser-tab cards, grouped by the existing lifecycle session.
-//!
-//! ## Threading model
-//!
-//! Mirrors `cursor/overlay.rs`:
-//!
-//! - The MCP/tokio server runs on a background thread.
-//! - AppKit MUST run on the main thread, which `cua-driver/src/main.rs`
-//!   parks in `NSApplication.run()` for the cursor overlay.
-//! - `push_frame()` is called from arbitrary tokio tasks. It packages
-//!   the frame into a heap-allocated `Box` and posts the actual UI
-//!   update onto the main queue via `dispatch_async_f`. The block
-//!   then constructs an `NSImage` from the PNG bytes and calls
-//!   `[imageView setImage:]` + `[label setStringValue:]`.
-//!
-//! ## Window properties
-//!
-//! - `NSWindowCollectionBehaviorCanJoinAllSpaces | FullScreenAuxiliary |
-//!    Stationary | Transient | IgnoresCycle`
-//! - `level = .floating` (kCGFloatingWindowLevel, between normal apps
-//!   and dock; high enough to stay visible, low enough not to obscure
-//!   menus or accessibility overlays).
-//! - `setIgnoresMouseEvents(false)` — user can click the red close
-//!   button. Backend cleanup happens on `shutdown()`; closing the
-//!   window manually decouples it from the session as the spec
-//!   requires.
-//! - No activation: `setHidesOnDeactivate(false)` and
-//!   `setBecomesKeyOnlyIfNeeded(true)` so the window never steals
-//!   keyboard focus from the user's frontmost app.
-//!
-//! ## Init lifecycle
-//!
-//! Because the cursor overlay already owns the main thread when
-//! enabled, `MacosPipBackend::start` cannot block on it. Instead it
-//! posts the window-creation block onto the main queue and returns
-//! immediately. The first frame may arrive before the window exists;
-//! that's fine — the push path reads the window pointer from a
-//! `Mutex<Option<usize>>` and silently no-ops until init finishes.
+//! A floating, resizable miniature desktop that uses the host wallpaper and
+//! presents exact native windows and browser tabs as aspect-aware macOS-like
+//! windows. Existing lifecycle sessions group presentation only; Agent View
+//! never claims, moves, resizes, or closes the underlying targets.
 
-use std::ffi::c_void;
-use std::sync::Mutex;
+use std::ffi::{c_void, CStr};
+use std::sync::{Mutex, OnceLock};
 
-use pip_preview::{PipBackend, PipBackendFactory, PipConfig, PipFrame, PipViewModel};
-
-// ── CGColor objc2 encoding shim ────────────────────────────────────────────
-//
-// `[NSColor CGColor]` returns a `CGColorRef` whose Objective-C type encoding
-// is `^{CGColor=}`. objc2's strict msg_send! enforcement rejects bare
-// `*mut c_void` (`^v`) for both sides of that call. Declare a phantom
-// struct with the matching encoding so we can typed-cast through it
-// without pulling in a wider CGColor binding crate.
+use pip_preview::{
+    layout_desktop, png_dimensions, PipBackend, PipBackendFactory, PipConfig, PipFrame,
+    PipTargetKind, PipViewModel, TargetSize,
+};
 
 #[repr(C)]
 struct CGColor {
     _opaque: [u8; 0],
 }
 
-// RefEncode supplies an automatic Encode impl for `*mut CGColor` /
-// `*const CGColor` via objc2's blanket — that's the route msg_send! needs
-// for both setting layer.backgroundColor and reading [NSColor CGColor].
-// `ENCODING_REF` is the encoding for one level of indirection, so the
-// pointer wrap goes here (objc encoding `^{CGColor=}`).
 unsafe impl objc2::RefEncode for CGColor {
     const ENCODING_REF: objc2::Encoding =
         objc2::Encoding::Pointer(&objc2::Encoding::Struct("CGColor", &[]));
 }
 
-// ── Native AppKit pointer cell ─────────────────────────────────────────────
-//
-// Window, image view, and label pointers are stashed as `usize` so
-// `Send` works (raw `*mut AnyObject` is `!Send`). The actual deref +
-// `msg_send!` happens only on the main queue inside the dispatched
-// block, so there is no thread-safety hazard from the Send promise.
-
 struct NativeHandles {
     window: usize,
-    content_view: usize,
+    canvas_view: usize,
+    wallpaper_view: usize,
+    delegate: usize,
 }
 
 static HANDLES: Mutex<Option<NativeHandles>> = Mutex::new(None);
 static VIEW_MODEL: Mutex<Option<PipViewModel>> = Mutex::new(None);
-
-// ── libdispatch glue — same shape as cursor::overlay ──────────────────────
 
 #[link(name = "dispatch", kind = "dylib")]
 extern "C" {
@@ -103,15 +51,10 @@ fn dispatch_to_main<T: Send + 'static>(payload: T, cb: unsafe extern "C" fn(*mut
     }
 }
 
-// ── Backend impl ──────────────────────────────────────────────────────────
-
 pub struct MacosPipBackend;
 
 impl PipBackend for MacosPipBackend {
     fn push_frame(&self, frame: PipFrame) {
-        // No window yet? Drop the frame silently — start() dispatches
-        // the create block onto the main queue and the very first
-        // tool call can race that block.
         if HANDLES.lock().unwrap().is_none() {
             return;
         }
@@ -133,11 +76,7 @@ unsafe extern "C" fn push_frame_cb(ctx: *mut c_void) {
         let mut model = VIEW_MODEL.lock().unwrap();
         let model = model.get_or_insert_with(|| PipViewModel::new(12));
         model.upsert(frame);
-        model
-            .ordered_frames()
-            .into_iter()
-            .cloned()
-            .collect::<Vec<_>>()
+        clone_ordered_frames(model)
     };
     render_frames(&frames);
 }
@@ -148,13 +87,26 @@ unsafe extern "C" fn remove_workspace_cb(ctx: *mut c_void) {
         let mut model = VIEW_MODEL.lock().unwrap();
         let model = model.get_or_insert_with(|| PipViewModel::new(12));
         model.remove_workspace(&workspace_id);
-        model
-            .ordered_frames()
-            .into_iter()
-            .cloned()
-            .collect::<Vec<_>>()
+        clone_ordered_frames(model)
     };
     render_frames(&frames);
+}
+
+fn clone_ordered_frames(model: &PipViewModel) -> Vec<PipFrame> {
+    model
+        .ordered_frames()
+        .into_iter()
+        .cloned()
+        .collect::<Vec<_>>()
+}
+
+fn current_frames() -> Vec<PipFrame> {
+    VIEW_MODEL
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(clone_ordered_frames)
+        .unwrap_or_default()
 }
 
 unsafe fn ns_string(value: &str) -> *mut objc2::runtime::AnyObject {
@@ -170,13 +122,53 @@ unsafe fn ns_string(value: &str) -> *mut objc2::runtime::AnyObject {
     ]
 }
 
+unsafe fn rust_string(value: *mut objc2::runtime::AnyObject) -> Option<String> {
+    use objc2::msg_send;
+
+    if value.is_null() {
+        return None;
+    }
+    let utf8: *const std::os::raw::c_char = msg_send![value, UTF8String];
+    (!utf8.is_null()).then(|| CStr::from_ptr(utf8).to_string_lossy().into_owned())
+}
+
+#[derive(Clone, Copy)]
+enum LabelTone {
+    Light,
+    Muted,
+    Dark,
+}
+
+unsafe fn color(red: f64, green: f64, blue: f64, alpha: f64) -> *mut objc2::runtime::AnyObject {
+    use objc2::{class, msg_send};
+
+    msg_send![
+        class!(NSColor),
+        colorWithCalibratedRed: red
+        green: green
+        blue: blue
+        alpha: alpha
+    ]
+}
+
+unsafe fn set_layer_background(
+    layer: *mut objc2::runtime::AnyObject,
+    background: *mut objc2::runtime::AnyObject,
+) {
+    use objc2::msg_send;
+
+    let cg_color: *mut CGColor = msg_send![background, CGColor];
+    let _: () = msg_send![layer, setBackgroundColor: cg_color];
+}
+
 unsafe fn add_text_label(
     parent: *mut objc2::runtime::AnyObject,
     frame: objc2_foundation::NSRect,
     text: &str,
     font_size: f64,
     bold: bool,
-    secondary: bool,
+    tone: LabelTone,
+    alignment: u64,
 ) {
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
@@ -189,16 +181,13 @@ unsafe fn add_text_label(
     let _: () = msg_send![label, setDrawsBackground: false];
     let _: () = msg_send![label, setEditable: false];
     let _: () = msg_send![label, setSelectable: false];
-    let color: *mut AnyObject = if secondary {
-        msg_send![
-            class!(NSColor),
-            colorWithCalibratedWhite: 0.78_f64
-            alpha: 1.0_f64
-        ]
-    } else {
-        msg_send![class!(NSColor), whiteColor]
+    let _: () = msg_send![label, setAlignment: alignment];
+    let text_color = match tone {
+        LabelTone::Light => color(1.0, 1.0, 1.0, 0.95),
+        LabelTone::Muted => color(1.0, 1.0, 1.0, 0.66),
+        LabelTone::Dark => color(0.12, 0.13, 0.15, 0.94),
     };
-    let _: () = msg_send![label, setTextColor: color];
+    let _: () = msg_send![label, setTextColor: text_color];
     let font: *mut AnyObject = if bold {
         msg_send![class!(NSFont), boldSystemFontOfSize: font_size]
     } else {
@@ -212,142 +201,435 @@ unsafe fn add_text_label(
     let _: () = msg_send![parent, addSubview: label];
 }
 
+unsafe fn rounded_view(
+    frame: objc2_foundation::NSRect,
+    radius: f64,
+    background: *mut objc2::runtime::AnyObject,
+    clips: bool,
+) -> *mut objc2::runtime::AnyObject {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+
+    let view: *mut AnyObject = {
+        let alloc: *mut AnyObject = msg_send![class!(NSView), alloc];
+        msg_send![alloc, initWithFrame: frame]
+    };
+    let _: () = msg_send![view, setWantsLayer: true];
+    let layer: *mut AnyObject = msg_send![view, layer];
+    let _: () = msg_send![layer, setCornerRadius: radius];
+    let _: () = msg_send![layer, setMasksToBounds: clips];
+    set_layer_background(layer, background);
+    view
+}
+
+unsafe fn add_circle(
+    parent: *mut objc2::runtime::AnyObject,
+    x: f64,
+    y: f64,
+    diameter: f64,
+    fill: *mut objc2::runtime::AnyObject,
+) {
+    use objc2::msg_send;
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    let circle = rounded_view(
+        NSRect::new(NSPoint::new(x, y), NSSize::new(diameter, diameter)),
+        diameter / 2.0,
+        fill,
+        true,
+    );
+    let _: () = msg_send![parent, addSubview: circle];
+}
+
+fn appkit_rect(rect: pip_preview::LayoutRect, bounds_height: f64) -> objc2_foundation::NSRect {
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    NSRect::new(
+        NSPoint::new(rect.x, bounds_height - rect.y - rect.height),
+        NSSize::new(rect.width, rect.height),
+    )
+}
+
+fn parse_native_pid(target_id: &str) -> Option<i32> {
+    let mut parts = target_id.split(':');
+    (parts.next()? == "window")
+        .then(|| parts.next()?.parse::<i32>().ok())
+        .flatten()
+}
+
+fn truncate_label(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let prefix = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        format!("{prefix}...")
+    } else {
+        prefix
+    }
+}
+
+unsafe fn target_identity(frame: &PipFrame) -> (String, *mut objc2::runtime::AnyObject, char) {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+
+    if frame.target.target_kind == PipTargetKind::NativeWindow {
+        if let Some(pid) = parse_native_pid(&frame.target.target_id) {
+            let app: *mut AnyObject = msg_send![
+                class!(NSRunningApplication),
+                runningApplicationWithProcessIdentifier: pid
+            ];
+            if !app.is_null() {
+                let name: *mut AnyObject = msg_send![app, localizedName];
+                let icon: *mut AnyObject = msg_send![app, icon];
+                if let Some(name) = rust_string(name) {
+                    let fallback = name.chars().next().unwrap_or('A').to_ascii_uppercase();
+                    return (truncate_label(&name, 28), icon, fallback);
+                }
+            }
+        }
+    }
+
+    let label = match frame.target.target_kind {
+        PipTargetKind::BrowserTab => {
+            if frame.target.target_label.trim().is_empty() {
+                "Browser".to_owned()
+            } else {
+                truncate_label(&frame.target.target_label, 28)
+            }
+        }
+        PipTargetKind::NativeWindow => truncate_label(&frame.target.workspace_label, 28),
+    };
+    let fallback = match frame.target.target_kind {
+        PipTargetKind::BrowserTab => 'B',
+        PipTargetKind::NativeWindow => label.chars().next().unwrap_or('A').to_ascii_uppercase(),
+    };
+    (label, std::ptr::null_mut(), fallback)
+}
+
+unsafe fn image_from_png(bytes: &[u8]) -> *mut objc2::runtime::AnyObject {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+
+    let data: *mut AnyObject = msg_send![
+        class!(NSData),
+        dataWithBytes: bytes.as_ptr() as *const c_void
+        length: bytes.len()
+    ];
+    if data.is_null() {
+        return std::ptr::null_mut();
+    }
+    let alloc: *mut AnyObject = msg_send![class!(NSImage), alloc];
+    msg_send![alloc, initWithData: data]
+}
+
+fn current_time_label() -> String {
+    unsafe {
+        let timestamp = libc::time(std::ptr::null_mut());
+        let mut local: libc::tm = std::mem::zeroed();
+        if libc::localtime_r(&timestamp, &mut local).is_null() {
+            return "--:--".to_owned();
+        }
+        format!("{:02}:{:02}", local.tm_hour, local.tm_min)
+    }
+}
+
+unsafe fn render_menu_bar(canvas: *mut objc2::runtime::AnyObject, frame: objc2_foundation::NSRect) {
+    use objc2::msg_send;
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    let bar = rounded_view(frame, 0.0, color(0.03, 0.05, 0.08, 0.68), false);
+    let text_height = frame.size.height.min(22.0);
+    add_text_label(
+        bar,
+        NSRect::new(
+            NSPoint::new(10.0, (frame.size.height - text_height) / 2.0 - 1.0),
+            NSSize::new((frame.size.width - 90.0).max(20.0), text_height),
+        ),
+        "Cua   File   View   Window",
+        9.5,
+        true,
+        LabelTone::Light,
+        0,
+    );
+    add_text_label(
+        bar,
+        NSRect::new(
+            NSPoint::new(
+                (frame.size.width - 68.0).max(0.0),
+                (frame.size.height - text_height) / 2.0 - 1.0,
+            ),
+            NSSize::new(58.0, text_height),
+        ),
+        &current_time_label(),
+        9.5,
+        false,
+        LabelTone::Light,
+        2,
+    );
+    let _: () = msg_send![canvas, addSubview: bar];
+}
+
+unsafe fn render_target_window(
+    canvas: *mut objc2::runtime::AnyObject,
+    frame: &PipFrame,
+    layout: pip_preview::TargetLayout,
+    bounds_height: f64,
+) {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    let window_frame = appkit_rect(layout.window, bounds_height);
+    let shadow: *mut AnyObject = {
+        let alloc: *mut AnyObject = msg_send![class!(NSView), alloc];
+        msg_send![alloc, initWithFrame: window_frame]
+    };
+    let _: () = msg_send![shadow, setWantsLayer: true];
+    let shadow_layer: *mut AnyObject = msg_send![shadow, layer];
+    let _: () = msg_send![shadow_layer, setShadowOpacity: 0.34_f32];
+    let _: () = msg_send![shadow_layer, setShadowRadius: 8.0_f64];
+    let _: () = msg_send![shadow_layer, setShadowOffset: NSSize::new(0.0, -3.0)];
+    let black = color(0.0, 0.0, 0.0, 0.75);
+    let black_cg: *mut CGColor = msg_send![black, CGColor];
+    let _: () = msg_send![shadow_layer, setShadowColor: black_cg];
+
+    let window = rounded_view(
+        NSRect::new(
+            NSPoint::new(0.0, 0.0),
+            NSSize::new(window_frame.size.width, window_frame.size.height),
+        ),
+        7.0,
+        color(0.96, 0.96, 0.97, 1.0),
+        true,
+    );
+    let title_height = layout.title_bar_height.min(window_frame.size.height);
+    let title_bar = rounded_view(
+        NSRect::new(
+            NSPoint::new(0.0, window_frame.size.height - title_height),
+            NSSize::new(window_frame.size.width, title_height),
+        ),
+        0.0,
+        color(0.94, 0.94, 0.95, 0.98),
+        false,
+    );
+    let separator = rounded_view(
+        NSRect::new(
+            NSPoint::new(0.0, window_frame.size.height - title_height),
+            NSSize::new(window_frame.size.width, 0.7),
+        ),
+        0.0,
+        color(1.0, 1.0, 1.0, 0.18),
+        false,
+    );
+    let traffic_size = title_height.clamp(5.5, 8.5) * 0.72;
+    let traffic_y = (title_height - traffic_size) / 2.0;
+    for (index, fill) in [
+        color(1.0, 0.32, 0.28, 1.0),
+        color(1.0, 0.72, 0.18, 1.0),
+        color(0.18, 0.76, 0.31, 1.0),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        add_circle(
+            title_bar,
+            8.0 + index as f64 * (traffic_size + 4.0),
+            traffic_y,
+            traffic_size,
+            fill,
+        );
+    }
+
+    let (title, _, _) = target_identity(frame);
+    add_text_label(
+        title_bar,
+        NSRect::new(
+            NSPoint::new(38.0, (title_height - 16.0) / 2.0 - 1.0),
+            NSSize::new((window_frame.size.width - 76.0).max(20.0), 16.0),
+        ),
+        &title,
+        title_height.clamp(8.0, 11.0) * 0.88,
+        false,
+        LabelTone::Dark,
+        1,
+    );
+
+    let content_height = (window_frame.size.height - title_height).max(1.0);
+    let image_view: *mut AnyObject = {
+        let alloc: *mut AnyObject = msg_send![class!(NSImageView), alloc];
+        msg_send![
+            alloc,
+            initWithFrame: NSRect::new(
+                NSPoint::new(0.0, 0.0),
+                NSSize::new(window_frame.size.width, content_height),
+            )
+        ]
+    };
+    let _: () = msg_send![image_view, setImageScaling: 3u64];
+    let image = image_from_png(&frame.png_bytes);
+    if !image.is_null() {
+        let _: () = msg_send![image_view, setImage: image];
+    }
+    let _: () = msg_send![window, addSubview: image_view];
+    let _: () = msg_send![window, addSubview: title_bar];
+    let _: () = msg_send![window, addSubview: separator];
+    let _: () = msg_send![shadow, addSubview: window];
+    let _: () = msg_send![canvas, addSubview: shadow];
+}
+
+unsafe fn render_dock(
+    canvas: *mut objc2::runtime::AnyObject,
+    frames: &[PipFrame],
+    layout: &pip_preview::DesktopLayout,
+    bounds_height: f64,
+) {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    let dock_frame = appkit_rect(layout.dock, bounds_height);
+    let dock = rounded_view(
+        dock_frame,
+        dock_frame.size.height * 0.24,
+        color(0.04, 0.06, 0.08, 0.66),
+        true,
+    );
+
+    for (frame, icon_layout) in frames.iter().zip(layout.dock_icons.iter()) {
+        let icon_global = appkit_rect(*icon_layout, bounds_height);
+        let icon_frame = NSRect::new(
+            NSPoint::new(
+                icon_global.origin.x - dock_frame.origin.x,
+                icon_global.origin.y - dock_frame.origin.y,
+            ),
+            icon_global.size,
+        );
+        let tile = rounded_view(
+            icon_frame,
+            icon_frame.size.width * 0.22,
+            color(0.98, 0.98, 0.99, 0.92),
+            true,
+        );
+        let (_, icon, fallback) = target_identity(frame);
+        if icon.is_null() {
+            add_text_label(
+                tile,
+                NSRect::new(
+                    NSPoint::new(0.0, (icon_frame.size.height - 24.0) / 2.0),
+                    NSSize::new(icon_frame.size.width, 24.0),
+                ),
+                &fallback.to_string(),
+                (icon_frame.size.width * 0.46).clamp(12.0, 22.0),
+                true,
+                LabelTone::Dark,
+                1,
+            );
+        } else {
+            let image_view: *mut AnyObject = {
+                let alloc: *mut AnyObject = msg_send![class!(NSImageView), alloc];
+                msg_send![
+                    alloc,
+                    initWithFrame: NSRect::new(
+                        NSPoint::new(3.0, 3.0),
+                        NSSize::new(
+                            (icon_frame.size.width - 6.0).max(1.0),
+                            (icon_frame.size.height - 6.0).max(1.0),
+                        ),
+                    )
+                ]
+            };
+            let _: () = msg_send![image_view, setImageScaling: 3u64];
+            let _: () = msg_send![image_view, setImage: icon];
+            let _: () = msg_send![tile, addSubview: image_view];
+        }
+        let _: () = msg_send![dock, addSubview: tile];
+
+        let dot_size = 4.0_f64.min(icon_frame.size.width * 0.12);
+        let dot_x =
+            icon_frame.origin.x - dock_frame.origin.x + (icon_frame.size.width - dot_size) / 2.0;
+        add_circle(dock, dot_x, 2.0, dot_size, color(0.20, 0.87, 0.42, 1.0));
+    }
+    let _: () = msg_send![canvas, addSubview: dock];
+}
+
+unsafe fn render_resize_affordance(canvas: *mut objc2::runtime::AnyObject, width: f64) {
+    use objc2::msg_send;
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    let marker = color(1.0, 1.0, 1.0, 0.55);
+    let horizontal = rounded_view(
+        NSRect::new(
+            NSPoint::new((width - 14.0).max(0.0), 4.0),
+            NSSize::new(9.0, 1.5),
+        ),
+        0.75,
+        marker,
+        false,
+    );
+    let vertical = rounded_view(
+        NSRect::new(
+            NSPoint::new((width - 5.5).max(0.0), 4.0),
+            NSSize::new(1.5, 9.0),
+        ),
+        0.75,
+        marker,
+        false,
+    );
+    let _: () = msg_send![canvas, addSubview: horizontal];
+    let _: () = msg_send![canvas, addSubview: vertical];
+}
+
 unsafe fn render_frames(frames: &[PipFrame]) {
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
     use objc2_foundation::{NSPoint, NSRect, NSSize};
 
-    let content_view = {
+    let canvas = {
         let guard = HANDLES.lock().unwrap();
         match guard.as_ref() {
-            Some(handles) => handles.content_view as *mut AnyObject,
+            Some(handles) => handles.canvas_view as *mut AnyObject,
             None => return,
         }
     };
     let empty: *mut AnyObject = msg_send![class!(NSArray), array];
-    let _: () = msg_send![content_view, setSubviews: empty];
+    let _: () = msg_send![canvas, setSubviews: empty];
 
-    let bounds: NSRect = msg_send![content_view, bounds];
+    let bounds: NSRect = msg_send![canvas, bounds];
+    let target_sizes = frames
+        .iter()
+        .map(|frame| {
+            png_dimensions(&frame.png_bytes).unwrap_or(TargetSize {
+                width: 16,
+                height: 10,
+            })
+        })
+        .collect::<Vec<_>>();
+    let layout = layout_desktop(bounds.size.width, bounds.size.height, &target_sizes);
+    render_menu_bar(canvas, appkit_rect(layout.menu_bar, bounds.size.height));
+
     if frames.is_empty() {
+        let waiting = appkit_rect(layout.desktop, bounds.size.height);
         add_text_label(
-            content_view,
+            canvas,
             NSRect::new(
-                NSPoint::new(16.0, (bounds.size.height - 24.0) / 2.0),
-                NSSize::new((bounds.size.width - 32.0).max(40.0), 24.0),
+                NSPoint::new(
+                    waiting.origin.x + 16.0,
+                    waiting.origin.y + waiting.size.height / 2.0 - 12.0,
+                ),
+                NSSize::new((waiting.size.width - 32.0).max(40.0), 24.0),
             ),
             "Waiting for an exact window or browser tab...",
             12.0,
             false,
-            true,
+            LabelTone::Muted,
+            1,
         );
-        return;
-    }
-
-    let count = frames.len();
-    let cols = match count {
-        1 => 1,
-        2..=4 => 2,
-        _ => 3,
-    };
-    let rows = count.div_ceil(cols);
-    let gap = 6.0_f64;
-    let card_width = ((bounds.size.width - gap * (cols as f64 + 1.0)) / cols as f64).max(40.0);
-    let card_height = ((bounds.size.height - gap * (rows as f64 + 1.0)) / rows as f64).max(40.0);
-    let header_height = 20.0_f64.min(card_height * 0.22);
-    let footer_height = 19.0_f64.min(card_height * 0.20);
-
-    for (index, frame) in frames.iter().enumerate() {
-        let col = index % cols;
-        let row = index / cols;
-        let x = gap + col as f64 * (card_width + gap);
-        let y = bounds.size.height - gap - (row as f64 + 1.0) * card_height - row as f64 * gap;
-        let card_rect = NSRect::new(NSPoint::new(x, y), NSSize::new(card_width, card_height));
-        let card: *mut AnyObject = {
-            let alloc: *mut AnyObject = msg_send![class!(NSView), alloc];
-            msg_send![alloc, initWithFrame: card_rect]
-        };
-        let _: () = msg_send![card, setWantsLayer: true];
-        let layer: *mut AnyObject = msg_send![card, layer];
-        let _: () = msg_send![layer, setCornerRadius: 9.0_f64];
-        let _: () = msg_send![layer, setMasksToBounds: true];
-        let bg: *mut AnyObject = msg_send![
-            class!(NSColor),
-            colorWithCalibratedRed: 0.055_f64
-            green: 0.065_f64
-            blue: 0.075_f64
-            alpha: 1.0_f64
-        ];
-        let bg_cg: *mut CGColor = msg_send![bg, CGColor];
-        let _: () = msg_send![layer, setBackgroundColor: bg_cg];
-        let accent: *mut AnyObject = match frame.target.target_kind {
-            pip_preview::PipTargetKind::BrowserTab => msg_send![
-                class!(NSColor),
-                colorWithCalibratedRed: 0.15_f64
-                green: 0.78_f64
-                blue: 0.65_f64
-                alpha: 0.95_f64
-            ],
-            pip_preview::PipTargetKind::NativeWindow => msg_send![
-                class!(NSColor),
-                colorWithCalibratedRed: 0.98_f64
-                green: 0.52_f64
-                blue: 0.20_f64
-                alpha: 0.95_f64
-            ],
-        };
-        let accent_cg: *mut CGColor = msg_send![accent, CGColor];
-        let _: () = msg_send![layer, setBorderColor: accent_cg];
-        let _: () = msg_send![layer, setBorderWidth: 1.5_f64];
-
-        let image_height = (card_height - header_height - footer_height).max(1.0);
-        let image_rect = NSRect::new(
-            NSPoint::new(0.0, footer_height),
-            NSSize::new(card_width, image_height),
-        );
-        let image_view: *mut AnyObject = {
-            let alloc: *mut AnyObject = msg_send![class!(NSImageView), alloc];
-            msg_send![alloc, initWithFrame: image_rect]
-        };
-        let _: () = msg_send![image_view, setImageScaling: 3u64];
-        let ns_data: *mut AnyObject = msg_send![
-            class!(NSData),
-            dataWithBytes: frame.png_bytes.as_ptr() as *const c_void
-            length: frame.png_bytes.len()
-        ];
-        if !ns_data.is_null() {
-            let alloc: *mut AnyObject = msg_send![class!(NSImage), alloc];
-            let image: *mut AnyObject = msg_send![alloc, initWithData: ns_data];
-            if !image.is_null() {
-                let _: () = msg_send![image_view, setImage: image];
-            }
+    } else {
+        for (frame, target_layout) in frames.iter().zip(layout.targets.iter().copied()) {
+            render_target_window(canvas, frame, target_layout, bounds.size.height);
         }
-        let _: () = msg_send![card, addSubview: image_view];
-
-        add_text_label(
-            card,
-            NSRect::new(
-                NSPoint::new(8.0, card_height - header_height),
-                NSSize::new((card_width - 16.0).max(20.0), header_height),
-            ),
-            &frame.target.workspace_label,
-            10.5,
-            true,
-            false,
-        );
-        let footer = format!("{} · {}", frame.target.target_label, frame.action_label);
-        add_text_label(
-            card,
-            NSRect::new(
-                NSPoint::new(8.0, 0.0),
-                NSSize::new((card_width - 16.0).max(20.0), footer_height),
-            ),
-            &footer,
-            9.5,
-            false,
-            true,
-        );
-        let _: () = msg_send![content_view, addSubview: card];
+        render_dock(canvas, frames, &layout, bounds.size.height);
     }
+    render_resize_affordance(canvas, bounds.size.width);
 }
 
 unsafe extern "C" fn shutdown_cb(_ctx: *mut c_void) {
@@ -356,27 +638,57 @@ unsafe extern "C" fn shutdown_cb(_ctx: *mut c_void) {
 
     let handles = HANDLES.lock().unwrap().take();
     VIEW_MODEL.lock().unwrap().take();
-    if let Some(h) = handles {
-        let win = h.window as *mut AnyObject;
-        if !win.is_null() {
-            let _: () = msg_send![win, orderOut: std::ptr::null_mut::<AnyObject>()];
-            let _: () = msg_send![win, close];
-        }
+    if let Some(handles) = handles {
+        let window = handles.window as *mut AnyObject;
+        let _: () = msg_send![window, setDelegate: std::ptr::null_mut::<AnyObject>()];
+        let _: () = msg_send![window, orderOut: std::ptr::null_mut::<AnyObject>()];
+        let _: () = msg_send![window, close];
+        let _ = handles.delegate;
     }
 }
 
-// ── AppKit main loop helper for Serve mode ───────────────────────────────
+fn agent_view_delegate_class() -> &'static objc2::runtime::AnyClass {
+    use objc2::class;
+    use objc2::declare::ClassBuilder;
 
-/// Park the main thread in `NSApplication.run()`. Used by `cua-driver
-/// serve --agent-view` so the dispatch_async_f → main queue
-/// path PiP frames go through can be drained. Mirrors the cursor
-/// overlay's `run_appkit` startup (Accessory activation policy →
-/// finishLaunching → run) without installing the overlay's
-/// CALayer-backed window itself.
-///
-/// Never returns — the background `serve::run_serve_cmd` thread calls
-/// `std::process::exit` when it finishes, which tears down NSApp at
-/// the same time.
+    static CLASS: OnceLock<&'static objc2::runtime::AnyClass> = OnceLock::new();
+    CLASS.get_or_init(|| {
+        let superclass = class!(NSObject);
+        let mut builder = ClassBuilder::new("CuaDriverAgentViewDelegate", superclass)
+            .expect("CuaDriverAgentViewDelegate already registered");
+        unsafe {
+            builder.add_method(
+                objc2::sel!(windowDidResize:),
+                on_window_did_resize as extern "C" fn(_, _, _),
+            );
+        }
+        builder.register()
+    })
+}
+
+unsafe fn agent_view_delegate_instance() -> *mut objc2::runtime::AnyObject {
+    use objc2::msg_send;
+    use objc2::runtime::AnyObject;
+
+    let class = agent_view_delegate_class();
+    let allocated: *mut AnyObject = msg_send![class, alloc];
+    msg_send![allocated, init]
+}
+
+extern "C" fn on_window_did_resize(
+    _delegate: *mut objc2::runtime::AnyObject,
+    _selector: objc2::runtime::Sel,
+    _notification: *mut objc2::runtime::AnyObject,
+) {
+    let frames = current_frames();
+    unsafe {
+        update_wallpaper_frame();
+        render_frames(&frames);
+    };
+}
+
+/// Park the main thread in `NSApplication.run()` for the main-queue AppKit
+/// work used by Agent View when the cursor overlay is disabled.
 pub fn run_appkit_main_loop() {
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
@@ -385,29 +697,97 @@ pub fn run_appkit_main_loop() {
         .expect("run_appkit_main_loop must be called from the main thread");
     unsafe {
         let app: *mut AnyObject = msg_send![class!(NSApplication), sharedApplication];
-        // Accessory policy: no Dock icon, no menu bar. Keeps the
-        // daemon out of the user's application switcher, same as
-        // the cursor overlay's NSApp setup.
         let _: bool = msg_send![app, setActivationPolicy: 1i64];
         let _: () = msg_send![app, finishLaunching];
         let _: () = msg_send![app, run];
     }
 }
 
-// ── Factory ──────────────────────────────────────────────────────────────
-
 pub struct MacosPipBackendFactory;
 
 impl PipBackendFactory for MacosPipBackendFactory {
     fn start(&self, cfg: &PipConfig) -> anyhow::Result<Box<dyn PipBackend>> {
-        // Window construction must happen on the main thread. We hand
-        // off via dispatch_async_f and return immediately — the first
-        // few frames may be dropped while init races, which is fine
-        // for a live-preview UX.
-        let cfg_clone = cfg.clone();
-        dispatch_to_main(cfg_clone, init_cb);
+        dispatch_to_main(cfg.clone(), init_cb);
         Ok(Box::new(MacosPipBackend))
     }
+}
+
+unsafe fn install_wallpaper(
+    content_view: *mut objc2::runtime::AnyObject,
+    screen: *mut objc2::runtime::AnyObject,
+    bounds: objc2_foundation::NSRect,
+) -> *mut objc2::runtime::AnyObject {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+
+    let wallpaper_view: *mut AnyObject = {
+        let allocated: *mut AnyObject = msg_send![class!(NSImageView), alloc];
+        msg_send![allocated, initWithFrame: bounds]
+    };
+    let _: () = msg_send![wallpaper_view, setImageScaling: 2u64];
+    let workspace: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+    let url: *mut AnyObject = msg_send![workspace, desktopImageURLForScreen: screen];
+    if !url.is_null() {
+        let allocated: *mut AnyObject = msg_send![class!(NSImage), alloc];
+        let wallpaper: *mut AnyObject = msg_send![allocated, initWithContentsOfURL: url];
+        if !wallpaper.is_null() {
+            let _: () = msg_send![wallpaper_view, setImage: wallpaper];
+        }
+    }
+    let _: () = msg_send![content_view, addSubview: wallpaper_view];
+
+    let tint = rounded_view(bounds, 0.0, color(0.01, 0.03, 0.05, 0.10), false);
+    let _: () = msg_send![tint, setAutoresizingMask: 18u64];
+    let _: () = msg_send![content_view, addSubview: tint];
+
+    wallpaper_view
+}
+
+fn aspect_fill_frame(
+    bounds: objc2_foundation::NSRect,
+    image_size: objc2_foundation::NSSize,
+) -> objc2_foundation::NSRect {
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    if image_size.width <= 0.0 || image_size.height <= 0.0 {
+        return bounds;
+    }
+    let scale = (bounds.size.width / image_size.width).max(bounds.size.height / image_size.height);
+    let width = image_size.width * scale;
+    let height = image_size.height * scale;
+    NSRect::new(
+        NSPoint::new(
+            bounds.origin.x + (bounds.size.width - width) / 2.0,
+            bounds.origin.y + (bounds.size.height - height) / 2.0,
+        ),
+        NSSize::new(width, height),
+    )
+}
+
+unsafe fn update_wallpaper_frame() {
+    use objc2::msg_send;
+    use objc2::runtime::AnyObject;
+    use objc2_foundation::{NSRect, NSSize};
+
+    let (canvas, wallpaper_view) = {
+        let guard = HANDLES.lock().unwrap();
+        let Some(handles) = guard.as_ref() else {
+            return;
+        };
+        (
+            handles.canvas_view as *mut AnyObject,
+            handles.wallpaper_view as *mut AnyObject,
+        )
+    };
+    let bounds: NSRect = msg_send![canvas, bounds];
+    let image: *mut AnyObject = msg_send![wallpaper_view, image];
+    let image_size = if image.is_null() {
+        NSSize::new(0.0, 0.0)
+    } else {
+        msg_send![image, size]
+    };
+    let frame = aspect_fill_frame(bounds, image_size);
+    let _: () = msg_send![wallpaper_view, setFrame: frame];
 }
 
 unsafe extern "C" fn init_cb(ctx: *mut c_void) {
@@ -416,113 +796,133 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     use objc2_foundation::{NSPoint, NSRect, NSSize};
 
     let cfg: PipConfig = *Box::from_raw(ctx as *mut PipConfig);
-
-    // Idempotency guard — `start()` should only be called once per
-    // process, but cheap to defend against duplicate calls.
     if HANDLES.lock().unwrap().is_some() {
         return;
     }
 
-    // ── Resolve geometry ──
-    // AppKit windows use a bottom-left origin in screen coordinates.
-    // The CLI flag uses a top-left X11-style origin (since that's the
-    // mental model agents have for screenshots). Flip Y here so a
-    // `+0+0` flag puts the window in the top-left corner.
     let screen: *mut AnyObject = msg_send![class!(NSScreen), mainScreen];
     if screen.is_null() {
-        // Headless environment (CI) — skip silently. The daemon keeps
-        // running without a PiP window.
         return;
     }
     let screen_frame: NSRect = msg_send![screen, frame];
-
-    let w = cfg.geometry.width as f64;
-    let h = cfg.geometry.height as f64;
-    // Default placement: top-right corner with a 24pt inset, mirroring
-    // the macOS conventions for floating utility windows.
+    let minimum = NSSize::new(360.0, 260.0);
+    let width = (cfg.geometry.width as f64).max(minimum.width);
+    let height = (cfg.geometry.height as f64).max(minimum.height);
     let inset = 24.0_f64;
     let (top_left_x, top_left_y) = match (cfg.geometry.x, cfg.geometry.y) {
         (Some(x), Some(y)) => (x as f64, y as f64),
-        _ => (screen_frame.size.width - w - inset, inset),
+        _ => (screen_frame.size.width - width - inset, inset),
     };
-    // Convert top-left → bottom-left for AppKit.
-    let bottom_y = screen_frame.size.height - top_left_y - h;
-    let rect = NSRect::new(NSPoint::new(top_left_x, bottom_y), NSSize::new(w, h));
+    let bottom_y = screen_frame.size.height - top_left_y - height;
+    let rect = NSRect::new(
+        NSPoint::new(top_left_x, bottom_y),
+        NSSize::new(width, height),
+    );
 
-    // ── NSWindow ──
-    // Borderless so the image owns the whole rectangle. No close button
-    // / title bar — the window is owned by the daemon session lifecycle.
-    // The rounded-corner look comes from a CALayer-backed content view
-    // with cornerRadius + masksToBounds; the window itself stays
-    // transparent outside the rounded rect.
-    //   NSWindowStyleMaskBorderless = 0
-    let style_mask: u64 = 0;
+    let style_mask: u64 = (1 << 3) | (1 << 7);
     let backing_store_buffered: u64 = 2;
-    let win: *mut AnyObject = {
-        let alloc: *mut AnyObject = msg_send![class!(NSWindow), alloc];
+    let window: *mut AnyObject = {
+        let allocated: *mut AnyObject = msg_send![class!(NSPanel), alloc];
         msg_send![
-            alloc,
+            allocated,
             initWithContentRect: rect
             styleMask: style_mask
             backing: backing_store_buffered
             defer: false
         ]
     };
-    if win.is_null() {
+    if window.is_null() {
         return;
     }
 
-    // Transparent backing so the corners outside the CALayer-clipped
-    // content view show whatever's underneath — gives the floating-pill
-    // look. The shadow comes from AppKit's default `hasShadow: true`.
     let clear: *mut AnyObject = msg_send![class!(NSColor), clearColor];
-    let _: () = msg_send![win, setBackgroundColor: clear];
-    let _: () = msg_send![win, setOpaque: false];
-    let _: () = msg_send![win, setHasShadow: true];
-    // Draggable from anywhere since there's no title bar.
-    let _: () = msg_send![win, setMovableByWindowBackground: true];
-
-    // Floating window level (NSFloatingWindowLevel = 3).
-    let _: () = msg_send![win, setLevel: 3i64];
-
-    // Collection behavior: visible across all spaces, no Mission
-    // Control affordance, never the main / key window.
-    // 1<<0 CanJoinAllSpaces | 1<<4 Stationary | 1<<8 FullScreenAuxiliary
-    // 1<<6 Transient | 1<<7 IgnoresCycle
+    let _: () = msg_send![window, setBackgroundColor: clear];
+    let _: () = msg_send![window, setOpaque: false];
+    let _: () = msg_send![window, setHasShadow: true];
+    let _: () = msg_send![window, setMovableByWindowBackground: true];
+    let _: () = msg_send![window, setIgnoresMouseEvents: false];
+    let _: () = msg_send![window, setBecomesKeyOnlyIfNeeded: true];
+    let _: () = msg_send![window, setFloatingPanel: true];
+    let _: () = msg_send![window, setLevel: 3i64];
+    let _: () = msg_send![window, setMinSize: minimum];
     let behavior: u64 = (1 << 0) | (1 << 4) | (1 << 8) | (1 << 6) | (1 << 7);
-    let _: () = msg_send![win, setCollectionBehavior: behavior];
+    let _: () = msg_send![window, setCollectionBehavior: behavior];
+    let _: () = msg_send![window, setReleasedWhenClosed: false];
+    let _: () = msg_send![window, setHidesOnDeactivate: false];
 
-    let _: () = msg_send![win, setReleasedWhenClosed: false];
-    let _: () = msg_send![win, setHidesOnDeactivate: false];
-
-    // ── Content view: rounded-corner black backing ──
-    // wantsLayer + masksToBounds clips the image view to the rounded
-    // rect. The backing CALayer color shows wherever the (proportionally
-    // scaled) image leaves gaps above/below or left/right.
-    let content_view: *mut AnyObject = msg_send![win, contentView];
+    let content_view: *mut AnyObject = msg_send![window, contentView];
     let _: () = msg_send![content_view, setWantsLayer: true];
     let content_layer: *mut AnyObject = msg_send![content_view, layer];
-    let _: () = msg_send![content_layer, setCornerRadius: 12.0_f64];
+    let _: () = msg_send![content_layer, setCornerRadius: 13.0_f64];
     let _: () = msg_send![content_layer, setMasksToBounds: true];
-    let black: *mut AnyObject = msg_send![
-        class!(NSColor),
-        colorWithCalibratedRed: 0.0_f64
-        green: 0.0_f64
-        blue: 0.0_f64
-        alpha: 1.0_f64
-    ];
-    let black_cg: *mut CGColor = msg_send![black, CGColor];
-    let _: () = msg_send![content_layer, setBackgroundColor: black_cg];
+    set_layer_background(content_layer, color(0.02, 0.04, 0.06, 1.0));
+    let bounds: NSRect = msg_send![content_view, bounds];
+    let wallpaper_view = install_wallpaper(content_view, screen, bounds);
 
-    // Show the window without making it key or activating the app.
-    let _: () = msg_send![win, orderFrontRegardless];
+    let canvas: *mut AnyObject = {
+        let allocated: *mut AnyObject = msg_send![class!(NSView), alloc];
+        msg_send![allocated, initWithFrame: bounds]
+    };
+    let _: () = msg_send![canvas, setAutoresizingMask: 18u64];
+    let _: () = msg_send![content_view, addSubview: canvas];
 
+    let delegate = agent_view_delegate_instance();
+    let _: () = msg_send![window, setDelegate: delegate];
     *HANDLES.lock().unwrap() = Some(NativeHandles {
-        window: win as usize,
-        content_view: content_view as usize,
+        window: window as usize,
+        canvas_view: canvas as usize,
+        wallpaper_view: wallpaper_view as usize,
+        delegate: delegate as usize,
     });
     *VIEW_MODEL.lock().unwrap() = Some(PipViewModel::new(12));
+    update_wallpaper_frame();
     render_frames(&[]);
+    let _: () = msg_send![window, orderFrontRegardless];
 
-    tracing::info!(target: "pip", "Agent View initialised ({}x{})", cfg.geometry.width, cfg.geometry.height);
+    tracing::info!(
+        target: "pip",
+        "Agent View miniature desktop initialised ({}x{})",
+        width,
+        height
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_native_pid_from_exact_window_target() {
+        assert_eq!(parse_native_pid("window:501:90210"), Some(501));
+        assert_eq!(parse_native_pid("browser:target:tab"), None);
+        assert_eq!(parse_native_pid("window:not-a-pid:7"), None);
+    }
+
+    #[test]
+    fn truncates_long_titles_without_touching_short_ones() {
+        assert_eq!(truncate_label("Calculator", 28), "Calculator");
+        assert_eq!(
+            truncate_label("abcdefghijklmnopqrstuvwxyz", 8),
+            "abcdefgh..."
+        );
+    }
+
+    #[test]
+    fn aspect_fill_centers_and_crops_without_distortion() {
+        use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+        let wide = aspect_fill_frame(
+            NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(640.0, 420.0)),
+            NSSize::new(1440.0, 900.0),
+        );
+        assert_eq!(wide.size, NSSize::new(672.0, 420.0));
+        assert_eq!(wide.origin, NSPoint::new(-16.0, 0.0));
+
+        let tall = aspect_fill_frame(
+            NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(380.0, 660.0)),
+            NSSize::new(1440.0, 900.0),
+        );
+        assert_eq!(tall.size, NSSize::new(1056.0, 660.0));
+        assert_eq!(tall.origin, NSPoint::new(-338.0, 0.0));
+    }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -6,7 +6,8 @@
 //! never claims, moves, resizes, or closes the underlying targets.
 
 use std::ffi::{c_void, CStr};
-use std::sync::{Mutex, OnceLock};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use pip_preview::{
     layout_desktop, png_dimensions, PipBackend, PipBackendFactory, PipConfig, PipFrame,
@@ -81,6 +82,11 @@ fn dispatch_to_main_sync<T>(payload: T, cb: unsafe extern "C" fn(*mut c_void)) {
 
 pub struct MacosPipBackend;
 
+struct InputPassthroughRequest {
+    passthrough: bool,
+    applied: Arc<AtomicBool>,
+}
+
 impl PipBackend for MacosPipBackend {
     fn push_frame(&self, frame: PipFrame) {
         if HANDLES.lock().unwrap().is_none() {
@@ -101,7 +107,17 @@ impl PipBackend for MacosPipBackend {
     }
 
     fn set_input_passthrough(&self, passthrough: bool) -> anyhow::Result<()> {
-        dispatch_to_main_sync(passthrough, set_input_passthrough_cb);
+        let applied = Arc::new(AtomicBool::new(false));
+        dispatch_to_main_sync(
+            InputPassthroughRequest {
+                passthrough,
+                applied: Arc::clone(&applied),
+            },
+            set_input_passthrough_cb,
+        );
+        if !applied.load(Ordering::Acquire) {
+            anyhow::bail!("Agent View window is not running");
+        }
         Ok(())
     }
 
@@ -114,11 +130,12 @@ unsafe extern "C" fn set_input_passthrough_cb(ctx: *mut c_void) {
     use objc2::msg_send;
     use objc2::runtime::AnyObject;
 
-    let passthrough: bool = *Box::from_raw(ctx as *mut bool);
+    let request: InputPassthroughRequest = *Box::from_raw(ctx as *mut InputPassthroughRequest);
     let handles = HANDLES.lock().unwrap();
     if let Some(handles) = handles.as_ref() {
         let window = handles.window as *mut AnyObject;
-        let _: () = msg_send![window, setIgnoresMouseEvents: passthrough];
+        let _: () = msg_send![window, setIgnoresMouseEvents: request.passthrough];
+        request.applied.store(true, Ordering::Release);
     }
 }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -368,7 +368,7 @@ unsafe extern "C" fn shutdown_cb(_ctx: *mut c_void) {
 // ── AppKit main loop helper for Serve mode ───────────────────────────────
 
 /// Park the main thread in `NSApplication.run()`. Used by `cua-driver
-/// serve --experimental-pip` so the dispatch_async_f → main queue
+/// serve --agent-view` so the dispatch_async_f → main queue
 /// path PiP frames go through can be drained. Mirrors the cursor
 /// overlay's `run_appkit` startup (Accessory activation policy →
 /// finishLaunching → run) without installing the overlay's

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -255,6 +255,49 @@ unsafe fn rounded_view(
     view
 }
 
+/// A layer-hosting view whose backing layer is a vertical `CAGradientLayer`.
+///
+/// The chrome body needs a top-to-bottom falloff to read as a lit glass
+/// surface rather than as a flat outline. AppKit keeps a view-assigned layer
+/// sized to its view, so this survives live resize without a manual pass.
+/// Layer-hosting views must not take subviews; overlay strips go on the
+/// enclosing chrome view instead.
+unsafe fn gradient_view(
+    frame: objc2_foundation::NSRect,
+    radius: f64,
+    top: *mut objc2::runtime::AnyObject,
+    bottom: *mut objc2::runtime::AnyObject,
+) -> *mut objc2::runtime::AnyObject {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+
+    let view: *mut AnyObject = {
+        let alloc: *mut AnyObject = msg_send![class!(NSView), alloc];
+        msg_send![alloc, initWithFrame: frame]
+    };
+    let layer: *mut AnyObject = {
+        let alloc: *mut AnyObject = msg_send![class!(CAGradientLayer), alloc];
+        msg_send![alloc, init]
+    };
+    let top_cg: *mut CGColor = msg_send![top, CGColor];
+    let bottom_cg: *mut CGColor = msg_send![bottom, CGColor];
+    let stops: [*mut CGColor; 2] = [top_cg, bottom_cg];
+    let colors: *mut AnyObject = msg_send![
+        class!(NSArray),
+        arrayWithObjects: stops.as_ptr() as *const *mut AnyObject
+        count: 2usize
+    ];
+    let _: () = msg_send![layer, setColors: colors];
+    let _: () = msg_send![layer, setStartPoint: objc2_foundation::NSPoint::new(0.5, 1.0)];
+    let _: () = msg_send![layer, setEndPoint: objc2_foundation::NSPoint::new(0.5, 0.0)];
+    let _: () = msg_send![layer, setCornerRadius: radius];
+    let _: () = msg_send![layer, setMasksToBounds: true];
+    set_continuous_corners(layer);
+    let _: () = msg_send![view, setLayer: layer];
+    let _: () = msg_send![view, setWantsLayer: true];
+    view
+}
+
 unsafe fn visual_effect_view(
     frame: objc2_foundation::NSRect,
     radius: f64,
@@ -677,21 +720,40 @@ unsafe fn install_wallpaper(
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
 
-    // Outer container chrome. A deterministic neutral layer keeps the rim free
-    // of the saturated wallpaper cast an NSVisualEffectView material picks up at
-    // this scale; the bright outer rim, the top specular, the dark inner
-    // hairline and a tight inset shadow supply the dimensionality instead.
+    // Outer container chrome. A deterministic layer keeps the rim free of the
+    // saturated wallpaper cast an NSVisualEffectView material picks up at this
+    // scale. This base is a low-alpha graphite tint; the gradient body below
+    // supplies the lit-to-dark falloff, so the bright outer rim reads as a
+    // highlight on a translucent glass body rather than as the whole frame.
     let glass_frame = rounded_view(
         bounds,
         CONTAINER_RADIUS,
-        color(0.58, 0.60, 0.64, 0.82),
+        color(0.26, 0.29, 0.34, 0.35),
         true,
     );
     let _: () = msg_send![glass_frame, setAutoresizingMask: 18u64];
     let glass_layer: *mut AnyObject = msg_send![glass_frame, layer];
     set_continuous_corners(glass_layer);
-    set_layer_border(glass_layer, 0.8, color(1.0, 1.0, 1.0, 0.52));
+    set_layer_border(glass_layer, 0.8, color(1.0, 1.0, 1.0, 0.50));
     let _: () = msg_send![content_view, addSubview: glass_frame];
+
+    // Vertical falloff across the chrome body. Lit at the top, graphite at the
+    // bottom, translucent enough to pick up depth from whatever sits behind.
+    let body = gradient_view(
+        objc2_foundation::NSRect::new(objc2_foundation::NSPoint::new(0.0, 0.0), bounds.size),
+        CONTAINER_RADIUS,
+        color(0.58, 0.61, 0.66, 0.72),
+        color(0.19, 0.22, 0.27, 0.82),
+    );
+    let _: () = msg_send![body, setAutoresizingMask: 18u64];
+    let body_layer: *mut AnyObject = msg_send![body, layer];
+    let scale: f64 = msg_send![screen, backingScaleFactor];
+    if scale > 0.0 {
+        // Layer-hosting views do not inherit the backing scale, and the chrome
+        // hairlines are sub-point.
+        let _: () = msg_send![body_layer, setContentsScale: scale];
+    }
+    let _: () = msg_send![glass_frame, addSubview: body];
 
     // Light-from-above specular along the top edge of the chrome.
     let highlight = rounded_view(
@@ -703,7 +765,7 @@ unsafe fn install_wallpaper(
             ),
         ),
         0.5,
-        color(1.0, 1.0, 1.0, 0.32),
+        color(1.0, 1.0, 1.0, 0.38),
         true,
     );
     let _: () = msg_send![highlight, setAutoresizingMask: 10u64];
@@ -737,6 +799,28 @@ unsafe fn install_wallpaper(
     let _: () = msg_send![shadow_layer, setShadowColor: shadow_cg];
     let _: () = msg_send![content_view, addSubview: wallpaper_shadow];
 
+    // Machined inner edge. It hugs the seam from the chrome side, so the
+    // miniature desktop stays separated from the graphite body whether the
+    // content under it is a bright wallpaper or a dark window.
+    let seam_outset = 0.75;
+    let seam = rounded_view(
+        objc2_foundation::NSRect::new(
+            objc2_foundation::NSPoint::new(inset - seam_outset, inset - seam_outset),
+            objc2_foundation::NSSize::new(
+                container_frame.size.width + 2.0 * seam_outset,
+                container_frame.size.height + 2.0 * seam_outset,
+            ),
+        ),
+        container_radius + seam_outset,
+        color(0.0, 0.0, 0.0, 0.0),
+        false,
+    );
+    let _: () = msg_send![seam, setAutoresizingMask: 18u64];
+    let seam_layer: *mut AnyObject = msg_send![seam, layer];
+    set_continuous_corners(seam_layer);
+    set_layer_border(seam_layer, seam_outset, color(1.0, 1.0, 1.0, 0.20));
+    let _: () = msg_send![content_view, addSubview: seam];
+
     let wallpaper_container = rounded_view(
         container_frame,
         container_radius,
@@ -746,8 +830,9 @@ unsafe fn install_wallpaper(
     let _: () = msg_send![wallpaper_container, setAutoresizingMask: 18u64];
     let container_layer: *mut AnyObject = msg_send![wallpaper_container, layer];
     set_continuous_corners(container_layer);
-    // Dark hairline where the miniature desktop meets the chrome.
-    set_layer_border(container_layer, 0.8, color(0.0, 0.0, 0.0, 0.42));
+    // Dark hairline where the miniature desktop meets the chrome. Softer than
+    // the flat-outline pass, because the graphite body now carries the seam.
+    set_layer_border(container_layer, 0.8, color(0.0, 0.0, 0.0, 0.30));
     let container_bounds: objc2_foundation::NSRect = msg_send![wallpaper_container, bounds];
     let wallpaper_view: *mut AnyObject = {
         let allocated: *mut AnyObject = msg_send![class!(NSImageView), alloc];

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/get_config.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/get_config.rs
@@ -63,11 +63,12 @@ impl Tool for GetConfigTool {
             .or_else(|| self.state.cursor_registry.get("default"))
             .map(|s| s.config.enabled)
             .unwrap_or(true);
-        // PiP values aren't in DriverConfig — they're file-only since the
+        // Agent View values aren't in DriverConfig — they're file-only since the
         // backend is initialised once at startup. Read fresh so the
         // response reflects whatever set_config (or a direct JSON edit)
         // last wrote.
-        let (pip_enabled, pip_geometry) = pip_preview::read_pip_keys_from_file();
+        let (agent_view_enabled, agent_view_geometry) =
+            pip_preview::read_agent_view_keys_from_file();
         ToolResult::text("cua-driver-rs configuration").with_structured(serde_json::json!({
             "version": env!("CARGO_PKG_VERSION"),
             // Maintainer E2E builds set this at compile time so the
@@ -82,8 +83,8 @@ impl Tool for GetConfigTool {
             "agent_cursor": {
                 "enabled": cursor_enabled,
             },
-            "experimental_pip": pip_enabled,
-            "experimental_pip_geometry": pip_geometry,
+            "agent_view": agent_view_enabled,
+            "agent_view_geometry": agent_view_geometry,
         }))
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/set_config.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/set_config.rs
@@ -26,7 +26,7 @@ fn def() -> &'static ToolDef {
         description: "Update cua-driver-rs configuration. Changes to \
             max_image_dimension take effect immediately. The \
             experimental_pip keys are persisted to ~/.cua-driver/config.json and \
-            take effect on the next daemon restart (the PiP backend is \
+            take effect on the next daemon restart (Agent View is \
             initialised once at startup).\n\nNote: capture_mode is a per-call \
             param (on get_window_state / click), not a stored setting. Capture \
             modality is selected by each action's target; the old \
@@ -49,12 +49,13 @@ fn def() -> &'static ToolDef {
                 },
                 "experimental_pip": {
                     "type": "boolean",
-                    "description": "Enable the experimental picture-in-picture preview window. \
-                        Applies on next daemon restart."
+                    "description": "Enable the experimental multi-target Agent View. Exact native \
+                        windows and Chrome tabs are grouped automatically by session; no target \
+                        claiming is involved. Applies on next daemon restart."
                 },
                 "experimental_pip_geometry": {
                     "type": "string",
-                    "description": "PiP window size + optional position in `WxH` or `WxH+X+Y` \
+                    "description": "Agent View size + optional position in `WxH` or `WxH+X+Y` \
                         form (e.g. `320x200+24+24`). Applies on next daemon restart."
                 }
             },

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/set_config.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/set_config.rs
@@ -25,7 +25,7 @@ fn def() -> &'static ToolDef {
         name: "set_config".into(),
         description: "Update cua-driver-rs configuration. Changes to \
             max_image_dimension take effect immediately. The \
-            experimental_pip keys are persisted to ~/.cua-driver/config.json and \
+            agent_view keys are persisted to ~/.cua-driver/config.json and \
             take effect on the next daemon restart (Agent View is \
             initialised once at startup).\n\nNote: capture_mode is a per-call \
             param (on get_window_state / click), not a stored setting. Capture \
@@ -47,13 +47,13 @@ fn def() -> &'static ToolDef {
                     "type": "integer",
                     "description": "Max dimension for screenshot resizing (0 = no limit)."
                 },
-                "experimental_pip": {
+                "agent_view": {
                     "type": "boolean",
                     "description": "Enable the experimental multi-target Agent View. Exact native \
                         windows and Chrome tabs are grouped automatically by session; no target \
                         claiming is involved. Applies on next daemon restart."
                 },
-                "experimental_pip_geometry": {
+                "agent_view_geometry": {
                     "type": "string",
                     "description": "Agent View size + optional position in `WxH` or `WxH+X+Y` \
                         form (e.g. `320x200+24+24`). Applies on next daemon restart."
@@ -105,6 +105,17 @@ impl Tool for SetConfigTool {
                 .filter(|(k, _)| k == name)
                 .and_then(|(_, v)| v.as_u64())
         };
+        let kv_bool = |name: &str| -> Option<bool> {
+            kv.as_ref()
+                .filter(|(k, _)| k == name)
+                .and_then(|(_, v)| v.as_bool())
+        };
+        let kv_str = |name: &str| -> Option<String> {
+            kv.as_ref()
+                .filter(|(k, _)| k == name)
+                .and_then(|(_, v)| v.as_str())
+                .map(ToOwned::to_owned)
+        };
 
         // Validate max_image_dimension up front so both branches share the
         // u32 check and we never half-apply.
@@ -146,36 +157,38 @@ impl Tool for SetConfigTool {
             }
             cfg.max_image_dimension
         };
-        // PiP keys persist to the same config.json but take effect only on
+        // Agent View keys persist to the same config.json but take effect only on
         // next daemon restart — the backend is initialised once at startup.
-        let mut pip_note = String::new();
-        if let Some(enabled) = args.get("experimental_pip").and_then(|v| v.as_bool()) {
-            if let Err(e) = pip_preview::write_config_key("experimental_pip", Value::Bool(enabled))
-            {
-                return ToolResult::error(format!("failed to persist experimental_pip: {e}"));
+        let mut agent_view_note = String::new();
+        if let Some(enabled) = args
+            .get("agent_view")
+            .and_then(|v| v.as_bool())
+            .or_else(|| kv_bool("agent_view"))
+        {
+            if let Err(e) = pip_preview::write_config_key("agent_view", Value::Bool(enabled)) {
+                return ToolResult::error(format!("failed to persist agent_view: {e}"));
             }
-            pip_note =
-                format!(" — restart cua-driver for experimental_pip={enabled} to take effect");
+            agent_view_note =
+                format!(" — restart cua-driver for agent_view={enabled} to take effect");
         }
-        if let Some(geom) = args.opt_str("experimental_pip_geometry") {
+        if let Some(geom) = args
+            .opt_str("agent_view_geometry")
+            .or_else(|| kv_str("agent_view_geometry"))
+        {
             // Validate before persisting so the user gets an immediate error.
             if pip_preview::PipGeometry::parse(&geom).is_none() {
                 return ToolResult::error(format!(
-                    "experimental_pip_geometry `{geom}` is not a valid WxH or WxH+X+Y string"
+                    "agent_view_geometry `{geom}` is not a valid WxH or WxH+X+Y string"
                 ));
             }
-            if let Err(e) = pip_preview::write_config_key(
-                "experimental_pip_geometry",
-                Value::String(geom.clone()),
-            ) {
-                return ToolResult::error(format!(
-                    "failed to persist experimental_pip_geometry: {e}"
-                ));
+            if let Err(e) =
+                pip_preview::write_config_key("agent_view_geometry", Value::String(geom.clone()))
+            {
+                return ToolResult::error(format!("failed to persist agent_view_geometry: {e}"));
             }
-            if pip_note.is_empty() {
-                pip_note = format!(
-                    " — restart cua-driver for experimental_pip_geometry={geom} to take effect"
-                );
+            if agent_view_note.is_empty() {
+                agent_view_note =
+                    format!(" — restart cua-driver for agent_view_geometry={geom} to take effect");
             }
         }
         let scope_note = if session_id.is_some() {
@@ -185,7 +198,7 @@ impl Tool for SetConfigTool {
         };
         ToolResult::text(format!(
             "Config updated: max_image_dimension={}{}{}",
-            effective_dim, scope_note, pip_note
+            effective_dim, scope_note, agent_view_note
         ))
         .with_structured(serde_json::json!({
             "version": env!("CARGO_PKG_VERSION"),

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/set_config.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/set_config.rs
@@ -49,7 +49,7 @@ fn def() -> &'static ToolDef {
                 },
                 "agent_view": {
                     "type": "boolean",
-                    "description": "Enable the experimental multi-target Agent View. Exact native \
+                    "description": "Enable the multi-target Agent View. Exact native \
                         windows and Chrome tabs are grouped automatically by session; no target \
                         claiming is involved. Applies on next daemon restart."
                 },

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/set_config.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/set_config.rs
@@ -56,7 +56,7 @@ fn def() -> &'static ToolDef {
                 "agent_view_geometry": {
                     "type": "string",
                     "description": "Agent View size + optional position in `WxH` or `WxH+X+Y` \
-                        form (e.g. `320x200+24+24`). Applies on next daemon restart."
+                        form (e.g. `640x420+24+24`). Applies on next daemon restart."
                 }
             },
             "additionalProperties": false

--- a/libs/cua-driver/rust/crates/platform-windows/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/pip/mod.rs
@@ -809,6 +809,7 @@ mod native {
                 png_bytes,
                 action_label: "click".to_owned(),
                 timestamp_ms,
+                cursor_position: None,
             }
         }
 

--- a/libs/cua-driver/rust/crates/platform-windows/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/pip/mod.rs
@@ -23,9 +23,9 @@ mod native {
     use cursor_overlay::{rasterize_inter_text, TextRaster};
     use image::imageops::FilterType;
     use pip_preview::{
-        layout_desktop_with_shell, png_dimensions, LayoutRect, PipBackend, PipBackendFactory,
-        PipConfig, PipFrame, PipTargetKind, PipViewModel, PipWorkspaceSummary, ShellStyle,
-        TargetSize,
+        layout_desktop_with_shell, layout_session_tabs, png_dimensions, LayoutRect, PipBackend,
+        PipBackendFactory, PipConfig, PipFrame, PipTargetKind, PipViewModel, PipWorkspaceSummary,
+        ShellStyle, TargetSize,
     };
     use windows::core::PCWSTR;
     use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, POINT, RECT, WPARAM};
@@ -74,7 +74,7 @@ mod native {
         fn set_input_passthrough(&self, passthrough: bool) -> anyhow::Result<()> {
             let hwnd = self.hwnd.load(Ordering::Acquire);
             if hwnd == 0 {
-                anyhow::bail!("Agent View window is not running");
+                return Ok(());
             }
             let applied = unsafe {
                 SendMessageW(
@@ -289,11 +289,20 @@ mod native {
                     let x = lparam.0 as i16 as i32;
                     let y = (lparam.0 >> 16) as i16 as i32;
                     let mut client = RECT::default();
-                    if GetClientRect(hwnd, &mut client).is_ok()
-                        && contains(switcher_rect(client.right - client.left), x, y)
-                    {
+                    if GetClientRect(hwnd, &mut client).is_ok() {
                         let state = &*state_ptr;
-                        let changed = state.model.lock().unwrap().select_next_workspace();
+                        let mut model = state.model.lock().unwrap();
+                        let workspaces = model.workspaces();
+                        let tabs = session_tabs_for_width(
+                            client.right - client.left,
+                            client.bottom - client.top,
+                            &workspaces,
+                            model.selected_workspace_id(),
+                        );
+                        let changed = tabs
+                            .hit_test(f64::from(x), f64::from(y))
+                            .map(|workspace_id| model.select_workspace(workspace_id))
+                            .unwrap_or(false);
                         if changed {
                             let _ = InvalidateRect(hwnd, None, false);
                         }
@@ -335,20 +344,24 @@ mod native {
                             y: screen_y,
                         };
                         let mut client = RECT::default();
-                        let has_switcher = if state_ptr.is_null() {
-                            false
-                        } else {
-                            (&*state_ptr).model.lock().unwrap().workspaces().len() > 1
-                        };
-                        if has_switcher
+                        let tabs_hit = if !state_ptr.is_null()
                             && ScreenToClient(hwnd, &mut client_point).as_bool()
                             && GetClientRect(hwnd, &mut client).is_ok()
-                            && contains(
-                                switcher_rect(client.right - client.left),
-                                client_point.x,
-                                client_point.y,
-                            )
                         {
+                            let model = (&*state_ptr).model.lock().unwrap();
+                            let workspaces = model.workspaces();
+                            session_tabs_for_width(
+                                client.right - client.left,
+                                client.bottom - client.top,
+                                &workspaces,
+                                model.selected_workspace_id(),
+                            )
+                            .hit_test(f64::from(client_point.x), f64::from(client_point.y))
+                            .is_some()
+                        } else {
+                            false
+                        };
+                        if tabs_hit {
                             return LRESULT(HTCLIENT as isize);
                         }
                         if screen_y - window.top < 28 {
@@ -387,7 +400,7 @@ mod native {
         }
         let width = (rect.right - rect.left).max(1) as u32;
         let height = (rect.bottom - rect.top).max(1) as u32;
-        let (frames, workspaces, selected_workspace_id) = {
+        let (frames, workspaces, selected_workspace_id, active_view_id) = {
             let model = state.model.lock().unwrap();
             (
                 model
@@ -397,6 +410,7 @@ mod native {
                     .collect::<Vec<_>>(),
                 model.workspaces(),
                 model.selected_workspace_id().map(str::to_owned),
+                model.active_view_id().map(str::to_owned),
             )
         };
         let pixels = render_view(
@@ -405,6 +419,7 @@ mod native {
             &frames,
             &workspaces,
             selected_workspace_id.as_deref(),
+            active_view_id.as_deref(),
         );
         let info = BITMAPINFO {
             bmiHeader: BITMAPINFOHEADER {
@@ -443,6 +458,7 @@ mod native {
         frames: &[PipFrame],
         workspaces: &[PipWorkspaceSummary],
         selected_workspace_id: Option<&str>,
+        active_view_id: Option<&str>,
     ) -> Vec<u8> {
         let mut canvas = Canvas::new(width, height);
         canvas.smoked_shell();
@@ -458,12 +474,8 @@ mod native {
                 })
             })
             .collect::<Vec<_>>();
-        let layout = layout_desktop_with_shell(
-            desktop.2 as f64,
-            desktop.3 as f64,
-            &sizes,
-            ShellStyle::EdgeTaskbar,
-        );
+        let layout =
+            layout_desktop_with_shell(desktop.2 as f64, desktop.3 as f64, &sizes, ShellStyle::None);
         canvas.border((0, 0, width as i32, height as i32), 14, [19, 12, 7, 225]);
         canvas.border(
             (1, 1, width as i32 - 2, height as i32 - 2),
@@ -494,38 +506,14 @@ mod native {
                 canvas.blit(&image, rect, 7);
             }
             canvas.border(rect, 7, [40, 52, 72, 76]);
+            if active_view_id == Some(frame.target.view_id().as_str()) {
+                canvas.border(
+                    (rect.0 - 3, rect.1 - 3, rect.2 + 6, rect.3 + 6),
+                    9,
+                    [230, 158, 73, 232],
+                );
+            }
         }
-        // Windows shells anchor their bar to the bottom screen edge instead of
-        // floating it, so the band is painted as a material over the desktop
-        // that is already composited beneath it rather than as a card on top.
-        let taskbar = offset_pixels(layout.dock, desktop.0, desktop.1);
-        canvas.taskbar_material(taskbar, desktop);
-        if let Some(start) = layout.start_button {
-            canvas.start_glyph(offset_pixels(start, desktop.0, desktop.1));
-        }
-        let active = active_target_index(frames);
-        for (index, icon) in layout.dock_icons.iter().enumerate() {
-            canvas.icon(
-                offset_pixels(*icon, desktop.0, desktop.1),
-                frames[index].target.target_kind,
-                index,
-            );
-        }
-        for (index, indicator) in layout.indicators.iter().enumerate() {
-            canvas.running_indicator(
-                offset_pixels(*indicator, desktop.0, desktop.1),
-                Some(index) == active,
-            );
-        }
-        if let Some(tray) = layout.tray {
-            canvas.tray(
-                offset_pixels(tray, desktop.0, desktop.1),
-                active.map(|index| frames[index].timestamp_ms),
-            );
-        }
-        // The bar reaches the desktop's bottom edge, so restore the rounded
-        // frame it just painted over.
-        canvas.border(desktop, 10, [181, 151, 122, 138]);
         canvas.data
     }
 
@@ -603,7 +591,25 @@ mod native {
     }
 
     fn switcher_rect(width: i32) -> (i32, i32, i32, i32) {
-        ((width - 58).max(8), 8, 50, 22)
+        (12, 8, (width - 24).max(1), 28)
+    }
+
+    fn session_tabs_for_width(
+        width: i32,
+        height: i32,
+        workspaces: &[PipWorkspaceSummary],
+        selected_workspace_id: Option<&str>,
+    ) -> pip_preview::SessionTabsLayout {
+        layout_session_tabs(
+            LayoutRect {
+                x: 12.0,
+                y: 8.0,
+                width: f64::from((width - 24).max(1)),
+                height: f64::from(height.max(1)),
+            },
+            workspaces,
+            selected_workspace_id,
+        )
     }
 
     fn contains(rect: (i32, i32, i32, i32), x: i32, y: i32) -> bool {
@@ -707,32 +713,34 @@ mod native {
             workspaces: &[PipWorkspaceSummary],
             selected_workspace_id: Option<&str>,
         ) {
-            self.shadow(rect);
-            self.fill(rect, 11, [42, 31, 24, 235]);
-            self.border(rect, 11, [205, 177, 148, 128]);
-
-            let visible = workspaces.len().min(4);
-            let selected = workspaces
-                .iter()
-                .position(|workspace| {
-                    Some(workspace.workspace_id.as_str()) == selected_workspace_id
-                })
-                .unwrap_or(0)
-                .min(visible.saturating_sub(1));
-            for index in 0..visible {
-                let color = if index == selected {
-                    [230, 158, 73, 255]
-                } else {
-                    [104, 92, 78, 255]
-                };
-                self.fill((rect.0 + 8 + index as i32 * 8, rect.1 + 8, 6, 6), 3, color);
-            }
-
-            let chevron_x = rect.0 + rect.2 - 10;
-            let chevron_y = rect.1 + rect.3 / 2;
-            for step in 0..4 {
-                self.set(chevron_x + step, chevron_y - 3 + step, [224, 210, 190, 255]);
-                self.set(chevron_x + step, chevron_y + 3 - step, [224, 210, 190, 255]);
+            let tabs = layout_session_tabs(
+                LayoutRect {
+                    x: f64::from(rect.0),
+                    y: f64::from(rect.1),
+                    width: f64::from(rect.2),
+                    height: f64::from(rect.3),
+                },
+                workspaces,
+                selected_workspace_id,
+            );
+            for tab in tabs.tabs {
+                let tab_rect = offset_pixels(tab.rect, 0, 0);
+                self.shadow(tab_rect);
+                self.fill(
+                    tab_rect,
+                    9,
+                    [42, 31, 24, if tab.selected { 242 } else { 204 }],
+                );
+                self.border(
+                    tab_rect,
+                    9,
+                    [
+                        tab.accent.0,
+                        tab.accent.1,
+                        tab.accent.2,
+                        if tab.selected { 235 } else { 128 },
+                    ],
+                );
             }
         }
 
@@ -1096,6 +1104,7 @@ mod native {
                 ],
                 &workspaces,
                 Some("workspace"),
+                None,
             );
             assert_eq!(data.len(), 480 * 320 * 4);
             assert!(data.chunks_exact(4).all(|pixel| pixel[3] == 255));
@@ -1122,7 +1131,7 @@ mod native {
             let width = 520;
             let height = 360;
             let workspaces = [workspace("workspace", 2, 1)];
-            let data = render_view(width, height, &frames, &workspaces, Some("workspace"));
+            let data = render_view(width, height, &frames, &workspaces, Some("workspace"), None);
             let desktop = desktop_rect(width, height, false);
             let layout = layout_desktop_with_shell(
                 desktop.2 as f64,
@@ -1170,7 +1179,7 @@ mod native {
         #[test]
         fn renderer_separates_dark_shell_from_inset_desktop() {
             let width = 360;
-            let data = render_view(width, 240, &[], &[], None);
+            let data = render_view(width, 240, &[], &[], None, None);
             let shell = pixel(&data, width, 4, 100);
             let desktop = pixel(&data, width, 180, 100);
             let highlight = pixel(&data, width, 180, 1);
@@ -1188,8 +1197,8 @@ mod native {
             let width = 420;
             let one = [workspace("agent-a", 1, 1)];
             let two = [workspace("agent-b", 1, 2), workspace("agent-a", 1, 1)];
-            let single = render_view(width, 280, &[], &one, Some("agent-a"));
-            let multiple = render_view(width, 280, &[], &two, Some("agent-a"));
+            let single = render_view(width, 280, &[], &one, Some("agent-a"), None);
+            let multiple = render_view(width, 280, &[], &two, Some("agent-a"), None);
             let switcher = switcher_rect(width as i32);
             let sample_x = (switcher.0 + switcher.2 / 2) as u32;
             let sample_y = (switcher.1 + switcher.3 / 2) as u32;
@@ -1306,6 +1315,7 @@ mod native {
                 ],
                 &[workspace("w", 2, 2)],
                 Some("w"),
+                None,
             );
             let center_x = (desktop.0 + desktop.2 / 2) as u32;
             let above = pixel(&data, width, center_x, (bar.1 - 6) as u32);
@@ -1325,6 +1335,7 @@ mod native {
                 &[frame("w", "a", PipTargetKind::BrowserTab, Vec::new(), 1)],
                 &[workspace("w", 1, 1)],
                 Some("w"),
+                None,
             );
 
             // The wallpaper's lower glow sits left of center, so a material
@@ -1361,6 +1372,7 @@ mod native {
                 ],
                 &[workspace("w", 2, 9)],
                 Some("w"),
+                None,
             );
             assert_eq!(layout.indicators.len(), 2);
             let brightness = |index: usize| {
@@ -1405,8 +1417,9 @@ mod native {
                 ],
                 &[workspace("w", 2, 42 * 60_000)],
                 Some("w"),
+                None,
             );
-            let empty = render_view(width, height, &[], &[workspace("w", 0, 1)], Some("w"));
+            let empty = render_view(width, height, &[], &[workspace("w", 0, 1)], Some("w"), None);
             let glyph_region = |data: &[u8], rect: (i32, i32, i32, i32)| {
                 let mut ink = 0u32;
                 for y in rect.1..rect.1 + rect.3 {

--- a/libs/cua-driver/rust/crates/platform-windows/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/pip/mod.rs
@@ -23,16 +23,16 @@ mod native {
     use image::imageops::FilterType;
     use pip_preview::{
         layout_desktop, png_dimensions, LayoutRect, PipBackend, PipBackendFactory, PipConfig,
-        PipFrame, PipTargetKind, PipViewModel, TargetSize,
+        PipFrame, PipTargetKind, PipViewModel, PipWorkspaceSummary, TargetSize,
     };
     use windows::core::PCWSTR;
-    use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, RECT, WPARAM};
+    use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, POINT, RECT, WPARAM};
     use windows::Win32::Graphics::Dwm::{
         DwmSetWindowAttribute, DWMWA_SYSTEMBACKDROP_TYPE, DWMWA_WINDOW_CORNER_PREFERENCE,
     };
     use windows::Win32::Graphics::Gdi::{
-        BeginPaint, EndPaint, InvalidateRect, StretchDIBits, UpdateWindow, BITMAPINFO,
-        BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS, PAINTSTRUCT, SRCCOPY,
+        BeginPaint, EndPaint, InvalidateRect, ScreenToClient, StretchDIBits, UpdateWindow,
+        BITMAPINFO, BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS, PAINTSTRUCT, SRCCOPY,
     };
     use windows::Win32::System::LibraryLoader::GetModuleHandleW;
     use windows::Win32::UI::WindowsAndMessaging::{
@@ -41,10 +41,10 @@ mod native {
         PostQuitMessage, RegisterClassExW, SetWindowLongPtrW, ShowWindow, TranslateMessage,
         CREATESTRUCTW, CS_HREDRAW, CS_VREDRAW, GWLP_USERDATA, HTBOTTOM, HTBOTTOMLEFT,
         HTBOTTOMRIGHT, HTCAPTION, HTCLIENT, HTLEFT, HTRIGHT, HTTOP, HTTOPLEFT, HTTOPRIGHT,
-        IDC_ARROW, MSG, SM_CXSCREEN, SM_CYSCREEN, SW_SHOWNOACTIVATE, WM_APP, WM_CLOSE, WM_DESTROY,
-        WM_ERASEBKGND, WM_NCCREATE, WM_NCDESTROY, WM_NCHITTEST, WM_PAINT, WM_SIZE, WNDCLASSEXW,
-        WS_CLIPCHILDREN, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_POPUP,
-        WS_THICKFRAME,
+        IDC_ARROW, MA_NOACTIVATE, MSG, SM_CXSCREEN, SM_CYSCREEN, SW_SHOWNOACTIVATE, WM_APP,
+        WM_CLOSE, WM_DESTROY, WM_ERASEBKGND, WM_LBUTTONUP, WM_MOUSEACTIVATE, WM_NCCREATE,
+        WM_NCDESTROY, WM_NCHITTEST, WM_PAINT, WM_SIZE, WNDCLASSEXW, WS_CLIPCHILDREN,
+        WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_POPUP, WS_THICKFRAME,
     };
 
     use super::WindowsPipBackendFactory;
@@ -83,6 +83,15 @@ mod native {
                 .lock()
                 .unwrap()
                 .remove_workspace(workspace_id);
+            self.state.post(REDRAW);
+        }
+
+        fn remove_target(&self, workspace_id: &str, identity_key: &str) {
+            self.state
+                .model
+                .lock()
+                .unwrap()
+                .remove_target(workspace_id, identity_key);
             self.state.post(REDRAW);
         }
 
@@ -229,6 +238,24 @@ mod native {
                 LRESULT(0)
             }
             WM_ERASEBKGND => LRESULT(1),
+            WM_MOUSEACTIVATE => LRESULT(MA_NOACTIVATE as isize),
+            WM_LBUTTONUP => {
+                if !state_ptr.is_null() {
+                    let x = lparam.0 as i16 as i32;
+                    let y = (lparam.0 >> 16) as i16 as i32;
+                    let mut client = RECT::default();
+                    if GetClientRect(hwnd, &mut client).is_ok()
+                        && contains(switcher_rect(client.right - client.left), x, y)
+                    {
+                        let state = &*state_ptr;
+                        let changed = state.model.lock().unwrap().select_next_workspace();
+                        if changed {
+                            let _ = InvalidateRect(hwnd, None, false);
+                        }
+                    }
+                }
+                LRESULT(0)
+            }
             WM_NCHITTEST => {
                 let hit = DefWindowProcW(hwnd, message, wparam, lparam);
                 if hit.0 == HTCLIENT as isize {
@@ -254,6 +281,27 @@ mod native {
                         };
                         if let Some(resize_hit) = resize_hit {
                             return LRESULT(resize_hit as isize);
+                        }
+                        let mut client_point = POINT {
+                            x: screen_x,
+                            y: screen_y,
+                        };
+                        let mut client = RECT::default();
+                        let has_switcher = if state_ptr.is_null() {
+                            false
+                        } else {
+                            (&*state_ptr).model.lock().unwrap().workspaces().len() > 1
+                        };
+                        if has_switcher
+                            && ScreenToClient(hwnd, &mut client_point).as_bool()
+                            && GetClientRect(hwnd, &mut client).is_ok()
+                            && contains(
+                                switcher_rect(client.right - client.left),
+                                client_point.x,
+                                client_point.y,
+                            )
+                        {
+                            return LRESULT(HTCLIENT as isize);
                         }
                         if screen_y - window.top < 28 {
                             return LRESULT(HTCAPTION as isize);
@@ -291,15 +339,25 @@ mod native {
         }
         let width = (rect.right - rect.left).max(1) as u32;
         let height = (rect.bottom - rect.top).max(1) as u32;
-        let frames = state
-            .model
-            .lock()
-            .unwrap()
-            .ordered_frames()
-            .into_iter()
-            .cloned()
-            .collect::<Vec<_>>();
-        let pixels = render_view(width, height, &frames);
+        let (frames, workspaces, selected_workspace_id) = {
+            let model = state.model.lock().unwrap();
+            (
+                model
+                    .selected_frames()
+                    .into_iter()
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                model.workspaces(),
+                model.selected_workspace_id().map(str::to_owned),
+            )
+        };
+        let pixels = render_view(
+            width,
+            height,
+            &frames,
+            &workspaces,
+            selected_workspace_id.as_deref(),
+        );
         let info = BITMAPINFO {
             bmiHeader: BITMAPINFOHEADER {
                 biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
@@ -331,10 +389,17 @@ mod native {
         let _ = EndPaint(hwnd, &ps);
     }
 
-    fn render_view(width: u32, height: u32, frames: &[PipFrame]) -> Vec<u8> {
+    fn render_view(
+        width: u32,
+        height: u32,
+        frames: &[PipFrame],
+        workspaces: &[PipWorkspaceSummary],
+        selected_workspace_id: Option<&str>,
+    ) -> Vec<u8> {
         let mut canvas = Canvas::new(width, height);
         canvas.smoked_shell();
-        let desktop = desktop_rect(width, height);
+        let show_switcher = workspaces.len() > 1;
+        let desktop = desktop_rect(width, height, show_switcher);
         canvas.wallpaper(desktop);
         let sizes = frames
             .iter()
@@ -358,6 +423,13 @@ mod native {
             [108, 82, 57, 105],
         );
         canvas.border(desktop, 10, [181, 151, 122, 138]);
+        if show_switcher {
+            canvas.switcher(
+                switcher_rect(width as i32),
+                workspaces,
+                selected_workspace_id,
+            );
+        }
         for (frame, target) in frames.iter().zip(&layout.targets) {
             let rect = offset_pixels(target.content, desktop.0, desktop.1);
             canvas.shadow(rect);
@@ -384,16 +456,24 @@ mod native {
         canvas.data
     }
 
-    fn desktop_rect(width: u32, height: u32) -> (i32, i32, i32, i32) {
+    fn desktop_rect(width: u32, height: u32, show_switcher: bool) -> (i32, i32, i32, i32) {
         const SIDE_INSET: i32 = 8;
-        const TOP_INSET: i32 = 14;
         const BOTTOM_INSET: i32 = 9;
+        let top_inset = if show_switcher { 36 } else { 14 };
         (
             SIDE_INSET,
-            TOP_INSET,
+            top_inset,
             (width as i32 - SIDE_INSET * 2).max(1),
-            (height as i32 - TOP_INSET - BOTTOM_INSET).max(1),
+            (height as i32 - top_inset - BOTTOM_INSET).max(1),
         )
+    }
+
+    fn switcher_rect(width: i32) -> (i32, i32, i32, i32) {
+        ((width - 58).max(8), 8, 50, 22)
+    }
+
+    fn contains(rect: (i32, i32, i32, i32), x: i32, y: i32) -> bool {
+        x >= rect.0 && y >= rect.1 && x < rect.0 + rect.2 && y < rect.1 + rect.3
     }
 
     fn pixels(rect: LayoutRect) -> (i32, i32, i32, i32) {
@@ -475,6 +555,41 @@ mod native {
                 for x in ((y & 7)..width.saturating_sub(8)).step_by(8) {
                     self.blend(x, y, [205, 181, 155, 7]);
                 }
+            }
+        }
+
+        fn switcher(
+            &mut self,
+            rect: (i32, i32, i32, i32),
+            workspaces: &[PipWorkspaceSummary],
+            selected_workspace_id: Option<&str>,
+        ) {
+            self.shadow(rect);
+            self.fill(rect, 11, [42, 31, 24, 235]);
+            self.border(rect, 11, [205, 177, 148, 128]);
+
+            let visible = workspaces.len().min(4);
+            let selected = workspaces
+                .iter()
+                .position(|workspace| {
+                    Some(workspace.workspace_id.as_str()) == selected_workspace_id
+                })
+                .unwrap_or(0)
+                .min(visible.saturating_sub(1));
+            for index in 0..visible {
+                let color = if index == selected {
+                    [230, 158, 73, 255]
+                } else {
+                    [104, 92, 78, 255]
+                };
+                self.fill((rect.0 + 8 + index as i32 * 8, rect.1 + 8, 6, 6), 3, color);
+            }
+
+            let chevron_x = rect.0 + rect.2 - 10;
+            let chevron_y = rect.1 + rect.3 / 2;
+            for step in 0..4 {
+                self.set(chevron_x + step, chevron_y - 3 + step, [224, 210, 190, 255]);
+                self.set(chevron_x + step, chevron_y + 3 - step, [224, 210, 190, 255]);
             }
         }
 
@@ -619,27 +734,62 @@ mod native {
             data[offset..offset + 4].try_into().unwrap()
         }
 
-        #[test]
-        fn renderer_tracks_each_target_and_requested_size() {
-            let frame = |id: &str, kind| PipFrame {
+        fn frame(
+            workspace: &str,
+            id: &str,
+            kind: PipTargetKind,
+            png_bytes: Vec<u8>,
+            timestamp_ms: u64,
+        ) -> PipFrame {
+            PipFrame {
                 target: PipTarget {
-                    workspace_id: "workspace".to_owned(),
-                    workspace_label: "Agent".to_owned(),
+                    workspace_id: workspace.to_owned(),
+                    workspace_label: workspace.to_owned(),
                     target_id: id.to_owned(),
+                    identity_key: id.to_owned(),
                     target_kind: kind,
                     target_label: id.to_owned(),
+                    native_container: None,
                 },
-                png_bytes: Vec::new(),
+                png_bytes,
                 action_label: "click".to_owned(),
-                timestamp_ms: 1,
-            };
+                timestamp_ms,
+            }
+        }
+
+        fn workspace(id: &str, target_count: usize, updated_ms: u64) -> PipWorkspaceSummary {
+            PipWorkspaceSummary {
+                workspace_id: id.to_owned(),
+                workspace_label: id.to_owned(),
+                target_count,
+                updated_ms,
+            }
+        }
+
+        #[test]
+        fn renderer_tracks_each_target_and_requested_size() {
+            let workspaces = [workspace("workspace", 2, 1)];
             let data = render_view(
                 480,
                 320,
                 &[
-                    frame("edge", PipTargetKind::BrowserTab),
-                    frame("notes", PipTargetKind::NativeWindow),
+                    frame(
+                        "workspace",
+                        "edge",
+                        PipTargetKind::BrowserTab,
+                        Vec::new(),
+                        1,
+                    ),
+                    frame(
+                        "workspace",
+                        "notes",
+                        PipTargetKind::NativeWindow,
+                        Vec::new(),
+                        1,
+                    ),
                 ],
+                &workspaces,
+                Some("workspace"),
             );
             assert_eq!(data.len(), 480 * 320 * 4);
             assert!(data.chunks_exact(4).all(|pixel| pixel[3] == 255));
@@ -647,34 +797,27 @@ mod native {
 
         #[test]
         fn renderer_preserves_target_pixels_across_mixed_form_factors() {
-            let frame = |id: &str, kind, png_bytes| PipFrame {
-                target: PipTarget {
-                    workspace_id: "workspace".to_owned(),
-                    workspace_label: "Agent".to_owned(),
-                    target_id: id.to_owned(),
-                    target_kind: kind,
-                    target_label: id.to_owned(),
-                },
-                png_bytes,
-                action_label: "click".to_owned(),
-                timestamp_ms: 1,
-            };
             let frames = [
                 frame(
+                    "workspace",
                     "wide",
                     PipTargetKind::BrowserTab,
                     solid_png(80, 32, [220, 30, 20, 255]),
+                    1,
                 ),
                 frame(
+                    "workspace",
                     "tall",
                     PipTargetKind::NativeWindow,
                     solid_png(24, 72, [20, 90, 230, 255]),
+                    1,
                 ),
             ];
             let width = 520;
             let height = 360;
-            let data = render_view(width, height, &frames);
-            let desktop = desktop_rect(width, height);
+            let workspaces = [workspace("workspace", 2, 1)];
+            let data = render_view(width, height, &frames, &workspaces, Some("workspace"));
+            let desktop = desktop_rect(width, height, false);
             let layout = layout_desktop(
                 desktop.2 as f64,
                 desktop.3 as f64,
@@ -720,7 +863,7 @@ mod native {
         #[test]
         fn renderer_separates_dark_shell_from_inset_desktop() {
             let width = 360;
-            let data = render_view(width, 240, &[]);
+            let data = render_view(width, 240, &[], &[], None);
             let shell = pixel(&data, width, 4, 100);
             let desktop = pixel(&data, width, 180, 100);
             let highlight = pixel(&data, width, 180, 1);
@@ -731,6 +874,77 @@ mod native {
             assert!(shell[0] > shell[1] && shell[1] > shell[2]);
             assert!(brightness(highlight) > brightness(shell));
             assert!(highlight[0] > highlight[1] && highlight[1] > highlight[2]);
+        }
+
+        #[test]
+        fn switcher_is_hidden_for_one_workspace_and_cycles_without_target_activation() {
+            let width = 420;
+            let one = [workspace("agent-a", 1, 1)];
+            let two = [workspace("agent-b", 1, 2), workspace("agent-a", 1, 1)];
+            let single = render_view(width, 280, &[], &one, Some("agent-a"));
+            let multiple = render_view(width, 280, &[], &two, Some("agent-a"));
+            let switcher = switcher_rect(width as i32);
+            let sample_x = (switcher.0 + switcher.2 / 2) as u32;
+            let sample_y = (switcher.1 + switcher.3 / 2) as u32;
+
+            assert_eq!(desktop_rect(width, 280, false).1, 14);
+            assert_eq!(desktop_rect(width, 280, true).1, 36);
+            assert_ne!(
+                pixel(&single, width, sample_x, sample_y),
+                pixel(&multiple, width, sample_x, sample_y)
+            );
+
+            let mut model = PipViewModel::new(4);
+            model.upsert(frame(
+                "agent-a",
+                "window-a",
+                PipTargetKind::NativeWindow,
+                Vec::new(),
+                1,
+            ));
+            model.upsert(frame(
+                "agent-b",
+                "window-b",
+                PipTargetKind::NativeWindow,
+                Vec::new(),
+                2,
+            ));
+            assert!(model.select_workspace("agent-a"));
+            assert_eq!(model.selected_frames()[0].target.workspace_id, "agent-a");
+            assert!(model.select_next_workspace());
+            assert_eq!(model.selected_frames()[0].target.workspace_id, "agent-b");
+        }
+
+        #[test]
+        fn exact_target_removal_and_workspace_cleanup_redraw_the_selected_session() {
+            let mut model = PipViewModel::new(6);
+            model.upsert(frame(
+                "agent-a",
+                "wide",
+                PipTargetKind::BrowserTab,
+                Vec::new(),
+                1,
+            ));
+            model.upsert(frame(
+                "agent-a",
+                "tall",
+                PipTargetKind::NativeWindow,
+                Vec::new(),
+                2,
+            ));
+            model.upsert(frame(
+                "agent-b",
+                "other",
+                PipTargetKind::NativeWindow,
+                Vec::new(),
+                3,
+            ));
+            assert!(model.select_workspace("agent-a"));
+            assert!(model.remove_target("agent-a", "wide"));
+            assert_eq!(model.selected_frames().len(), 1);
+            assert_eq!(model.selected_frames()[0].target.identity_key, "tall");
+            assert_eq!(model.remove_workspace("agent-a").len(), 1);
+            assert_eq!(model.selected_workspace_id(), Some("agent-b"));
         }
     }
 }

--- a/libs/cua-driver/rust/crates/platform-windows/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/pip/mod.rs
@@ -17,7 +17,7 @@ pub struct WindowsPipBackendFactory;
 
 #[cfg(target_os = "windows")]
 mod native {
-    use std::sync::atomic::{AtomicIsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
     use std::sync::{mpsc, Arc, Mutex};
 
     use image::imageops::FilterType;
@@ -38,22 +38,25 @@ mod native {
     use windows::Win32::UI::WindowsAndMessaging::{
         CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetClientRect,
         GetMessageW, GetSystemMetrics, GetWindowLongPtrW, GetWindowRect, LoadCursorW, PostMessageW,
-        PostQuitMessage, RegisterClassExW, SetWindowLongPtrW, ShowWindow, TranslateMessage,
-        CREATESTRUCTW, CS_HREDRAW, CS_VREDRAW, GWLP_USERDATA, HTBOTTOM, HTBOTTOMLEFT,
-        HTBOTTOMRIGHT, HTCAPTION, HTCLIENT, HTLEFT, HTRIGHT, HTTOP, HTTOPLEFT, HTTOPRIGHT,
-        IDC_ARROW, MA_NOACTIVATE, MSG, SM_CXSCREEN, SM_CYSCREEN, SW_SHOWNOACTIVATE, WM_APP,
-        WM_CLOSE, WM_DESTROY, WM_ERASEBKGND, WM_LBUTTONUP, WM_MOUSEACTIVATE, WM_NCCREATE,
-        WM_NCDESTROY, WM_NCHITTEST, WM_PAINT, WM_SIZE, WNDCLASSEXW, WS_CLIPCHILDREN,
-        WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_POPUP, WS_THICKFRAME,
+        PostQuitMessage, RegisterClassExW, SendMessageW, SetWindowLongPtrW, ShowWindow,
+        TranslateMessage, CREATESTRUCTW, CS_HREDRAW, CS_VREDRAW, GWLP_USERDATA, GWL_EXSTYLE,
+        HTBOTTOM, HTBOTTOMLEFT, HTBOTTOMRIGHT, HTCAPTION, HTCLIENT, HTLEFT, HTRIGHT, HTTOP,
+        HTTOPLEFT, HTTOPRIGHT, HTTRANSPARENT, IDC_ARROW, MA_NOACTIVATE, MSG, SM_CXSCREEN,
+        SM_CYSCREEN, SW_SHOWNOACTIVATE, WM_APP, WM_CLOSE, WM_DESTROY, WM_ERASEBKGND, WM_LBUTTONUP,
+        WM_MOUSEACTIVATE, WM_NCCREATE, WM_NCDESTROY, WM_NCHITTEST, WM_PAINT, WM_SIZE, WNDCLASSEXW,
+        WS_CLIPCHILDREN, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_EX_TRANSPARENT,
+        WS_POPUP, WS_THICKFRAME,
     };
 
     use super::WindowsPipBackendFactory;
 
     const REDRAW: u32 = WM_APP + 1;
     const SHUTDOWN: u32 = WM_APP + 2;
+    const SET_INPUT_PASSTHROUGH: u32 = WM_APP + 3;
 
     struct State {
         hwnd: AtomicIsize,
+        input_passthrough: AtomicBool,
         model: Mutex<PipViewModel>,
     }
 
@@ -64,6 +67,26 @@ mod native {
                 let _ =
                     unsafe { PostMessageW(HWND(hwnd as *mut _), message, WPARAM(0), LPARAM(0)) };
             }
+        }
+
+        fn set_input_passthrough(&self, passthrough: bool) -> anyhow::Result<()> {
+            let hwnd = self.hwnd.load(Ordering::Acquire);
+            if hwnd == 0 {
+                anyhow::bail!("Agent View window is not running");
+            }
+            let applied = unsafe {
+                SendMessageW(
+                    HWND(hwnd as *mut _),
+                    SET_INPUT_PASSTHROUGH,
+                    WPARAM(usize::from(passthrough)),
+                    LPARAM(0),
+                )
+            };
+            anyhow::ensure!(
+                applied.0 == 1,
+                "Agent View rejected the synchronous input-passthrough update"
+            );
+            Ok(())
         }
     }
 
@@ -95,6 +118,10 @@ mod native {
             self.state.post(REDRAW);
         }
 
+        fn set_input_passthrough(&self, passthrough: bool) -> anyhow::Result<()> {
+            self.state.set_input_passthrough(passthrough)
+        }
+
         fn shutdown(self: Box<Self>) {
             self.state.post(SHUTDOWN);
         }
@@ -104,6 +131,7 @@ mod native {
         fn start(&self, cfg: &PipConfig) -> anyhow::Result<Box<dyn PipBackend>> {
             let state = Arc::new(State {
                 hwnd: AtomicIsize::new(0),
+                input_passthrough: AtomicBool::new(false),
                 model: Mutex::new(PipViewModel::new(12)),
             });
             let thread_state = Arc::clone(&state);
@@ -239,6 +267,21 @@ mod native {
             }
             WM_ERASEBKGND => LRESULT(1),
             WM_MOUSEACTIVATE => LRESULT(MA_NOACTIVATE as isize),
+            SET_INPUT_PASSTHROUGH => {
+                let passthrough = wparam.0 != 0;
+                if !state_ptr.is_null() {
+                    (&*state_ptr)
+                        .input_passthrough
+                        .store(passthrough, Ordering::Release);
+                }
+                let style = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+                SetWindowLongPtrW(
+                    hwnd,
+                    GWL_EXSTYLE,
+                    extended_style_with_input_passthrough(style, passthrough),
+                );
+                LRESULT(1)
+            }
             WM_LBUTTONUP => {
                 if !state_ptr.is_null() {
                     let x = lparam.0 as i16 as i32;
@@ -257,6 +300,9 @@ mod native {
                 LRESULT(0)
             }
             WM_NCHITTEST => {
+                if !state_ptr.is_null() && (&*state_ptr).input_passthrough.load(Ordering::Acquire) {
+                    return LRESULT(HTTRANSPARENT as isize);
+                }
                 let hit = DefWindowProcW(hwnd, message, wparam, lparam);
                 if hit.0 == HTCLIENT as isize {
                     let screen_x = lparam.0 as i16 as i32;
@@ -474,6 +520,15 @@ mod native {
 
     fn contains(rect: (i32, i32, i32, i32), x: i32, y: i32) -> bool {
         x >= rect.0 && y >= rect.1 && x < rect.0 + rect.2 && y < rect.1 + rect.3
+    }
+
+    fn extended_style_with_input_passthrough(style: isize, passthrough: bool) -> isize {
+        let transparent = WS_EX_TRANSPARENT.0 as isize;
+        if passthrough {
+            style | transparent
+        } else {
+            style & !transparent
+        }
     }
 
     fn pixels(rect: LayoutRect) -> (i32, i32, i32, i32) {
@@ -945,6 +1000,17 @@ mod native {
             assert_eq!(model.selected_frames()[0].target.identity_key, "tall");
             assert_eq!(model.remove_workspace("agent-a").len(), 1);
             assert_eq!(model.selected_workspace_id(), Some("agent-b"));
+        }
+
+        #[test]
+        fn input_passthrough_only_toggles_the_transparent_extended_style() {
+            let base = (WS_EX_TOPMOST | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW).0 as isize;
+            let passthrough = extended_style_with_input_passthrough(base, true);
+            assert_ne!(passthrough & WS_EX_TRANSPARENT.0 as isize, 0);
+            assert_eq!(passthrough & base, base);
+
+            let interactive = extended_style_with_input_passthrough(passthrough, false);
+            assert_eq!(interactive, base);
         }
     }
 }

--- a/libs/cua-driver/rust/crates/platform-windows/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/pip/mod.rs
@@ -333,7 +333,9 @@ mod native {
 
     fn render_view(width: u32, height: u32, frames: &[PipFrame]) -> Vec<u8> {
         let mut canvas = Canvas::new(width, height);
-        canvas.wallpaper();
+        canvas.smoked_shell();
+        let desktop = desktop_rect(width, height);
+        canvas.wallpaper(desktop);
         let sizes = frames
             .iter()
             .map(|frame| {
@@ -343,14 +345,21 @@ mod native {
                 })
             })
             .collect::<Vec<_>>();
-        let layout = layout_desktop(width as f64, height as f64, &sizes);
+        let layout = layout_desktop(desktop.2 as f64, desktop.3 as f64, &sizes);
+        canvas.border((0, 0, width as i32, height as i32), 14, [19, 12, 7, 225]);
         canvas.border(
             (1, 1, width as i32 - 2, height as i32 - 2),
-            14,
-            [224, 239, 250, 118],
+            13,
+            [211, 184, 151, 118],
         );
+        canvas.border(
+            (2, 2, width as i32 - 4, height as i32 - 4),
+            12,
+            [108, 82, 57, 105],
+        );
+        canvas.border(desktop, 10, [181, 151, 122, 138]);
         for (frame, target) in frames.iter().zip(&layout.targets) {
-            let rect = pixels(target.content);
+            let rect = offset_pixels(target.content, desktop.0, desktop.1);
             canvas.shadow(rect);
             canvas.fill(rect, 7, [244, 247, 251, 255]);
             if let Ok(image) = image::load_from_memory(&frame.png_bytes) {
@@ -361,13 +370,30 @@ mod native {
             }
             canvas.border(rect, 7, [40, 52, 72, 76]);
         }
-        let dock = pixels(layout.dock);
-        canvas.fill(dock, 11, [41, 79, 137, 198]);
-        canvas.border(dock, 11, [225, 239, 255, 150]);
+        let dock = offset_pixels(layout.dock, desktop.0, desktop.1);
+        canvas.shadow(dock);
+        canvas.fill(dock, 11, [40, 30, 23, 218]);
+        canvas.border(dock, 11, [204, 176, 145, 118]);
         for (index, icon) in layout.dock_icons.iter().enumerate() {
-            canvas.icon(pixels(*icon), frames[index].target.target_kind, index);
+            canvas.icon(
+                offset_pixels(*icon, desktop.0, desktop.1),
+                frames[index].target.target_kind,
+                index,
+            );
         }
         canvas.data
+    }
+
+    fn desktop_rect(width: u32, height: u32) -> (i32, i32, i32, i32) {
+        const SIDE_INSET: i32 = 8;
+        const TOP_INSET: i32 = 14;
+        const BOTTOM_INSET: i32 = 9;
+        (
+            SIDE_INSET,
+            TOP_INSET,
+            (width as i32 - SIDE_INSET * 2).max(1),
+            (height as i32 - TOP_INSET - BOTTOM_INSET).max(1),
+        )
     }
 
     fn pixels(rect: LayoutRect) -> (i32, i32, i32, i32) {
@@ -377,6 +403,11 @@ mod native {
             rect.width.round().max(1.0) as i32,
             rect.height.round().max(1.0) as i32,
         )
+    }
+
+    fn offset_pixels(rect: LayoutRect, x: i32, y: i32) -> (i32, i32, i32, i32) {
+        let rect = pixels(rect);
+        (rect.0 + x, rect.1 + y, rect.2, rect.3)
     }
 
     struct Canvas {
@@ -394,25 +425,55 @@ mod native {
             }
         }
 
-        fn wallpaper(&mut self) {
-            let w = self.width.max(1) as f32;
-            let h = self.height.max(1) as f32;
-            for y in 0..self.height {
-                for x in 0..self.width {
+        fn wallpaper(&mut self, rect: (i32, i32, i32, i32)) {
+            let w = rect.2.max(1) as f32;
+            let h = rect.3.max(1) as f32;
+            for y in 0..rect.3 {
+                for x in 0..rect.2 {
+                    if !Self::inside(x, y, rect.2, rect.3, 10) {
+                        continue;
+                    }
                     let nx = x as f32 / w;
                     let ny = y as f32 / h;
-                    let glow = ((nx - 0.78).powi(2) + (ny - 0.15).powi(2)).sqrt();
-                    let wave = ((ny - 0.72 + 0.22 * (nx * 4.2).sin()).abs() * 7.0).min(1.0);
+                    let upper_glow =
+                        (1.0 - (((nx - 0.72).powi(2) + (ny - 0.08).powi(2)).sqrt() * 1.5)).max(0.0);
+                    let lower_glow =
+                        (1.0 - (((nx - 0.18).powi(2) + (ny - 0.88).powi(2)).sqrt() * 1.8)).max(0.0);
+                    let ribbon =
+                        (1.0 - ((ny - 0.64 + 0.08 * (nx * 5.4).sin()).abs() * 6.5)).max(0.0);
                     self.set(
-                        x as i32,
-                        y as i32,
+                        rect.0 + x,
+                        rect.1 + y,
                         [
-                            (139.0 + 87.0 * (1.0 - glow).max(0.0) + 25.0 * wave) as u8,
-                            (69.0 + 95.0 * (1.0 - glow).max(0.0) + 19.0 * wave) as u8,
-                            (22.0 + 72.0 * (1.0 - glow).max(0.0) + 5.0 * wave) as u8,
+                            (35.0 + 45.0 * upper_glow + 25.0 * lower_glow + 19.0 * ribbon) as u8,
+                            (25.0 + 36.0 * upper_glow + 17.0 * lower_glow + 11.0 * ribbon) as u8,
+                            (18.0 + 22.0 * upper_glow + 10.0 * lower_glow + 5.0 * ribbon) as u8,
                             255,
                         ],
                     );
+                }
+            }
+        }
+
+        fn smoked_shell(&mut self) {
+            let width = self.width as i32;
+            let height = self.height as i32;
+            self.fill((0, 0, width, height), 0, [15, 10, 7, 255]);
+            self.fill((0, 0, width, height), 14, [24, 16, 10, 255]);
+
+            let header_height = (height / 12).clamp(24, 42);
+            self.fill(
+                (2, 2, width.saturating_sub(4), header_height),
+                12,
+                [66, 50, 36, 92],
+            );
+            self.fill((16, 3, width.saturating_sub(32), 1), 0, [235, 211, 181, 92]);
+
+            // Fine, low-contrast grain keeps the painted fallback from looking
+            // flat when the system backdrop is unavailable (for example RDP).
+            for y in (8..height.saturating_sub(8)).step_by(4) {
+                for x in ((y & 7)..width.saturating_sub(8)).step_by(8) {
+                    self.blend(x, y, [205, 181, 155, 7]);
                 }
             }
         }
@@ -540,8 +601,23 @@ mod native {
 
     #[cfg(test)]
     mod tests {
+        use std::io::Cursor;
+
         use super::*;
+        use image::{ImageFormat, Rgba, RgbaImage};
         use pip_preview::PipTarget;
+
+        fn solid_png(width: u32, height: u32, color: [u8; 4]) -> Vec<u8> {
+            let image = RgbaImage::from_pixel(width, height, Rgba(color));
+            let mut bytes = Cursor::new(Vec::new());
+            image.write_to(&mut bytes, ImageFormat::Png).unwrap();
+            bytes.into_inner()
+        }
+
+        fn pixel(data: &[u8], width: u32, x: u32, y: u32) -> [u8; 4] {
+            let offset = ((y * width + x) * 4) as usize;
+            data[offset..offset + 4].try_into().unwrap()
+        }
 
         #[test]
         fn renderer_tracks_each_target_and_requested_size() {
@@ -567,6 +643,94 @@ mod native {
             );
             assert_eq!(data.len(), 480 * 320 * 4);
             assert!(data.chunks_exact(4).all(|pixel| pixel[3] == 255));
+        }
+
+        #[test]
+        fn renderer_preserves_target_pixels_across_mixed_form_factors() {
+            let frame = |id: &str, kind, png_bytes| PipFrame {
+                target: PipTarget {
+                    workspace_id: "workspace".to_owned(),
+                    workspace_label: "Agent".to_owned(),
+                    target_id: id.to_owned(),
+                    target_kind: kind,
+                    target_label: id.to_owned(),
+                },
+                png_bytes,
+                action_label: "click".to_owned(),
+                timestamp_ms: 1,
+            };
+            let frames = [
+                frame(
+                    "wide",
+                    PipTargetKind::BrowserTab,
+                    solid_png(80, 32, [220, 30, 20, 255]),
+                ),
+                frame(
+                    "tall",
+                    PipTargetKind::NativeWindow,
+                    solid_png(24, 72, [20, 90, 230, 255]),
+                ),
+            ];
+            let width = 520;
+            let height = 360;
+            let data = render_view(width, height, &frames);
+            let desktop = desktop_rect(width, height);
+            let layout = layout_desktop(
+                desktop.2 as f64,
+                desktop.3 as f64,
+                &[
+                    TargetSize {
+                        width: 80,
+                        height: 32,
+                    },
+                    TargetSize {
+                        width: 24,
+                        height: 72,
+                    },
+                ],
+            );
+
+            let wide = offset_pixels(layout.targets[0].content, desktop.0, desktop.1);
+            let tall = offset_pixels(layout.targets[1].content, desktop.0, desktop.1);
+            assert_eq!(
+                pixel(
+                    &data,
+                    width,
+                    (wide.0 + wide.2 / 2) as u32,
+                    (wide.1 + wide.3 / 2) as u32,
+                ),
+                [20, 30, 220, 255]
+            );
+            assert_eq!(
+                pixel(
+                    &data,
+                    width,
+                    (tall.0 + tall.2 / 2) as u32,
+                    (tall.1 + tall.3 / 2) as u32,
+                ),
+                [230, 90, 20, 255]
+            );
+            assert!(wide.2 > wide.3);
+            assert!(tall.3 > tall.2);
+            assert!(wide.0 >= desktop.0 && wide.1 >= desktop.1);
+            assert!(tall.0 + tall.2 <= desktop.0 + desktop.2);
+            assert!(tall.1 + tall.3 <= desktop.1 + desktop.3);
+        }
+
+        #[test]
+        fn renderer_separates_dark_shell_from_inset_desktop() {
+            let width = 360;
+            let data = render_view(width, 240, &[]);
+            let shell = pixel(&data, width, 4, 100);
+            let desktop = pixel(&data, width, 180, 100);
+            let highlight = pixel(&data, width, 180, 1);
+            let brightness = |color: [u8; 4]| color[0] as u16 + color[1] as u16 + color[2] as u16;
+
+            assert_ne!(shell, desktop);
+            assert!(brightness(shell) < brightness(desktop));
+            assert!(shell[0] > shell[1] && shell[1] > shell[2]);
+            assert!(brightness(highlight) > brightness(shell));
+            assert!(highlight[0] > highlight[1] && highlight[1] > highlight[2]);
         }
     }
 }

--- a/libs/cua-driver/rust/crates/platform-windows/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/pip/mod.rs
@@ -1,24 +1,572 @@
-//! Windows picture-in-picture preview stub.
+//! Windows multi-target Agent View.
 //!
-//! The Win32 implementation is a follow-up to the experimental macOS
-//! drop. The plan is a layered, no-activate `WS_EX_NOACTIVATE |
-//! WS_EX_TOPMOST` HWND with a child `STATIC` showing the bitmap of
-//! the latest screenshot, fed via `SetWindowPos` for the never-key
-//! behavior the spec requires. Tracking issue is linked in the docs.
-//!
-//! Until that lands, `start()` returns a clear error so `main.rs`
-//! can log "PiP unavailable on this platform" and continue without
-//! the window.
+//! The preview owns a Win32 message-loop thread and never activates, so it can
+//! remain visible without stealing focus from the application being automated.
 
+#[cfg(not(target_os = "windows"))]
 use pip_preview::{PipBackend, PipBackendFactory, PipConfig};
+
+#[cfg(not(target_os = "windows"))]
+impl PipBackendFactory for WindowsPipBackendFactory {
+    fn start(&self, _cfg: &PipConfig) -> anyhow::Result<Box<dyn PipBackend>> {
+        Err(anyhow::anyhow!("Windows Agent View requires Windows"))
+    }
+}
 
 pub struct WindowsPipBackendFactory;
 
-impl PipBackendFactory for WindowsPipBackendFactory {
-    fn start(&self, _cfg: &PipConfig) -> anyhow::Result<Box<dyn PipBackend>> {
-        Err(anyhow::anyhow!(
-            "PiP preview is not yet implemented on Windows — track \
-             trycua/cua follow-up issue for status"
-        ))
+#[cfg(target_os = "windows")]
+mod native {
+    use std::sync::atomic::{AtomicIsize, Ordering};
+    use std::sync::{mpsc, Arc, Mutex};
+
+    use image::imageops::FilterType;
+    use pip_preview::{
+        layout_desktop, png_dimensions, LayoutRect, PipBackend, PipBackendFactory, PipConfig,
+        PipFrame, PipTargetKind, PipViewModel, TargetSize,
+    };
+    use windows::core::PCWSTR;
+    use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, RECT, WPARAM};
+    use windows::Win32::Graphics::Dwm::{
+        DwmSetWindowAttribute, DWMWA_SYSTEMBACKDROP_TYPE, DWMWA_WINDOW_CORNER_PREFERENCE,
+    };
+    use windows::Win32::Graphics::Gdi::{
+        BeginPaint, EndPaint, InvalidateRect, StretchDIBits, UpdateWindow, BITMAPINFO,
+        BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS, PAINTSTRUCT, SRCCOPY,
+    };
+    use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetClientRect,
+        GetMessageW, GetSystemMetrics, GetWindowLongPtrW, GetWindowRect, LoadCursorW, PostMessageW,
+        PostQuitMessage, RegisterClassExW, SetWindowLongPtrW, ShowWindow, TranslateMessage,
+        CREATESTRUCTW, CS_HREDRAW, CS_VREDRAW, GWLP_USERDATA, HTBOTTOM, HTBOTTOMLEFT,
+        HTBOTTOMRIGHT, HTCAPTION, HTCLIENT, HTLEFT, HTRIGHT, HTTOP, HTTOPLEFT, HTTOPRIGHT,
+        IDC_ARROW, MSG, SM_CXSCREEN, SM_CYSCREEN, SW_SHOWNOACTIVATE, WM_APP, WM_CLOSE, WM_DESTROY,
+        WM_ERASEBKGND, WM_NCCREATE, WM_NCDESTROY, WM_NCHITTEST, WM_PAINT, WM_SIZE, WNDCLASSEXW,
+        WS_CLIPCHILDREN, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_POPUP,
+        WS_THICKFRAME,
+    };
+
+    use super::WindowsPipBackendFactory;
+
+    const REDRAW: u32 = WM_APP + 1;
+    const SHUTDOWN: u32 = WM_APP + 2;
+
+    struct State {
+        hwnd: AtomicIsize,
+        model: Mutex<PipViewModel>,
+    }
+
+    impl State {
+        fn post(&self, message: u32) {
+            let hwnd = self.hwnd.load(Ordering::Acquire);
+            if hwnd != 0 {
+                let _ =
+                    unsafe { PostMessageW(HWND(hwnd as *mut _), message, WPARAM(0), LPARAM(0)) };
+            }
+        }
+    }
+
+    struct WindowsPipBackend {
+        state: Arc<State>,
+    }
+
+    impl PipBackend for WindowsPipBackend {
+        fn push_frame(&self, frame: PipFrame) {
+            self.state.model.lock().unwrap().upsert(frame);
+            self.state.post(REDRAW);
+        }
+
+        fn remove_workspace(&self, workspace_id: &str) {
+            self.state
+                .model
+                .lock()
+                .unwrap()
+                .remove_workspace(workspace_id);
+            self.state.post(REDRAW);
+        }
+
+        fn shutdown(self: Box<Self>) {
+            self.state.post(SHUTDOWN);
+        }
+    }
+
+    impl PipBackendFactory for WindowsPipBackendFactory {
+        fn start(&self, cfg: &PipConfig) -> anyhow::Result<Box<dyn PipBackend>> {
+            let state = Arc::new(State {
+                hwnd: AtomicIsize::new(0),
+                model: Mutex::new(PipViewModel::new(12)),
+            });
+            let thread_state = Arc::clone(&state);
+            let cfg = cfg.clone();
+            let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+            std::thread::Builder::new()
+                .name("cua-agent-view-windows".to_owned())
+                .spawn(move || run_window(cfg, thread_state, ready_tx))?;
+            ready_rx
+                .recv()
+                .map_err(|_| anyhow::anyhow!("Agent View UI thread exited during startup"))??;
+            Ok(Box::new(WindowsPipBackend { state }))
+        }
+    }
+
+    fn wide(value: &str) -> Vec<u16> {
+        value.encode_utf16().chain(std::iter::once(0)).collect()
+    }
+
+    fn run_window(cfg: PipConfig, state: Arc<State>, ready: mpsc::SyncSender<anyhow::Result<()>>) {
+        let hwnd = match unsafe { create_window(&cfg, &state) } {
+            Ok(hwnd) => hwnd,
+            Err(error) => {
+                let _ = ready.send(Err(error));
+                return;
+            }
+        };
+        state.hwnd.store(hwnd.0 as isize, Ordering::Release);
+        let _ = ready.send(Ok(()));
+        unsafe {
+            let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+            let _ = UpdateWindow(hwnd);
+            let mut message = MSG::default();
+            while GetMessageW(&mut message, None, 0, 0).as_bool() {
+                let _ = TranslateMessage(&message);
+                DispatchMessageW(&message);
+            }
+        }
+        state.hwnd.store(0, Ordering::Release);
+    }
+
+    unsafe fn create_window(cfg: &PipConfig, state: &Arc<State>) -> anyhow::Result<HWND> {
+        let instance = GetModuleHandleW(None)?;
+        let class_name = wide("CuaAgentViewWindow");
+        let class = WNDCLASSEXW {
+            cbSize: std::mem::size_of::<WNDCLASSEXW>() as u32,
+            style: CS_HREDRAW | CS_VREDRAW,
+            lpfnWndProc: Some(window_proc),
+            hInstance: instance.into(),
+            hCursor: LoadCursorW(None, IDC_ARROW)?,
+            lpszClassName: PCWSTR(class_name.as_ptr()),
+            ..Default::default()
+        };
+        if RegisterClassExW(&class) == 0 {
+            let error = windows::core::Error::from_win32();
+            if error.code().0 != 0x8007_0582u32 as i32 {
+                return Err(error.into());
+            }
+        }
+
+        let width = cfg.geometry.width.max(320) as i32;
+        let height = cfg.geometry.height.max(240) as i32;
+        let x = cfg
+            .geometry
+            .x
+            .unwrap_or_else(|| (GetSystemMetrics(SM_CXSCREEN) - width - 24).max(0));
+        let y = cfg
+            .geometry
+            .y
+            .unwrap_or(24)
+            .min((GetSystemMetrics(SM_CYSCREEN) - height).max(0));
+        let title = wide(&cfg.title);
+        let state_ptr = Box::into_raw(Box::new(Arc::clone(state)));
+        let hwnd = match CreateWindowExW(
+            WS_EX_TOPMOST | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW,
+            PCWSTR(class_name.as_ptr()),
+            PCWSTR(title.as_ptr()),
+            WS_POPUP | WS_THICKFRAME | WS_CLIPCHILDREN,
+            x,
+            y,
+            width,
+            height,
+            None,
+            None,
+            instance,
+            Some(state_ptr.cast()),
+        ) {
+            Ok(hwnd) => hwnd,
+            Err(error) => {
+                drop(Box::from_raw(state_ptr));
+                return Err(error.into());
+            }
+        };
+        let corner = 2i32; // DWMWCP_ROUND
+        let _ = DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_WINDOW_CORNER_PREFERENCE,
+            (&corner as *const i32).cast(),
+            std::mem::size_of_val(&corner) as u32,
+        );
+        let backdrop = 3i32; // DWMSBT_TRANSIENTWINDOW
+        let _ = DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_SYSTEMBACKDROP_TYPE,
+            (&backdrop as *const i32).cast(),
+            std::mem::size_of_val(&backdrop) as u32,
+        );
+        Ok(hwnd)
+    }
+
+    unsafe extern "system" fn window_proc(
+        hwnd: HWND,
+        message: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> LRESULT {
+        if message == WM_NCCREATE {
+            let create = &*(lparam.0 as *const CREATESTRUCTW);
+            SetWindowLongPtrW(hwnd, GWLP_USERDATA, create.lpCreateParams as isize);
+            return LRESULT(1);
+        }
+        let state_ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut Arc<State>;
+        match message {
+            REDRAW | WM_SIZE => {
+                let _ = InvalidateRect(hwnd, None, false);
+                LRESULT(0)
+            }
+            WM_PAINT => {
+                if !state_ptr.is_null() {
+                    paint(hwnd, &*state_ptr);
+                }
+                LRESULT(0)
+            }
+            WM_ERASEBKGND => LRESULT(1),
+            WM_NCHITTEST => {
+                let hit = DefWindowProcW(hwnd, message, wparam, lparam);
+                if hit.0 == HTCLIENT as isize {
+                    let screen_x = lparam.0 as i16 as i32;
+                    let screen_y = (lparam.0 >> 16) as i16 as i32;
+                    let mut window = RECT::default();
+                    if GetWindowRect(hwnd, &mut window).is_ok() {
+                        let border = 8;
+                        let left = screen_x - window.left < border;
+                        let right = window.right - screen_x <= border;
+                        let top = screen_y - window.top < border;
+                        let bottom = window.bottom - screen_y <= border;
+                        let resize_hit = match (left, right, top, bottom) {
+                            (true, _, true, _) => Some(HTTOPLEFT),
+                            (_, true, true, _) => Some(HTTOPRIGHT),
+                            (true, _, _, true) => Some(HTBOTTOMLEFT),
+                            (_, true, _, true) => Some(HTBOTTOMRIGHT),
+                            (true, _, _, _) => Some(HTLEFT),
+                            (_, true, _, _) => Some(HTRIGHT),
+                            (_, _, true, _) => Some(HTTOP),
+                            (_, _, _, true) => Some(HTBOTTOM),
+                            _ => None,
+                        };
+                        if let Some(resize_hit) = resize_hit {
+                            return LRESULT(resize_hit as isize);
+                        }
+                        if screen_y - window.top < 28 {
+                            return LRESULT(HTCAPTION as isize);
+                        }
+                    }
+                }
+                hit
+            }
+            SHUTDOWN | WM_CLOSE => {
+                let _ = DestroyWindow(hwnd);
+                LRESULT(0)
+            }
+            WM_DESTROY => {
+                PostQuitMessage(0);
+                LRESULT(0)
+            }
+            WM_NCDESTROY => {
+                SetWindowLongPtrW(hwnd, GWLP_USERDATA, 0);
+                if !state_ptr.is_null() {
+                    drop(Box::from_raw(state_ptr));
+                }
+                DefWindowProcW(hwnd, message, wparam, lparam)
+            }
+            _ => DefWindowProcW(hwnd, message, wparam, lparam),
+        }
+    }
+
+    unsafe fn paint(hwnd: HWND, state: &Arc<State>) {
+        let mut ps = PAINTSTRUCT::default();
+        let hdc = BeginPaint(hwnd, &mut ps);
+        let mut rect = RECT::default();
+        if GetClientRect(hwnd, &mut rect).is_err() {
+            let _ = EndPaint(hwnd, &ps);
+            return;
+        }
+        let width = (rect.right - rect.left).max(1) as u32;
+        let height = (rect.bottom - rect.top).max(1) as u32;
+        let frames = state
+            .model
+            .lock()
+            .unwrap()
+            .ordered_frames()
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let pixels = render_view(width, height, &frames);
+        let info = BITMAPINFO {
+            bmiHeader: BITMAPINFOHEADER {
+                biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+                biWidth: width as i32,
+                biHeight: -(height as i32),
+                biPlanes: 1,
+                biBitCount: 32,
+                biCompression: BI_RGB.0,
+                biSizeImage: pixels.len() as u32,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        StretchDIBits(
+            hdc,
+            0,
+            0,
+            width as i32,
+            height as i32,
+            0,
+            0,
+            width as i32,
+            height as i32,
+            Some(pixels.as_ptr().cast()),
+            &info,
+            DIB_RGB_COLORS,
+            SRCCOPY,
+        );
+        let _ = EndPaint(hwnd, &ps);
+    }
+
+    fn render_view(width: u32, height: u32, frames: &[PipFrame]) -> Vec<u8> {
+        let mut canvas = Canvas::new(width, height);
+        canvas.wallpaper();
+        let sizes = frames
+            .iter()
+            .map(|frame| {
+                png_dimensions(&frame.png_bytes).unwrap_or(TargetSize {
+                    width: 16,
+                    height: 10,
+                })
+            })
+            .collect::<Vec<_>>();
+        let layout = layout_desktop(width as f64, height as f64, &sizes);
+        canvas.border(
+            (1, 1, width as i32 - 2, height as i32 - 2),
+            14,
+            [224, 239, 250, 118],
+        );
+        for (frame, target) in frames.iter().zip(&layout.targets) {
+            let rect = pixels(target.content);
+            canvas.shadow(rect);
+            canvas.fill(rect, 7, [244, 247, 251, 255]);
+            if let Ok(image) = image::load_from_memory(&frame.png_bytes) {
+                let image = image
+                    .resize_exact(rect.2 as u32, rect.3 as u32, FilterType::Lanczos3)
+                    .to_rgba8();
+                canvas.blit(&image, rect, 7);
+            }
+            canvas.border(rect, 7, [40, 52, 72, 76]);
+        }
+        let dock = pixels(layout.dock);
+        canvas.fill(dock, 11, [41, 79, 137, 198]);
+        canvas.border(dock, 11, [225, 239, 255, 150]);
+        for (index, icon) in layout.dock_icons.iter().enumerate() {
+            canvas.icon(pixels(*icon), frames[index].target.target_kind, index);
+        }
+        canvas.data
+    }
+
+    fn pixels(rect: LayoutRect) -> (i32, i32, i32, i32) {
+        (
+            rect.x.round() as i32,
+            rect.y.round() as i32,
+            rect.width.round().max(1.0) as i32,
+            rect.height.round().max(1.0) as i32,
+        )
+    }
+
+    struct Canvas {
+        width: u32,
+        height: u32,
+        data: Vec<u8>,
+    }
+
+    impl Canvas {
+        fn new(width: u32, height: u32) -> Self {
+            Self {
+                width,
+                height,
+                data: vec![0; width as usize * height as usize * 4],
+            }
+        }
+
+        fn wallpaper(&mut self) {
+            let w = self.width.max(1) as f32;
+            let h = self.height.max(1) as f32;
+            for y in 0..self.height {
+                for x in 0..self.width {
+                    let nx = x as f32 / w;
+                    let ny = y as f32 / h;
+                    let glow = ((nx - 0.78).powi(2) + (ny - 0.15).powi(2)).sqrt();
+                    let wave = ((ny - 0.72 + 0.22 * (nx * 4.2).sin()).abs() * 7.0).min(1.0);
+                    self.set(
+                        x as i32,
+                        y as i32,
+                        [
+                            (139.0 + 87.0 * (1.0 - glow).max(0.0) + 25.0 * wave) as u8,
+                            (69.0 + 95.0 * (1.0 - glow).max(0.0) + 19.0 * wave) as u8,
+                            (22.0 + 72.0 * (1.0 - glow).max(0.0) + 5.0 * wave) as u8,
+                            255,
+                        ],
+                    );
+                }
+            }
+        }
+
+        fn set(&mut self, x: i32, y: i32, color: [u8; 4]) {
+            if x < 0 || y < 0 || x >= self.width as i32 || y >= self.height as i32 {
+                return;
+            }
+            let at = (y as usize * self.width as usize + x as usize) * 4;
+            self.data[at..at + 4].copy_from_slice(&color);
+        }
+
+        fn blend(&mut self, x: i32, y: i32, color: [u8; 4]) {
+            if x < 0 || y < 0 || x >= self.width as i32 || y >= self.height as i32 {
+                return;
+            }
+            let at = (y as usize * self.width as usize + x as usize) * 4;
+            let alpha = color[3] as u16;
+            for channel in 0..3 {
+                self.data[at + channel] = ((color[channel] as u16 * alpha
+                    + self.data[at + channel] as u16 * (255 - alpha))
+                    / 255) as u8;
+            }
+            self.data[at + 3] = 255;
+        }
+
+        fn inside(x: i32, y: i32, width: i32, height: i32, radius: i32) -> bool {
+            let dx = if x < radius {
+                radius - x
+            } else if x >= width - radius {
+                x - width + radius + 1
+            } else {
+                0
+            };
+            let dy = if y < radius {
+                radius - y
+            } else if y >= height - radius {
+                y - height + radius + 1
+            } else {
+                0
+            };
+            dx == 0 || dy == 0 || dx * dx + dy * dy <= radius * radius
+        }
+
+        fn fill(&mut self, rect: (i32, i32, i32, i32), radius: i32, color: [u8; 4]) {
+            for y in 0..rect.3 {
+                for x in 0..rect.2 {
+                    if Self::inside(x, y, rect.2, rect.3, radius) {
+                        self.blend(rect.0 + x, rect.1 + y, color);
+                    }
+                }
+            }
+        }
+
+        fn border(&mut self, rect: (i32, i32, i32, i32), radius: i32, color: [u8; 4]) {
+            for y in 0..rect.3 {
+                for x in 0..rect.2 {
+                    let outer = Self::inside(x, y, rect.2, rect.3, radius);
+                    let inner = x > 0
+                        && y > 0
+                        && x < rect.2 - 1
+                        && y < rect.3 - 1
+                        && Self::inside(x - 1, y - 1, rect.2 - 2, rect.3 - 2, radius - 1);
+                    if outer && !inner {
+                        self.blend(rect.0 + x, rect.1 + y, color);
+                    }
+                }
+            }
+        }
+
+        fn shadow(&mut self, rect: (i32, i32, i32, i32)) {
+            for spread in (1..=8).rev() {
+                self.border(
+                    (
+                        rect.0 - spread,
+                        rect.1 - spread + 2,
+                        rect.2 + spread * 2,
+                        rect.3 + spread * 2,
+                    ),
+                    7 + spread,
+                    [8, 24, 49, (26 / spread) as u8],
+                );
+            }
+        }
+
+        fn blit(&mut self, image: &image::RgbaImage, rect: (i32, i32, i32, i32), radius: i32) {
+            for y in 0..rect.3 {
+                for x in 0..rect.2 {
+                    if Self::inside(x, y, rect.2, rect.3, radius) {
+                        let p = image.get_pixel(x as u32, y as u32).0;
+                        self.blend(rect.0 + x, rect.1 + y, [p[2], p[1], p[0], p[3]]);
+                    }
+                }
+            }
+        }
+
+        fn icon(&mut self, rect: (i32, i32, i32, i32), kind: PipTargetKind, index: usize) {
+            let colors = match kind {
+                PipTargetKind::BrowserTab => ([31, 180, 210, 255], [205, 91, 28, 255]),
+                PipTargetKind::NativeWindow => [
+                    ([205, 91, 138, 255], [131, 53, 92, 255]),
+                    ([78, 166, 66, 255], [35, 104, 26, 255]),
+                    ([43, 145, 235, 255], [21, 84, 180, 255]),
+                ][index % 3],
+            };
+            self.fill(rect, (rect.2 / 4).max(3), colors.0);
+            let inset = (rect.2 / 4).max(3);
+            self.fill(
+                (
+                    rect.0 + inset,
+                    rect.1 + inset,
+                    rect.2 - inset * 2,
+                    rect.3 - inset * 2,
+                ),
+                3,
+                colors.1,
+            );
+            self.fill(
+                (rect.0 + rect.2 / 5, rect.1 + rect.3 + 4, rect.2 * 3 / 5, 3),
+                1,
+                [245, 248, 255, 235],
+            );
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use pip_preview::PipTarget;
+
+        #[test]
+        fn renderer_tracks_each_target_and_requested_size() {
+            let frame = |id: &str, kind| PipFrame {
+                target: PipTarget {
+                    workspace_id: "workspace".to_owned(),
+                    workspace_label: "Agent".to_owned(),
+                    target_id: id.to_owned(),
+                    target_kind: kind,
+                    target_label: id.to_owned(),
+                },
+                png_bytes: Vec::new(),
+                action_label: "click".to_owned(),
+                timestamp_ms: 1,
+            };
+            let data = render_view(
+                480,
+                320,
+                &[
+                    frame("edge", PipTargetKind::BrowserTab),
+                    frame("notes", PipTargetKind::NativeWindow),
+                ],
+            );
+            assert_eq!(data.len(), 480 * 320 * 4);
+            assert!(data.chunks_exact(4).all(|pixel| pixel[3] == 255));
+        }
     }
 }

--- a/libs/cua-driver/rust/crates/platform-windows/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/pip/mod.rs
@@ -20,10 +20,12 @@ mod native {
     use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
     use std::sync::{mpsc, Arc, Mutex};
 
+    use cursor_overlay::{rasterize_inter_text, TextRaster};
     use image::imageops::FilterType;
     use pip_preview::{
-        layout_desktop, png_dimensions, LayoutRect, PipBackend, PipBackendFactory, PipConfig,
-        PipFrame, PipTargetKind, PipViewModel, PipWorkspaceSummary, TargetSize,
+        layout_desktop_with_shell, png_dimensions, LayoutRect, PipBackend, PipBackendFactory,
+        PipConfig, PipFrame, PipTargetKind, PipViewModel, PipWorkspaceSummary, ShellStyle,
+        TargetSize,
     };
     use windows::core::PCWSTR;
     use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, POINT, RECT, WPARAM};
@@ -456,7 +458,12 @@ mod native {
                 })
             })
             .collect::<Vec<_>>();
-        let layout = layout_desktop(desktop.2 as f64, desktop.3 as f64, &sizes);
+        let layout = layout_desktop_with_shell(
+            desktop.2 as f64,
+            desktop.3 as f64,
+            &sizes,
+            ShellStyle::EdgeTaskbar,
+        );
         canvas.border((0, 0, width as i32, height as i32), 14, [19, 12, 7, 225]);
         canvas.border(
             (1, 1, width as i32 - 2, height as i32 - 2),
@@ -488,10 +495,15 @@ mod native {
             }
             canvas.border(rect, 7, [40, 52, 72, 76]);
         }
-        let dock = offset_pixels(layout.dock, desktop.0, desktop.1);
-        canvas.shadow(dock);
-        canvas.fill(dock, 11, [40, 30, 23, 218]);
-        canvas.border(dock, 11, [204, 176, 145, 118]);
+        // Windows shells anchor their bar to the bottom screen edge instead of
+        // floating it, so the band is painted as a material over the desktop
+        // that is already composited beneath it rather than as a card on top.
+        let taskbar = offset_pixels(layout.dock, desktop.0, desktop.1);
+        canvas.taskbar_material(taskbar, desktop);
+        if let Some(start) = layout.start_button {
+            canvas.start_glyph(offset_pixels(start, desktop.0, desktop.1));
+        }
+        let active = active_target_index(frames);
         for (index, icon) in layout.dock_icons.iter().enumerate() {
             canvas.icon(
                 offset_pixels(*icon, desktop.0, desktop.1),
@@ -499,7 +511,83 @@ mod native {
                 index,
             );
         }
+        for (index, indicator) in layout.indicators.iter().enumerate() {
+            canvas.running_indicator(
+                offset_pixels(*indicator, desktop.0, desktop.1),
+                Some(index) == active,
+            );
+        }
+        if let Some(tray) = layout.tray {
+            canvas.tray(
+                offset_pixels(tray, desktop.0, desktop.1),
+                active.map(|index| frames[index].timestamp_ms),
+            );
+        }
+        // The bar reaches the desktop's bottom edge, so restore the rounded
+        // frame it just painted over.
+        canvas.border(desktop, 10, [181, 151, 122, 138]);
         canvas.data
+    }
+
+    /// Index of the card whose capture is newest, which the taskbar marks as
+    /// the foreground app.
+    ///
+    /// Ties resolve to the earliest card so one repaint never reorders the
+    /// highlight for an unchanged set of frames.
+    fn active_target_index(frames: &[PipFrame]) -> Option<usize> {
+        frames
+            .iter()
+            .enumerate()
+            .max_by_key(|(index, frame)| (frame.timestamp_ms, std::cmp::Reverse(*index)))
+            .map(|(index, _)| index)
+    }
+
+    /// `HH:MM` for one epoch-millisecond capture stamp, in UTC.
+    ///
+    /// The clock reads the newest card's capture time rather than the wall
+    /// clock so a rendered frame stays reproducible from its inputs alone.
+    fn clock_label(timestamp_ms: u64) -> String {
+        let minutes = timestamp_ms / 60_000;
+        format!("{:02}:{:02}", minutes / 60 % 24, minutes % 60)
+    }
+
+    /// Separable box blur over a tightly packed 3-channel buffer.
+    fn box_blur(source: &[u8], width: usize, height: usize, radius: usize) -> Vec<u8> {
+        let mut pass = source.to_vec();
+        let mut out = vec![0u8; source.len()];
+        for vertical in [false, true] {
+            let (major, minor) = if vertical {
+                (width, height)
+            } else {
+                (height, width)
+            };
+            for outer in 0..major {
+                for inner in 0..minor {
+                    let low = inner.saturating_sub(radius);
+                    let high = (inner + radius).min(minor - 1);
+                    let taps = (high - low + 1) as u32;
+                    for channel in 0..3 {
+                        let mut sum = 0u32;
+                        for tap in low..=high {
+                            let at = if vertical {
+                                tap * width + outer
+                            } else {
+                                outer * width + tap
+                            };
+                            sum += pass[at * 3 + channel] as u32;
+                        }
+                        let at = if vertical {
+                            inner * width + outer
+                        } else {
+                            outer * width + inner
+                        };
+                        out[at * 3 + channel] = (sum / taps) as u8;
+                    }
+                }
+            }
+            std::mem::swap(&mut pass, &mut out);
+        }
+        pass
     }
 
     fn desktop_rect(width: u32, height: u32, show_switcher: bool) -> (i32, i32, i32, i32) {
@@ -761,11 +849,173 @@ mod native {
                 3,
                 colors.1,
             );
+        }
+
+        /// Acrylic-like backdrop for the edge-anchored taskbar band.
+        ///
+        /// The band is a material, not a card: it blurs whatever Agent View
+        /// already composited beneath it, tints the result, and adds fine
+        /// noise, which is why it runs after the wallpaper and the target
+        /// cards. Painting is clipped to the miniature desktop so the bar
+        /// keeps the desktop's rounded bottom corners.
+        fn taskbar_material(&mut self, rect: (i32, i32, i32, i32), clip: (i32, i32, i32, i32)) {
+            const BLUR_RADIUS: usize = 5;
+            /// Tint strength out of 255. Leaving some backdrop through is what
+            /// separates acrylic from a flat fill.
+            const TINT_ALPHA: u32 = 196;
+            const TINT: [u32; 3] = [44, 34, 27];
+
+            let width = rect.2.max(0) as usize;
+            let height = rect.3.max(0) as usize;
+            if width == 0 || height == 0 {
+                return;
+            }
+            // Sample with clamped coordinates so the blur never smears the
+            // surrounding shell frame into the band.
+            let mut backdrop = vec![0u8; width * height * 3];
+            for y in 0..height {
+                for x in 0..width {
+                    let sx = (rect.0 + x as i32).clamp(0, self.width as i32 - 1);
+                    let sy = (rect.1 + y as i32).clamp(0, self.height as i32 - 1);
+                    let from = (sy as usize * self.width as usize + sx as usize) * 4;
+                    let to = (y * width + x) * 3;
+                    backdrop[to..to + 3].copy_from_slice(&self.data[from..from + 3]);
+                }
+            }
+            let blurred = box_blur(&backdrop, width, height, BLUR_RADIUS);
+
+            for y in 0..height {
+                for x in 0..width {
+                    let px = rect.0 + x as i32;
+                    let py = rect.1 + y as i32;
+                    if !Self::inside(px - clip.0, py - clip.1, clip.2, clip.3, 10) {
+                        continue;
+                    }
+                    let sample = (y * width + x) * 3;
+                    let mut color = [0u8; 4];
+                    for channel in 0..3 {
+                        color[channel] = ((blurred[sample + channel] as u32 * (255 - TINT_ALPHA)
+                            + TINT[channel] * TINT_ALPHA)
+                            / 255) as u8;
+                    }
+                    color[3] = 255;
+                    self.set(px, py, color);
+                    // Deterministic grain, the visual signature of acrylic.
+                    if (x ^ y) & 3 == 0 {
+                        self.blend(px, py, [188, 170, 150, 6]);
+                    }
+                }
+            }
+
+            // A single bright hairline along the top edge reads as the lit
+            // lip of the bar and keeps it separated from the wallpaper.
+            for x in 0..rect.2 {
+                let px = rect.0 + x;
+                if Self::inside(px - clip.0, rect.1 - clip.1, clip.2, clip.3, 10) {
+                    self.blend(px, rect.1, [214, 190, 162, 96]);
+                }
+            }
+        }
+
+        /// Four-pane launcher glyph anchored at the head of the icon cluster.
+        fn start_glyph(&mut self, rect: (i32, i32, i32, i32)) {
+            let gap = (rect.2 / 9).max(1);
+            let pane_width = ((rect.2 - gap) / 2).max(1);
+            let pane_height = ((rect.3 - gap) / 2).max(1);
+            // Center the glyph inside its slot, which is sized like an app icon.
+            let x = rect.0 + (rect.2 - (pane_width * 2 + gap)) / 2;
+            let y = rect.1 + (rect.3 - (pane_height * 2 + gap)) / 2;
+            for row in 0..2 {
+                for column in 0..2 {
+                    self.fill(
+                        (
+                            x + column * (pane_width + gap),
+                            y + row * (pane_height + gap),
+                            pane_width,
+                            pane_height,
+                        ),
+                        1,
+                        [230, 158, 73, 235],
+                    );
+                }
+            }
+        }
+
+        /// Running-app mark beneath one taskbar icon.
+        ///
+        /// The foreground card gets the full accent pill; the rest get a
+        /// shorter, dimmer mark, matching how a Windows taskbar distinguishes
+        /// the active window from other running ones.
+        fn running_indicator(&mut self, rect: (i32, i32, i32, i32), active: bool) {
+            let (width, color) = if active {
+                (rect.2, [230, 158, 73, 255])
+            } else {
+                ((rect.2 / 2).max(2), [176, 158, 138, 190])
+            };
             self.fill(
-                (rect.0 + rect.2 / 5, rect.1 + rect.3 + 4, rect.2 * 3 / 5, 3),
-                1,
-                [245, 248, 255, 235],
+                (rect.0 + (rect.2 - width) / 2, rect.1, width, rect.3),
+                rect.3 / 2,
+                color,
             );
+        }
+
+        /// Trailing status band: a chevron, a battery mark, and the clock.
+        ///
+        /// Every element is dropped rather than crowded when the band is too
+        /// narrow, so a small Agent View degrades instead of overlapping the
+        /// centered icon cluster.
+        fn tray(&mut self, rect: (i32, i32, i32, i32), timestamp_ms: Option<u64>) {
+            const INK: [u8; 4] = [224, 210, 190, 235];
+            let padding = 8;
+            let mut right = rect.0 + rect.2 - padding;
+
+            let font_size = (rect.3 as f32 * 0.2).clamp(8.0, 13.0);
+            let clock = timestamp_ms
+                .map(clock_label)
+                .and_then(|label| rasterize_inter_text(&label, font_size));
+            if let Some(raster) = clock {
+                if raster.width as i32 + padding * 2 <= rect.2 {
+                    right -= raster.width as i32;
+                    let y = rect.1 + (rect.3 - raster.height as i32) / 2;
+                    self.text(&raster, right, y, INK);
+                }
+            }
+
+            let center_y = rect.1 + rect.3 / 2;
+            // Battery: an outline pill with a nub, drawn only when it fits
+            // clear of the clock.
+            let battery_width = 14;
+            if right - (battery_width + 10) >= rect.0 + padding {
+                right -= battery_width + 10;
+                self.border((right, center_y - 4, battery_width, 8), 2, INK);
+                self.fill((right + battery_width, center_y - 2, 2, 4), 1, INK);
+            }
+            // Chevron: the "show hidden icons" affordance.
+            if right - 12 >= rect.0 + padding {
+                right -= 12;
+                for step in 0..4 {
+                    self.blend(right + step, center_y + 1 - step, INK);
+                    self.blend(right + 6 - step, center_y + 1 - step, INK);
+                }
+            }
+        }
+
+        /// Composite one rasterized text mask in the buffer's channel order.
+        fn text(&mut self, raster: &TextRaster, x: i32, y: i32, color: [u8; 4]) {
+            for row in 0..raster.height {
+                for column in 0..raster.width {
+                    let coverage = raster.coverage[(row * raster.width + column) as usize];
+                    if coverage == 0 {
+                        continue;
+                    }
+                    let alpha = (color[3] as u16 * coverage as u16 / 255) as u8;
+                    self.blend(
+                        x + column as i32,
+                        y + row as i32,
+                        [color[0], color[1], color[2], alpha],
+                    );
+                }
+            }
         }
     }
 
@@ -874,7 +1124,7 @@ mod native {
             let workspaces = [workspace("workspace", 2, 1)];
             let data = render_view(width, height, &frames, &workspaces, Some("workspace"));
             let desktop = desktop_rect(width, height, false);
-            let layout = layout_desktop(
+            let layout = layout_desktop_with_shell(
                 desktop.2 as f64,
                 desktop.3 as f64,
                 &[
@@ -887,6 +1137,7 @@ mod native {
                         height: 72,
                     },
                 ],
+                ShellStyle::EdgeTaskbar,
             );
 
             let wide = offset_pixels(layout.targets[0].content, desktop.0, desktop.1);
@@ -1001,6 +1252,220 @@ mod native {
             assert_eq!(model.selected_frames()[0].target.identity_key, "tall");
             assert_eq!(model.remove_workspace("agent-a").len(), 1);
             assert_eq!(model.selected_workspace_id(), Some("agent-b"));
+        }
+
+        fn taskbar_layout(width: u32, height: u32, targets: usize) -> pip_preview::DesktopLayout {
+            let desktop = desktop_rect(width, height, false);
+            let sizes = vec![
+                TargetSize {
+                    width: 16,
+                    height: 10,
+                };
+                targets
+            ];
+            layout_desktop_with_shell(
+                desktop.2 as f64,
+                desktop.3 as f64,
+                &sizes,
+                ShellStyle::EdgeTaskbar,
+            )
+        }
+
+        /// Mean of one channel over a small window, which averages out the
+        /// material's deterministic grain.
+        fn mean_channel(data: &[u8], width: u32, x: u32, y: u32, channel: usize) -> f32 {
+            let mut sum = 0u32;
+            for dy in 0..4 {
+                for dx in 0..4 {
+                    sum += pixel(data, width, x + dx, y + dy)[channel] as u32;
+                }
+            }
+            sum as f32 / 16.0
+        }
+
+        #[test]
+        fn taskbar_is_edge_anchored_and_spans_the_miniature_desktop() {
+            let (width, height) = (520u32, 360u32);
+            let desktop = desktop_rect(width, height, false);
+            let layout = taskbar_layout(width, height, 2);
+
+            assert_eq!(layout.shell, ShellStyle::EdgeTaskbar);
+            let bar = offset_pixels(layout.dock, desktop.0, desktop.1);
+            assert_eq!(bar.0, desktop.0);
+            assert_eq!(bar.2, desktop.2);
+            assert!(((bar.1 + bar.3) - (desktop.1 + desktop.3)).abs() <= 1);
+
+            // The band is a distinct material, so the wallpaper just above the
+            // bar's top edge never matches the pixels just inside it.
+            let data = render_view(
+                width,
+                height,
+                &[
+                    frame("w", "a", PipTargetKind::BrowserTab, Vec::new(), 1),
+                    frame("w", "b", PipTargetKind::NativeWindow, Vec::new(), 2),
+                ],
+                &[workspace("w", 2, 2)],
+                Some("w"),
+            );
+            let center_x = (desktop.0 + desktop.2 / 2) as u32;
+            let above = pixel(&data, width, center_x, (bar.1 - 6) as u32);
+            let inside = pixel(&data, width, center_x, (bar.1 + 6) as u32);
+            assert_ne!(above, inside);
+        }
+
+        #[test]
+        fn taskbar_material_carries_the_blurred_backdrop_instead_of_a_flat_fill() {
+            let (width, height) = (520u32, 360u32);
+            let desktop = desktop_rect(width, height, false);
+            let layout = taskbar_layout(width, height, 1);
+            let bar = offset_pixels(layout.dock, desktop.0, desktop.1);
+            let data = render_view(
+                width,
+                height,
+                &[frame("w", "a", PipTargetKind::BrowserTab, Vec::new(), 1)],
+                &[workspace("w", 1, 1)],
+                Some("w"),
+            );
+
+            // The wallpaper's lower glow sits left of center, so a material
+            // that samples what it covers stays brighter on the left. A flat
+            // fill would make these identical.
+            let sample_y = (bar.1 + bar.3 / 3) as u32;
+            let left = mean_channel(&data, width, (desktop.0 + 80) as u32, sample_y, 0);
+            let right = mean_channel(
+                &data,
+                width,
+                (desktop.0 + desktop.2 - 90) as u32,
+                sample_y,
+                0,
+            );
+            assert!(
+                left - right >= 3.0,
+                "expected a blurred backdrop gradient, got {left} vs {right}"
+            );
+            // It is still a heavy tint, not a window into the wallpaper.
+            assert!(left < 90.0);
+        }
+
+        #[test]
+        fn taskbar_marks_the_newest_card_more_strongly_than_the_others() {
+            let (width, height) = (560u32, 380u32);
+            let desktop = desktop_rect(width, height, false);
+            let layout = taskbar_layout(width, height, 2);
+            let data = render_view(
+                width,
+                height,
+                &[
+                    frame("w", "a", PipTargetKind::BrowserTab, Vec::new(), 1),
+                    frame("w", "b", PipTargetKind::NativeWindow, Vec::new(), 9),
+                ],
+                &[workspace("w", 2, 9)],
+                Some("w"),
+            );
+            assert_eq!(layout.indicators.len(), 2);
+            let brightness = |index: usize| {
+                let mark = offset_pixels(layout.indicators[index], desktop.0, desktop.1);
+                let color = pixel(
+                    &data,
+                    width,
+                    (mark.0 + mark.2 / 2) as u32,
+                    (mark.1 + mark.3 / 2) as u32,
+                );
+                color[0] as i32 + color[1] as i32 + color[2] as i32
+            };
+            // Index 1 is newest, so it wears the accent pill.
+            assert!(brightness(1) != brightness(0));
+            let active = offset_pixels(layout.indicators[1], desktop.0, desktop.1);
+            let accent = pixel(
+                &data,
+                width,
+                (active.0 + active.2 / 2) as u32,
+                (active.1 + active.3 / 2) as u32,
+            );
+            assert!(accent[0] > accent[1] && accent[1] > accent[2]);
+        }
+
+        #[test]
+        fn start_slot_and_tray_paint_inside_the_bar() {
+            let (width, height) = (560u32, 380u32);
+            let desktop = desktop_rect(width, height, false);
+            let layout = taskbar_layout(width, height, 2);
+            let bar = offset_pixels(layout.dock, desktop.0, desktop.1);
+            let start = offset_pixels(layout.start_button.unwrap(), desktop.0, desktop.1);
+            let tray = offset_pixels(layout.tray.unwrap(), desktop.0, desktop.1);
+            assert!(start.1 >= bar.1 && start.1 + start.3 <= bar.1 + bar.3);
+            assert_eq!(tray.0 + tray.2, bar.0 + bar.2);
+
+            let data = render_view(
+                width,
+                height,
+                &[
+                    frame("w", "a", PipTargetKind::BrowserTab, Vec::new(), 42 * 60_000),
+                    frame("w", "b", PipTargetKind::NativeWindow, Vec::new(), 1),
+                ],
+                &[workspace("w", 2, 42 * 60_000)],
+                Some("w"),
+            );
+            let empty = render_view(width, height, &[], &[workspace("w", 0, 1)], Some("w"));
+            let glyph_region = |data: &[u8], rect: (i32, i32, i32, i32)| {
+                let mut ink = 0u32;
+                for y in rect.1..rect.1 + rect.3 {
+                    for x in rect.0..rect.0 + rect.2 {
+                        ink += pixel(data, width, x as u32, y as u32)[0] as u32;
+                    }
+                }
+                ink
+            };
+            // Both the launcher glyph and the tray band paint measurably
+            // brighter than the bare material behind them.
+            assert!(glyph_region(&data, start) > glyph_region(&empty, start));
+            assert!(glyph_region(&data, tray) > glyph_region(&empty, tray));
+        }
+
+        #[test]
+        fn clock_and_foreground_selection_are_derived_only_from_frame_inputs() {
+            assert_eq!(clock_label(0), "00:00");
+            assert_eq!(clock_label(9 * 3_600_000 + 5 * 60_000), "09:05");
+            assert_eq!(clock_label(23 * 3_600_000 + 59 * 60_000), "23:59");
+            // Wrapping past a day keeps a valid time rather than overflowing.
+            assert_eq!(clock_label(25 * 3_600_000), "01:00");
+
+            let make = |stamps: [u64; 3]| {
+                stamps
+                    .iter()
+                    .enumerate()
+                    .map(|(index, stamp)| {
+                        frame(
+                            "w",
+                            &index.to_string(),
+                            PipTargetKind::NativeWindow,
+                            Vec::new(),
+                            *stamp,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            };
+            assert_eq!(active_target_index(&[]), None);
+            assert_eq!(active_target_index(&make([1, 7, 3])), Some(1));
+            // Ties resolve to the earliest card so repaints stay stable.
+            assert_eq!(active_target_index(&make([7, 7, 7])), Some(0));
+        }
+
+        #[test]
+        fn box_blur_flattens_an_impulse_without_changing_a_uniform_field() {
+            let uniform = vec![120u8; 9 * 9 * 3];
+            assert_eq!(box_blur(&uniform, 9, 9, 2), uniform);
+
+            let mut impulse = vec![0u8; 9 * 9 * 3];
+            let center = (4 * 9 + 4) * 3;
+            impulse[center..center + 3].copy_from_slice(&[255, 255, 255]);
+            let blurred = box_blur(&impulse, 9, 9, 2);
+            assert!(blurred[center] < 255);
+            // Energy spreads to the neighbours the impulse never touched.
+            assert!(blurred[((4 * 9 + 6) * 3)] > 0);
+            assert!(blurred[((2 * 9 + 4) * 3)] > 0);
+            // ...but not past the kernel radius.
+            assert_eq!(blurred[((4 * 9 + 8) * 3)], 0);
         }
 
         #[test]

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -8031,7 +8031,8 @@ impl Tool for GetConfigTool {
         // and read it from the overlay deterministically — `all_states().first()`
         // was a nondeterministic HashMap read across sessions (macOS BUG 3).
         let cursor_enabled = crate::overlay::is_enabled(&resolve_cursor_key(&args));
-        let (pip_enabled, pip_geometry) = pip_preview::read_pip_keys_from_file();
+        let (agent_view_enabled, agent_view_geometry) =
+            pip_preview::read_agent_view_keys_from_file();
         let payload = json!({
             "schema_version":      1,
             "version":             env!("CARGO_PKG_VERSION"),
@@ -8040,8 +8041,8 @@ impl Tool for GetConfigTool {
             "capture_mode":        cfg.capture_mode,
             "max_image_dimension": cfg.max_image_dimension,
             "agent_cursor":        { "enabled": cursor_enabled },
-            "experimental_pip":    pip_enabled,
-            "experimental_pip_geometry": pip_geometry,
+            "agent_view":          agent_view_enabled,
+            "agent_view_geometry": agent_view_geometry,
         });
         // Match Swift's text format 1:1: `"✅ <pretty JSON>"`.
         let pretty = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| payload.to_string());
@@ -8076,16 +8077,16 @@ impl Tool for SetConfigTool {
                   `get_window_state` always returns both the UIA tree and a screenshot. Still \
                   accepted/persisted for back-compat but has no effect.\n\
                 - `max_image_dimension` (integer)\n\
-                - `experimental_pip` (boolean; enables the multi-target Agent View after restart — Windows backend stubbed today, see issue #1729)\n\
-                - `experimental_pip_geometry` (Agent View size as `WxH` or `WxH+X+Y`; persisted; applies on next daemon restart)\n\n\
+                - `agent_view` (boolean; enables the multi-target Agent View after restart — Windows backend stubbed today, see issue #1729)\n\
+                - `agent_view_geometry` (Agent View size as `WxH` or `WxH+X+Y`; persisted; applies on next daemon restart)\n\n\
                 Returns the full updated config in the same shape as `get_config`.".into(),
             input_schema: json!({"type":"object","properties":{
                 "key":{"type":"string","description":"Dotted snake_case path to a leaf config field (Swift-compatible shape). Pair with `value`."},
                 "value":{"description":"New value for `key`. JSON type depends on the key."},
                 "capture_mode":{"type":"string","enum":["ax","vision"],"description":"DEPRECATED and ignored — get_window_state always returns both the UIA tree and a screenshot. Still accepted/persisted for back-compat but has no effect. (\"som\"/\"screenshot\" still decode as deprecated aliases.)"},
                 "max_image_dimension":{"type":"integer","description":"Legacy per-field shape."},
-                "experimental_pip":{"type":"boolean","description":"Legacy per-field shape. Enables the multi-target Agent View (applies next restart)."},
-                "experimental_pip_geometry":{"type":"string","description":"Legacy per-field shape. Agent View size + optional position."}
+                "agent_view":{"type":"boolean","description":"Per-field shape. Enables the multi-target Agent View (applies next restart)."},
+                "agent_view_geometry":{"type":"string","description":"Per-field shape. Agent View size + optional position."}
             },"additionalProperties":false}),
             read_only: false, destructive: false, idempotent: true, open_world: false,
         })
@@ -8130,31 +8131,31 @@ impl Tool for SetConfigTool {
                     }
                     None    => return ToolResult::error(format!("`max_image_dimension` must be an integer, got {val}.")),
                 },
-                "experimental_pip" => match val.as_bool() {
+                "agent_view" => match val.as_bool() {
                     Some(b) => {
-                        if let Err(e) = pip_preview::write_config_key("experimental_pip", Value::Bool(b)) {
-                            return ToolResult::error(format!("failed to persist experimental_pip: {e}"));
+                        if let Err(e) = pip_preview::write_config_key("agent_view", Value::Bool(b)) {
+                            return ToolResult::error(format!("failed to persist agent_view: {e}"));
                         }
                         applied = true;
                     }
-                    None => return ToolResult::error(format!("`experimental_pip` must be a boolean, got {val}.")),
+                    None => return ToolResult::error(format!("`agent_view` must be a boolean, got {val}.")),
                 },
-                "experimental_pip_geometry" => match val.as_str() {
+                "agent_view_geometry" => match val.as_str() {
                     Some(s) => {
                         if pip_preview::PipGeometry::parse(s).is_none() {
                             return ToolResult::error(format!(
-                                "experimental_pip_geometry `{s}` is not a valid WxH or WxH+X+Y string"
+                                "agent_view_geometry `{s}` is not a valid WxH or WxH+X+Y string"
                             ));
                         }
-                        if let Err(e) = pip_preview::write_config_key("experimental_pip_geometry", Value::String(s.to_owned())) {
-                            return ToolResult::error(format!("failed to persist experimental_pip_geometry: {e}"));
+                        if let Err(e) = pip_preview::write_config_key("agent_view_geometry", Value::String(s.to_owned())) {
+                            return ToolResult::error(format!("failed to persist agent_view_geometry: {e}"));
                         }
                         applied = true;
                     }
-                    None => return ToolResult::error(format!("`experimental_pip_geometry` must be a string, got {val}.")),
+                    None => return ToolResult::error(format!("`agent_view_geometry` must be a string, got {val}.")),
                 },
                 other => return ToolResult::error(format!(
-                    "Unknown config key `{other}`. Known: capture_mode, max_image_dimension, experimental_pip, experimental_pip_geometry."
+                    "Unknown config key `{other}`. Known: capture_mode, max_image_dimension, agent_view, agent_view_geometry."
                 )),
             }
         }
@@ -8175,29 +8176,22 @@ impl Tool for SetConfigTool {
             }
             applied = true;
         }
-        if let Some(enabled) = args.get("experimental_pip").and_then(|v| v.as_bool()) {
-            if let Err(e) = pip_preview::write_config_key("experimental_pip", Value::Bool(enabled))
-            {
-                return ToolResult::error(format!("failed to persist experimental_pip: {e}"));
+        if let Some(enabled) = args.get("agent_view").and_then(|v| v.as_bool()) {
+            if let Err(e) = pip_preview::write_config_key("agent_view", Value::Bool(enabled)) {
+                return ToolResult::error(format!("failed to persist agent_view: {e}"));
             }
             applied = true;
         }
-        if let Some(geom) = args
-            .get("experimental_pip_geometry")
-            .and_then(|v| v.as_str())
-        {
+        if let Some(geom) = args.get("agent_view_geometry").and_then(|v| v.as_str()) {
             if pip_preview::PipGeometry::parse(geom).is_none() {
                 return ToolResult::error(format!(
-                    "experimental_pip_geometry `{geom}` is not a valid WxH or WxH+X+Y string"
+                    "agent_view_geometry `{geom}` is not a valid WxH or WxH+X+Y string"
                 ));
             }
-            if let Err(e) = pip_preview::write_config_key(
-                "experimental_pip_geometry",
-                Value::String(geom.to_owned()),
-            ) {
-                return ToolResult::error(format!(
-                    "failed to persist experimental_pip_geometry: {e}"
-                ));
+            if let Err(e) =
+                pip_preview::write_config_key("agent_view_geometry", Value::String(geom.to_owned()))
+            {
+                return ToolResult::error(format!("failed to persist agent_view_geometry: {e}"));
             }
             applied = true;
         }
@@ -8215,7 +8209,8 @@ impl Tool for SetConfigTool {
             .first()
             .map(|s| s.config.enabled)
             .unwrap_or(true);
-        let (pip_enabled, pip_geometry) = pip_preview::read_pip_keys_from_file();
+        let (agent_view_enabled, agent_view_geometry) =
+            pip_preview::read_agent_view_keys_from_file();
         let payload = json!({
             "schema_version":      1,
             "version":             env!("CARGO_PKG_VERSION"),
@@ -8224,8 +8219,8 @@ impl Tool for SetConfigTool {
             "capture_mode":        cfg.capture_mode,
             "max_image_dimension": cfg.max_image_dimension,
             "agent_cursor":        { "enabled": cursor_enabled },
-            "experimental_pip":    pip_enabled,
-            "experimental_pip_geometry": pip_geometry,
+            "agent_view":          agent_view_enabled,
+            "agent_view_geometry": agent_view_geometry,
         });
         let pretty = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| payload.to_string());
         ToolResult::text(format!("✅ {pretty}")).with_structured(payload)

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -8076,16 +8076,16 @@ impl Tool for SetConfigTool {
                   `get_window_state` always returns both the UIA tree and a screenshot. Still \
                   accepted/persisted for back-compat but has no effect.\n\
                 - `max_image_dimension` (integer)\n\
-                - `experimental_pip` (boolean; persisted to config.json, applies on next daemon restart — Windows backend stubbed today, see issue #1729)\n\
-                - `experimental_pip_geometry` (string `WxH` or `WxH+X+Y`; persisted; applies on next daemon restart)\n\n\
+                - `experimental_pip` (boolean; enables the multi-target Agent View after restart — Windows backend stubbed today, see issue #1729)\n\
+                - `experimental_pip_geometry` (Agent View size as `WxH` or `WxH+X+Y`; persisted; applies on next daemon restart)\n\n\
                 Returns the full updated config in the same shape as `get_config`.".into(),
             input_schema: json!({"type":"object","properties":{
                 "key":{"type":"string","description":"Dotted snake_case path to a leaf config field (Swift-compatible shape). Pair with `value`."},
                 "value":{"description":"New value for `key`. JSON type depends on the key."},
                 "capture_mode":{"type":"string","enum":["ax","vision"],"description":"DEPRECATED and ignored — get_window_state always returns both the UIA tree and a screenshot. Still accepted/persisted for back-compat but has no effect. (\"som\"/\"screenshot\" still decode as deprecated aliases.)"},
                 "max_image_dimension":{"type":"integer","description":"Legacy per-field shape."},
-                "experimental_pip":{"type":"boolean","description":"Legacy per-field shape. Enables PiP preview (applies next restart)."},
-                "experimental_pip_geometry":{"type":"string","description":"Legacy per-field shape. PiP window size + optional position."}
+                "experimental_pip":{"type":"boolean","description":"Legacy per-field shape. Enables the multi-target Agent View (applies next restart)."},
+                "experimental_pip_geometry":{"type":"string","description":"Legacy per-field shape. Agent View size + optional position."}
             },"additionalProperties":false}),
             read_only: false, destructive: false, idempotent: true, open_world: false,
         })

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -8077,7 +8077,7 @@ impl Tool for SetConfigTool {
                   `get_window_state` always returns both the UIA tree and a screenshot. Still \
                   accepted/persisted for back-compat but has no effect.\n\
                 - `max_image_dimension` (integer)\n\
-                - `agent_view` (boolean; enables the multi-target Agent View after restart — Windows backend stubbed today, see issue #1729)\n\
+                - `agent_view` (boolean; enables the multi-target Agent View after restart)\n\
                 - `agent_view_geometry` (Agent View size as `WxH` or `WxH+X+Y`; persisted; applies on next daemon restart)\n\n\
                 Returns the full updated config in the same shape as `get_config`.".into(),
             input_schema: json!({"type":"object","properties":{


### PR DESCRIPTION
## What changed

- replaces the experimental PiP preview with a responsive, resizable Agent View on macOS, Windows, and Linux (X11/XWayland);
- presents exact native windows and Chrome tabs as a miniature desktop while preserving mixed target form factors;
- uses platform-native visual treatments: a glass hardware-like macOS shell and Dock, Windows desktop/taskbar styling, and a GNOME-like Linux frame/dash;
- removes synthetic target title bars so each card preserves the exact captured target pixels;
- groups cards by existing lifecycle sessions without adding claim/release, leases, target movement, target resizing, or target-close semantics;
- removes obsolete experimental PiP aliases and keeps `--agent-view`, `--agent-view-geometry`, `agent_view`, and `agent_view_geometry`;
- updates CLI/config copy to describe the three implemented native backends.

## Contract boundary

Agent View is presentation over existing lifecycle sessions. CLI/MCP action targets remain unchanged, and session grouping is presentation metadata rather than ownership. Browser sessions can continue to address multiple tabs independently.

Resizing Agent View changes only the composition; it never moves or resizes the underlying target windows.

## Validation

Current draft candidate SHA: `c13bd10940a2104954ec3086f8f6f9cfcc7f18ec`

Focused local validation:

- `cargo fmt --all -- --check`;
- `cargo test -p pip-preview` - 16 passed;
- `cargo test -p platform-macos pip` - 4 passed;
- `cargo test -p platform-linux pip::tests` - 4 passed;
- `cargo test -p platform-windows pip::tests` - host compile/filter passed; native renderer proof is listed below;
- `cargo test -p cua-driver cursor_overlay_hosts_the_shared_appkit_loop_when_agent_view_is_enabled` - passed;
- `git diff --check` - passed.

Native platform evidence:

- macOS Lume: exact candidate installed with the stable certificate-backed identity; Accessibility and Screen Recording remained granted; mixed Chrome, Calculator, and TextEdit targets rendered inside the inset shell with top grip, side/bottom rails, shell resize affordance, Dock spacing, preserved target form factors, and a real behind-window `NSVisualEffectView` that blurs and tints the host content through the shell rails;
- Windows Azure (`cua-win-071`): native build and focused renderer test passed; Cua Driver confirmed resize from `800x560` to `920x640`; Calculator and Notepad remained separate and relaid out correctly;
- Linux Fibonacci (`fbonacci-xfce-vm`): 4 focused native tests and the ignored interactive X11 smoke passed; Cua Driver confirmed resize from `720x520` to `820x600`; three distinct form factors remained visible.

The complete representative desktop matrix will be rerun on the final candidate before this draft is marked ready. The macOS build retains the pre-existing duplicate Swift CoreMedia linker warnings.

## Demonstrations

These recordings predate the final shell refinement but exercise the same target/session model:

- [Responsive mixed-target layout](https://cuademo06261324.blob.core.windows.net/demo/cua-driver-agent-view/bf91c1d/responsive-resize.mp4)
- [Background input isolation](https://cuademo06261324.blob.core.windows.net/demo/cua-driver-agent-view/bf91c1d/background-input-isolation.mp4)

## TCC helper attribution

The Lume documentation and runner seed disposable guest TCC grants over SSH, removing the old `vncdottool` setup preamble. This work was salvaged from #3266 and preserves Johnny's co-author credit in commit `1a33a45f616344f69afb9d7a4b90a44dfae30e46`.

Closes #3365

