### PR TITLE
fix(cua-driver): ignore unrelated Wayland cursor teardown

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -2053,7 +2053,25 @@ async fn overlay_glide_to_for(cursor_id: &str, sx: f64, sy: f64) {
     // loop uses (which is invisible on those compositors anyway). No-op if the
     // extension isn't installed.
     if crate::wayland::is_wayland() {
-        crate::wayland::shell_helper::move_cursor(sx as i32, sy as i32);
+        if crate::wayland::shell_helper::semantic_cursor_available() {
+            // The compositor helper owns the cursor on Mutter-style sessions
+            // and performs its own easing. Do not also enqueue a layer-shell
+            // command or the two renderers will fight over the position.
+            crate::wayland::shell_helper::move_cursor(sx as i32, sy as i32);
+        } else {
+            // Hyprland/wlroots uses the native layer-shell renderer. Unlike
+            // the X11 renderer it has no arrival channel, so enqueue the
+            // animated command and let its owner thread advance independently.
+            crate::overlay::send_command_for(
+                cursor_id.to_owned(),
+                cursor_overlay::OverlayCommand::MoveTo {
+                    x: sx,
+                    y: sy,
+                    end_heading_radians: std::f64::consts::FRAC_PI_4,
+                },
+            );
+        }
+        return;
     }
     let pos = crate::overlay::current_position_for(cursor_id);
     if pos.0 < 0.0 && pos.1 < 0.0 {

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
@@ -26,7 +26,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crossbeam_channel::{bounded, Receiver, Sender};
-use cursor_overlay::{CursorConfig, OverlayCommand, OverlayMsg, RenderStateCore};
+use cursor_overlay::{CursorConfig, CursorKey, OverlayCommand, OverlayMsg, RenderStateCore};
 use wayland_client::{
     protocol::{
         wl_buffer::WlBuffer,
@@ -50,8 +50,8 @@ use wayland_protocols_wlr::layer_shell::v1::client::{
 /// SetPressed) are forwarded as-is so the layer-shell overlay matches the
 /// X11 visual: bloom + animated arrow + click pulse + press ring.
 enum WlOverlayCmd {
-    Cmd { cmd: OverlayCommand },
-    Remove,
+    Cmd { key: CursorKey, cmd: OverlayCommand },
+    Remove { key: CursorKey },
     Shutdown,
 }
 
@@ -98,8 +98,9 @@ pub fn forward(msg: &OverlayMsg) -> bool {
     if !should_forward(CONFIG_ENABLED.load(Ordering::Acquire), msg) {
         return false;
     }
-    // The native Wayland path owns one cursor and does not keep keyed session
-    // tombstones. Accept revival without starting the compositor thread.
+    // The native Wayland path renders one cursor at a time, but it still keeps
+    // the active session key so teardown of an unrelated transport session
+    // cannot hide the cursor that is currently on screen.
     if matches!(msg, OverlayMsg::Revive(_)) {
         return true;
     }
@@ -115,8 +116,7 @@ pub fn forward(msg: &OverlayMsg) -> bool {
     let Some(tx) = tx() else { return false };
     match msg {
         OverlayMsg::Remove(k) => {
-            let _ = k;
-            let _ = tx.try_send(WlOverlayCmd::Remove);
+            let _ = tx.try_send(WlOverlayCmd::Remove { key: k.clone() });
             true
         }
         OverlayMsg::Cmd(kc) => {
@@ -124,6 +124,7 @@ pub fn forward(msg: &OverlayMsg) -> bool {
                 return false;
             }
             let _ = tx.try_send(WlOverlayCmd::Cmd {
+                key: kc.key.clone(),
                 cmd: kc.cmd.clone(),
             });
             true
@@ -163,6 +164,8 @@ struct OverlayState {
     /// Cross-platform render core: position, animation, gradient arrow,
     /// bloom, click pulse, idle-fade. Shared verbatim with the X11 path.
     core: RenderStateCore,
+    /// Session currently represented by the single layer-shell cursor.
+    active_cursor_key: Option<CursorKey>,
     /// In-flight wl_shm buffers awaiting `wl_buffer.release` from the
     /// compositor. Keyed by `WlBuffer` object id; value is the
     /// `(mmap ptr, mmap size, memfd fd)` triple that must be unmapped +
@@ -193,6 +196,7 @@ impl Default for OverlayState {
             layer_surface: None,
             configured: false,
             core: RenderStateCore::new(CursorConfig::default()),
+            active_cursor_key: None,
             pending_buffers: HashMap::new(),
         }
     }
@@ -313,7 +317,11 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                     shutdown = true;
                     break;
                 }
-                Ok(WlOverlayCmd::Cmd { cmd }) => {
+                Ok(WlOverlayCmd::Cmd { key, cmd }) => {
+                    if state.active_cursor_key.as_deref() != Some(key.as_str()) {
+                        state.active_cursor_key = Some(key);
+                        state.core.visible = true;
+                    }
                     // Seed: if the cursor is still at the off-screen sentinel
                     // `(-200, -200)` from `RenderStateCore::new`, snap to a
                     // point near the MoveTo / SnapTo target so the spring
@@ -344,13 +352,8 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                         quiesce_hidden(&mut state.core);
                     }
                 }
-                Ok(WlOverlayCmd::Remove) => {
-                    // Single-cursor overlay: removing the active cursor
-                    // hides it. Multi-cursor wlroots support can layer on
-                    // top of this in a follow-up if needed.
-                    dirty |= state.core.visible || state.core.pos.0 >= -100.0;
-                    state.core.visible = false;
-                    quiesce_hidden(&mut state.core);
+                Ok(WlOverlayCmd::Remove { key }) => {
+                    dirty |= remove_cursor_if_active(&mut state, &key);
                 }
                 Err(crossbeam_channel::TryRecvError::Empty) => break,
                 Err(crossbeam_channel::TryRecvError::Disconnected) => {
@@ -470,6 +473,17 @@ fn quiesce_hidden(core: &mut RenderStateCore) {
     core.spring = None;
     core.spring_tgt = None;
     core.click_t = None;
+}
+
+fn remove_cursor_if_active(state: &mut OverlayState, key: &str) -> bool {
+    if state.active_cursor_key.as_deref() != Some(key) {
+        return false;
+    }
+    let dirty = state.core.visible || state.core.pos.0 >= -100.0;
+    state.active_cursor_key = None;
+    state.core.visible = false;
+    quiesce_hidden(&mut state.core);
+    dirty
 }
 
 /// Render one cursor frame into a fresh wl_shm ARGB8888 buffer and attach
@@ -845,11 +859,30 @@ mod tests {
     #[test]
     fn blocked_scheduler_wakes_on_command_arrival() {
         let (tx, rx) = bounded(1);
-        tx.send(WlOverlayCmd::Remove).unwrap();
+        tx.send(WlOverlayCmd::Remove {
+            key: "test".to_owned(),
+        })
+        .unwrap();
         assert!(matches!(
             wait_for_work(&rx, WlWait::Block),
-            WlWake::Command(WlOverlayCmd::Remove)
+            WlWake::Command(WlOverlayCmd::Remove { key }) if key == "test"
         ));
+    }
+
+    #[test]
+    fn unrelated_session_teardown_does_not_hide_active_cursor() {
+        let mut state = OverlayState::default();
+        state.active_cursor_key = Some("named-demo".to_owned());
+        state.core.pos = (300.0, 240.0);
+        state.core.visible = true;
+
+        assert!(!remove_cursor_if_active(&mut state, "implicit-cli-session"));
+        assert_eq!(state.active_cursor_key.as_deref(), Some("named-demo"));
+        assert!(state.core.visible);
+
+        assert!(remove_cursor_if_active(&mut state, "named-demo"));
+        assert!(state.active_cursor_key.is_none());
+        assert!(!state.core.visible);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
@@ -605,6 +605,10 @@ fn redraw(
         state.core.pos.0, state.core.pos.1, state.core.visible
     ));
     surface.attach(Some(&buffer), 0, 0);
+    // Mark both logical and buffer-space damage. Some wlroots versions do
+    // not repaint transparent pixels reliably when only damage_buffer is
+    // supplied, which leaves stale cursor frames visible as trails.
+    surface.damage(0, 0, w as i32, h as i32);
     surface.damage_buffer(0, 0, w as i32, h as i32);
     surface.commit();
     pool.destroy();

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
@@ -324,11 +324,10 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                     }
                     // Seed: if the cursor is still at the off-screen sentinel
                     // `(-200, -200)` from `RenderStateCore::new`, snap to a
-                    // point near the MoveTo / SnapTo target so the spring
+                    // point near the MoveTo / SnapTo target so the glide
                     // animation starts on-screen. Mirrors X11 overlay.rs's
                     // `seed_start_if_sentinel` helper — without it, the
-                    // spring oscillates around the sentinel and the cursor
-                    // never reaches the screen.
+                    // path would start from the off-screen sentinel.
                     let seed_target = match &cmd {
                         OverlayCommand::MoveTo { x, y, .. }
                         | OverlayCommand::SnapTo { x, y, .. }
@@ -337,7 +336,7 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                     };
                     if let Some((tx, ty)) = seed_target {
                         if state.core.pos.0 < -50.0 {
-                            const SEED_OFFSET: f64 = 16.0;
+                            const SEED_OFFSET: f64 = 140.0;
                             let sx = (tx - SEED_OFFSET).max(2.0);
                             let sy = (ty - SEED_OFFSET).max(2.0);
                             state.core.pos = (sx, sy);


### PR DESCRIPTION
## Why

Omarchy/Hyprland exposed two Wayland cursor-overlay issues:

- A teardown from an unrelated session could hide the active synthetic cursor.
- The Linux action path sent Wayland moves through the compositor helper (or an initial click snap) without enqueueing the native layer-shell `MoveTo`, so the Cua synthetic cursor appeared to jump instead of glide.

## What changed

- Key Wayland cursor teardown by `CursorKey` and ignore non-active session removal.
- Route wlroots/Hyprland moves to the native layer-shell renderer, while retaining the compositor helper only for sessions where it owns the cursor.
- Seed a first native Wayland glide from a visible offset rather than a 16px near-target snap.
- Add a regression test for unrelated-session teardown.

## Validation

- `cargo test -p platform-linux` (macOS host): 16 passed.
- `cargo fmt --manifest-path libs/cua-driver/rust/Cargo.toml --all -- --check`
- `git diff --check`
- Native Wayland execution remains covered by Linux CI; this macOS host cannot run the Hyprland layer-shell test directly.
