### PR TITLE
fix(cua-sandbox): honor Fleet request timeouts

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/transport/cyclops_http_client.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cyclops_http_client.py
@@ -14,15 +14,21 @@ class CyclopsHttpClient(HttpClient):
         self._owns_client = client is None
 
     async def execute(self, request: HttpRequest) -> HttpResponse:
+        request_kwargs = {
+            "headers": {header.name: header.value for header in request.headers},
+            "content": request.body,
+        }
+        if request.timeout_secs is not None:
+            request_kwargs["timeout"] = request.timeout_secs
+
         try:
             response = await self._client.request(
                 request.method,
                 request.url,
-                headers={header.name: header.value for header in request.headers},
-                content=request.body,
+                **request_kwargs,
             )
         except httpx.TransportError as error:
-            raise HttpError.Transport(str(error)) from error
+            raise HttpError.Transport(str(error) or type(error).__name__) from error
         return HttpResponse(
             status=response.status_code,
             headers=[

--- a/libs/python/cua-sandbox/tests/test_cyclops_http_client.py
+++ b/libs/python/cua-sandbox/tests/test_cyclops_http_client.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from cua_sandbox.transport.cyclops_http_client import CyclopsHttpClient
+from fleet_sdk import HttpError, HttpRequest
+
+
+class RecordingClient:
+    def __init__(self, response: httpx.Response | Exception) -> None:
+        self.response = response
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        self.calls.append((method, url, kwargs))
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+
+def fleet_request(timeout_secs: int | None) -> HttpRequest:
+    return HttpRequest(
+        method="POST",
+        url="https://fleet.example/api/svc/ns/computer-server/cmd",
+        headers=[],
+        body=b"{}",
+        timeout_secs=timeout_secs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_forwards_per_request_timeout_to_httpx() -> None:
+    response = httpx.Response(200, content=b"ok")
+    client = RecordingClient(response)
+
+    result = await CyclopsHttpClient(client).execute(fleet_request(120))
+
+    assert result.status == 200
+    assert client.calls == [
+        (
+            "POST",
+            "https://fleet.example/api/svc/ns/computer-server/cmd",
+            {"headers": {}, "content": b"{}", "timeout": 120},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_uses_shared_client_default_without_request_timeout() -> None:
+    client = RecordingClient(httpx.Response(200, content=b"ok"))
+
+    await CyclopsHttpClient(client).execute(fleet_request(None))
+
+    assert "timeout" not in client.calls[0][2]
+
+
+@pytest.mark.asyncio
+async def test_execute_reports_transport_error_type_when_message_is_empty() -> None:
+    client = RecordingClient(httpx.ReadTimeout(""))
+
+    with pytest.raises(HttpError.Transport) as raised:
+        await CyclopsHttpClient(client).execute(fleet_request(120))
+
+    assert raised.value.reason == "ReadTimeout"


### PR DESCRIPTION
## Problem

`CyclopsHttpClient` creates a shared `httpx.AsyncClient` with a 30-second default but does not forward `fleet_sdk.HttpRequest.timeout_secs` to individual requests. As a result, hosted service calls fail at about 30 seconds even when the Fleet transport emits a larger timeout.

Fixes #3312.

Live production reproduction: trycua/cloud#7130.

## Changes

- pass `HttpRequest.timeout_secs` to `httpx` for bounded requests
- preserve the shared client default when the SDK request omits a timeout
- retain the exception type as the transport reason when httpx provides an empty timeout message
- add no-infrastructure unit coverage for all three behaviors

## Validation

- `uv run --project libs/python/cua-sandbox pytest -q libs/python/cua-sandbox/tests/test_cyclops_http_client.py libs/python/cua-sandbox/tests/test_fleet_cloud_client.py libs/python/cua-sandbox/tests/test_fleet_transport.py libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py` (`74 passed`)
- `uvx ruff check libs/python/cua-sandbox/cua_sandbox/transport/cyclops_http_client.py libs/python/cua-sandbox/tests/test_cyclops_http_client.py`
- `uvx ruff format --check libs/python/cua-sandbox/cua_sandbox/transport/cyclops_http_client.py libs/python/cua-sandbox/tests/test_cyclops_http_client.py`