### PR TITLE
ci(cua-driver): add focused browser diagnostics

### DIFF
--- a/libs/cua-driver/scripts/tests/test_macos_lume_runner.py
+++ b/libs/cua-driver/scripts/tests/test_macos_lume_runner.py
@@ -23,6 +23,7 @@ RUN_ALL = REPO_ROOT / "libs/cua-driver/tests/runners/macos-lume/run-all.sh"
 SEED_TCC = REPO_ROOT / "libs/cua-driver/tests/runners/macos-lume/seed-tcc.sh"
 SEED_TCC_GUEST = REPO_ROOT / "libs/cua-driver/tests/runners/macos-lume/seed-tcc-guest.sh"
 RUN_RUST_E2E = REPO_ROOT / "scripts/ci/macos/run-rust-e2e.sh"
+STANDALONE_BROWSER_RUNNER = REPO_ROOT / "scripts/ci/run-rust-standalone-browser-e2e.sh"
 ELECTRON_BUILD = REPO_ROOT / "libs/cua-driver/tests/fixtures/apps/cross-platform/electron/build.sh"
 ELECTRON_LOCK = (
     REPO_ROOT / "libs/cua-driver/tests/fixtures/apps/cross-platform/electron/package-lock.json"
@@ -79,7 +80,15 @@ def _fields(output: str) -> dict[str, str]:
 
 @pytest.mark.parametrize(
     "script",
-    [RUN_ALL, RUN_RUST_E2E, SEED_TCC, SEED_TCC_GUEST, ELECTRON_BUILD, TAURI_BUILD],
+    [
+        RUN_ALL,
+        RUN_RUST_E2E,
+        STANDALONE_BROWSER_RUNNER,
+        SEED_TCC,
+        SEED_TCC_GUEST,
+        ELECTRON_BUILD,
+        TAURI_BUILD,
+    ],
     ids=lambda path: f"{path.parent.name}/{path.name}",
 )
 def test_runner_scripts_have_valid_bash_syntax(script: Path) -> None:
@@ -543,6 +552,7 @@ REPORT_OPTIONS = (
     'printf "attempts=%s\\n" "$RETRY_ATTEMPTS"\n'
     'printf "only=%s\\n" "$RETRY_ONLY"\n'
     'printf "standalone=%s\\n" "$RUN_STANDALONE_BROWSER"\n'
+    'printf "standalone_test=%s\\n" "$STANDALONE_BROWSER_TEST"\n'
     'printf "nobuild=%s\\n" "$NO_BUILD"\n'
     'printf "lane=%s\\n" "$RETRY_INTERNAL_LANE"\n'
 )
@@ -561,6 +571,13 @@ def test_default_invocation_runs_the_full_matrix() -> None:
     assert fields["only"] == "0"
     assert fields["standalone"] == "0"
     assert fields["nobuild"] == "0"
+
+
+def test_standalone_browser_diagnostic_selection_is_accepted() -> None:
+    fields = _parse(["--standalone-browser-test", "standalone_browser_existing_profile_setup"])
+    assert fields["status"] == "0"
+    assert fields["standalone"] == "0"
+    assert fields["standalone_test"] == "standalone_browser_existing_profile_setup"
 
 
 def test_full_retry_selection_is_accepted() -> None:
@@ -657,6 +674,31 @@ def test_native_swiftui_selector_matches_exactly_one_owned_cell() -> None:
             ["--retry-cell", "cell", "--retry-only", "--standalone-browser"],
             id="retry-only-with-standalone-browser",
         ),
+        pytest.param(
+            [
+                "--standalone-browser-test",
+                "standalone_browser_roundtrip",
+                "--standalone-browser",
+            ],
+            id="focused-with-full-standalone-browser",
+        ),
+        pytest.param(
+            [
+                "--standalone-browser-test",
+                "standalone_browser_roundtrip",
+                "--retry-cell",
+                "cell",
+            ],
+            id="focused-with-retry",
+        ),
+        pytest.param(
+            ["--standalone-browser-test", "../escape"],
+            id="focused-path-traversal",
+        ),
+        pytest.param(
+            ["--standalone-browser-test"],
+            id="focused-missing-value",
+        ),
         pytest.param(["--unknown"], id="unknown-argument"),
     ],
 )
@@ -670,6 +712,55 @@ def test_help_exits_without_running() -> None:
     fields = _fields(completed.stdout)
     assert fields["status"] == "3"
     assert "--retry-cell" in completed.stdout
+    assert "--standalone-browser-test" in completed.stdout
+
+
+def test_standalone_browser_runner_help_has_no_setup_side_effects(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "artifacts"
+    completed = subprocess.run(
+        ["bash", str(STANDALONE_BROWSER_RUNNER), "--help"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CUA_E2E_ARTIFACT_DIR": str(artifact_dir)},
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "--test" in completed.stdout
+    assert not artifact_dir.exists()
+
+
+def test_standalone_browser_runner_refuses_malformed_test_before_setup(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "artifacts"
+    completed = subprocess.run(
+        ["bash", str(STANDALONE_BROWSER_RUNNER), "--test", "../escape"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CUA_E2E_ARTIFACT_DIR": str(artifact_dir)},
+        check=False,
+    )
+    assert completed.returncode == 2
+    assert "artifact-safe" in completed.stderr
+    assert not artifact_dir.exists()
+
+
+def test_macos_focused_browser_runner_forwards_exact_selection(tmp_path: Path) -> None:
+    fake_repo = tmp_path / "repo"
+    output = tmp_path / "selection.txt"
+    _write_executable(
+        fake_repo / "scripts/ci/run-rust-standalone-browser-e2e.sh",
+        'printf "test=%s\\nartifact=%s\\n" "$2" "$CUA_E2E_ARTIFACT_DIR" > "$OUTPUT"\n',
+    )
+    completed = _run(
+        RUN_ALL,
+        f'REPO_ROOT="{fake_repo}"\n'
+        "ensure_unrestricted_daemon() { :; }\n"
+        "run_standalone_browser_tests standalone_browser_existing_profile_setup\n",
+        env={"OUTPUT": str(output)},
+    )
+    assert completed.returncode == 0, completed.stderr
+    fields = _fields(output.read_text(encoding="utf-8"))
+    assert fields["test"] == "standalone_browser_existing_profile_setup"
+    assert fields["artifact"] == str(fake_repo / "artifacts/cua-driver/macos-standalone-browser")
 
 
 def test_full_matrix_clears_inherited_retry_filters(tmp_path: Path) -> None:

--- a/libs/cua-driver/tests/runners/macos-lume/README.md
+++ b/libs/cua-driver/tests/runners/macos-lume/README.md
@@ -386,7 +386,21 @@ cd ~/cua
 libs/cua-driver/tests/runners/macos-lume/run-all.sh --standalone-browser
 ```
 
-This adds the declared adversarial installed-browser rows and writes their
+For one focused browser diagnostic, keep the same exact-source installation,
+permission checks, fixture staging, unrestricted daemon transition, evidence
+setup, and standard-daemon restoration:
+
+```bash
+cd ~/cua
+libs/cua-driver/tests/runners/macos-lume/run-all.sh \
+  --standalone-browser-test standalone_browser_existing_profile_setup
+```
+
+This skips the canonical repo-local matrix and runs only one browser test that
+is declared for macOS. Its artifact includes `diagnostic-selection.json` with
+`canonical: false`; it cannot replace either complete matrix.
+
+`--standalone-browser` adds the declared adversarial installed-browser rows and writes their
 separate typed results and MP4 evidence under
 `artifacts/cua-driver/macos-standalone-browser/`. Missing external browsers are
 a hard failure for this option; they never shrink the reported matrix. On a

--- a/libs/cua-driver/tests/runners/macos-lume/run-all.sh
+++ b/libs/cua-driver/tests/runners/macos-lume/run-all.sh
@@ -43,6 +43,7 @@ RETRYABLE_LANES=(
 usage() {
   cat <<'EOF'
 Usage: run-all.sh [--no-build] [--standalone-browser]
+                  [--standalone-browser-test <exact-rust-test-name>]
                   [--retry-cell <cell-id> [--retry-harness <harness>]
                    [--retry-attempts <1-3>] [--retry-only]]
 
@@ -52,6 +53,11 @@ logged-in desktop session, not over SSH.
 
 --standalone-browser also runs the optional installed Chrome/Edge browser-tool
 matrix after the canonical repo-local harness matrix.
+
+--standalone-browser-test runs one exact declared browser test as a diagnostic,
+after the same source install, fixture setup, and daemon authorization. It skips
+the canonical repo-local matrix and cannot be combined with retry options or
+--standalone-browser. Its result is not canonical certification evidence.
 
 --retry-cell authorizes exactly one bounded retry selection. After a failing
 full matrix the runner retries that single cell only when it was the matrix's
@@ -68,6 +74,7 @@ EOF
 }
 
 RUN_STANDALONE_BROWSER=0
+STANDALONE_BROWSER_TEST=""
 NO_BUILD=0
 RETRY_CELL=""
 RETRY_HARNESS=""
@@ -76,6 +83,7 @@ RETRY_ONLY=0
 
 parse_arguments() {
   RUN_STANDALONE_BROWSER=0
+  STANDALONE_BROWSER_TEST=""
   NO_BUILD=0
   RETRY_CELL=""
   RETRY_HARNESS=""
@@ -85,16 +93,18 @@ parse_arguments() {
     case "$1" in
       --no-build) NO_BUILD=1 ;;
       --standalone-browser) RUN_STANDALONE_BROWSER=1 ;;
+      --standalone-browser-test=*) STANDALONE_BROWSER_TEST="${1#*=}" ;;
       --retry-only) RETRY_ONLY=1 ;;
       --retry-cell=*) RETRY_CELL="${1#*=}" ;;
       --retry-harness=*) RETRY_HARNESS="${1#*=}" ;;
       --retry-attempts=*) RETRY_ATTEMPTS="${1#*=}" ;;
-      --retry-cell|--retry-harness|--retry-attempts)
+      --standalone-browser-test|--retry-cell|--retry-harness|--retry-attempts)
         if (($# < 2)) || [[ -z "$2" || "$2" == -* ]]; then
           echo "$1 requires a value" >&2
           return 2
         fi
         case "$1" in
+          --standalone-browser-test) STANDALONE_BROWSER_TEST="$2" ;;
           --retry-cell) RETRY_CELL="$2" ;;
           --retry-harness) RETRY_HARNESS="$2" ;;
           --retry-attempts) RETRY_ATTEMPTS="$2" ;;
@@ -110,6 +120,23 @@ parse_arguments() {
 }
 
 validate_arguments() {
+  if [[ -n "${STANDALONE_BROWSER_TEST}" ]]; then
+    if [[ ! "${STANDALONE_BROWSER_TEST}" =~ ^standalone_browser_[a-z0-9_]+$ ]]; then
+      echo "--standalone-browser-test must be one artifact-safe standalone_browser_* Rust test name" >&2
+      return 2
+    fi
+    if [[ "${RUN_STANDALONE_BROWSER}" == 1 ]]; then
+      echo "--standalone-browser-test cannot be combined with --standalone-browser" >&2
+      return 2
+    fi
+    if [[ -n "${RETRY_CELL}" || -n "${RETRY_HARNESS}" || -n "${RETRY_ATTEMPTS}" \
+        || "${RETRY_ONLY}" == 1 ]]; then
+      echo "--standalone-browser-test cannot be combined with retry options" >&2
+      return 2
+    fi
+    return 0
+  fi
+
   if [[ -z "${RETRY_CELL}" ]]; then
     if [[ -n "${RETRY_HARNESS}" ]]; then
       echo "--retry-harness requires --retry-cell" >&2
@@ -715,6 +742,31 @@ run_retry_sequence() {
   return 1
 }
 
+run_standalone_browser_tests() {
+  local selected_test="${1:-}"
+  local browser_args=()
+  local browser_status=0
+  local browser_artifact_dir="${REPO_ROOT}/artifacts/cua-driver/macos-standalone-browser"
+  if [[ -n "${selected_test}" ]]; then
+    browser_args=(--test "${selected_test}")
+    echo "[E2E] Running standalone browser diagnostic ${selected_test}"
+  else
+    echo "[E2E] Running the optional standalone browser matrix"
+  fi
+  if [[ -d "${browser_artifact_dir}" ]] \
+      && [[ -n "$(find "${browser_artifact_dir}" -mindepth 1 -print -quit)" ]]; then
+    local browser_artifact_archive
+    browser_artifact_archive="$(mktemp -d "${TMPDIR:-/tmp}/cua-macos-browser-e2e.XXXXXX")"
+    mv "${browser_artifact_dir}" "${browser_artifact_archive}/macos-standalone-browser"
+    echo "Previous standalone-browser evidence preserved at ${browser_artifact_archive}/macos-standalone-browser"
+  fi
+  ensure_unrestricted_daemon
+  CUA_E2E_ARTIFACT_DIR="${browser_artifact_dir}" \
+    "${REPO_ROOT}/scripts/ci/run-rust-standalone-browser-e2e.sh" \
+    "${browser_args[@]}" || browser_status=$?
+  return "${browser_status}"
+}
+
 if [[ "${CUA_E2E_RUNNER_LIB_ONLY:-0}" == 1 ]]; then
   # Sourced by the focused runner tests, which exercise the helpers above
   # without a macOS GUI session.
@@ -892,6 +944,11 @@ fi
 RESULTS_FILE="${ARTIFACT_DIR}/results.jsonl"
 FAILURES_FILE="${ARTIFACT_DIR}/failures.json"
 
+if [[ -n "${STANDALONE_BROWSER_TEST}" ]]; then
+  run_standalone_browser_tests "${STANDALONE_BROWSER_TEST}"
+  exit $?
+fi
+
 if [[ "${RETRY_ONLY}" == 1 ]]; then
   echo "[E2E] Running only the authorized retry selection for ${RETRY_CELL}"
   RETRY_STATUS=0
@@ -944,22 +1001,5 @@ elif [[ -n "${RETRY_CELL}" ]]; then
 fi
 
 if [[ "${RUN_STANDALONE_BROWSER}" == 1 ]]; then
-  echo "[E2E] Running the optional standalone browser matrix"
-  BROWSER_ARTIFACT_DIR="${REPO_ROOT}/artifacts/cua-driver/macos-standalone-browser"
-  if [[ -d "${BROWSER_ARTIFACT_DIR}" ]] \
-      && [[ -n "$(find "${BROWSER_ARTIFACT_DIR}" -mindepth 1 -print -quit)" ]]; then
-    BROWSER_ARTIFACT_ARCHIVE="$(mktemp -d "${TMPDIR:-/tmp}/cua-macos-browser-e2e.XXXXXX")"
-    mv "${BROWSER_ARTIFACT_DIR}" "${BROWSER_ARTIFACT_ARCHIVE}/macos-standalone-browser"
-    echo "Previous standalone-browser evidence preserved at ${BROWSER_ARTIFACT_ARCHIVE}/macos-standalone-browser"
-  fi
-  ensure_unrestricted_daemon
-  set +e
-  CUA_E2E_ARTIFACT_DIR="${BROWSER_ARTIFACT_DIR}" \
-    "${REPO_ROOT}/scripts/ci/run-rust-standalone-browser-e2e.sh"
-  BROWSER_STATUS=$?
-  set -e
-
-  if [[ "${BROWSER_STATUS}" != 0 ]]; then
-    exit "${BROWSER_STATUS}"
-  fi
+  run_standalone_browser_tests
 fi

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -18,6 +18,18 @@ scripts/ci/run-rust-standalone-browser-e2e.sh
 scripts/ci/windows/run-rust-standalone-browser-e2e.ps1
 ```
 
+The Unix runner also accepts one exact diagnostic selection:
+
+```bash
+scripts/ci/run-rust-standalone-browser-e2e.sh \
+  --test standalone_browser_existing_profile_setup
+```
+
+This still builds the source driver, stages the sentinel, writes isolated
+evidence, and validates the report, but `diagnostic-selection.json` marks the
+result non-canonical. The selector must name one test declared for the current
+platform. The no-selector command remains the complete installed-browser gate.
+
 The runners require an existing desktop user session and a fresh artifact
 directory. They stage the repo-owned Electron foreground sentinel when the
 fixture is absent and execute each scenario in an independent Cargo process.
@@ -105,7 +117,10 @@ The maintainer-facing macOS command is
 Lume seed, installs the exact committed source, and then delegates to the thin
 `macos/run-rust-e2e.sh` matrix runner above. There is no GitHub-hosted macOS GUI
 job. Pass `--standalone-browser` to run the optional installed Chrome/Edge
-browser matrix after the canonical repo-local harness matrix.
+browser matrix after the canonical repo-local harness matrix. For one macOS
+browser diagnostic with the same signed source install and daemon lifecycle,
+use `--standalone-browser-test <exact-rust-test-name>`; this skips the repo-local
+matrix and produces explicitly non-canonical evidence.
 
 Run the Wayland wrapper through `nix develop .#cua-driver-wayland-e2e`. It
 creates a pure Wayland session with Xwayland disabled and delegates every

--- a/scripts/ci/run-rust-standalone-browser-e2e.sh
+++ b/scripts/ci/run-rust-standalone-browser-e2e.sh
@@ -7,6 +7,39 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 RUST_ROOT="${REPO_ROOT}/libs/cua-driver/rust"
 ARTIFACT_DIR="${CUA_E2E_ARTIFACT_DIR:-${REPO_ROOT}/artifacts/cua-driver/standalone-browser}"
 
+usage() {
+  cat <<'EOF'
+Usage: run-rust-standalone-browser-e2e.sh [--test <exact-rust-test-name>]
+
+Run the complete external Chromium browser matrix by default.
+
+--test runs one exact declared Rust test as a local diagnostic. Its result is
+not a canonical matrix result and cannot be used to shorten certification.
+EOF
+}
+
+SELECTED_TEST=""
+while (($#)); do
+  case "$1" in
+    --test=*) SELECTED_TEST="${1#*=}" ;;
+    --test)
+      if (($# < 2)) || [[ -z "$2" || "$2" == -* ]]; then
+        echo "--test requires one exact Rust test name" >&2
+        exit 2
+      fi
+      SELECTED_TEST="$2"
+      shift
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+if [[ -n "${SELECTED_TEST}" && ! "${SELECTED_TEST}" =~ ^standalone_browser_[a-z0-9_]+$ ]]; then
+  echo "--test must be one artifact-safe standalone_browser_* Rust test name" >&2
+  exit 2
+fi
+
 if [[ -d "${ARTIFACT_DIR}" ]] \
     && [[ -n "$(find "${ARTIFACT_DIR}" -mindepth 1 -print -quit)" ]]; then
   echo "Standalone-browser artifact directory is not empty: ${ARTIFACT_DIR}" >&2
@@ -79,6 +112,13 @@ fi
 : > "${CUA_E2E_ENVIRONMENT_FILE}"
 : > "${CUA_E2E_BROWSER_PROVENANCE_FILE}"
 : > "${CUA_E2E_RESULTS_FILE}"
+if [[ -n "${SELECTED_TEST}" ]]; then
+  jq -n \
+    --arg schema 'cua-driver/standalone-browser-diagnostic@v1' \
+    --arg test "${SELECTED_TEST}" \
+    '{schema: $schema, test: $test, canonical: false}' \
+    > "${ARTIFACT_DIR}/diagnostic-selection.json"
+fi
 
 SOURCE_MARKER="${REPO_ROOT}/.cua-e2e-source-sha"
 if [[ -f "${SOURCE_MARKER}" ]]; then
@@ -136,6 +176,23 @@ else
     standalone_browser_window_collision
   )
 fi
+
+if [[ -n "${SELECTED_TEST}" ]]; then
+  declared=0
+  for test_name in "${tests[@]}"; do
+    if [[ "${test_name}" == "${SELECTED_TEST}" ]]; then
+      declared=1
+      break
+    fi
+  done
+  if [[ "${declared}" != 1 ]]; then
+    echo "--test is not declared for ${HOST_OS}: ${SELECTED_TEST}" >&2
+    exit 2
+  fi
+  tests=("${SELECTED_TEST}")
+  echo "[DIAGNOSTIC] Running only ${SELECTED_TEST}; this is not a canonical matrix"
+fi
+
 failure_count=0
 for test_name in "${tests[@]}"; do
   echo "[RUN] ${test_name}"
@@ -168,8 +225,16 @@ if [[ "${report_status}" != 0 ]]; then
 fi
 
 if [[ "${failure_count}" != 0 ]]; then
-  echo "Standalone-browser E2E had ${failure_count} failing step(s)" >&2
+  if [[ -n "${SELECTED_TEST}" ]]; then
+    echo "Standalone-browser diagnostic ${SELECTED_TEST} had ${failure_count} failing step(s)" >&2
+  else
+    echo "Standalone-browser E2E had ${failure_count} failing step(s)" >&2
+  fi
   exit 1
 fi
 
-echo "Standalone-browser E2E completed"
+if [[ -n "${SELECTED_TEST}" ]]; then
+  echo "Standalone-browser diagnostic completed for ${SELECTED_TEST}"
+else
+  echo "Standalone-browser E2E completed"
+fi


### PR DESCRIPTION
## problem

reproducing one installed-browser row on macos required bypassing the runner and manually rebuilding its environment. direct `cargo test` omitted fixture staging, exact-source installation, signed-daemon authorization, isolated evidence, and daemon restoration.

## scope

- add `--test <exact-rust-test-name>` to the cross-platform unix standalone-browser runner
- add `--standalone-browser-test <exact-rust-test-name>` to the macos lume wrapper
- validate exact selectors against the platform's declared browser tests
- reuse source installation, sentinel staging, unrestricted-daemon transition, artifact preservation, report validation, and standard-daemon restoration
- write `diagnostic-selection.json` with `canonical: false`
- leave every no-selector command as the complete canonical matrix

## duplicate check

no active issue or pull request owns a focused standalone-browser selector. Refs #2892 for the broader browser coverage work.

## validation

- `bash -n scripts/ci/run-rust-standalone-browser-e2e.sh libs/cua-driver/tests/runners/macos-lume/run-all.sh`
- `ruff check libs/cua-driver/scripts/tests/test_macos_lume_runner.py`
- `ruff format --check libs/cua-driver/scripts/tests/test_macos_lume_runner.py`
- `pytest libs/cua-driver/scripts/tests/test_macos_lume_runner.py -q`: 100 passed
- focused shell checks prove help and malformed selectors exit before setup
- live macos smoke at exact source `ae3fee301f7e3a78392f1784220d20d694569fbb` selected only `standalone_browser_roundtrip`, staged the sentinel, emitted `diagnostic-selection.json`, and produced one case/result row; the row then failed the host sentinel-focus precondition before its behavioral video boundary

## known gaps

- the new lume option still needs one live disposable-worker invocation before this draft is ready

