### PR TITLE
feat(fleet): publish browser and Node SDK with Computer lifecycle

### DIFF
--- a/.github/workflows/ci-ts-fleet.yml
+++ b/.github/workflows/ci-ts-fleet.yml
@@ -1,0 +1,18 @@
+name: "CI: @trycua/fleet"
+
+on:
+  pull_request:
+    paths:
+      - "libs/typescript/fleet/**"
+      - "libs/typescript/pnpm-lock.yaml"
+      - "libs/typescript/pnpm-workspace.yaml"
+      - ".github/workflows/ci-ts-fleet.yml"
+      - ".github/workflows/ts-reusable-build.yml"
+
+jobs:
+  build:
+    uses: ./.github/workflows/ts-reusable-build.yml
+    with:
+      package_name: "fleet"
+      package_dir: "libs/typescript/fleet"
+      package_manager: "pnpm"

--- a/docs/content/docs/how-to-guides/sandbox/create-pool-with-typescript.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/create-pool-with-typescript.mdx
@@ -14,8 +14,6 @@ The package provides separate runtime entry points:
 - `@trycua/fleet/browser` loads the Fleet WebAssembly module in a browser.
 - `@trycua/fleet/node` loads the same WebAssembly module from disk and provides
   a fetch-based HTTP transport.
-- `@trycua/computer` can claim an existing Fleet pool and expose the familiar
-  Computer screenshot and input APIs from Node.js.
 
 ## Prerequisites
 
@@ -40,10 +38,10 @@ public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04@sha256:82702ebdd32d1f8fc05f2ea409a7c67d
 <Tabs groupId="fleet-typescript-runtime" persist items={['Node.js', 'Browser']}>
   <Tab value="Node.js">
 
-Install the Fleet lifecycle SDK, Computer SDK, and a TypeScript runner:
+Install the Fleet lifecycle SDK and a TypeScript runner:
 
 ```bash
-npm install @trycua/fleet @trycua/computer
+npm install @trycua/fleet
 npm install --save-dev tsx typescript
 ```
 
@@ -58,8 +56,8 @@ Save this script as `create-pool.ts`:
 
 ```ts title="create-pool.ts"
 import { writeFile } from 'node:fs/promises';
-import { FleetComputer, OSType } from '@trycua/computer';
 import {
+  CreateClaimRequestBuilder,
   CreatePoolRequestBuilder,
   CreateTemplateRequestBuilder,
   CyclopsTokenProviderConfigurationBuilder,
@@ -69,6 +67,7 @@ import {
   SandboxTemplateRefBuilder,
   VmTemplateBuilder,
   createFleetClient,
+  type Claim,
 } from '@trycua/fleet/node';
 
 const IMAGE =
@@ -85,6 +84,19 @@ function requiredEnv(name: string): string {
   return value;
 }
 
+function screenshotBase64(responseBody: ArrayBuffer): string {
+  const text = new TextDecoder().decode(responseBody);
+  const dataLine = text.split('\n').find((line) => line.startsWith('data: '));
+  if (!dataLine) throw new Error(`No screenshot data frame: ${text.slice(0, 200)}`);
+
+  const payload = JSON.parse(dataLine.slice(6));
+  if (!payload.success) throw new Error(payload.error ?? 'Screenshot failed');
+
+  const encoded = payload.image_data ?? payload.result?.image_data;
+  if (typeof encoded !== 'string') throw new Error('Screenshot response has no image data');
+  return encoded;
+}
+
 const configuration = new CyclopsTokenProviderConfigurationBuilder()
   .baseUrl(BASE_URL)
   .poolPollIntervalMs(5_000n)
@@ -92,9 +104,9 @@ const configuration = new CyclopsTokenProviderConfigurationBuilder()
   .claimPollIntervalMs(5_000n)
   .claimPollLimit(120)
   .build();
-
 const client = await createFleetClient(configuration, ACCESS_TOKEN);
 
+let claim: Claim | undefined;
 try {
   const service = new SandboxServiceBuilder().name('server').targetPort(8000).build();
   const vm = new VmTemplateBuilder()
@@ -111,39 +123,47 @@ try {
     .build();
 
   const pool = await client.createPool(
-    new CreatePoolRequestBuilder().namespace(POOL_NAME).spec(poolSpec).build()
+    new CreatePoolRequestBuilder().namespace(POOL_NAME).spec(poolSpec).build(),
   );
   const template = await client.createTemplate(
     new CreateTemplateRequestBuilder()
       .namespace(POOL_NAME)
       .name(TEMPLATE_NAME)
       .spec(templateSpec)
-      .build()
+      .build(),
   );
 
   console.log(`Created pool ${pool.metadata.name}`);
   console.log(`Created template ${template.metadata.name}`);
 
-  const computer = new FleetComputer({
-    name: `${POOL_NAME}-screenshot`,
-    osType: OSType.LINUX,
-    accessToken: ACCESS_TOKEN,
-    poolName: POOL_NAME,
-    namespace: POOL_NAME,
-    fleetBaseUrl: BASE_URL,
-    serviceName: 'server',
-  });
+  claim = await client.createClaim(
+    new CreateClaimRequestBuilder().pool(pool).build(),
+  );
+  const sandbox = await client.waitClaim(claim);
 
-  await computer.run();
-  try {
-    await writeFile('sandbox.png', await computer.interface.screenshot());
-    console.log('Wrote sandbox.png');
-  } finally {
-    // Releases the claim. The pool and its warm replica remain available.
-    await computer.stop();
+  const requestBody = await new Blob([
+    JSON.stringify({ command: 'screenshot' }),
+  ]).arrayBuffer();
+  const response = await client.serviceRequest(sandbox, 'server', '/cmd', {
+    method: 'POST',
+    url: 'https://service.invalid/cmd',
+    headers: [{ name: 'content-type', value: 'application/json' }],
+    body: requestBody,
+    timeoutSecs: 60n,
+  });
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`Screenshot request failed with HTTP ${response.status}`);
   }
+
+  await writeFile('sandbox.png', Buffer.from(screenshotBase64(response.body), 'base64'));
+  console.log('Wrote sandbox.png');
 } finally {
-  client.uniffiDestroy();
+  try {
+    // Release the claim but leave the reusable pool warm.
+    if (claim) await client.deleteClaim(claim);
+  } finally {
+    client.uniffiDestroy();
+  }
 }
 ```
 
@@ -153,9 +173,9 @@ Run it:
 npx tsx create-pool.ts
 ```
 
-The script writes `sandbox.png` in the current directory. `FleetComputer`
-creates and waits for a claim, connects through Fleet's authenticated WebSocket
-proxy, and deletes the claim in `stop()`.
+The script writes `sandbox.png` in the current directory. The Fleet client
+creates and waits for the claim, routes `POST /cmd` through the authenticated
+`server` service proxy, and deletes the claim before closing.
 
   </Tab>
   <Tab value="Browser">

--- a/docs/content/docs/how-to-guides/sandbox/create-pool-with-typescript.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/create-pool-with-typescript.mdx
@@ -1,0 +1,369 @@
+---
+title: Create a sandbox pool with TypeScript
+description: Create a reusable Fleet pool and capture a sandbox screenshot from browser or Node.js TypeScript.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Use `@trycua/fleet` to create a reusable sandbox pool from TypeScript. This
+guide creates a one-replica Linux pool, claims a sandbox, captures a screenshot,
+and releases the claim while leaving the pool warm.
+
+The package provides separate runtime entry points:
+
+- `@trycua/fleet/browser` loads the Fleet WebAssembly module in a browser.
+- `@trycua/fleet/node` loads the same WebAssembly module from disk and provides
+  a fetch-based HTTP transport.
+- `@trycua/computer` can claim an existing Fleet pool and expose the familiar
+  Computer screenshot and input APIs from Node.js.
+
+## Prerequisites
+
+- Node.js 20 or newer.
+- A run.cua.ai access token with permission to manage sandbox pools.
+- A globally unique, lowercase DNS-label pool name.
+
+This guide uses the public Linux computer-server image:
+
+```text
+public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e9f1a89ce40989d5f4475d
+```
+
+<Callout type="warn">
+  Browser code can read every `VITE_*` value bundled into the application. Use the browser example
+  only in a trusted local or internal application with a short-lived, narrowly scoped token. Keep
+  long-lived credentials in Node.js or exchange them for a short-lived token on your backend.
+</Callout>
+
+## Choose a runtime
+
+<Tabs groupId="fleet-typescript-runtime" persist items={['Node.js', 'Browser']}>
+  <Tab value="Node.js">
+
+Install the Fleet lifecycle SDK, Computer SDK, and a TypeScript runner:
+
+```bash
+npm install @trycua/fleet @trycua/computer
+npm install --save-dev tsx typescript
+```
+
+Set the token and a unique pool name:
+
+```bash
+export CUA_FLEET_ACCESS_TOKEN="<your-access-token>"
+export CUA_POOL_NAME="my-team-js-pool"
+```
+
+Save this script as `create-pool.ts`:
+
+```ts title="create-pool.ts"
+import { writeFile } from 'node:fs/promises';
+import { FleetComputer, OSType } from '@trycua/computer';
+import {
+  CreatePoolRequestBuilder,
+  CreateTemplateRequestBuilder,
+  CyclopsTokenProviderConfigurationBuilder,
+  OsGymSandboxTemplateSpecBuilder,
+  OsGymSandboxWarmPoolSpecBuilder,
+  SandboxServiceBuilder,
+  SandboxTemplateRefBuilder,
+  VmTemplateBuilder,
+  createFleetClient,
+} from '@trycua/fleet/node';
+
+const IMAGE =
+  'public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04' +
+  '@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e9f1a89ce40989d5f4475d';
+const BASE_URL = process.env.CUA_FLEET_BASE_URL ?? 'https://run.cua.ai';
+const ACCESS_TOKEN = requiredEnv('CUA_FLEET_ACCESS_TOKEN');
+const POOL_NAME = requiredEnv('CUA_POOL_NAME');
+const TEMPLATE_NAME = `${POOL_NAME}-template`;
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing environment variable: ${name}`);
+  return value;
+}
+
+const configuration = new CyclopsTokenProviderConfigurationBuilder()
+  .baseUrl(BASE_URL)
+  .poolPollIntervalMs(5_000n)
+  .poolPollLimit(120)
+  .claimPollIntervalMs(5_000n)
+  .claimPollLimit(120)
+  .build();
+
+const client = await createFleetClient(configuration, ACCESS_TOKEN);
+
+try {
+  const service = new SandboxServiceBuilder().name('server').targetPort(8000).build();
+  const vm = new VmTemplateBuilder()
+    .containerDiskImage(IMAGE)
+    .cpuCores(4)
+    .memory('4Gi')
+    .services([service])
+    .build();
+  const templateSpec = new OsGymSandboxTemplateSpecBuilder().vmTemplate(vm).build();
+  const templateRef = new SandboxTemplateRefBuilder().name(TEMPLATE_NAME).build();
+  const poolSpec = new OsGymSandboxWarmPoolSpecBuilder()
+    .replicas(1)
+    .sandboxTemplateRef(templateRef)
+    .build();
+
+  const pool = await client.createPool(
+    new CreatePoolRequestBuilder().namespace(POOL_NAME).spec(poolSpec).build()
+  );
+  const template = await client.createTemplate(
+    new CreateTemplateRequestBuilder()
+      .namespace(POOL_NAME)
+      .name(TEMPLATE_NAME)
+      .spec(templateSpec)
+      .build()
+  );
+
+  console.log(`Created pool ${pool.metadata.name}`);
+  console.log(`Created template ${template.metadata.name}`);
+
+  const computer = new FleetComputer({
+    name: `${POOL_NAME}-screenshot`,
+    osType: OSType.LINUX,
+    accessToken: ACCESS_TOKEN,
+    poolName: POOL_NAME,
+    namespace: POOL_NAME,
+    fleetBaseUrl: BASE_URL,
+    serviceName: 'server',
+  });
+
+  await computer.run();
+  try {
+    await writeFile('sandbox.png', await computer.interface.screenshot());
+    console.log('Wrote sandbox.png');
+  } finally {
+    // Releases the claim. The pool and its warm replica remain available.
+    await computer.stop();
+  }
+} finally {
+  client.uniffiDestroy();
+}
+```
+
+Run it:
+
+```bash
+npx tsx create-pool.ts
+```
+
+The script writes `sandbox.png` in the current directory. `FleetComputer`
+creates and waits for a claim, connects through Fleet's authenticated WebSocket
+proxy, and deletes the claim in `stop()`.
+
+  </Tab>
+  <Tab value="Browser">
+
+Create a Vite TypeScript project and install the browser SDK:
+
+```bash
+npm create vite@latest fleet-browser -- --template vanilla-ts
+cd fleet-browser
+npm install
+npm install @trycua/fleet
+```
+
+Create `.env.local` with a short-lived access token and a unique pool name:
+
+```bash title=".env.local"
+VITE_CUA_FLEET_ACCESS_TOKEN=<your-short-lived-access-token>
+VITE_CUA_POOL_NAME=my-team-browser-pool
+```
+
+Replace `src/main.ts` with the following code:
+
+```ts title="src/main.ts"
+import {
+  CreateClaimRequestBuilder,
+  CreatePoolRequestBuilder,
+  CreateTemplateRequestBuilder,
+  CyclopsClient,
+  CyclopsTokenProviderConfigurationBuilder,
+  OsGymSandboxTemplateSpecBuilder,
+  OsGymSandboxWarmPoolSpecBuilder,
+  SandboxServiceBuilder,
+  SandboxTemplateRefBuilder,
+  VmTemplateBuilder,
+  uniffiInitAsync,
+  type Claim,
+} from '@trycua/fleet/browser';
+
+const IMAGE =
+  'public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04' +
+  '@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e9f1a89ce40989d5f4475d';
+const BASE_URL = import.meta.env.VITE_CUA_FLEET_BASE_URL ?? 'https://run.cua.ai';
+const ACCESS_TOKEN = requiredEnv('VITE_CUA_FLEET_ACCESS_TOKEN');
+const POOL_NAME = requiredEnv('VITE_CUA_POOL_NAME');
+const TEMPLATE_NAME = `${POOL_NAME}-template`;
+
+function requiredEnv(name: string): string {
+  const value = import.meta.env[name];
+  if (!value) throw new Error(`Missing environment variable: ${name}`);
+  return value;
+}
+
+function screenshotBase64(responseBody: ArrayBuffer): string {
+  const text = new TextDecoder().decode(responseBody);
+  const dataLine = text.split('\n').find((line) => line.startsWith('data: '));
+  if (!dataLine) throw new Error(`No screenshot data frame: ${text.slice(0, 200)}`);
+
+  const payload = JSON.parse(dataLine.slice(6));
+  if (!payload.success) throw new Error(payload.error ?? 'Screenshot failed');
+
+  const encoded = payload.image_data ?? payload.result?.image_data;
+  if (typeof encoded !== 'string') throw new Error('Screenshot response has no image data');
+  return encoded;
+}
+
+function pngBlob(encoded: string): Blob {
+  const bytes = Uint8Array.from(atob(encoded), (character) => character.charCodeAt(0));
+  return new Blob([bytes], { type: 'image/png' });
+}
+
+await uniffiInitAsync();
+
+const configuration = new CyclopsTokenProviderConfigurationBuilder()
+  .baseUrl(BASE_URL)
+  .poolPollIntervalMs(5_000n)
+  .poolPollLimit(120)
+  .claimPollIntervalMs(5_000n)
+  .claimPollLimit(120)
+  .build();
+const client = CyclopsClient.connectBrowserWithAccessToken(configuration, ACCESS_TOKEN);
+
+let claim: Claim | undefined;
+try {
+  const service = new SandboxServiceBuilder().name('server').targetPort(8000).build();
+  const vm = new VmTemplateBuilder()
+    .containerDiskImage(IMAGE)
+    .cpuCores(4)
+    .memory('4Gi')
+    .services([service])
+    .build();
+  const templateSpec = new OsGymSandboxTemplateSpecBuilder().vmTemplate(vm).build();
+  const templateRef = new SandboxTemplateRefBuilder().name(TEMPLATE_NAME).build();
+  const poolSpec = new OsGymSandboxWarmPoolSpecBuilder()
+    .replicas(1)
+    .sandboxTemplateRef(templateRef)
+    .build();
+
+  const pool = await client.createPool(
+    new CreatePoolRequestBuilder().namespace(POOL_NAME).spec(poolSpec).build()
+  );
+  const template = await client.createTemplate(
+    new CreateTemplateRequestBuilder()
+      .namespace(POOL_NAME)
+      .name(TEMPLATE_NAME)
+      .spec(templateSpec)
+      .build()
+  );
+
+  console.log(`Created pool ${pool.metadata.name} with template ${template.metadata.name}`);
+
+  claim = await client.createClaim(new CreateClaimRequestBuilder().pool(pool).build());
+  const sandbox = await client.waitClaim(claim);
+
+  const requestBody = await new Blob([JSON.stringify({ command: 'screenshot' })]).arrayBuffer();
+  const response = await client.serviceRequest(sandbox, 'server', '/cmd', {
+    method: 'POST',
+    url: 'https://service.invalid/cmd',
+    headers: [{ name: 'content-type', value: 'application/json' }],
+    body: requestBody,
+    timeoutSecs: 60n,
+  });
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`Screenshot request failed with HTTP ${response.status}`);
+  }
+
+  const image = document.querySelector<HTMLImageElement>('#screenshot');
+  if (!image) throw new Error('Missing #screenshot image element');
+  image.src = URL.createObjectURL(pngBlob(screenshotBase64(response.body)));
+} finally {
+  // Release the claim but leave the reusable pool warm.
+  if (claim) await client.deleteClaim(claim);
+}
+```
+
+Replace `index.html` with a minimal screenshot page:
+
+```html title="index.html"
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fleet screenshot</title>
+  </head>
+  <body>
+    <h1>Fleet sandbox screenshot</h1>
+    <img id="screenshot" alt="Fleet sandbox desktop" />
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>
+```
+
+Start the development server and open the printed URL:
+
+```bash
+npm run dev
+```
+
+The browser SDK authenticates the Fleet API request, routes `POST /cmd` through
+the named `server` service, decodes the computer-server event-stream response,
+and displays the PNG.
+
+  </Tab>
+</Tabs>
+
+## Keep or delete the pool
+
+Both examples release only the claim, so the one-replica pool remains warm for
+the next task. This is the normal reusable-pool lifecycle.
+
+The low-level Fleet SDK creates resources rather than reconciling them. Reusing
+the same pool name in the creation script returns an already-exists error. To
+reuse the pool, skip the creation calls and load it with:
+
+```ts
+const pool = await client.getPool(POOL_NAME);
+```
+
+To remove the pool permanently, retain the `pool` and `template` values and run
+the following after every claim has been released:
+
+```ts
+await client.deletePool(pool);
+await client.deleteTemplate(template);
+```
+
+Pool names are globally unique across Cua accounts. If creation returns HTTP
+403, choose another pool name; changing the claim name does not resolve a pool
+namespace conflict.
+
+## Use autoscaling instead of one replica
+
+Replace `.replicas(1)` with an autoscaling policy and omit `replicas`:
+
+```ts
+import { WarmPoolAutoscalingBuilder } from '@trycua/fleet/node';
+
+const autoscaling = new WarmPoolAutoscalingBuilder()
+  .minPoolSize(0)
+  .initialPoolSize(2)
+  .maxPoolSize(10)
+  .build();
+
+const poolSpec = new OsGymSandboxWarmPoolSpecBuilder()
+  .autoscaling(autoscaling)
+  .sandboxTemplateRef(templateRef)
+  .build();
+```
+
+Use the matching `@trycua/fleet/browser` import in browser code. With a minimum
+size of zero, the first claim after an idle period cold-starts a sandbox.

--- a/docs/content/docs/how-to-guides/sandbox/meta.json
+++ b/docs/content/docs/how-to-guides/sandbox/meta.json
@@ -4,6 +4,7 @@
     "lifecycle",
     "configure-pool-with-terraform",
     "create-pool-with-python",
+    "create-pool-with-typescript",
     "expire-pools-and-claims",
     "secrets",
     "scale-out",

--- a/libs/typescript/README.md
+++ b/libs/typescript/README.md
@@ -3,21 +3,23 @@
 This repository contains TypeScript implementations of the Cua libraries:
 
 - `@trycua/core`: Core functionality including telemetry and logging
-- `@trycua/computer`: Computer interaction SDK for VM management and control
+- `@trycua/fleet`: Browser and Node.js SDK for sandbox templates, pools, claims, and services
+- `@trycua/computer`: Legacy computer interaction and control compatibility SDK
 
 ## Project Structure
 
 ```text
 libs/typescript/
-├── computer/       # Computer SDK package
+├── computer/       # Computer-control compatibility package
 ├── core/           # Core functionality package
+├── fleet/          # Fleet sandbox lifecycle package
 ├── package.json    # Root package configuration
 └── pnpm-workspace.yaml  # Workspace configuration
 ```
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) (v18 or later)
+- [Node.js](https://nodejs.org/) (v20 or later)
 - [pnpm](https://pnpm.io/) (v10 or later)
 
 ## Setup and Installation
@@ -50,7 +52,10 @@ Build specific packages:
 # Build core package
 pnpm --filter @trycua/core build
 
-# Build computer package
+# Build Fleet package
+pnpm --filter @trycua/fleet build
+
+# Build computer compatibility package
 pnpm --filter @trycua/computer build
 ```
 
@@ -97,9 +102,10 @@ Core functionality for Cua libraries including:
 
 ### @trycua/computer
 
-Computer interaction SDK for managing and controlling virtual machines:
+Compatibility SDK for existing computer-control integrations. Use `@trycua/fleet`
+for new sandbox lifecycle code instead of managing Fleet resources here.
 
-- VM provider system (Cloud)
+- Legacy VM provider system (Cloud)
 - Interface system for OS-specific interactions
 - Screenshot, keyboard, and mouse control
 - Command execution

--- a/libs/typescript/computer/README.md
+++ b/libs/typescript/computer/README.md
@@ -1,36 +1,31 @@
 # @trycua/computer
 
-Computer-use interface for controlling local, legacy Cloud, and Fleet-backed
-macOS, Linux, and Windows sandboxes.
+Computer-use interface for controlling local and legacy Cloud macOS, Linux, and
+Windows sandboxes.
 
-## Fleet
+## Use Fleet for sandbox lifecycle
 
-`FleetComputer` claims a sandbox from an existing Fleet pool, connects to its
-computer-server service through the authenticated Fleet WebSocket proxy, and
-releases the claim on `stop()` or `disconnect()`.
+New applications should use `@trycua/fleet` to create templates, pools, and
+claims and to send authenticated requests to services inside Fleet sandboxes:
 
-```ts
-import { FleetComputer, OSType } from '@trycua/computer';
-
-const computer = new FleetComputer({
-  name: 'keiki-task',
-  osType: OSType.LINUX,
-  accessToken: process.env.CUA_FLEET_ACCESS_TOKEN!,
-  poolName: 'keiki-pool',
-  namespace: 'keiki',
-  serviceName: 'server',
-});
-
-await computer.run();
-try {
-  const screenshot = await computer.interface.screenshot();
-  console.log(screenshot.length);
-} finally {
-  await computer.stop();
-}
+```bash
+npm install @trycua/fleet
 ```
 
-The package depends on `@trycua/fleet/node`; it does not vendor a second copy of
-the Fleet lifecycle implementation.
+Use the runtime-specific entry point in application code:
+
+```ts
+import { createFleetClient } from '@trycua/fleet/node';
+// Browser applications use @trycua/fleet/browser.
+```
+
+Do not call the legacy VM API or implement a second copy of Fleet lifecycle
+logic through `@trycua/computer`. See
+[Create a sandbox pool with TypeScript](https://cua.ai/docs/how-to-guides/sandbox/create-pool-with-typescript)
+for complete Node.js and browser examples, including screenshots.
+
+`@trycua/computer` remains available for existing computer-control integrations.
+Its Fleet compatibility provider delegates lifecycle operations to
+`@trycua/fleet`; new Fleet integrations should use the Fleet package directly.
 
 **[Documentation](https://cua.ai/docs/cua/reference/computer-sdk)** - Installation, guides, and configuration.

--- a/libs/typescript/computer/README.md
+++ b/libs/typescript/computer/README.md
@@ -1,5 +1,36 @@
 # @trycua/computer
 
-Computer-Use Interface (CUI) framework for interacting with local macOS and Linux sandboxes.
+Computer-use interface for controlling local, legacy Cloud, and Fleet-backed
+macOS, Linux, and Windows sandboxes.
+
+## Fleet
+
+`FleetComputer` claims a sandbox from an existing Fleet pool, connects to its
+computer-server service through the authenticated Fleet WebSocket proxy, and
+releases the claim on `stop()` or `disconnect()`.
+
+```ts
+import { FleetComputer, OSType } from '@trycua/computer';
+
+const computer = new FleetComputer({
+  name: 'keiki-task',
+  osType: OSType.LINUX,
+  accessToken: process.env.CUA_FLEET_ACCESS_TOKEN!,
+  poolName: 'keiki-pool',
+  namespace: 'keiki',
+  serviceName: 'server',
+});
+
+await computer.run();
+try {
+  const screenshot = await computer.interface.screenshot();
+  console.log(screenshot.length);
+} finally {
+  await computer.stop();
+}
+```
+
+The package depends on `@trycua/fleet/node`; it does not vendor a second copy of
+the Fleet lifecycle implementation.
 
 **[Documentation](https://cua.ai/docs/cua/reference/computer-sdk)** - Installation, guides, and configuration.

--- a/libs/typescript/computer/package.json
+++ b/libs/typescript/computer/package.json
@@ -5,13 +5,14 @@
   "description": "Typescript SDK for Cua computer interaction",
   "type": "module",
   "license": "MIT",
-  "homepage": "https://github.com/trycua/cua/tree/feature/computer/typescript/libs/typescript/computer",
+  "homepage": "https://github.com/trycua/cua/tree/main/libs/typescript/computer",
   "bugs": {
     "url": "https://github.com/trycua/cua/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/trycua/cua.git"
+    "url": "git+https://github.com/trycua/cua.git",
+    "directory": "libs/typescript/computer"
   },
   "author": "cua",
   "files": [
@@ -35,13 +36,17 @@
     "test": "vitest",
     "typecheck": "tsc --noEmit",
     "release": "bumpp && pnpm publish",
-    "prepublishOnly": "pnpm run build"
+    "prepublishOnly": "pnpm run build",
+    "prebuild": "pnpm --filter @trycua/core build && pnpm --filter @trycua/fleet build",
+    "pretest": "pnpm --filter @trycua/core build && pnpm --filter @trycua/fleet build",
+    "pretypecheck": "pnpm --filter @trycua/core build && pnpm --filter @trycua/fleet build"
   },
   "dependencies": {
     "@trycua/core": "workspace:^",
     "pino": "^9.7.0",
     "uuid": "^11.1.1",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "@trycua/fleet": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "^22.15.17",

--- a/libs/typescript/computer/src/computer/index.ts
+++ b/libs/typescript/computer/src/computer/index.ts
@@ -1,1 +1,2 @@
-export { BaseComputer, CloudComputer } from './providers';
+export { BaseComputer, CloudComputer, FleetComputer } from './providers';
+export type { CloudComputerConfig, FleetComputerConfig } from './types';

--- a/libs/typescript/computer/src/computer/providers/fleet.ts
+++ b/libs/typescript/computer/src/computer/providers/fleet.ts
@@ -1,0 +1,163 @@
+import { createHash } from 'node:crypto';
+import {
+  CreateClaimRequestBuilder,
+  CyclopsTokenProviderConfigurationBuilder,
+  createFleetClient,
+  type Claim,
+  type CyclopsClient,
+} from '@trycua/fleet/node';
+import pino from 'pino';
+import { v4 as uuidv4 } from 'uuid';
+import { type BaseComputerInterface, InterfaceFactory } from '../../interface/index';
+import type { FleetComputerConfig } from '../types';
+import { VMProviderType } from '../types';
+import { BaseComputer } from './base';
+
+const DEFAULT_FLEET_BASE_URL = process.env.CUA_FLEET_BASE_URL || 'https://run.cua.ai';
+const DEFAULT_SERVICE_NAME = 'server';
+
+function hashAccessToken(accessToken: string): string {
+  return createHash('sha256').update(accessToken).digest('hex');
+}
+
+function websocketProxyUrl(
+  baseUrl: string,
+  namespace: string,
+  sandboxName: string,
+  serviceName: string
+): string {
+  const url = new URL(
+    `/api/svc/${encodeURIComponent(namespace)}/${encodeURIComponent(`${sandboxName}-${serviceName}`)}/ws`,
+    baseUrl
+  );
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  return url.toString();
+}
+
+/** Computer implementation backed by a claim from an existing Fleet pool. */
+export class FleetComputer extends BaseComputer {
+  private readonly config: FleetComputerConfig;
+  private readonly sessionId = uuidv4();
+  private readonly accessTokenHash: string;
+  private iface?: BaseComputerInterface;
+  private client?: CyclopsClient;
+  private claim?: Claim;
+  private proxyUrl?: string;
+  private initialized = false;
+  private sessionStartTime?: number;
+
+  protected logger = pino({ name: 'computer.provider_fleet' });
+
+  constructor(config: FleetComputerConfig) {
+    super({ ...config, vmProvider: VMProviderType.FLEET });
+    this.config = config;
+    this.accessTokenHash = hashAccessToken(config.accessToken);
+  }
+
+  get ip(): string {
+    return this.proxyUrl ?? this.config.fleetBaseUrl ?? DEFAULT_FLEET_BASE_URL;
+  }
+
+  async run(): Promise<void> {
+    if (this.initialized) return;
+
+    try {
+      const configuration = new CyclopsTokenProviderConfigurationBuilder()
+        .baseUrl(this.config.fleetBaseUrl ?? DEFAULT_FLEET_BASE_URL)
+        .poolPollIntervalMs(this.config.poolPollIntervalMs ?? 5_000n)
+        .poolPollLimit(this.config.poolPollLimit ?? 120)
+        .claimPollIntervalMs(this.config.claimPollIntervalMs ?? 5_000n)
+        .claimPollLimit(this.config.claimPollLimit ?? 120)
+        .build();
+      this.client = await createFleetClient(configuration, this.config.accessToken);
+
+      const pool = await this.client.getPool(this.config.poolName);
+      if (this.config.namespace && pool.metadata.namespace !== this.config.namespace) {
+        throw new Error(
+          `Pool ${this.config.poolName} belongs to namespace ${pool.metadata.namespace}`
+        );
+      }
+
+      this.claim = await this.client.createClaim(
+        new CreateClaimRequestBuilder().pool(pool).build()
+      );
+      const sandbox = await this.client.waitClaim(this.claim);
+      this.proxyUrl = websocketProxyUrl(
+        this.config.fleetBaseUrl ?? DEFAULT_FLEET_BASE_URL,
+        sandbox.namespace,
+        sandbox.name,
+        this.config.serviceName ?? DEFAULT_SERVICE_NAME
+      );
+      this.iface = InterfaceFactory.createInterfaceForOS(
+        this.osType,
+        sandbox.name,
+        undefined,
+        undefined,
+        {
+          wsUrl: this.proxyUrl,
+          headers: { Authorization: `Bearer ${this.config.accessToken}` },
+        }
+      );
+      await this.iface.waitForReady();
+
+      this.initialized = true;
+      this.sessionStartTime = Date.now();
+      this.telemetry.recordEvent('ts_session_start', {
+        session_id: this.sessionId,
+        os_type: this.osType,
+        connection_type: 'fleet',
+        access_token_hash: this.accessTokenHash,
+        pool_name: this.config.poolName,
+      });
+    } catch (error) {
+      try {
+        await this.release();
+      } catch (releaseError) {
+        this.logger.warn(
+          `Failed to release Fleet claim after initialization error: ${releaseError}`
+        );
+      }
+      throw new Error(`Failed to initialize Fleet computer: ${error}`);
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.sessionStartTime) {
+      this.telemetry.recordEvent('ts_session_end', {
+        session_id: this.sessionId,
+        duration_seconds: (Date.now() - this.sessionStartTime) / 1000,
+        access_token_hash: this.accessTokenHash,
+        pool_name: this.config.poolName,
+      });
+    }
+    await this.release();
+  }
+
+  get interface(): BaseComputerInterface {
+    if (!this.iface) throw new Error('Computer not initialized. Call run() first.');
+    return this.iface;
+  }
+
+  async disconnect(): Promise<void> {
+    await this.stop();
+  }
+
+  private async release(): Promise<void> {
+    this.iface?.disconnect();
+    this.iface = undefined;
+
+    const client = this.client;
+    const claim = this.claim;
+    this.client = undefined;
+    this.claim = undefined;
+    this.initialized = false;
+    this.sessionStartTime = undefined;
+    this.proxyUrl = undefined;
+
+    try {
+      if (client && claim) await client.deleteClaim(claim);
+    } finally {
+      client?.uniffiDestroy();
+    }
+  }
+}

--- a/libs/typescript/computer/src/computer/providers/index.ts
+++ b/libs/typescript/computer/src/computer/providers/index.ts
@@ -1,2 +1,3 @@
 export * from './base';
 export * from './cloud';
+export * from './fleet';

--- a/libs/typescript/computer/src/computer/types.ts
+++ b/libs/typescript/computer/src/computer/types.ts
@@ -1,45 +1,37 @@
 import type { OSType, ScreenSize } from '../types';
 
-/**
- * Display configuration for the computer.
- */
+/** Display configuration for the computer. */
 export interface Display extends ScreenSize {
   scale_factor?: number;
 }
 
-/**
- * Computer configuration model.
- */
 export interface BaseComputerConfig {
-  /**
-   * The VM name
-   * @default ""
-   */
   name: string;
-
-  /**
-   * The operating system type ('macos', 'windows', or 'linux')
-   * @default "macos"
-   */
   osType: OSType;
-
-  /**
-   * The VM provider type
-   */
   vmProvider?: VMProviderType;
 }
 
 export interface CloudComputerConfig extends BaseComputerConfig {
-  /**
-   * Optional API key for cloud providers
-   */
   apiKey: string;
+}
+
+export interface FleetComputerConfig extends BaseComputerConfig {
+  accessToken: string;
+  poolName: string;
+  namespace?: string;
+  fleetBaseUrl?: string;
+  serviceName?: string;
+  poolPollIntervalMs?: bigint;
+  poolPollLimit?: number;
+  claimPollIntervalMs?: bigint;
+  claimPollLimit?: number;
 }
 
 export enum VMProviderType {
   DOCKER = 'docker',
   LUME = 'lume',
   CLOUD = 'cloud',
+  FLEET = 'fleet',
   QEMU = 'qemu',
   WINDOWS_SANDBOX = 'windows-sandbox',
   HOST = 'host',

--- a/libs/typescript/computer/src/index.ts
+++ b/libs/typescript/computer/src/index.ts
@@ -1,5 +1,4 @@
-// Export classes
-export { CloudComputer as Computer } from './computer';
-
+export { CloudComputer as Computer, CloudComputer, FleetComputer } from './computer';
+export type { CloudComputerConfig, FleetComputerConfig } from './computer/types';
 export { OSType } from './types';
 export { VMProviderType as ProviderType } from './computer/types';

--- a/libs/typescript/computer/src/interface/base.ts
+++ b/libs/typescript/computer/src/interface/base.ts
@@ -10,6 +10,11 @@ import type { ScreenSize } from '../types';
 
 export type MouseButton = 'left' | 'middle' | 'right';
 
+export interface ComputerInterfaceConnection {
+  wsUrl?: string;
+  headers?: Record<string, string>;
+}
+
 export interface CursorPosition {
   x: number;
   y: number;
@@ -41,6 +46,7 @@ export abstract class BaseComputerInterface {
   protected ws: WebSocket;
   protected apiKey?: string;
   protected vmName?: string;
+  protected connection: ComputerInterfaceConnection;
 
   protected logger = pino({ name: 'computer.interface-base' });
 
@@ -53,30 +59,29 @@ export abstract class BaseComputerInterface {
     username = 'lume',
     password = 'lume',
     apiKey?: string,
-    vmName?: string
+    vmName?: string,
+    connection: ComputerInterfaceConnection = {}
   ) {
     this.ipAddress = ipAddress;
     this.username = username;
     this.password = password;
     this.apiKey = apiKey;
     this.vmName = vmName;
+    this.connection = connection;
 
     // Initialize telemetry
     this.telemetry = new Telemetry();
     this.sessionId = uuidv4();
 
-    // Initialize WebSocket with headers if needed
-    const headers: { [key: string]: string } = {};
+    this.ws = this.createWebSocket();
+  }
+
+  private createWebSocket(): WebSocket {
+    const headers: Record<string, string> = { ...this.connection.headers };
     if (this.apiKey && this.vmName) {
       headers['X-API-Key'] = this.apiKey;
       headers['X-VM-Name'] = this.vmName;
     }
-
-    // Create the WebSocket instance
-    this.ws = this.createWebSocket(headers);
-  }
-
-  private createWebSocket(headers: { [key: string]: string }): WebSocket {
     const ws = new WebSocket(this.wsUri, { headers });
     // Constructors open immediately, and some tests only verify inheritance
     // without ever calling connect(). Keep those failed background attempts
@@ -93,6 +98,8 @@ export abstract class BaseComputerInterface {
    * Subclasses can override this to customize the URI.
    */
   protected get wsUri(): string {
+    if (this.connection.wsUrl) return this.connection.wsUrl;
+
     const protocol = this.apiKey ? 'wss' : 'ws';
 
     // Check if ipAddress already includes a port
@@ -186,12 +193,7 @@ export abstract class BaseComputerInterface {
     // If the WebSocket is closed or closing, reinitialize it
     if (this.ws.readyState === WebSocket.CLOSED || this.ws.readyState === WebSocket.CLOSING) {
       this.logger.info('Websocket is closed. Reinitializing connection.');
-      const headers: { [key: string]: string } = {};
-      if (this.apiKey && this.vmName) {
-        headers['X-API-Key'] = this.apiKey;
-        headers['X-VM-Name'] = this.vmName;
-      }
-      this.ws = this.createWebSocket(headers);
+      this.ws = this.createWebSocket();
     }
 
     // Connect and authenticate

--- a/libs/typescript/computer/src/interface/factory.ts
+++ b/libs/typescript/computer/src/interface/factory.ts
@@ -3,35 +3,27 @@
  */
 
 import type { OSType } from '../types';
-import type { BaseComputerInterface } from './base';
+import type { BaseComputerInterface, ComputerInterfaceConnection } from './base';
 import { LinuxComputerInterface } from './linux';
 import { MacOSComputerInterface } from './macos';
 import { WindowsComputerInterface } from './windows';
 
 export const InterfaceFactory = {
-  /**
-   * Create an interface for the specified OS.
-   *
-   * @param os Operating system type ('macos', 'linux', or 'windows')
-   * @param ipAddress IP address of the computer to control
-   * @param apiKey Optional API key for cloud authentication
-   * @param vmName Optional VM name for cloud authentication
-   * @returns The appropriate interface for the OS
-   * @throws Error if the OS type is not supported
-   */
+  /** Create an interface for the specified operating system and connection. */
   createInterfaceForOS(
     os: OSType,
     ipAddress: string,
     apiKey?: string,
-    vmName?: string
+    vmName?: string,
+    connection?: ComputerInterfaceConnection
   ): BaseComputerInterface {
     switch (os) {
       case 'macos':
-        return new MacOSComputerInterface(ipAddress, 'lume', 'lume', apiKey, vmName);
+        return new MacOSComputerInterface(ipAddress, 'lume', 'lume', apiKey, vmName, connection);
       case 'linux':
-        return new LinuxComputerInterface(ipAddress, 'lume', 'lume', apiKey, vmName);
+        return new LinuxComputerInterface(ipAddress, 'lume', 'lume', apiKey, vmName, connection);
       case 'windows':
-        return new WindowsComputerInterface(ipAddress, 'lume', 'lume', apiKey, vmName);
+        return new WindowsComputerInterface(ipAddress, 'lume', 'lume', apiKey, vmName, connection);
       default:
         throw new Error(`Unsupported OS type: ${os}`);
     }

--- a/libs/typescript/computer/tests/computer/fleet.test.ts
+++ b/libs/typescript/computer/tests/computer/fleet.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FleetComputer, OSType, ProviderType } from '../../src';
+import { InterfaceFactory } from '../../src/interface/factory';
+
+const fleetMocks = vi.hoisted(() => ({
+  createFleetClient: vi.fn(),
+}));
+
+vi.mock('@trycua/fleet/node', () => ({
+  createFleetClient: fleetMocks.createFleetClient,
+  CyclopsTokenProviderConfigurationBuilder: class {
+    private configuration: Record<string, unknown> = {};
+
+    baseUrl(value: string) {
+      this.configuration.baseUrl = value;
+      return this;
+    }
+
+    poolPollIntervalMs(value: bigint) {
+      this.configuration.poolPollIntervalMs = value;
+      return this;
+    }
+
+    poolPollLimit(value: number) {
+      this.configuration.poolPollLimit = value;
+      return this;
+    }
+
+    claimPollIntervalMs(value: bigint) {
+      this.configuration.claimPollIntervalMs = value;
+      return this;
+    }
+
+    claimPollLimit(value: number) {
+      this.configuration.claimPollLimit = value;
+      return this;
+    }
+
+    build() {
+      return this.configuration;
+    }
+  },
+  CreateClaimRequestBuilder: class {
+    private request: Record<string, unknown> = {};
+
+    pool(value: unknown) {
+      this.request.pool = value;
+      return this;
+    }
+
+    build() {
+      return this.request;
+    }
+  },
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fleetMocks.createFleetClient.mockReset();
+});
+
+describe('FleetComputer', () => {
+  it('claims a sandbox, connects through the Fleet proxy, and releases it', async () => {
+    const pool = { metadata: { namespace: 'keiki' } };
+    const claim = { metadata: { name: 'claim-1' } };
+    const sandbox = { namespace: 'keiki', name: 'sandbox-1', services: ['server'] };
+    const client = {
+      getPool: vi.fn().mockResolvedValue(pool),
+      createClaim: vi.fn().mockResolvedValue(claim),
+      waitClaim: vi.fn().mockResolvedValue(sandbox),
+      deleteClaim: vi.fn().mockResolvedValue(undefined),
+      uniffiDestroy: vi.fn(),
+    };
+    fleetMocks.createFleetClient.mockResolvedValue(client);
+
+    const iface = {
+      waitForReady: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+    };
+    const interfaceSpy = vi
+      .spyOn(InterfaceFactory, 'createInterfaceForOS')
+      .mockReturnValue(iface as never);
+
+    const computer = new FleetComputer({
+      name: 'keiki-task',
+      osType: OSType.LINUX,
+      vmProvider: ProviderType.FLEET,
+      accessToken: 'secret-token',
+      poolName: 'keiki-pool',
+      namespace: 'keiki',
+      serviceName: 'server',
+    });
+
+    await computer.run();
+
+    expect(computer.getVMProviderType()).toBe(ProviderType.FLEET);
+    expect(client.getPool).toHaveBeenCalledWith('keiki-pool');
+    expect(client.createClaim).toHaveBeenCalledWith({ pool });
+    expect(interfaceSpy).toHaveBeenCalledWith(OSType.LINUX, 'sandbox-1', undefined, undefined, {
+      wsUrl: 'wss://run.cua.ai/api/svc/keiki/sandbox-1-server/ws',
+      headers: { Authorization: 'Bearer secret-token' },
+    });
+    expect(computer.ip).toBe('wss://run.cua.ai/api/svc/keiki/sandbox-1-server/ws');
+
+    await computer.stop();
+
+    expect(iface.disconnect).toHaveBeenCalledOnce();
+    expect(client.deleteClaim).toHaveBeenCalledWith(claim);
+    expect(client.uniffiDestroy).toHaveBeenCalledOnce();
+  });
+
+  it('releases a claim when interface initialization fails', async () => {
+    const claim = { metadata: { name: 'claim-1' } };
+    const client = {
+      getPool: vi.fn().mockResolvedValue({ metadata: { namespace: 'keiki' } }),
+      createClaim: vi.fn().mockResolvedValue(claim),
+      waitClaim: vi
+        .fn()
+        .mockResolvedValue({ namespace: 'keiki', name: 'sandbox-1', services: ['server'] }),
+      deleteClaim: vi.fn().mockResolvedValue(undefined),
+      uniffiDestroy: vi.fn(),
+    };
+    fleetMocks.createFleetClient.mockResolvedValue(client);
+    vi.spyOn(InterfaceFactory, 'createInterfaceForOS').mockReturnValue({
+      waitForReady: vi.fn().mockRejectedValue(new Error('not ready')),
+      disconnect: vi.fn(),
+    } as never);
+
+    const computer = new FleetComputer({
+      name: 'keiki-task',
+      osType: OSType.LINUX,
+      accessToken: 'secret-token',
+      poolName: 'keiki-pool',
+    });
+
+    await expect(computer.run()).rejects.toThrow('Failed to initialize Fleet computer');
+    expect(client.deleteClaim).toHaveBeenCalledWith(claim);
+    expect(client.uniffiDestroy).toHaveBeenCalledOnce();
+  });
+});

--- a/libs/typescript/computer/tsdown.config.ts
+++ b/libs/typescript/computer/tsdown.config.ts
@@ -8,7 +8,7 @@ export default defineConfig([
     entry: ['./src/index.ts'],
     platform: 'node',
     dts: true,
-    external: ['child_process', 'util'],
+    external: ['child_process', 'util', '@trycua/fleet/node'],
     define: {
       __CUA_VERSION__: JSON.stringify(pkg.version),
     },

--- a/libs/typescript/fleet/README.md
+++ b/libs/typescript/fleet/README.md
@@ -1,17 +1,81 @@
 # @trycua/fleet
 
-> **Name reservation** — this package name is reserved for **Cua Fleet**, an upcoming
-> component of the [Cua](https://github.com/trycua/cua) project for orchestrating fleets
-> of computer-use agents and sandboxes.
+Browser and WebAssembly bindings for the Cua Fleet control plane. The package
+exposes the generated lifecycle client used to create templates, pools, and
+claims and to connect to services running inside a sandbox.
 
-This is a placeholder release: it installs an empty module and has no functionality yet.
-Watch [trycua/cua](https://github.com/trycua/cua) for the first real release.
+The package is built from the public Fleet mirror in
+[`libs/fleet`](../../fleet). That mirror is synchronized from the canonical
+Fleet repository, so the npm release and the public SDK source stay in the same
+repository and release history.
 
-In the meantime, check out the Cua TypeScript SDK:
+## Install
 
 ```bash
-npm install @trycua/computer @trycua/agent
+npm install @trycua/fleet
 ```
+
+## Use an existing pool
+
+Initialize the WebAssembly module once, create a client with a Fleet access
+token, and claim a sandbox from an existing pool:
+
+```ts
+import {
+  CreateClaimRequestBuilder,
+  CyclopsClient,
+  CyclopsTokenProviderConfigurationBuilder,
+  uniffiInitAsync,
+} from '@trycua/fleet';
+
+await uniffiInitAsync();
+
+const configuration = new CyclopsTokenProviderConfigurationBuilder()
+  .baseUrl('https://run.cua.ai')
+  .poolPollIntervalMs(5_000n)
+  .poolPollLimit(120)
+  .claimPollIntervalMs(5_000n)
+  .claimPollLimit(120)
+  .build();
+
+const client = CyclopsClient.connectBrowserWithAccessToken(configuration, accessToken);
+
+const pool = await client.getPool('my-pool');
+const claim = await client.createClaim(new CreateClaimRequestBuilder().pool(pool).build());
+const sandbox = await client.waitClaim(claim);
+
+try {
+  const response = await client.serviceRequest(sandbox, 'mcp', '/health', {
+    method: 'GET',
+    url: 'https://ignored.invalid/health',
+    headers: [],
+  });
+  console.log(response.status);
+} finally {
+  await client.deleteClaim(claim);
+  client.uniffiDestroy();
+}
+```
+
+The current package targets browser-compatible runtimes with `fetch`,
+`WebAssembly`, `TextEncoder`, and `TextDecoder`. The checked-in Node binding
+under `libs/fleet/sdk-bindings/ts-uniffi` requires a native `libcyclops_sdk`
+library and is not part of this package.
+
+## Development
+
+The build regenerates the browser UniFFI binding from `libs/fleet`, compiles
+the Rust SDK to WebAssembly, bundles the JavaScript entry point, and emits
+TypeScript declarations:
+
+```bash
+pnpm --dir libs/typescript/fleet build
+pnpm --dir libs/typescript/fleet pack:check
+```
+
+Build prerequisites are Rust, `rustup`, Cargo, Node.js 20 or newer, and npm.
+The build script installs the pinned `wasm32-unknown-unknown` target and the
+matching `wasm-bindgen-cli` when they are missing.
 
 ## Links
 

--- a/libs/typescript/fleet/README.md
+++ b/libs/typescript/fleet/README.md
@@ -1,13 +1,13 @@
 # @trycua/fleet
 
-Browser and WebAssembly bindings for the Cua Fleet control plane. The package
-exposes the generated lifecycle client used to create templates, pools, and
-claims and to connect to services running inside a sandbox.
+Browser and Node.js WebAssembly bindings for the Cua Fleet control plane. Both
+entry points expose the generated lifecycle client used to create templates,
+pools, claims, and authenticated requests to sandbox services.
 
 The package is built from the public Fleet mirror in
 [`libs/fleet`](../../fleet). That mirror is synchronized from the canonical
-Fleet repository, so the npm release and the public SDK source stay in the same
-repository and release history.
+Fleet repository, so the npm release and public SDK source share one repository
+and release history.
 
 ## Install
 
@@ -15,20 +15,34 @@ repository and release history.
 npm install @trycua/fleet
 ```
 
-## Use an existing pool
-
-Initialize the WebAssembly module once, create a client with a Fleet access
-token, and claim a sandbox from an existing pool:
+## Browser
 
 ```ts
 import {
-  CreateClaimRequestBuilder,
   CyclopsClient,
   CyclopsTokenProviderConfigurationBuilder,
   uniffiInitAsync,
-} from '@trycua/fleet';
+} from '@trycua/fleet/browser';
 
 await uniffiInitAsync();
+const configuration = new CyclopsTokenProviderConfigurationBuilder()
+  .baseUrl('https://run.cua.ai')
+  .poolPollIntervalMs(5_000n)
+  .poolPollLimit(120)
+  .claimPollIntervalMs(5_000n)
+  .claimPollLimit(120)
+  .build();
+const client = CyclopsClient.connectBrowserWithAccessToken(configuration, accessToken);
+```
+
+## Node.js
+
+The Node entry loads the same WASM artifact from disk and supplies a fetch-based
+UniFFI HTTP transport, so it does not require a platform-specific native
+`libcyclops_sdk`.
+
+```ts
+import { CyclopsTokenProviderConfigurationBuilder, createFleetClient } from '@trycua/fleet/node';
 
 const configuration = new CyclopsTokenProviderConfigurationBuilder()
   .baseUrl('https://run.cua.ai')
@@ -37,45 +51,23 @@ const configuration = new CyclopsTokenProviderConfigurationBuilder()
   .claimPollIntervalMs(5_000n)
   .claimPollLimit(120)
   .build();
-
-const client = CyclopsClient.connectBrowserWithAccessToken(configuration, accessToken);
-
-const pool = await client.getPool('my-pool');
-const claim = await client.createClaim(new CreateClaimRequestBuilder().pool(pool).build());
-const sandbox = await client.waitClaim(claim);
-
-try {
-  const response = await client.serviceRequest(sandbox, 'mcp', '/health', {
-    method: 'GET',
-    url: 'https://ignored.invalid/health',
-    headers: [],
-  });
-  console.log(response.status);
-} finally {
-  await client.deleteClaim(claim);
-  client.uniffiDestroy();
-}
+const client = await createFleetClient(configuration, accessToken);
 ```
 
-The current package targets browser-compatible runtimes with `fetch`,
-`WebAssembly`, `TextEncoder`, and `TextDecoder`. The checked-in Node binding
-under `libs/fleet/sdk-bindings/ts-uniffi` requires a native `libcyclops_sdk`
-library and is not part of this package.
+The package root uses conditional exports: browser-aware bundlers receive the
+browser entry and Node.js receives the Node entry. Explicit subpath imports are
+recommended for application code and tests.
 
 ## Development
-
-The build regenerates the browser UniFFI binding from `libs/fleet`, compiles
-the Rust SDK to WebAssembly, bundles the JavaScript entry point, and emits
-TypeScript declarations:
 
 ```bash
 pnpm --dir libs/typescript/fleet build
 pnpm --dir libs/typescript/fleet pack:check
 ```
 
-Build prerequisites are Rust, `rustup`, Cargo, Node.js 20 or newer, and npm.
-The build script installs the pinned `wasm32-unknown-unknown` target and the
-matching `wasm-bindgen-cli` when they are missing.
+The build regenerates the browser UniFFI binding from `libs/fleet`, compiles the
+pinned Rust SDK to WebAssembly, and emits both ESM entry points plus TypeScript
+declarations.
 
 ## Links
 

--- a/libs/typescript/fleet/index.d.ts
+++ b/libs/typescript/fleet/index.d.ts
@@ -1,1 +1,0 @@
-export declare const version: string;

--- a/libs/typescript/fleet/index.js
+++ b/libs/typescript/fleet/index.js
@@ -1,5 +1,0 @@
-// @trycua/fleet is reserved for Cua Fleet, an upcoming component of the Cua
-// project (https://github.com/trycua/cua) for orchestrating fleets of
-// computer-use agents and sandboxes. This is a placeholder release with no
-// functionality yet.
-export const version = '0.0.1';

--- a/libs/typescript/fleet/package.json
+++ b/libs/typescript/fleet/package.json
@@ -26,13 +26,23 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/node.js",
+  "module": "./dist/node.js",
+  "types": "./dist/node.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./dist/node.d.ts",
+      "browser": "./dist/browser.js",
+      "node": "./dist/node.js",
+      "import": "./dist/node.js"
+    },
+    "./browser": {
+      "types": "./dist/browser.d.ts",
+      "import": "./dist/browser.js"
+    },
+    "./node": {
+      "types": "./dist/node.d.ts",
+      "import": "./dist/node.js"
     },
     "./package.json": "./package.json"
   },
@@ -48,6 +58,8 @@
   },
   "devDependencies": {
     "esbuild": "^0.27.0",
-    "typescript": "^5.9.0"
-  }
+    "typescript": "^5.9.0",
+    "@types/node": "^22.15.17"
+  },
+  "browser": "./dist/browser.js"
 }

--- a/libs/typescript/fleet/package.json
+++ b/libs/typescript/fleet/package.json
@@ -2,16 +2,17 @@
   "name": "@trycua/fleet",
   "version": "0.0.3",
   "packageManager": "pnpm@10.12.3",
-  "description": "Reserved for Cua Fleet — fleet orchestration for computer-use agents and sandboxes. Placeholder release.",
+  "description": "Browser and WebAssembly SDK for Cua Fleet sandbox lifecycle management",
   "type": "module",
   "license": "MIT",
-  "homepage": "https://github.com/trycua/cua",
+  "homepage": "https://github.com/trycua/cua/tree/main/libs/typescript/fleet",
   "bugs": {
     "url": "https://github.com/trycua/cua/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/trycua/cua.git"
+    "url": "git+https://github.com/trycua/cua.git",
+    "directory": "libs/typescript/fleet"
   },
   "author": "cua",
   "keywords": [
@@ -23,17 +24,30 @@
     "automation"
   ],
   "files": [
-    "index.js",
-    "index.d.ts"
+    "dist"
   ],
-  "main": "./index.js",
-  "module": "./index.js",
-  "types": "./index.d.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./index.js",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "node ./scripts/build.mjs",
+    "pack:check": "pnpm run build && npm pack --dry-run"
+  },
+  "dependencies": {
+    "@ubjs/core": "0.31.0-3"
+  },
+  "devDependencies": {
+    "esbuild": "^0.27.0",
+    "typescript": "^5.9.0"
   }
 }

--- a/libs/typescript/fleet/scripts/build.mjs
+++ b/libs/typescript/fleet/scripts/build.mjs
@@ -1,0 +1,115 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { cpSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { build } from 'esbuild';
+
+const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repositoryRoot = resolve(packageDirectory, '../../..');
+const bindingDirectory = join(repositoryRoot, 'libs/fleet/sdk-bindings/ts-uniffi-browser');
+const generatedDirectory = join(bindingDirectory, 'ts');
+const generatedEntry = join(generatedDirectory, 'index.web.ts');
+const distributionDirectory = join(packageDirectory, 'dist');
+const declarationsDirectory = join(distributionDirectory, '.declarations');
+const rustToolchainFile = join(repositoryRoot, 'libs/fleet/rust-toolchain.toml');
+const rustToolchainMatch = readFileSync(rustToolchainFile, 'utf8').match(
+  /^channel\s*=\s*"([^"]+)"/m
+);
+if (!rustToolchainMatch) {
+  throw new Error(`Could not read the Rust channel from ${rustToolchainFile}`);
+}
+const rustToolchain = rustToolchainMatch[1];
+const wasmBindgenVersion = '0.2.126';
+
+function run(command, args, workingDirectory = packageDirectory) {
+  execFileSync(command, args, {
+    cwd: workingDirectory,
+    stdio: 'inherit',
+  });
+}
+
+function hasWasmBindgenVersion() {
+  const result = spawnSync('wasm-bindgen', ['--version'], {
+    encoding: 'utf8',
+  });
+  return result.status === 0 && result.stdout.trim() === `wasm-bindgen ${wasmBindgenVersion}`;
+}
+
+rmSync(distributionDirectory, { force: true, recursive: true });
+mkdirSync(distributionDirectory, { recursive: true });
+
+run('rustup', ['toolchain', 'install', rustToolchain, '--profile', 'minimal']);
+run('rustup', ['target', 'add', 'wasm32-unknown-unknown', '--toolchain', rustToolchain]);
+if (!hasWasmBindgenVersion()) {
+  run('cargo', [
+    `+${rustToolchain}`,
+    'install',
+    'wasm-bindgen-cli',
+    '--version',
+    wasmBindgenVersion,
+    '--locked',
+  ]);
+}
+
+run('npm', ['ci'], bindingDirectory);
+run('npm', ['run', 'build:wasm'], bindingDirectory);
+
+await build({
+  entryPoints: [generatedEntry],
+  bundle: true,
+  format: 'esm',
+  platform: 'browser',
+  target: ['es2022'],
+  outdir: distributionDirectory,
+  entryNames: 'index',
+  assetNames: 'fleet',
+  loader: {
+    '.wasm': 'file',
+  },
+});
+
+const bundlePath = join(distributionDirectory, 'index.js');
+const wasmReference = '"./fleet.wasm"';
+const bundle = readFileSync(bundlePath, 'utf8');
+if (bundle.split(wasmReference).length !== 2) {
+  throw new Error('Expected exactly one bundled WebAssembly asset reference');
+}
+writeFileSync(
+  bundlePath,
+  bundle.replace(wasmReference, 'new URL("./fleet.wasm", import.meta.url)')
+);
+
+const typescript = join(packageDirectory, 'node_modules/.bin/tsc');
+run(typescript, [
+  '--declaration',
+  '--emitDeclarationOnly',
+  '--outDir',
+  declarationsDirectory,
+  '--module',
+  'esnext',
+  '--moduleResolution',
+  'bundler',
+  '--target',
+  'es2022',
+  '--skipLibCheck',
+  '--allowArbitraryExtensions',
+  'true',
+  generatedEntry,
+]);
+
+for (const file of [
+  'cyclops_sdk_schema-ffi.d.ts',
+  'cyclops_sdk_schema.d.ts',
+  'fleet_sdk-ffi.d.ts',
+  'fleet_sdk.d.ts',
+]) {
+  cpSync(join(declarationsDirectory, file), join(distributionDirectory, file));
+}
+renameSync(
+  join(declarationsDirectory, 'index.web.d.ts'),
+  join(distributionDirectory, 'index.d.ts')
+);
+const declarationPath = join(distributionDirectory, 'index.d.ts');
+writeFileSync(declarationPath, readFileSync(declarationPath, 'utf8').replaceAll('.//', './'));
+rmSync(declarationsDirectory, { force: true, recursive: true });

--- a/libs/typescript/fleet/scripts/build.mjs
+++ b/libs/typescript/fleet/scripts/build.mjs
@@ -9,7 +9,8 @@ const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const repositoryRoot = resolve(packageDirectory, '../../..');
 const bindingDirectory = join(repositoryRoot, 'libs/fleet/sdk-bindings/ts-uniffi-browser');
 const generatedDirectory = join(bindingDirectory, 'ts');
-const generatedEntry = join(generatedDirectory, 'index.web.ts');
+const browserEntry = join(generatedDirectory, 'package.browser.ts');
+const nodeEntry = join(generatedDirectory, 'package.node.ts');
 const distributionDirectory = join(packageDirectory, 'dist');
 const declarationsDirectory = join(distributionDirectory, '.declarations');
 const rustToolchainFile = join(repositoryRoot, 'libs/fleet/rust-toolchain.toml');
@@ -21,6 +22,88 @@ if (!rustToolchainMatch) {
 }
 const rustToolchain = rustToolchainMatch[1];
 const wasmBindgenVersion = '0.2.126';
+
+const sharedExports = `
+export * from './cyclops_sdk_schema'
+export * from './fleet_sdk'
+
+import * as cyclops_sdk_schema from './cyclops_sdk_schema'
+import * as fleet_sdk from './fleet_sdk'
+import initAsync from './wasm-bindgen/index.js'
+import wasmPath from './wasm-bindgen/index_bg.wasm'
+
+let initialization: Promise<void> | undefined
+
+function initializeBindings(): void {
+  cyclops_sdk_schema.default.initialize()
+  fleet_sdk.default.initialize()
+}
+
+export default {
+  cyclops_sdk_schema,
+  fleet_sdk,
+}
+`;
+
+const browserSource = `${sharedExports}
+export function uniffiInitAsync(): Promise<void> {
+  initialization ??= (async () => {
+    await initAsync({ module_or_path: new URL(wasmPath as unknown as string, import.meta.url) })
+    initializeBindings()
+  })()
+  return initialization
+}
+`;
+
+const nodeSource = `
+import { readFile } from 'node:fs/promises'
+import type { HttpClient, HttpRequest, HttpResponse } from './fleet_sdk'
+${sharedExports}
+
+export class FetchHttpClient implements HttpClient {
+  async execute(
+    request: HttpRequest,
+    asyncOpts_?: { signal: AbortSignal },
+  ): Promise<HttpResponse> {
+    const timeoutSignal = request.timeoutSecs
+      ? AbortSignal.timeout(Number(request.timeoutSecs) * 1_000)
+      : undefined
+    const response = await fetch(request.url, {
+      method: request.method,
+      headers: request.headers.map(({ name, value }) => [name, value] as [string, string]),
+      body: request.body,
+      signal: asyncOpts_?.signal ?? timeoutSignal,
+      redirect: 'manual',
+    })
+    return {
+      status: response.status,
+      headers: [...response.headers].map(([name, value]) => ({ name, value })),
+      body: await response.arrayBuffer(),
+    }
+  }
+}
+
+export function uniffiInitAsync(): Promise<void> {
+  initialization ??= (async () => {
+    const wasm = await readFile(new URL(wasmPath as unknown as string, import.meta.url))
+    await initAsync({ module_or_path: wasm })
+    initializeBindings()
+  })()
+  return initialization
+}
+
+export async function createFleetClient(
+  configuration: fleet_sdk.CyclopsTokenProviderConfiguration,
+  accessToken: string,
+): Promise<fleet_sdk.CyclopsClient> {
+  await uniffiInitAsync()
+  return fleet_sdk.CyclopsClient.connectWithAccessToken(
+    configuration,
+    accessToken,
+    new FetchHttpClient(),
+  ) as fleet_sdk.CyclopsClient
+}
+`;
 
 function run(command, args, workingDirectory = packageDirectory) {
   execFileSync(command, args, {
@@ -34,6 +117,14 @@ function hasWasmBindgenVersion() {
     encoding: 'utf8',
   });
   return result.status === 0 && result.stdout.trim() === `wasm-bindgen ${wasmBindgenVersion}`;
+}
+
+function normalizeDeclarationImports(source) {
+  return source
+    .replaceAll('.//', './')
+    .replace(/(from\s+['"])(\.\/[^'"]+?)(['"])/g, (_match, prefix, specifier, suffix) => {
+      return `${prefix}${specifier.endsWith('.js') ? specifier : `${specifier}.js`}${suffix}`;
+    });
 }
 
 rmSync(distributionDirectory, { force: true, recursive: true });
@@ -54,62 +145,83 @@ if (!hasWasmBindgenVersion()) {
 
 run('npm', ['ci'], bindingDirectory);
 run('npm', ['run', 'build:wasm'], bindingDirectory);
+writeFileSync(browserEntry, browserSource);
+writeFileSync(nodeEntry, nodeSource);
 
-await build({
-  entryPoints: [generatedEntry],
-  bundle: true,
-  format: 'esm',
-  platform: 'browser',
-  target: ['es2022'],
-  outdir: distributionDirectory,
-  entryNames: 'index',
-  assetNames: 'fleet',
-  loader: {
-    '.wasm': 'file',
-  },
-});
+try {
+  await build({
+    entryPoints: { browser: browserEntry },
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: ['es2022'],
+    outdir: distributionDirectory,
+    assetNames: 'fleet',
+    loader: {
+      '.wasm': 'file',
+    },
+  });
 
-const bundlePath = join(distributionDirectory, 'index.js');
-const wasmReference = '"./fleet.wasm"';
-const bundle = readFileSync(bundlePath, 'utf8');
-if (bundle.split(wasmReference).length !== 2) {
-  throw new Error('Expected exactly one bundled WebAssembly asset reference');
+  await build({
+    entryPoints: { node: nodeEntry },
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    target: ['node20'],
+    outdir: distributionDirectory,
+    assetNames: 'fleet',
+    loader: {
+      '.wasm': 'file',
+    },
+  });
+
+  const typescript = join(packageDirectory, 'node_modules/.bin/tsc');
+  run(typescript, [
+    '--declaration',
+    '--emitDeclarationOnly',
+    '--outDir',
+    declarationsDirectory,
+    '--module',
+    'esnext',
+    '--moduleResolution',
+    'bundler',
+    '--target',
+    'es2022',
+    '--types',
+    'node',
+    '--skipLibCheck',
+    '--allowArbitraryExtensions',
+    'true',
+    browserEntry,
+    nodeEntry,
+  ]);
+
+  const declarationFiles = [
+    'cyclops_sdk_schema-ffi.d.ts',
+    'cyclops_sdk_schema.d.ts',
+    'fleet_sdk-ffi.d.ts',
+    'fleet_sdk.d.ts',
+  ];
+  for (const file of declarationFiles) {
+    cpSync(join(declarationsDirectory, file), join(distributionDirectory, file));
+  }
+  renameSync(
+    join(declarationsDirectory, 'package.browser.d.ts'),
+    join(distributionDirectory, 'browser.d.ts')
+  );
+  renameSync(
+    join(declarationsDirectory, 'package.node.d.ts'),
+    join(distributionDirectory, 'node.d.ts')
+  );
+  for (const file of [...declarationFiles, 'browser.d.ts', 'node.d.ts']) {
+    const declarationPath = join(distributionDirectory, file);
+    writeFileSync(
+      declarationPath,
+      normalizeDeclarationImports(readFileSync(declarationPath, 'utf8'))
+    );
+  }
+} finally {
+  rmSync(browserEntry, { force: true });
+  rmSync(nodeEntry, { force: true });
+  rmSync(declarationsDirectory, { force: true, recursive: true });
 }
-writeFileSync(
-  bundlePath,
-  bundle.replace(wasmReference, 'new URL("./fleet.wasm", import.meta.url)')
-);
-
-const typescript = join(packageDirectory, 'node_modules/.bin/tsc');
-run(typescript, [
-  '--declaration',
-  '--emitDeclarationOnly',
-  '--outDir',
-  declarationsDirectory,
-  '--module',
-  'esnext',
-  '--moduleResolution',
-  'bundler',
-  '--target',
-  'es2022',
-  '--skipLibCheck',
-  '--allowArbitraryExtensions',
-  'true',
-  generatedEntry,
-]);
-
-for (const file of [
-  'cyclops_sdk_schema-ffi.d.ts',
-  'cyclops_sdk_schema.d.ts',
-  'fleet_sdk-ffi.d.ts',
-  'fleet_sdk.d.ts',
-]) {
-  cpSync(join(declarationsDirectory, file), join(distributionDirectory, file));
-}
-renameSync(
-  join(declarationsDirectory, 'index.web.d.ts'),
-  join(distributionDirectory, 'index.d.ts')
-);
-const declarationPath = join(distributionDirectory, 'index.d.ts');
-writeFileSync(declarationPath, readFileSync(declarationPath, 'utf8').replaceAll('.//', './'));
-rmSync(declarationsDirectory, { force: true, recursive: true });

--- a/libs/typescript/package.json
+++ b/libs/typescript/package.json
@@ -16,7 +16,8 @@
     "test": "pnpm -r test",
     "typecheck": "pnpm build:core && pnpm -r typecheck",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "build:fleet": "pnpm --filter @trycua/fleet build"
   },
   "packageManager": "pnpm@10.12.3",
   "devDependencies": {

--- a/libs/typescript/pnpm-lock.yaml
+++ b/libs/typescript/pnpm-lock.yaml
@@ -146,6 +146,19 @@ importers:
         specifier: 4.1.0
         version: 4.1.0(@types/node@22.19.8)(happy-dom@20.8.9)(vite@7.3.5(@types/node@22.19.8)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  fleet:
+    dependencies:
+      "@ubjs/core":
+        specifier: 0.31.0-3
+        version: 0.31.0-3
+    devDependencies:
+      esbuild:
+        specifier: ^0.27.0
+        version: 0.27.2
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
+
   playground:
     dependencies:
       "@radix-ui/react-dialog":
@@ -1633,6 +1646,12 @@ packages:
     resolution:
       {
         integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==,
+      }
+
+  "@ubjs/core@0.31.0-3":
+    resolution:
+      {
+        integrity: sha512-39XrJgUZ2VVb561sSnkXPhczNoeBsNiSRArecsV0JE7CJq69ajFkcn9/tBAUS2NpgHkLIDU+z6Ks2+1wXnboxg==,
       }
 
   "@ungap/structured-clone@1.3.0":
@@ -4150,6 +4169,8 @@ snapshots:
   "@types/ws@8.18.1":
     dependencies:
       "@types/node": 22.19.8
+
+  "@ubjs/core@0.31.0-3": {}
 
   "@ungap/structured-clone@1.3.0": {}
 

--- a/libs/typescript/pnpm-lock.yaml
+++ b/libs/typescript/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       "@trycua/core":
         specifier: workspace:^
         version: link:../core
+      "@trycua/fleet":
+        specifier: workspace:^
+        version: link:../fleet
       pino:
         specifier: ^9.7.0
         version: 9.14.0
@@ -152,6 +155,9 @@ importers:
         specifier: 0.31.0-3
         version: 0.31.0-3
     devDependencies:
+      "@types/node":
+        specifier: ^22.15.17
+        version: 22.19.8
       esbuild:
         specifier: ^0.27.0
         version: 0.27.2

--- a/libs/typescript/pnpm-workspace.yaml
+++ b/libs/typescript/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - "computer"
   - "core"
   - "agent"
+  - "fleet"
   - "playground"
 
 minimumReleaseAge: 46080


### PR DESCRIPTION
## Why

Keiki needs the current Fleet lifecycle API from TypeScript without calling the legacy VM API directly or introducing a Python sidecar. It also needs the same SDK in browser and Node.js applications, while `@trycua/computer` should consume Fleet rather than maintain a second lifecycle implementation.

The generated browser/WASM lifecycle bindings already live in the public `libs/fleet` mirror. This PR turns the reserved `@trycua/fleet` package into the publishable SDK and adds a Fleet-backed provider to `@trycua/computer`.

## What changed

- publish `@trycua/fleet/browser` for browser WASM loading
- publish `@trycua/fleet/node` using the same WASM artifact loaded from disk, with a fetch-based UniFFI HTTP transport and `createFleetClient`
- use conditional package-root exports while keeping explicit browser and Node subpaths
- emit NodeNext-compatible declarations and package the shared `fleet.wasm` once
- add `@trycua/fleet` as a workspace dependency of `@trycua/computer`; Fleet remains the owner of lifecycle logic and WASM
- export `FleetComputer`, `FleetComputerConfig`, and `ProviderType.FLEET`
- claim from an existing Fleet pool, wait for binding, connect through the authenticated Fleet WebSocket proxy, and release the claim on stop, disconnect, or failed initialization
- allow Computer interfaces to use an explicit WebSocket URL and upgrade headers without changing legacy Cloud authentication
- document both Fleet runtimes and the Fleet-backed Computer flow
- add a Fleet-only TypeScript how-to that creates a reusable pool and captures a screenshot from both Node.js and browser runtimes
- direct `@trycua/computer` users to `@trycua/fleet` for all new sandbox lifecycle code

## Validation

- full Rust -> UniFFI -> WASM -> browser/Node ESM build
- full `@trycua/computer` suite: 7 files / 57 tests
- focused Fleet lifecycle coverage, including cleanup after failed initialization
- `@trycua/computer` build and TypeScript checks
- `pnpm pack` consumer install for `@trycua/core`, `@trycua/fleet`, and `@trycua/computer`
- external NodeNext typecheck for `@trycua/fleet/browser`, `@trycua/fleet/node`, and `FleetComputer`
- installed-tarball Node WASM initialization
- installed-tarball Chromium WASM initialization through `@trycua/fleet/browser`
- documented Node.js and browser examples typechecked against packed packages
- docs formatting, hygiene, and internal link checks
- production docs build with the new route
- Fleet tarball: about 524 KB compressed / 2.70 MB unpacked
- `pnpm -C libs/typescript format:check`
- `git diff --check`

A live claim against a production Fleet pool was not run because this environment does not have a Fleet access token or test pool.

## Release

Please apply `bump:minor` through the release-owner flow so the first functional package publishes as `@trycua/fleet@0.1.0` rather than reusing the existing `0.0.3` reservation version.
