### PR TITLE
fix(cua-driver): accept signed browser bundles with metadata

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/browser/platform.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/browser/platform.rs
@@ -172,6 +172,19 @@ fn codesign_identity_matches(details: &str, identifier: &str, team_identifier: &
     observed_identifier == Some(identifier) && observed_team == Some(team_identifier)
 }
 
+fn codesign_verification_args(requirement: &str) -> [&str; 4] {
+    // The explicit requirement already pins the Apple anchor, vendor team, and
+    // bundle identifier. Bare `--strict` also rejects harmless Finder/resource-
+    // fork metadata. Retain sealed-symlink validation without requiring
+    // sideband hygiene.
+    [
+        "--verify",
+        "--strict=symlinks",
+        "--test-requirement",
+        requirement,
+    ]
+}
+
 fn has_trusted_codesign_identity(
     executable: &std::path::Path,
     identifier: &str,
@@ -181,7 +194,7 @@ fn has_trusted_codesign_identity(
         "=anchor apple generic and certificate leaf[subject.OU] = \"{team_identifier}\" and identifier \"{identifier}\""
     );
     let verified = std::process::Command::new("/usr/bin/codesign")
-        .args(["--verify", "--strict", "--test-requirement", &requirement])
+        .args(codesign_verification_args(&requirement))
         .arg(executable)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -1192,6 +1205,21 @@ mod tests {
             "com.google.Chrome",
             "EQHXZ8M8AV"
         ));
+    }
+
+    #[test]
+    fn vendor_verification_does_not_require_filesystem_metadata_hygiene() {
+        let requirement = "=anchor apple generic and identifier \"com.example.Browser\"";
+        assert_eq!(
+            codesign_verification_args(requirement),
+            [
+                "--verify",
+                "--strict=symlinks",
+                "--test-requirement",
+                requirement
+            ]
+        );
+        assert!(!codesign_verification_args(requirement).contains(&"--strict"));
     }
 
     fn window(window_id: u32, pid: i32, title: &str) -> crate::windows::WindowInfo {


### PR DESCRIPTION
## Summary

- Problem this solves: macOS isolated-browser preparation rejects a valid vendor-signed Chromium bundle when harmless Finder or resource-fork metadata is present.
- What changed: preserve signature, Apple-anchor, vendor-team, bundle-identifier, and sealed-symlink validation without enabling the unrelated sideband-hygiene checks from bare `--strict`.

## Related work

No existing issue or pull request matched this focused fix.

RFC: not required; this corrects an implementation false rejection without changing the public API or permission model.

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: valid notarized Chrome or Edge installations can be selected for an isolated profile even when their bundles carry harmless sideband metadata.
- Risk and rollback: low and macOS-only. The explicit Apple signing anchor, expected vendor team, exact bundle identifier, ordinary signature verification, and sealed-symlink validation remain required. Revert this commit to restore the previous behavior.

## Validation

- `cargo test -p platform-macos --locked` (343 passed, 1 intentionally ignored)
- `cargo build -p cua-driver --locked`
- `cargo fmt --all -- --check`
- `cargo clippy -p platform-macos --lib --no-deps --locked` (passes; reports existing warnings outside this change)
- Manual macOS reproduction: bare `--strict` rejected a notarized browser solely for sideband metadata, while the same explicit signer requirement with `--strict=symlinks` passed. The signed 0.22 driver returned `browser_route_unavailable` before launch on the former path.
- Known gap: signed-release isolated-browser E2E remains required after merge and release.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC.
- [x] Tests and platform evidence are included; signed-release E2E is identified above.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] No external contribution is included.
- [x] This is a user-facing fix and should receive the normal cua-driver release treatment.
