### PR TITLE
docs(lume): fix sgdisk dependency and shell guidance in Omarchy ARM64 guide

### DIFF
--- a/docs/content/docs/how-to-guides/lume/run-omarchy-arm64.mdx
+++ b/docs/content/docs/how-to-guides/lume/run-omarchy-arm64.mdx
@@ -105,7 +105,11 @@ lume run omarchy-arm64 \
   --display vnc
 ```
 
-Wait for networking, then open a root shell in Archboot.
+Wait for networking, then open a root shell in Archboot. When the boot
+messages offer `Hit ENTER for login routine or CTRL-C for bash prompt.`, press
+Ctrl-C to open a root shell. The `setup` wizard is optional for this guide:
+DHCP comes up by itself, and everything the installer needs is already in the
+live environment.
 
 ## Install Arch Linux ARM
 
@@ -140,6 +144,17 @@ Boot the VM without the ISO, then sign in as `omarchy` on the text console:
 ```bash
 lume run omarchy-arm64 --display vnc
 ```
+
+The base system enables SSH and password authentication, so headless operation
+works without the display:
+
+```bash
+lume ssh omarchy-arm64 --user omarchy --password <password> "command"
+```
+
+Scripted console input should keep one persistent VNC connection. Opening and
+closing many short-lived connections in bursts can crash the VNC server and
+take the VM down with it.
 
 ## Install the pinned Omarchy source
 

--- a/docs/public/scripts/omarchy-arm64-lume/install-arch.sh
+++ b/docs/public/scripts/omarchy-arm64-lume/install-arch.sh
@@ -20,9 +20,10 @@ printf 'Installing Arch Linux ARM to %s. ALL DATA ON THIS DISK WILL BE LOST.\n' 
 read -r -p 'Type ERASE to continue: ' confirmation
 [[ ${confirmation} == ERASE ]] || exit 1
 
-sgdisk --zap-all "${disk}"
-sgdisk -n 1:1MiB:+1GiB -t 1:ef00 -c 1:EFI "${disk}"
-sgdisk -n 2:0:0 -t 2:8300 -c 2:ROOT "${disk}"
+# gptfdisk is not part of the Archboot live environment; use util-linux only.
+wipefs -a "${disk}"
+printf '%s\n' 'label: gpt' 'start=1MiB, size=+1GiB, type=uefi, name=EFI' 'type=linux, name=ROOT' \
+  | sfdisk "${disk}"
 partx -u "${disk}"
 udevadm settle
 


### PR DESCRIPTION
## Problem

The "Install Arch Linux ARM" section:

```sh
curl -fLO https://raw.githubusercontent.com/trycua/cua/main/docs/public/scripts/omarchy-arm64-lume/install-arch.sh
chmod +x install-arch.sh
TIMEZONE=UTC ./install-arch.sh /dev/vda
```

The step itself looks fine because the assumption is hidden one level down, inside the downloaded script:

1. The step assumes `install-arch.sh` runs to completion in the Archboot live environment.
2. The script's line 23 assumes the live environment ships `sgdisk` (the `gptfdisk` package).
3. It doesn't — the live rootfs contains `sfdisk`/`wipefs`/`fdisk` from util-linux, but zero gptfdisk files.

## Summary

Two fixes from a cold-run of the [Omarchy ARM64 Lume guide](https://cua.ai/docs/how-to-guides/lume/run-omarchy-arm64) on an M-series Mac:

1. **`install-arch.sh` called `sgdisk` (gptfdisk), which the Archboot live environment does not ship.** The documented run fails at the partition step with `sgdisk: command not found` on the tested `archboot-2026.08` image. Replaced with `wipefs` + `sfdisk` from util-linux (both present), producing the identical GPT layout: 1 GiB `ef00` ESP + remaining `8300` root.
2. **`open a root shell in Archboot` was underspecified.** The live environment boots to `Hit ENTER for login routine or CTRL-C for bash prompt.` and/or the `setup` wizard (whose raw-mode keymap also traps VT switching). Documented the Ctrl-C path, noted DHCP comes up by itself, and that the wizard is optional here.

Also added: how to use `lume ssh` for headless guest access after the base install, and a warning that scripted console input should keep one persistent VNC connection — bursty client reconnects can crash the VNC server and take the VM down (three repros here; crash is an EXC_BREAKPOINT inside Apple's `Virtualization` framework at `-[_VZVirtualMachineAccessor addAccessorObserver:]` via `_VZVNCServer`, lume 0.5.3).

## Validation

- sfdisk/wipefs variant executed end-to-end in the actual flow: ERASE → partition → pacstrap of all 217 packages → chroot setup → clean poweroff → boot from disk → `install-omarchy.sh` via `lume ssh` → SDDM autologin → Hyprland running (aarch64, kernel 7.2.0-2-aarch64-ARCH, pinned commit 13f18b2c).
- `bash -n` + shellcheck clean on the edited script.
- MDX edits are prose-only; no new Callout types introduced.

## Notes

Draft for review of the VNC-crash wording and wizard guidance — happy to trim or split (script fix vs. doc guidance) if that's easier to land.
