### PR TITLE
test(cua-driver): prevent embedded fixture spawn race

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/tests/embedded_host_sdk_mcp_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/embedded_host_sdk_mcp_test.rs
@@ -60,11 +60,6 @@ fn write_test_shell_script(path: &std::path::Path, body: &str) {
             })
         })
         .expect("test environment must provide a shell");
-    // Write in a separate process. If this multithreaded test process opens the
-    // future executable for writing, a concurrent spawn can inherit that file
-    // descriptor before its exec closes CLOEXEC descriptors. Linux then rejects
-    // this fixture's exec with ETXTBSY while that short-lived child still holds
-    // the inherited writer.
     let script = format!("#!{}\n{body}\n", shell.display());
     let status = std::process::Command::new(&shell)
         .args([

--- a/libs/cua-driver/rust/crates/cua-driver/tests/embedded_host_sdk_mcp_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/embedded_host_sdk_mcp_test.rs
@@ -60,7 +60,23 @@ fn write_test_shell_script(path: &std::path::Path, body: &str) {
             })
         })
         .expect("test environment must provide a shell");
-    std::fs::write(path, format!("#!{}\n{body}\n", shell.display())).unwrap();
+    // Write in a separate process. If this multithreaded test process opens the
+    // future executable for writing, a concurrent spawn can inherit that file
+    // descriptor before its exec closes CLOEXEC descriptors. Linux then rejects
+    // this fixture's exec with ETXTBSY while that short-lived child still holds
+    // the inherited writer.
+    let script = format!("#!{}\n{body}\n", shell.display());
+    let status = std::process::Command::new(&shell)
+        .args([
+            std::ffi::OsStr::new("-c"),
+            std::ffi::OsStr::new("umask 077; printf '%s' \"$1\" > \"$2\""),
+            std::ffi::OsStr::new("cua-driver-test-fixture-writer"),
+        ])
+        .arg(script)
+        .arg(path)
+        .status()
+        .expect("spawn test fixture writer");
+    assert!(status.success(), "test fixture writer failed: {status}");
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).unwrap();
 }
 


### PR DESCRIPTION
closes #2466

## summary

- create executable shell fixtures in a completed helper process instead of opening the future executable in the multithreaded test process
- prevent concurrent process spawns from briefly inheriting the fixture's writable file descriptor and causing linux `execve` to fail with `etxtbsy`
- retain the exact early-exit status and stopped-state lifecycle assertions

## root cause

`write_test_shell_script` used `std::fs::write` in the integration-test process. the rust test harness runs five tests concurrently, and several of them spawn embedded daemons. if another spawn cloned the process while the fixture writer was open, its pre-exec child briefly inherited that descriptor. `o_cloexec` closes the descriptor only when that child reaches `exec`; an overlapping attempt to execute the fixture therefore failed with linux `etxtbsy` (`text file busy`) before the expected exit-status poll.

this reproduces the exact previously discarded error:

```text
attempt 1/64 returned Spawn {
  binary_path: ".../early-exit-driver",
  reason: "Text file busy (os error 26)"
}
```

a controlled fork reproduced the kernel rule with an inherited `o_wronly|o_cloexec` descriptor: closing the descriptor in the parent did not make the executable runnable until the pre-exec child released its inherited copy.

## validation

exact candidate: `09706aa2ed800039f58fea849713db8e5f85c0f7`

- focused regression: 64/64 starts passed
- unchanged helper, full five-test binary: reproduced `etxtbsy` twice in 21 parallel runs
- fixed helper, full five-test binary: 100/100 parallel runs passed, covering 6,400 early-exit starts
- `cargo +1.97.1 fmt --manifest-path libs/cua-driver/rust/Cargo.toml --all -- --check`
- `git diff --check`
- [nix rust unit tests](https://github.com/trycua/cua/actions/runs/33039655684/job/98410125018): passed
- ordinary linux, windows, generated-contract, format, documentation, attribution, and release-metadata checks: passed

the final candidate adds only removal of an explanatory source comment after the certified behavior change. this changes test-fixture construction only; no product executable behavior changed, so the `no-release` label is intentional.