### PR TITLE
fix(cua-sandbox): allow network access in bare-metal QEMU build VMs

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/builder/build.py
+++ b/libs/python/cua-sandbox/cua_sandbox/builder/build.py
@@ -349,7 +349,7 @@ async def build_user_image(
     # Boot the overlay and execute layers
     from cua_sandbox.runtime.qemu import QEMUBaremetalRuntime
 
-    runtime = QEMUBaremetalRuntime(api_port=18098, memory_mb=8192, cpu_count=4)
+    runtime = QEMUBaremetalRuntime(api_port=18098, memory_mb=8192, cpu_count=4, network_restrict=False)
 
     build_image = Image.from_file(str(user_path), os_type=image.os_type)
     try:

--- a/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
@@ -229,6 +229,7 @@ class QEMUBaremetalRuntime(Runtime):
         arch: str = "x86_64",
         qmp_port: int = 4444,
         use_qmp_transport: bool = False,
+        network_restrict: bool = True,
         extra_args: Optional[list[str]] = None,
     ):
         self.api_port = api_port
@@ -238,6 +239,7 @@ class QEMUBaremetalRuntime(Runtime):
         self.arch = arch
         self.qmp_port = qmp_port
         self.use_qmp_transport = use_qmp_transport
+        self.network_restrict = network_restrict
         self.extra_args = extra_args or []
         self._processes: dict[str, subprocess.Popen] = {}
 
@@ -390,11 +392,12 @@ class QEMUBaremetalRuntime(Runtime):
                     f"if=pflash,format=raw,file={efivars}",
                 ]
 
+            network_restrict = "on" if self.network_restrict else "off"
             cmd += [
                 "-drive",
                 f"file={disk_path},format={disk_fmt},if=virtio",
                 "-netdev",
-                f"user,id=net0,restrict=on,"
+                f"user,id=net0,restrict={network_restrict},"
                 f"hostfwd=tcp:127.0.0.1:{hostfwd_port}-:{guest_port}{extra_hostfwd}",
                 "-device",
                 "virtio-net-pci,netdev=net0,mac=52:55:00:d1:55:01",
@@ -488,6 +491,7 @@ class QEMUBaremetalRuntime(Runtime):
                 memory_mb=memory,
                 cpu_count=cpus,
                 arch=self.arch,
+                network_restrict=self.network_restrict,
                 status="running",
             )
 
@@ -727,12 +731,13 @@ class QEMUBaremetalRuntime(Runtime):
             disk_ext, "raw"
         )
         guest_port = 8000
+        network_restrict = "on" if state.get("network_restrict", self.network_restrict) else "off"
 
         cmd += [
             "-drive",
             f"file={disk_path},format={disk_fmt},if=virtio",
             "-netdev",
-            f"user,id=net0,restrict=on,hostfwd=tcp:127.0.0.1:{api_port}-:{guest_port}",
+            f"user,id=net0,restrict={network_restrict},hostfwd=tcp:127.0.0.1:{api_port}-:{guest_port}",
             "-device",
             "virtio-net-pci,netdev=net0,mac=52:55:00:d1:55:01",
             "-vnc",

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox_state.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox_state.py
@@ -40,6 +40,7 @@ def save(
     memory_mb: Optional[int] = None,
     cpu_count: Optional[int] = None,
     arch: Optional[str] = None,
+    network_restrict: bool = True,
     status: str = "running",
 ) -> None:
     """Write or overwrite the state file for a local sandbox."""
@@ -62,6 +63,7 @@ def save(
         "memory_mb": memory_mb,
         "cpu_count": cpu_count,
         "arch": arch,
+        "network_restrict": network_restrict,
         "status": status,
         "created_at": datetime.now(timezone.utc).isoformat(),
     }


### PR DESCRIPTION
## Summary

- Problem this solves: Local bare-metal QEMU image builds execute `Image` layers (`apt_install`, `pip_install`, `run`, ...) inside a dedicated build VM booted by `build_user_image()`. That VM's only NIC was hardcoded `restrict=on`, isolating the guest from DNS and the internet, so any layer that fetches packages failed — `apt-get update` could not reach the archive and installs reported "Unable to locate package". Networking options passed to the sandbox runtime never reached this internal build VM.
- What changed: `QEMUBaremetalRuntime` now accepts a `network_restrict` option (default `True`, preserving prior behavior) controlling guest NIC isolation. The internal build VM is created unrestricted, since building means running package installers. The policy is persisted in the sandbox state and honored across suspend/resume, which previously reverted to `restrict=on` on the `-loadvm` path.

## Related work

Refs #

RFC (required for a public SDK, CLI, MCP, protocol, compatibility, permission,
or cross-component contract change): Not linked. This is an additive,
backward-compatible option on the public `QEMUBaremetalRuntime` constructor;
no existing behavior or contract changes.

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: Additive SDK option `network_restrict: bool = True` on `QEMUBaremetalRuntime`; the default preserves the existing `restrict=on` behavior, so current users see no change. Sandbox state files gain a `network_restrict` field; state files written before this change are read with a fallback to the runtime's configured value. No CLI/MCP changes.
- Risk and rollback: Low. The only behavior change without an opt-in is that internal build VMs now get network access, which is what their package-install layers require. Callers opting into `network_restrict=False` should be aware the guest can then reach the host network and the internet. Roll back by reverting; already-built user images remain valid.

## Validation

- Focused tests and checks: `py_compile` on all modified modules. No new automated tests — gap acknowledged; the flag is observable via the logged QEMU command line, and a unit test asserting the generated `-netdev` string would be a reasonable follow-up.
- Manual or platform evidence: Built a Linux image carrying `.apt_install("python3-gi", "gir1.2-gtk-4.0")` layers on bare-metal QEMU — previously failed with "Unable to locate package"; the build now completes and the resulting user image boots with the demo app running.
- Known gaps or CI still required: `extra_args` are still not replayed on `resume()` (pre-existing, out of scope). No automated coverage for the new option.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [ ] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.
