### PR TITLE
fix(cua-driver): report every layer when list_windows is given a pid

### DIFF
--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -46,14 +46,14 @@ Use this for "is X installed?" as well as "is X running?". For per-window state 
 
 ### `list_windows`
 
-List all layer-0 top-level windows currently known to WindowServer. Includes off-screen windows (minimized, on another Space, hidden-launched). Use this to find a window_id before calling get_window_state.
+List top-level windows currently known to WindowServer. Without `pid` the result is layer-0 only, because tooltips, popovers, menus and the Dock would swamp a whole-desktop listing; with `pid` every layer of that process is reported, so an app whose UI is an accessory window (floating panel, HUD, SwiftUI onboarding) is reachable instead of looking closed. Includes off-screen windows (minimized, on another Space, hidden-launched). Use this to find a window_id before calling get_window_state.
 
 Per-record fields: window_id, pid, app_name, title, bounds (x/y/width/height, top-left origin), z_index (integer or null; higher values are closer to the front; null means stacking order is unavailable and callers must not infer one), is_on_screen, space_ids, current_space_id (the active Space on that window's display), and on_current_space. The top-level current_space_id is WindowServer's main/global active Space and can differ from a record's current_space_id when displays use independent Spaces. To select a frontmost candidate, take the maximum integer z_index; if every value is null, use an explicit fallback instead of relying on array order.
 
 **Arguments:**
 
 - `on_screen_only` (boolean, optional): When true, drop windows not on the current Space. Default false.
-- `pid` (integer, optional): Optional pid filter. When set, only this pid's windows are returned.
+- `pid` (integer, optional): Optional pid filter. When set, only this pid's windows are returned, and every CGWindow layer is admitted -- a caller that already named the process is not at risk of being swamped. All per-record fields, Space attribution included, are reported the same as in the layer-0 listing.
 
 ### `get_window_state`
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/launch_app.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/launch_app.rs
@@ -517,15 +517,21 @@ fn protected_host_launch_refusal() -> ToolResult {
 
 // ── Blocking helpers ──────────────────────────────────────────────────────────
 
-/// Poll for the pid's layer-0 windows, retrying up to 5x100ms to absorb
+/// Poll for the pid's windows, retrying up to 5x100ms to absorb
 /// LaunchServices → WindowServer latency (mirrors the Swift reference).
+/// Every layer is enumerated so an accessory-only app still comes up
+/// window-ready; layer-0 windows win whenever the process has one.
 fn resolve_windows_for_pid(pid: i32) -> Vec<crate::windows::WindowInfo> {
     for attempt in 0..5 {
-        let found: Vec<_> = crate::windows::all_windows()
+        let found = crate::windows::prefer_layer0(
+            crate::windows::enumerate_windows(
+                crate::windows::WindowQuery::for_pid(pid).skip_spaces(),
+            )
+            .windows
             .into_iter()
-            .filter(|w| w.pid == pid && w.layer == 0)
             .filter(|w| w.bounds.width > 1.0 && w.bounds.height > 1.0)
-            .collect();
+            .collect(),
+        );
         if !found.is_empty() {
             return found;
         }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
@@ -12,7 +12,11 @@ static DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();
 fn def() -> &'static ToolDef {
     DEF.get_or_init(|| ToolDef {
         name: "list_windows".into(),
-        description: "List all layer-0 top-level windows currently known to WindowServer. \
+        description: "List top-level windows currently known to WindowServer. Without `pid` the \
+            result is layer-0 only, because tooltips, popovers, menus and the Dock would swamp a \
+            whole-desktop listing; with `pid` every layer of that process is reported, so an app \
+            whose UI is an accessory window (floating panel, HUD, SwiftUI onboarding) is reachable \
+            instead of looking closed. \
             Includes off-screen windows (minimized, on another Space, hidden-launched). \
             Use this to find a window_id before calling get_window_state.\n\n\
             Per-record fields: window_id, pid, app_name, title, bounds \
@@ -29,7 +33,10 @@ fn def() -> &'static ToolDef {
             "properties": {
                 "pid": {
                     "type": "integer",
-                    "description": "Optional pid filter. When set, only this pid's windows are returned."
+                    "description": "Optional pid filter. When set, only this pid's windows are \
+returned, and every CGWindow layer is admitted -- a caller that already named the process is not \
+at risk of being swamped. Space attribution (space_ids, on_current_space, current_space_id) is not \
+resolved for that enumeration and comes back null."
                 },
                 "on_screen_only": {
                     "type": "boolean",
@@ -56,10 +63,17 @@ impl Tool for ListWindowsTool {
         let pid_filter: Option<i32> = args.opt_i64("pid").map(|v| v as i32);
         let on_screen_only = args.bool_or("on_screen_only", false);
 
-        let enumeration = if on_screen_only {
-            crate::windows::visible_windows_with_space_snapshot()
-        } else {
-            crate::windows::all_windows_with_space_snapshot()
+        // Con pid, todas las capas. Es la semantica que el issue #1451 pidio y
+        // el PR #1452 dejo en el backend Swift; la reescritura a Rust la
+        // perdio, y con ella la unica via de alcanzar una app cuya UI entera
+        // vive en una capa accesoria. El motivo del filtro -- no inundar al
+        // llamante con tooltips, popovers, menus y el Dock -- solo aplica al
+        // listado del escritorio entero, que sigue igual.
+        let enumeration = match (on_screen_only, pid_filter.is_some()) {
+            (true, false) => crate::windows::visible_windows_with_space_snapshot(),
+            (false, false) => crate::windows::all_windows_with_space_snapshot(),
+            (true, true) => crate::windows::visible_windows_any_layer_with_space_snapshot(),
+            (false, true) => crate::windows::all_windows_any_layer_with_space_snapshot(),
         };
         let current_space_id = enumeration.current_space_id;
         let mut windows = enumeration.windows;
@@ -103,6 +117,24 @@ pub(super) fn window_record_json(w: &crate::windows::WindowInfo) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Sin pid el listado sigue siendo de capa 0: nadie que pregunte por el
+    /// escritorio entero debe recibir el Dock, un tooltip ni cada NSMenu
+    /// abierto. Con pid, el llamante ya nombro el proceso y no hay tal riesgo.
+    #[test]
+    fn pid_filter_documents_that_it_admits_every_layer() {
+        let described = def().input_schema["properties"]["pid"]["description"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            described.contains("every CGWindow layer"),
+            "el contrato de capas tiene que estar en el esquema, no solo en el codigo: {described}"
+        );
+        assert!(
+            def().description.contains("layer-0 only"),
+            "y el listado sin pid debe seguir anunciandose como capa 0"
+        );
+    }
 
     #[test]
     fn window_record_includes_observed_z_index() {

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
@@ -111,9 +111,10 @@ pub(super) fn window_record_json(w: &crate::windows::WindowInfo) -> Value {
 mod tests {
     use super::*;
 
-    /// The schema is the contract agents read: a pid query admits every
-    /// layer, a desktop query stays layer-0. The behavior itself is covered
-    /// in `crate::windows::tests`.
+    /// The layer contract — pid queries admit every layer, desktop queries
+    /// stay layer-0 — must be stated in the tool's schema, since callers can
+    /// only learn it from there. The behavior itself is covered in
+    /// `crate::windows::tests`.
     #[test]
     fn pid_filter_documents_that_it_admits_every_layer() {
         let described = def().input_schema["properties"]["pid"]["description"]

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
@@ -35,8 +35,8 @@ fn def() -> &'static ToolDef {
                     "type": "integer",
                     "description": "Optional pid filter. When set, only this pid's windows are \
 returned, and every CGWindow layer is admitted -- a caller that already named the process is not \
-at risk of being swamped. Space attribution (space_ids, on_current_space, current_space_id) is not \
-resolved for that enumeration and comes back null."
+at risk of being swamped. All per-record fields, Space attribution included, are reported the \
+same as in the layer-0 listing."
                 },
                 "on_screen_only": {
                     "type": "boolean",
@@ -63,26 +63,19 @@ impl Tool for ListWindowsTool {
         let pid_filter: Option<i32> = args.opt_i64("pid").map(|v| v as i32);
         let on_screen_only = args.bool_or("on_screen_only", false);
 
-        // Con pid, todas las capas. Es la semantica que el issue #1451 pidio y
-        // el PR #1452 dejo en el backend Swift; la reescritura a Rust la
-        // perdio, y con ella la unica via de alcanzar una app cuya UI entera
-        // vive en una capa accesoria. El motivo del filtro -- no inundar al
-        // llamante con tooltips, popovers, menus y el Dock -- solo aplica al
-        // listado del escritorio entero, que sigue igual.
-        let enumeration = match (on_screen_only, pid_filter.is_some()) {
-            (true, false) => crate::windows::visible_windows_with_space_snapshot(),
-            (false, false) => crate::windows::all_windows_with_space_snapshot(),
-            (true, true) => crate::windows::visible_windows_any_layer_with_space_snapshot(),
-            (false, true) => crate::windows::all_windows_any_layer_with_space_snapshot(),
+        let query = match pid_filter {
+            Some(pid) => crate::windows::WindowQuery::for_pid(pid),
+            None => crate::windows::WindowQuery::desktop(),
         };
+        let query = if on_screen_only {
+            query.on_screen_only()
+        } else {
+            query
+        };
+        let enumeration = crate::windows::enumerate_windows(query);
         let current_space_id = enumeration.current_space_id;
-        let mut windows = enumeration.windows;
 
-        if let Some(pid) = pid_filter {
-            windows.retain(|w| w.pid == pid);
-        }
-
-        let windows_json: Vec<Value> = windows.iter().map(window_record_json).collect();
+        let windows_json: Vec<Value> = enumeration.windows.iter().map(window_record_json).collect();
 
         ToolResult::text(format!("Found {} window(s).", windows_json.len())).with_structured(
             serde_json::json!({
@@ -118,9 +111,9 @@ pub(super) fn window_record_json(w: &crate::windows::WindowInfo) -> Value {
 mod tests {
     use super::*;
 
-    /// Sin pid el listado sigue siendo de capa 0: nadie que pregunte por el
-    /// escritorio entero debe recibir el Dock, un tooltip ni cada NSMenu
-    /// abierto. Con pid, el llamante ya nombro el proceso y no hay tal riesgo.
+    /// The schema is the contract agents read: a pid query admits every
+    /// layer, a desktop query stays layer-0. The behavior itself is covered
+    /// in `crate::windows::tests`.
     #[test]
     fn pid_filter_documents_that_it_admits_every_layer() {
         let described = def().input_schema["properties"]["pid"]["description"]
@@ -128,11 +121,11 @@ mod tests {
             .unwrap_or_default();
         assert!(
             described.contains("every CGWindow layer"),
-            "el contrato de capas tiene que estar en el esquema, no solo en el codigo: {described}"
+            "the layer contract must be in the schema, not just the code: {described}"
         );
         assert!(
             def().description.contains("layer-0 only"),
-            "y el listado sin pid debe seguir anunciandose como capa 0"
+            "the no-pid listing must keep advertising itself as layer-0"
         );
     }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
@@ -51,7 +51,11 @@ fn pid_window_target_candidates(pid: i64) -> Vec<WindowTargetCandidate> {
     let Ok(pid) = i32::try_from(pid) else {
         return Vec::new();
     };
-    window_target_candidates_for_pid(crate::windows::all_windows(), pid)
+    let windows = crate::windows::prefer_layer0(
+        crate::windows::enumerate_windows(crate::windows::WindowQuery::for_pid(pid).skip_spaces())
+            .windows,
+    );
+    window_target_candidates_for_pid(windows, pid)
 }
 
 fn window_target_candidates_for_pid(

--- a/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
@@ -581,12 +581,21 @@ mod tests {
     fn desktop_query_stays_layer0_and_pid_query_admits_every_layer() {
         let desktop = WindowQuery::desktop();
         assert!(desktop.admits(0, 800));
-        assert!(!desktop.admits(3, 800), "the Dock, tooltips and NSMenus must stay out of a whole-desktop listing");
+        assert!(
+            !desktop.admits(3, 800),
+            "the Dock, tooltips and NSMenus must stay out of a whole-desktop listing"
+        );
 
         let for_pid = WindowQuery::for_pid(800);
         assert!(for_pid.admits(0, 800));
-        assert!(for_pid.admits(3, 800), "issue #1451: an accessory-only app must be reachable through its pid");
-        assert!(!for_pid.admits(0, 801), "another process's windows never leak into a pid query");
+        assert!(
+            for_pid.admits(3, 800),
+            "issue #1451: an accessory-only app must be reachable through its pid"
+        );
+        assert!(
+            !for_pid.admits(0, 801),
+            "another process's windows never leak into a pid query"
+        );
     }
 
     /// A fixed Space attribution table standing in for SkyLight.

--- a/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
@@ -88,14 +88,31 @@ pub(crate) fn visible_windows_with_space_snapshot() -> WindowEnumeration {
 /// Enumerate windows on every CGWindow layer, including the accessory layers
 /// (`layer != 0`) that [`all_windows`] hides.
 ///
-/// Only used to answer "does this CGWindowID exist, and who owns it?" — the
-/// question `list_windows` must NOT answer, because surfacing tooltips,
+/// Used to answer "does this CGWindowID exist, and who owns it?" — the question
+/// `list_windows` must not answer *by default*, because surfacing tooltips,
 /// popovers, the Dock and every NSMenu window would swamp callers. Keeping the
-/// layer filter on enumeration and off identity lookup is what lets
+/// layer filter on by default and off identity lookup is what lets
 /// `get_window_state` tell "no such window" apart from "exists, but is not a
 /// layer-0 window" (issue #2237).
+///
+/// A caller that already knows which process it means can opt in through
+/// `list_windows`' `include_all_layers`, which is the only way to reach an app
+/// whose entire UI lives on an accessory layer — a floating panel, a HUD, a
+/// SwiftUI onboarding window. For those, the layer-0 list is empty and the app
+/// looks closed.
 fn all_windows_any_layer() -> Vec<WindowInfo> {
-    enumerate_windows(kCGWindowListExcludeDesktopElements, LayerFilter::AnyLayer).windows
+    all_windows_any_layer_with_space_snapshot().windows
+}
+
+pub(crate) fn all_windows_any_layer_with_space_snapshot() -> WindowEnumeration {
+    enumerate_windows(kCGWindowListExcludeDesktopElements, LayerFilter::AnyLayer)
+}
+
+pub(crate) fn visible_windows_any_layer_with_space_snapshot() -> WindowEnumeration {
+    enumerate_windows(
+        kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
+        LayerFilter::AnyLayer,
+    )
 }
 
 /// Which CGWindow layers an enumeration admits.

--- a/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
@@ -357,9 +357,6 @@ impl SpaceMetadataSource for crate::input::skylight::SpaceQuery {
 }
 
 /// Attribute Spaces to every window in the enumeration, whatever its layer.
-/// Layer selection and Space lookup are independent: a pid-filtered
-/// enumeration admits accessory layers *and* keeps Space metadata on its
-/// layer-0 records.
 pub(crate) fn resolve_space_metadata(
     windows: &mut [WindowInfo],
     source: &impl SpaceMetadataSource,

--- a/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
@@ -64,67 +64,120 @@ extern "C" {
     ) -> core_foundation::array::CFArrayRef;
 }
 
-/// Enumerate all windows (including off-screen).
+/// Enumerate all layer-0 windows (including off-screen).
 pub fn all_windows() -> Vec<WindowInfo> {
-    all_windows_with_space_snapshot().windows
+    enumerate_windows(WindowQuery::desktop()).windows
 }
 
-pub(crate) fn all_windows_with_space_snapshot() -> WindowEnumeration {
-    enumerate_windows(kCGWindowListExcludeDesktopElements, LayerFilter::ZeroOnly)
-}
-
-/// Enumerate only on-screen windows.
+/// Enumerate only on-screen layer-0 windows.
 pub fn visible_windows() -> Vec<WindowInfo> {
-    visible_windows_with_space_snapshot().windows
-}
-
-pub(crate) fn visible_windows_with_space_snapshot() -> WindowEnumeration {
-    enumerate_windows(
-        kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
-        LayerFilter::ZeroOnly,
-    )
-}
-
-/// Enumerate windows on every CGWindow layer, including the accessory layers
-/// (`layer != 0`) that [`all_windows`] hides.
-///
-/// Used to answer "does this CGWindowID exist, and who owns it?" — the question
-/// `list_windows` must not answer *by default*, because surfacing tooltips,
-/// popovers, the Dock and every NSMenu window would swamp callers. Keeping the
-/// layer filter on by default and off identity lookup is what lets
-/// `get_window_state` tell "no such window" apart from "exists, but is not a
-/// layer-0 window" (issue #2237).
-///
-/// A caller that already knows which process it means can opt in through
-/// `list_windows`' `include_all_layers`, which is the only way to reach an app
-/// whose entire UI lives on an accessory layer — a floating panel, a HUD, a
-/// SwiftUI onboarding window. For those, the layer-0 list is empty and the app
-/// looks closed.
-fn all_windows_any_layer() -> Vec<WindowInfo> {
-    all_windows_any_layer_with_space_snapshot().windows
-}
-
-pub(crate) fn all_windows_any_layer_with_space_snapshot() -> WindowEnumeration {
-    enumerate_windows(kCGWindowListExcludeDesktopElements, LayerFilter::AnyLayer)
-}
-
-pub(crate) fn visible_windows_any_layer_with_space_snapshot() -> WindowEnumeration {
-    enumerate_windows(
-        kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
-        LayerFilter::AnyLayer,
-    )
+    enumerate_windows(WindowQuery::desktop().on_screen_only()).windows
 }
 
 /// Which CGWindow layers an enumeration admits.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LayerFilter {
-    /// Normal application windows only — what `list_windows` reports.
+pub(crate) enum LayerFilter {
+    /// Normal application windows only — what a whole-desktop listing reports,
+    /// because tooltips, popovers, the Dock and every NSMenu window would
+    /// swamp a caller that didn't name a process.
     ZeroOnly,
     /// Every layer, accessory windows included.
     AnyLayer,
 }
 
-fn enumerate_windows(options: u32, layers: LayerFilter) -> WindowEnumeration {
+/// Whether an enumeration resolves per-window Space attribution via SkyLight.
+///
+/// Independent of [`LayerFilter`]: a layer never decides whether Space data is
+/// looked up. Identity lookups skip it because they answer "does this id
+/// exist?" on hot input paths where per-window SkyLight round-trips are pure
+/// cost.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SpaceLookup {
+    Resolve,
+    Skip,
+}
+
+/// One description of a window enumeration. Layer selection, pid filtering,
+/// on-screen filtering and Space lookup are independent axes; every caller —
+/// `list_windows`, `launch_app`, main-window resolution, identity lookup —
+/// goes through [`enumerate_windows`] with one of these.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct WindowQuery {
+    pub(crate) on_screen_only: bool,
+    pub(crate) layers: LayerFilter,
+    pub(crate) pid: Option<i32>,
+    pub(crate) spaces: SpaceLookup,
+}
+
+impl WindowQuery {
+    /// Whole-desktop listing: layer 0 only, Space attribution resolved.
+    pub(crate) fn desktop() -> Self {
+        Self {
+            on_screen_only: false,
+            layers: LayerFilter::ZeroOnly,
+            pid: None,
+            spaces: SpaceLookup::Resolve,
+        }
+    }
+
+    /// Everything one process owns, on every layer, Space attribution
+    /// resolved. Admitting every layer is what makes an app whose entire UI
+    /// is an accessory window (floating panel, HUD, SwiftUI onboarding)
+    /// reachable instead of looking closed (issue #1451): a caller that
+    /// already named the process is not at risk of being swamped by the
+    /// desktop-wide accessory noise.
+    pub(crate) fn for_pid(pid: i32) -> Self {
+        Self {
+            on_screen_only: false,
+            layers: LayerFilter::AnyLayer,
+            pid: Some(pid),
+            spaces: SpaceLookup::Resolve,
+        }
+    }
+
+    /// Identity lookup: "does this CGWindowID exist, and who owns it?" — every
+    /// layer, no Space resolution. Keeping the layer filter off identity
+    /// lookup is what lets `get_window_state` tell "no such window" apart
+    /// from "exists, but is not a layer-0 window" (issue #2237).
+    fn identity() -> Self {
+        Self {
+            on_screen_only: false,
+            layers: LayerFilter::AnyLayer,
+            pid: None,
+            spaces: SpaceLookup::Skip,
+        }
+    }
+
+    pub(crate) fn on_screen_only(mut self) -> Self {
+        self.on_screen_only = true;
+        self
+    }
+
+    pub(crate) fn skip_spaces(mut self) -> Self {
+        self.spaces = SpaceLookup::Skip;
+        self
+    }
+
+    /// Whether an enumerated window survives this query's filters.
+    fn admits(&self, layer: i32, pid: i32) -> bool {
+        let layer_ok = self.layers == LayerFilter::AnyLayer || layer == 0;
+        let pid_ok = self.pid.is_none_or(|wanted| wanted == pid);
+        layer_ok && pid_ok
+    }
+}
+
+/// The pid's windows with layer-0 preferred: when the process has any layer-0
+/// window, accessory windows stay out (existing behavior for every normal
+/// app); when it has none, the accessory windows are all there is to return.
+pub(crate) fn prefer_layer0(windows: Vec<WindowInfo>) -> Vec<WindowInfo> {
+    if windows.iter().any(|w| w.layer == 0) {
+        windows.into_iter().filter(|w| w.layer == 0).collect()
+    } else {
+        windows
+    }
+}
+
+pub(crate) fn enumerate_windows(query: WindowQuery) -> WindowEnumeration {
     use core_foundation::{
         array::CFArray,
         base::{CFGetTypeID, CFTypeRef, TCFType},
@@ -135,13 +188,18 @@ fn enumerate_windows(options: u32, layers: LayerFilter) -> WindowEnumeration {
     };
     use std::os::raw::c_void;
 
-    let space_query = (layers == LayerFilter::ZeroOnly)
+    let space_query = (query.spaces == SpaceLookup::Resolve)
         .then(crate::input::skylight::SpaceQuery::new)
         .flatten();
     let current_space_id = space_query
         .as_ref()
         .and_then(|query| query.current_space_id());
 
+    let options = if query.on_screen_only {
+        kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements
+    } else {
+        kCGWindowListExcludeDesktopElements
+    };
     let raw_ref = unsafe { CGWindowListCopyWindowInfo(options, kCGNullWindowID) };
     if raw_ref.is_null() {
         return WindowEnumeration {
@@ -215,8 +273,7 @@ fn enumerate_windows(options: u32, layers: LayerFilter) -> WindowEnumeration {
         let layer = get_num("kCGWindowLayer") as i32;
         let is_on_screen = get_bool("kCGWindowIsOnscreen");
 
-        // Only include layer-0 windows, unless the caller asked for every layer.
-        if layer != 0 && layers == LayerFilter::ZeroOnly {
+        if !query.admits(layer, pid) {
             continue;
         }
 
@@ -269,25 +326,50 @@ fn enumerate_windows(options: u32, layers: LayerFilter) -> WindowEnumeration {
         });
     }
 
-    if layers == LayerFilter::ZeroOnly {
-        let Some(query) = &space_query else {
-            return WindowEnumeration {
-                windows: results,
-                current_space_id,
-            };
-        };
-        for window in &mut results {
-            let space_ids = query.window_space_ids(window.window_id);
-            let display_space_id = space_ids
-                .as_ref()
-                .and_then(|_| query.current_space_for_window(window.window_id));
-            apply_window_space_metadata(window, space_ids, display_space_id);
-        }
+    if let Some(query) = &space_query {
+        resolve_space_metadata(&mut results, query);
     }
 
     WindowEnumeration {
         windows: results,
         current_space_id,
+    }
+}
+
+/// Where per-window Space attribution comes from. [`SpaceQuery`] in
+/// production; a fixture in tests, so the attribution pipeline is testable
+/// without a WindowServer.
+///
+/// [`SpaceQuery`]: crate::input::skylight::SpaceQuery
+pub(crate) trait SpaceMetadataSource {
+    fn space_ids(&self, window_id: u32) -> Option<Vec<u64>>;
+    fn display_space(&self, window_id: u32) -> Option<u64>;
+}
+
+impl SpaceMetadataSource for crate::input::skylight::SpaceQuery {
+    fn space_ids(&self, window_id: u32) -> Option<Vec<u64>> {
+        self.window_space_ids(window_id)
+    }
+
+    fn display_space(&self, window_id: u32) -> Option<u64> {
+        self.current_space_for_window(window_id)
+    }
+}
+
+/// Attribute Spaces to every window in the enumeration, whatever its layer.
+/// Layer selection and Space lookup are independent: a pid-filtered
+/// enumeration admits accessory layers *and* keeps Space metadata on its
+/// layer-0 records.
+pub(crate) fn resolve_space_metadata(
+    windows: &mut [WindowInfo],
+    source: &impl SpaceMetadataSource,
+) {
+    for window in windows {
+        let space_ids = source.space_ids(window.window_id);
+        let display_space_id = space_ids
+            .as_ref()
+            .and_then(|_| source.display_space(window.window_id));
+        apply_window_space_metadata(window, space_ids, display_space_id);
     }
 }
 
@@ -344,7 +426,8 @@ fn get_bounds_num(
 /// Returns `None` only when WindowServer has no record of the id at all —
 /// which is precisely the "closed or fabricated window_id" signal callers need.
 pub fn window_info_by_id(window_id: u32) -> Option<WindowInfo> {
-    all_windows_any_layer()
+    enumerate_windows(WindowQuery::identity())
+        .windows
         .into_iter()
         .find(|w| w.window_id == window_id)
 }
@@ -391,29 +474,40 @@ pub fn resolve_window_owner_in(windows: &[WindowInfo], pid: i32, window_id: u32)
 /// Resolve whether `pid` really owns `window_id`. Blocking (one CGWindowList
 /// enumeration).
 pub fn resolve_window_owner(pid: i32, window_id: u32) -> WindowOwner {
-    resolve_window_owner_in(&all_windows_any_layer(), pid, window_id)
+    resolve_window_owner_in(
+        &enumerate_windows(WindowQuery::identity()).windows,
+        pid,
+        window_id,
+    )
 }
 
-/// Select the best window_id for a pid.
+/// Select the best window_id for a pid. Every layer is enumerated so an app
+/// whose entire UI is an accessory window resolves at all; layer-0 windows
+/// still win whenever the process has one.
 pub fn resolve_main_window_id(pid: i32) -> anyhow::Result<u32> {
-    let windows = all_windows();
-    let pid_windows: Vec<&WindowInfo> = windows.iter().filter(|w| w.pid == pid).collect();
-    if pid_windows.is_empty() {
-        anyhow::bail!("pid {pid} has no windows");
-    }
-    let mut on_screen: Vec<&&WindowInfo> = pid_windows.iter().filter(|w| w.is_on_screen).collect();
+    let windows = prefer_layer0(enumerate_windows(WindowQuery::for_pid(pid).skip_spaces()).windows);
+    select_main_window(&windows).ok_or_else(|| anyhow::anyhow!("pid {pid} has no windows"))
+}
+
+/// Pure form of [`resolve_main_window_id`]'s selection over an
+/// already-enumerated window list: frontmost on-screen window, else the
+/// largest one.
+pub(crate) fn select_main_window(windows: &[WindowInfo]) -> Option<u32> {
+    let mut on_screen: Vec<&WindowInfo> = windows.iter().filter(|w| w.is_on_screen).collect();
     if !on_screen.is_empty() {
         on_screen.sort_by_key(|window| std::cmp::Reverse(window.z_index));
-        return Ok(on_screen[0].window_id);
+        return Some(on_screen[0].window_id);
     }
-    let largest = pid_windows.iter().max_by(|a, b| {
-        let area_a = a.bounds.width * a.bounds.height;
-        let area_b = b.bounds.width * b.bounds.height;
-        area_a
-            .partial_cmp(&area_b)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-    Ok(largest.unwrap().window_id)
+    windows
+        .iter()
+        .max_by(|a, b| {
+            let area_a = a.bounds.width * a.bounds.height;
+            let area_b = b.bounds.width * b.bounds.height;
+            area_a
+                .partial_cmp(&area_b)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|w| w.window_id)
 }
 
 #[cfg(test)]
@@ -478,6 +572,149 @@ mod tests {
             on_current_space: None,
             space_ids: None,
         }
+    }
+
+    fn accessory_window(window_id: u32, pid: i32, app_name: &str, layer: i32) -> WindowInfo {
+        let mut w = window(window_id, pid, app_name);
+        w.layer = layer;
+        w
+    }
+
+    #[test]
+    fn desktop_query_stays_layer0_and_pid_query_admits_every_layer() {
+        let desktop = WindowQuery::desktop();
+        assert!(desktop.admits(0, 800));
+        assert!(!desktop.admits(3, 800), "the Dock, tooltips and NSMenus must stay out of a whole-desktop listing");
+
+        let for_pid = WindowQuery::for_pid(800);
+        assert!(for_pid.admits(0, 800));
+        assert!(for_pid.admits(3, 800), "issue #1451: an accessory-only app must be reachable through its pid");
+        assert!(!for_pid.admits(0, 801), "another process's windows never leak into a pid query");
+    }
+
+    /// A fixed Space attribution table standing in for SkyLight.
+    struct SpaceTable(Vec<(u32, Vec<u64>, u64)>);
+
+    impl SpaceMetadataSource for SpaceTable {
+        fn space_ids(&self, window_id: u32) -> Option<Vec<u64>> {
+            self.0
+                .iter()
+                .find(|(id, _, _)| *id == window_id)
+                .map(|(_, spaces, _)| spaces.clone())
+        }
+
+        fn display_space(&self, window_id: u32) -> Option<u64> {
+            self.0
+                .iter()
+                .find(|(id, _, _)| *id == window_id)
+                .map(|(_, _, display)| *display)
+        }
+    }
+
+    /// The regression the any-layer pid path must not reintroduce: admitting
+    /// accessory layers into an enumeration must not cost the layer-0 records
+    /// their Space attribution. `list_windows({pid})` on TextEdit has to keep
+    /// returning space_ids/on_current_space/current_space_id for the document
+    /// window while also reporting any accessory window.
+    #[test]
+    fn space_attribution_is_independent_of_layer_selection() {
+        let mut windows = vec![
+            window(41, 800, "TextEdit"),
+            accessory_window(194, 800, "TextEdit", 3),
+        ];
+        let table = SpaceTable(vec![(41, vec![2, 4], 4), (194, vec![4], 4)]);
+
+        resolve_space_metadata(&mut windows, &table);
+
+        let document = &windows[0];
+        assert_eq!(document.space_ids, Some(vec![2, 4]));
+        assert_eq!(document.current_space_id, Some(4));
+        assert_eq!(document.on_current_space, Some(true));
+
+        let panel = &windows[1];
+        assert_eq!(panel.space_ids, Some(vec![4]));
+        assert_eq!(panel.on_current_space, Some(true));
+    }
+
+    #[test]
+    fn space_attribution_stays_null_only_when_skylight_has_no_record() {
+        let mut windows = vec![window(41, 800, "TextEdit")];
+        resolve_space_metadata(&mut windows, &SpaceTable(vec![]));
+        assert_eq!(windows[0].space_ids, None);
+        assert_eq!(windows[0].on_current_space, None);
+    }
+
+    #[test]
+    fn layer0_still_wins_main_window_resolution_when_the_app_has_one() {
+        let windows = prefer_layer0(vec![
+            accessory_window(194, 800, "TextEdit", 3),
+            window(41, 800, "TextEdit"),
+        ]);
+        assert_eq!(select_main_window(&windows), Some(41));
+    }
+
+    /// Issue #1451: before the shared any-layer pid path, this app resolved to
+    /// "pid has no windows" and launch_app reported it as window-less.
+    #[test]
+    fn accessory_only_app_resolves_its_accessory_window_as_main() {
+        let windows = prefer_layer0(vec![accessory_window(194, 800, "OnboardingApp", 3)]);
+        assert_eq!(select_main_window(&windows), Some(194));
+    }
+
+    /// Live check against WindowServer for the review regression: a
+    /// pid-filtered enumeration must keep Space attribution on layer-0
+    /// records. Needs a running TextEdit; run with
+    /// `TEXTEDIT_PID=$(pgrep -x TextEdit) cargo test -p platform-macos live_pid -- --ignored --nocapture`.
+    #[test]
+    #[ignore = "needs a live WindowServer and a running TextEdit"]
+    fn live_pid_enumeration_keeps_space_attribution_on_layer0() {
+        let pid: i32 = std::env::var("TEXTEDIT_PID")
+            .expect("set TEXTEDIT_PID")
+            .parse()
+            .expect("TEXTEDIT_PID must be a pid");
+        let windows = enumerate_windows(WindowQuery::for_pid(pid)).windows;
+        assert!(!windows.is_empty(), "TextEdit should have windows");
+        for w in &windows {
+            eprintln!(
+                "id={} layer={} {}x{} spaces={:?} on_current={:?} display_space={:?}",
+                w.window_id,
+                w.layer,
+                w.bounds.width,
+                w.bounds.height,
+                w.space_ids,
+                w.on_current_space,
+                w.current_space_id
+            );
+        }
+        // The regression bar: layer-0 records must carry exactly the Space
+        // attribution the layer-0 desktop listing gives them. (Some windows
+        // legitimately have none — SkyLight has no Space record for
+        // never-shown windows — so equality, not is_some, is the check.)
+        let desktop = enumerate_windows(WindowQuery::desktop()).windows;
+        for w in windows.iter().filter(|w| w.layer == 0) {
+            let reference = desktop
+                .iter()
+                .find(|d| d.window_id == w.window_id)
+                .expect("layer-0 window must appear in the desktop listing");
+            assert_eq!(w.space_ids, reference.space_ids, "id={}", w.window_id);
+            assert_eq!(
+                w.on_current_space, reference.on_current_space,
+                "id={}",
+                w.window_id
+            );
+            assert_eq!(
+                w.current_space_id, reference.current_space_id,
+                "id={}",
+                w.window_id
+            );
+        }
+        assert!(
+            windows
+                .iter()
+                .filter(|w| w.layer == 0 && w.is_on_screen)
+                .all(|w| w.space_ids.is_some() && w.on_current_space.is_some()),
+            "on-screen layer-0 records must keep Space attribution in a pid enumeration"
+        );
     }
 
     #[test]


### PR DESCRIPTION
An app whose entire UI is an accessory window is unreachable from cua-driver today. `list_windows` filters to CGWindow layer 0 unconditionally, so that app comes back with an empty window list, which is indistinguishable from a closed app. Without a `window_id` there is nothing to pass to `get_window_state` either.

This is the same gap as #1451, which #1452 fixed for the Swift backend: with a `pid` filter, admit every layer. The Rust port kept the layer-0 enumeration and turned `pid` into a post-filter, so the fix was lost.

The reason for filtering hasn't changed and neither has the default. A whole-desktop listing would drown you in tooltips, popovers, menus and the Dock. But a caller that already named the process isn't at risk of that, and naming it is the only way to reach the window it means.

The enumeration itself needed nothing new. `all_windows_any_layer` already existed for identity lookup. It gets a public sibling that carries the Space snapshot, plus an on-screen variant so `on_screen_only` still composes.

Measured on macOS 26.5 against a SwiftUI app whose only window is layer 3:

```
before: list_windows {"pid": N}  ->  4 windows, all of them 1024x30 menu-bar strips
after:  list_windows {"pid": N}  ->  the same 4, plus id=194 layer=3 640x600
```

With that id, `get_window_state` returns the tree and a screenshot of the window's real contents.

One caveat carried over from the existing code path: any-layer enumerations don't resolve Space attribution, so `space_ids`, `on_current_space` and `current_space_id` come back null. The schema now says so.

I hit this building [mav](https://github.com/bitomule/mav), which drives macOS apps for coding agents. Happy to change the shape if you'd rather gate it behind an explicit flag than infer it from `pid`.
