### PR TITLE
fix(cua-driver): read macOS browser checkbox state

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -24,6 +24,7 @@
     "f@trycua.com": "f-trycua",
     "fbonacci@fbonacci-xfce-vm.b40fumexvs1ujlod2ppcyfh5qa.bx.internal.cloudapp.net": "f-trycua",
     "i@jyunko.cn": "HsiangNianian",
+    "jf-mac-mini@jf-mac-mini-4.local": "0xjohnnydev",
     "klymenko@adobe.com": "pavelklymenko",
     "m.fuechtenkoetter@posteo.de": "ai-ag2026",
     "manfred@ubuntu26.04-vm": "ai-ag2026",
@@ -33,6 +34,7 @@
     "rwendt1337@gmail.com": "r33drichards",
     "rsyuzyov@gmail.com": "rsyuzyov",
     "sarinajin.li@gmail.com": "sarinali",
+    "umtcgnd@gmail.com": "c8dhjp4tyv-bit",
     "zane.chee.2023@scis.smu.edu.sg": "injaneity",
     "zongxin_yang@hms.harvard.edu": "z-x-yang"
   },

--- a/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
@@ -230,6 +230,47 @@ pub unsafe fn copy_bool_attr(element: AXUIElementRef, attr_name: &str) -> Option
     None
 }
 
+/// Convert a borrowed AX attribute value only when it is an exact binary state.
+unsafe fn coerce_binary_value(value: CFTypeRef) -> Option<bool> {
+    use core_foundation::boolean::CFBoolean;
+    use core_foundation::number::CFNumber;
+    let type_id = core_foundation::base::CFGetTypeID(value);
+    if type_id == CFBoolean::type_id() {
+        return Some(CFBoolean::wrap_under_get_rule(value as _).into());
+    }
+    if type_id == CFNumber::type_id() {
+        return match CFNumber::wrap_under_get_rule(value as _).to_f64()? {
+            value if value.abs() < f64::EPSILON => Some(false),
+            value if (value - 1.0).abs() < f64::EPSILON => Some(true),
+            _ => None,
+        };
+    }
+    None
+}
+
+/// Copy an exact binary attribute from an AX element in one read.
+///
+/// Accepts native `CFBoolean` values and numeric `0` or `1`. Other numeric
+/// values and all other types return `None` instead of being coerced to true.
+/// Use this for two-state controls whose intermediate or malformed values must
+/// fail closed; use [`copy_bool_attr`] for ordinary truthy attributes.
+///
+/// # Safety
+///
+/// `element` must be a valid Accessibility object reference for the duration
+/// of this call.
+pub unsafe fn copy_binary_attr(element: AXUIElementRef, attr_name: &str) -> Option<bool> {
+    let attr = CFStr::new(attr_name);
+    let mut value: CFTypeRef = std::ptr::null();
+    let err = AXUIElementCopyAttributeValue(element, attr.as_concrete_TypeRef(), &mut value);
+    if err != kAXErrorSuccess || value.is_null() {
+        return None;
+    }
+    let result = coerce_binary_value(value);
+    CFRelease(value);
+    result
+}
+
 /// A copied AX attribute represented for both existing string-only consumers
 /// and the wider structured control-state response.
 #[derive(Debug, PartialEq, Eq)]
@@ -723,6 +764,40 @@ pub unsafe fn copy_ax_windows(element: AXUIElementRef) -> Vec<AXUIElementRef> {
 mod tests {
     use super::*;
     use core_foundation::{boolean::CFBoolean, number::CFNumber};
+
+    #[test]
+    fn binary_value_accepts_booleans_and_exact_zero_or_one() {
+        let true_value = CFBoolean::true_value();
+        let false_value = CFBoolean::false_value();
+        let zero = CFNumber::from(0.0);
+        let one = CFNumber::from(1.0);
+        let fractional = CFNumber::from(0.5);
+        let other = CFNumber::from(2.0);
+        let string = CFStr::new("1");
+
+        assert_eq!(
+            unsafe { coerce_binary_value(true_value.as_CFTypeRef()) },
+            Some(true)
+        );
+        assert_eq!(
+            unsafe { coerce_binary_value(false_value.as_CFTypeRef()) },
+            Some(false)
+        );
+        assert_eq!(
+            unsafe { coerce_binary_value(zero.as_CFTypeRef()) },
+            Some(false)
+        );
+        assert_eq!(
+            unsafe { coerce_binary_value(one.as_CFTypeRef()) },
+            Some(true)
+        );
+        assert_eq!(
+            unsafe { coerce_binary_value(fractional.as_CFTypeRef()) },
+            None
+        );
+        assert_eq!(unsafe { coerce_binary_value(other.as_CFTypeRef()) }, None);
+        assert_eq!(unsafe { coerce_binary_value(string.as_CFTypeRef()) }, None);
+    }
 
     #[test]
     fn stringish_value_coerces_cfstring_cfnumber_and_cfboolean() {

--- a/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
@@ -230,7 +230,6 @@ pub unsafe fn copy_bool_attr(element: AXUIElementRef, attr_name: &str) -> Option
     None
 }
 
-/// Convert a borrowed AX attribute value only when it is an exact binary state.
 unsafe fn coerce_binary_value(value: CFTypeRef) -> Option<bool> {
     use core_foundation::boolean::CFBoolean;
     use core_foundation::number::CFNumber;
@@ -248,17 +247,6 @@ unsafe fn coerce_binary_value(value: CFTypeRef) -> Option<bool> {
     None
 }
 
-/// Copy an exact binary attribute from an AX element in one read.
-///
-/// Accepts native `CFBoolean` values and numeric `0` or `1`. Other numeric
-/// values and all other types return `None` instead of being coerced to true.
-/// Use this for two-state controls whose intermediate or malformed values must
-/// fail closed; use [`copy_bool_attr`] for ordinary truthy attributes.
-///
-/// # Safety
-///
-/// `element` must be a valid Accessibility object reference for the duration
-/// of this call.
 pub unsafe fn copy_binary_attr(element: AXUIElementRef, attr_name: &str) -> Option<bool> {
     let attr = CFStr::new(attr_name);
     let mut value: CFTypeRef = std::ptr::null();

--- a/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
@@ -240,8 +240,8 @@ unsafe fn coerce_binary_value(value: CFTypeRef) -> Option<bool> {
     }
     if type_id == CFNumber::type_id() {
         return match CFNumber::wrap_under_get_rule(value as _).to_f64()? {
-            value if value.abs() < f64::EPSILON => Some(false),
-            value if (value - 1.0).abs() < f64::EPSILON => Some(true),
+            0.0 => Some(false),
+            1.0 => Some(true),
             _ => None,
         };
     }
@@ -797,6 +797,28 @@ mod tests {
         );
         assert_eq!(unsafe { coerce_binary_value(other.as_CFTypeRef()) }, None);
         assert_eq!(unsafe { coerce_binary_value(string.as_CFTypeRef()) }, None);
+    }
+
+    #[test]
+    fn binary_value_rejects_near_binary_and_non_finite_numbers() {
+        for value in [
+            1e-20,
+            -1e-20,
+            f64::from_bits(1),
+            -f64::from_bits(1),
+            f64::from_bits(1.0_f64.to_bits() - 1),
+            f64::from_bits(1.0_f64.to_bits() + 1),
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ] {
+            let number = CFNumber::from(value);
+            assert_eq!(
+                unsafe { coerce_binary_value(number.as_CFTypeRef()) },
+                None,
+                "unexpected binary state for {value:?}"
+            );
+        }
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-macos/src/browser/setup_ui.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/browser/setup_ui.rs
@@ -13,7 +13,7 @@ use cua_driver_core::browser::{
 };
 
 use crate::ax::bindings::{
-    copy_number_attr, copy_string_attr, element_screen_center, focused_element_of_pid,
+    copy_binary_attr, copy_string_attr, element_screen_center, focused_element_of_pid,
     kAXErrorSuccess, perform_action, set_bool_attr_true, set_string_attr, AXUIElementRef,
 };
 use crate::ax::tree::{walk_tree, AXNode, TreeWalkResult};
@@ -875,11 +875,11 @@ fn press_pixel_checkbox(
     })
 }
 
-fn checkbox_state(value: Option<f64>) -> Result<CheckboxState, BrowserRefusal> {
+fn checkbox_state(value: Option<bool>) -> Result<CheckboxState, BrowserRefusal> {
     match value {
-        Some(value) if value.abs() < f64::EPSILON => Ok(CheckboxState::Off),
-        Some(value) if (value - 1.0).abs() < f64::EPSILON => Ok(CheckboxState::On),
-        _ => Err(refusal(
+        Some(false) => Ok(CheckboxState::Off),
+        Some(true) => Ok(CheckboxState::On),
+        None => Err(refusal(
             BrowserRefusalCode::BrowserWrongTargetRefused,
             "the exact remote-debugging checkbox had an unknown checked state",
         )),
@@ -923,7 +923,7 @@ impl SetupUiHandle {
             let checkbox = exact_setup_checkbox(&tree, self.descriptor);
             let result = match checkbox {
                 Ok(Some(element)) => {
-                    let value = unsafe { copy_number_attr(element as AXUIElementRef, "AXValue") };
+                    let value = unsafe { copy_binary_attr(element as AXUIElementRef, "AXValue") };
                     match checkbox_state(value) {
                         Ok(CheckboxState::Off) => Some(true),
                         Ok(CheckboxState::On) => {
@@ -1493,7 +1493,7 @@ fn set_remote_debugging(
         let checkbox = exact_setup_checkbox(&tree, descriptor);
         match checkbox {
             Ok(Some(element)) => {
-                let value = unsafe { copy_number_attr(element as AXUIElementRef, "AXValue") };
+                let value = unsafe { copy_binary_attr(element as AXUIElementRef, "AXValue") };
                 match checkbox_state(value) {
                     Ok(state) if (state == CheckboxState::On) == desired_enabled => {
                         if desired_enabled
@@ -2348,14 +2348,10 @@ mod tests {
 
     #[test]
     fn unknown_checkbox_values_refuse() {
-        assert_eq!(checkbox_state(Some(0.0)).unwrap(), CheckboxState::Off);
-        assert_eq!(checkbox_state(Some(1.0)).unwrap(), CheckboxState::On);
+        assert_eq!(checkbox_state(Some(false)).unwrap(), CheckboxState::Off);
+        assert_eq!(checkbox_state(Some(true)).unwrap(), CheckboxState::On);
         assert_eq!(
             checkbox_state(None).unwrap_err().code,
-            BrowserRefusalCode::BrowserWrongTargetRefused
-        );
-        assert_eq!(
-            checkbox_state(Some(0.5)).unwrap_err().code,
             BrowserRefusalCode::BrowserWrongTargetRefused
         );
     }


### PR DESCRIPTION
## problem

chrome 151 on macos exposes the exact `chrome://inspect/#remote-debugging` checkbox with a boolean `axvalue`. the adapter accepted only numeric `0`/`1`, so existing-profile preparation refused with `the exact remote-debugging checkbox had an unknown checked state` before browser use or session cleanup could run.

## scope

- add a shared macos ax binary-attribute reader that performs one native read
- accept native `cfboolean` values and exact numeric `0`/`1`
- reject fractional, other numeric, string, missing, and unsupported values
- consume the normalized state for browser setup enable and rollback
- leave the existing truthy `copy_bool_attr` contract unchanged

## duplicate and conflict check

no active pr already implements strict macos binary ax reads. [#1757](https://github.com/trycua/cua/pull/1757) changes batched tree reads in the same binding file but does not normalize boolean/numeric control state. [#2064](https://github.com/trycua/cua/pull/2064) added numeric `axvalue` support but does not cover binary reads.

## validation

exact source: `ad79aa13eb06a52c13cc21a0a87c8cc80d389dd1`

- `cargo test -p platform-macos ax::bindings::tests`: 2 passed
- `cargo test -p platform-macos browser::setup_ui::tests`: 20 passed
- `cargo fmt --all -- --check`
- `git diff --check`
- source-installed cua driver 0.22.1 on macos 26.5.2 with chrome 151.0.7922.174:
  - the pre-fix live case reproduced `unknown checked state`
  - the fixed build completed existing-profile setup, page navigation, a dom click with fixture-state readback, `end_session`, devtools-listener shutdown, and the final native-tree assertion that `allow remote debugging` was absent
  - supporting diagnostic evidence: `artifacts/cua-driver/macos-binary-checkbox-diagnostic-20260827T024423Z/`
- version-matched supporting run with Google Chrome for Testing 151.0.7922.172 arm64 also completed setup, browser use, listener shutdown, and banner-absence cleanup; this is not the reporter’s official `com.google.Chrome` build because Google’s public stable endpoint no longer serves that patch

## known gaps

- the supporting live run skipped the foreground, z-order, leaked-input, and cursor sentinels because this non-isolated host repeatedly stole chrome foreground during setup. those side-effect oracles remain unproven here.
- the complete canonical macos lume matrix remains required before this draft is made ready.



## review follow-up

- `1eab1b524`: require exact numeric `0`/`1`; added near-zero, near-one, and non-finite rejection coverage. macos focused validation: 3 binding tests and 20 setup-ui tests passed; formatting and diff checks passed.
- `5ea809a10`: synced the two trusted contributor identity mappings already on main. `.github/release-attribution-config.json` now matches main; no product-code changes after the focused validation above.
- canonical macos lume E2E remains outstanding and must run on the final candidate before merge.
