### PR TITLE
ci: hold nightlies on unresolved attribution

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -24,6 +24,7 @@
     "f@trycua.com": "f-trycua",
     "fbonacci@fbonacci-xfce-vm.b40fumexvs1ujlod2ppcyfh5qa.bx.internal.cloudapp.net": "f-trycua",
     "i@jyunko.cn": "HsiangNianian",
+    "jf-mac-mini@jf-mac-mini-4.local": "0xjohnnydev",
     "klymenko@adobe.com": "pavelklymenko",
     "m.fuechtenkoetter@posteo.de": "ai-ag2026",
     "manfred@ubuntu26.04-vm": "ai-ag2026",

--- a/.github/releases/README.md
+++ b/.github/releases/README.md
@@ -23,6 +23,13 @@ The first nightly is bounded by the component's current stable tag; later
 nightlies are bounded by the previous published nightly. A component therefore
 needs a reachable stable tag before its nightly channel is enabled.
 
+Before starting platform builds, the nightly planner scans that exact range for
+unresolved human coauthors. It returns `reason=held-attribution` and creates or
+refreshes one component-specific maintainer issue instead of spending build and
+signing capacity on a candidate that cannot be published. Resolve the identity
+through a linked GitHub email or a verified `identityOverrides` entry; never use
+wildcard or human-email ignores to clear a hold.
+
 ## Persistent consumer selection
 
 Components that let users follow a channel should reuse the same consumer

--- a/.github/scripts/release_attribution.py
+++ b/.github/scripts/release_attribution.py
@@ -331,6 +331,30 @@ def _normalized_set(config: Mapping[str, Any], key: str) -> set[str]:
     return {str(item).strip().lower() for item in config.get(key, [])}
 
 
+def unresolved_coauthor_identities(
+    commits: Sequence[CommitRecord], config: Mapping[str, Any]
+) -> list[dict[str, str]]:
+    """Return commit trailers that cannot resolve to a trusted contributor."""
+    ignored = _normalized_set(config, "ignoredCoauthorEmails")
+    overrides = _normalized_map(config, "identityOverrides")
+    coauthor_overrides = _normalized_map(config, "coauthorOverrides")
+    unresolved: dict[tuple[str, str], dict[str, str]] = {}
+    for commit in commits:
+        for match in COAUTHOR_RE.finditer(commit.body):
+            name = match.group("name").strip() or "unknown"
+            email = match.group("email").strip().lower()
+            if not email or email in ignored:
+                continue
+            identity = f"{name} <{email}>".lower()
+            login = coauthor_overrides.get(identity) or login_from_email(email, overrides)
+            if login:
+                continue
+            unresolved.setdefault(
+                (commit.sha, email), {"sha": commit.sha, "name": name, "email": email}
+            )
+    return sorted(unresolved.values(), key=lambda item: (item["email"], item["sha"]))
+
+
 def validate_pr_attribution(
     *,
     repository: str,
@@ -423,19 +447,11 @@ def validate_pr_attribution(
         author_email = str(author.get("email") or "").strip().lower()
         linked_author = str((item.get("author") or {}).get("login") or "").strip()
         author_login = resolved_login(author_name, author_email, linked_author)
-        committer = commit.get("committer") or {}
-        committer_email = str(committer.get("email") or "").strip().lower()
-        linked_committer = str((item.get("committer") or {}).get("login") or "").strip()
         parents = [str(parent.get("sha") or "") for parent in item.get("parents") or []]
         is_base_sync_merge = len(parents) > 1 and any(
             parent and parent not in commit_shas for parent in parents[1:]
         )
-        preserved_unlinked_author = (
-            not author_login
-            and bool(pull_login)
-            and linked_committer.lower() == pull_login.lower()
-            and author_email != committer_email
-        )
+        unlinked_author = not author_login and author_email not in ignored
         distinct_external_author = bool(author_login) and (
             author_login.lower() != pull_login.lower()
             and not is_bot(author_login, bots)
@@ -457,12 +473,12 @@ def validate_pr_attribution(
                     "distinct from the landing PR author, but that contribution is not "
                     f"credited; add `{trailer}` to a commit in this PR"
                 )
-        elif preserved_unlinked_author and author_email not in ignored:
+        elif unlinked_author:
             record_unresolved(
                 email=author_email,
                 name=author_name,
                 sha=sha,
-                kind="commit author",
+                kind="unlinked commit author (would become a squash coauthor)",
                 references=references,
             )
         elif distinct_external_author:
@@ -753,8 +769,9 @@ def _change_contributors(
         login = coauthor_overrides.get(identity) or login_from_email(email, overrides)
         if not login:
             raise ReleaseError(
-                f"commit {commit.sha} has an unresolved human coauthor email; "
-                "add an exceptional identityOverrides entry"
+                f"commit {commit.sha} has unresolved human coauthor {email}; "
+                "link that email to GitHub, amend the commit with a recognized email, "
+                "or add a verified identityOverrides entry"
             )
         if is_bot(login, bots) or login.lower() in opt_out:
             continue
@@ -905,9 +922,12 @@ def build_manifest(
         )
         if not entries:
             continue
-        contributors, issues, pull_visual = _change_contributors(
-            pull, commit, github, repository, attribution_config
-        )
+        try:
+            contributors, issues, pull_visual = _change_contributors(
+                pull, commit, github, repository, attribution_config
+            )
+        except ReleaseError as error:
+            raise ReleaseError(f"pull request #{pull_number}: {error}") from error
         visual_requested = visual_requested or pull_visual
         all_contributors.extend(contributors)
 

--- a/.github/scripts/release_channels.py
+++ b/.github/scripts/release_channels.py
@@ -406,6 +406,23 @@ def _git(root: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
+def nightly_attribution_preflight(
+    *,
+    root: Path,
+    previous_tag: str | None,
+    source_ref: str,
+    paths: Sequence[str],
+    config_path: Path,
+) -> list[dict[str, str]]:
+    """Find unresolved squash-generated coauthors before an expensive build."""
+    try:
+        config = read_json(config_path)
+        commits = release_attribution.commits_in_range(root, previous_tag, source_ref, paths)
+        return release_attribution.unresolved_coauthor_identities(commits, config)
+    except release_attribution.ReleaseError as error:
+        raise ChannelError(f"nightly attribution preflight failed: {error}") from error
+
+
 def plan_nightly(
     name: str,
     source_sha: str,
@@ -416,6 +433,7 @@ def plan_nightly(
     force: bool = False,
     registry_path: Path = DEFAULT_REGISTRY,
     root: Path = ROOT,
+    attribution_config_path: Path | None = None,
 ) -> dict[str, Any]:
     if not SHA_RE.fullmatch(source_sha):
         raise ChannelError(f"source SHA must be 40 lowercase hex characters: {source_sha!r}")
@@ -458,6 +476,18 @@ def plan_nightly(
         changed = _git(root, "diff", "--name-only", previous_sha, source_sha, "--", *paths)
         should_build = bool(changed)
         reason = "relevant-changes" if should_build else "component-unchanged"
+    attribution_issues: list[dict[str, str]] = []
+    if should_build and attribution_config_path is not None:
+        attribution_issues = nightly_attribution_preflight(
+            root=root,
+            previous_tag=attribution_base_tag,
+            source_ref=source_sha,
+            paths=paths,
+            config_path=attribution_config_path,
+        )
+        if attribution_issues:
+            should_build = False
+            reason = "held-attribution"
     return {
         "component": name,
         "channel": "nightly",
@@ -472,6 +502,7 @@ def plan_nightly(
         "attributionBaseSha": attribution_base_sha,
         "shouldBuild": should_build,
         "reason": reason,
+        "attributionIssues": attribution_issues,
     }
 
 
@@ -662,6 +693,7 @@ def parser() -> argparse.ArgumentParser:
     plan.add_argument("--run", required=True)
     plan.add_argument("--releases", type=Path, required=True)
     plan.add_argument("--force", action="store_true")
+    plan.add_argument("--attribution-config", type=Path)
     plan.add_argument("--output", type=Path)
     plan.add_argument("--github-output", type=Path)
 
@@ -729,6 +761,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 force=args.force,
                 registry_path=args.registry,
                 root=root,
+                attribution_config_path=args.attribution_config,
             )
             rendered = json.dumps(result, indent=2) + "\n"
             if args.output:

--- a/.github/scripts/tests/test_nightly_release_wiring.py
+++ b/.github/scripts/tests/test_nightly_release_wiring.py
@@ -40,7 +40,7 @@ def test_driver_nightly_reuses_builder_without_stable_state_mutation():
     assert "Collect PR-first attribution and render nightly body" in nightly
     assert "GH_TOKEN: ${{ github.token }}" in nightly
     assert "needs.plan.outputs.attribution_base_tag" in nightly
-    assert "issues: read" in nightly
+    assert "issues: write" in nightly
     assert "pull-requests: read" in nightly
     assert "release_channels.py apply-version" not in nightly
     assert "release_channels.py stage-versioned-tree" in nightly
@@ -60,7 +60,7 @@ def test_lume_nightly_reuses_notarized_builder_and_never_becomes_latest():
     assert "Collect PR-first attribution and render nightly body" in nightly
     assert "GH_TOKEN: ${{ github.token }}" in nightly
     assert "needs.plan.outputs.attribution_base_tag" in nightly
-    assert "issues: read" in nightly
+    assert "issues: write" in nightly
     assert "pull-requests: read" in nightly
     assert builder.index("- name: Set version") < builder.index(
         "- name: Stage nightly artifact version"
@@ -82,6 +82,11 @@ def test_planner_requires_main_ancestry_and_preserves_immutable_evidence():
     assert "fetch-depth: 0" in planner
     assert "nightly-plan-${{ inputs.component }}" in planner
     assert "attribution_base_tag" in planner
+    assert "attribution_issues" in planner
+    assert "--attribution-config .github/release-attribution-config.json" in planner
+    assert "needs.plan.outputs.reason == 'held-attribution'" in planner
+    assert "gh issue create" in planner
+    assert "gh issue edit" in planner
     assert "cancel-in-progress: false" in source("nightly-cua-driver.yml")
     assert "cancel-in-progress: false" in source("nightly-lume.yml")
 

--- a/.github/scripts/tests/test_pr_attribution.py
+++ b/.github/scripts/tests/test_pr_attribution.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import pytest
 
-from release_attribution import ReleaseError, source_pull_numbers, validate_pr_attribution
+from release_attribution import (
+    CommitRecord,
+    ReleaseError,
+    source_pull_numbers,
+    unresolved_coauthor_identities,
+    validate_pr_attribution,
+)
 
 
 def config(**overrides):
@@ -101,6 +107,22 @@ def test_resolvable_github_and_noreply_identities_pass():
     )
 
 
+def test_unresolved_coauthor_identity_helper_reports_squash_risk():
+    identities = unresolved_coauthor_identities(
+        [
+            CommitRecord(
+                "deadbeef",
+                "fix: preserve attribution",
+                "Co-authored-by: Local Machine <machine@example.invalid>",
+            )
+        ],
+        config(),
+    )
+    assert identities == [
+        {"sha": "deadbeef", "name": "Local Machine", "email": "machine@example.invalid"}
+    ]
+
+
 def test_distinct_resolvable_commit_author_requires_preserved_source():
     external = commit(login="source-author", email="source@institution.example")
     with pytest.raises(ReleaseError, match="distinct from landing PR author"):
@@ -179,7 +201,7 @@ def test_merge_coauthor_still_requires_source_evidence():
                         "Merge main\n\n"
                         "Co-authored-by: Contributor <contributor@institution.example>"
                     ),
-                )
+                ),
             ]
         )
 
@@ -196,18 +218,24 @@ def test_explicit_cherry_pick_source_reference_is_parsed_but_supersedes_is_not()
     assert source_pull_numbers("Supersedes #2280", "trycua/cua") == []
 
 
-def test_direct_contributor_with_unlinked_email_does_not_fail():
+def test_direct_contributor_with_unlinked_email_is_rejected_before_squash_merge():
+    with pytest.raises(ReleaseError) as error:
+        validate(
+            pull_value=pull(login="direct-contributor"),
+            commits=[commit(email="private@institution.example")],
+        )
+    message = str(error.value)
+    assert "would become a squash coauthor" in message
+    assert "private@institution.example" in message
+    assert "linked GitHub/noreply email" in message
+
+
+def test_direct_contributor_with_verified_override_is_merge_ready():
+    base = config(identityOverrides={"private@institution.example": "direct-contributor"})
     validate(
         pull_value=pull(login="direct-contributor"),
         commits=[commit(email="private@institution.example")],
-    )
-
-    validate(
-        pull_value=pull(
-            login="direct-contributor",
-            body="Based on #99 for the API shape",
-        ),
-        commits=[commit(email="private@institution.example")],
+        base=base,
     )
 
 

--- a/.github/scripts/tests/test_release_attribution.py
+++ b/.github/scripts/tests/test_release_attribution.py
@@ -638,3 +638,30 @@ def test_pr_2805_coauthor_resolves_through_trusted_identity_override():
     ]
     assert issues == []
     assert visual_requested is False
+
+
+def test_pr_3266_squash_coauthor_resolves_through_verified_identity_override():
+    config = json.loads((REPO_ROOT / ".github/release-attribution-config.json").read_text())
+    commit = CommitRecord(
+        "2fd8bfc6dd5d7d67d00a4151c1159e665abb9ef0",
+        "test(cua-driver): seed macOS Lume TCC grants (#3266)",
+        "Co-authored-by: jf-mac-mini <jf-mac-mini@jf-mac-mini-4.local>",
+    )
+    pull = {
+        "user": {"login": "0xjohnnydev"},
+        "author_association": "CONTRIBUTOR",
+        "body": "",
+        "labels": [],
+    }
+
+    contributors, _, _ = _change_contributors(
+        pull,
+        commit,
+        FakeGitHub(commit.sha),
+        "trycua/cua",
+        config,
+    )
+    assert contributors == [
+        {"login": "0xjohnnydev", "role": "author", "external": True},
+        {"login": "0xjohnnydev", "role": "coauthor", "external": True},
+    ]

--- a/.github/scripts/tests/test_release_channels.py
+++ b/.github/scripts/tests/test_release_channels.py
@@ -268,6 +268,67 @@ def test_plan_builds_only_for_declared_relevant_changes(monkeypatch: pytest.Monk
     assert plan["attributionBaseTag"] == plan["previousNightlyTag"]
 
 
+def test_plan_holds_before_build_for_unresolved_attribution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    previous_sha = "b" * 40
+    source_sha = "c" * 40
+    config_path = tmp_path / "release-attribution-config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "ignoredCoauthorEmails": [],
+                "identityOverrides": {},
+                "coauthorOverrides": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_git(_root, command, *args):
+        if command == "rev-list":
+            return previous_sha
+        if command == "merge-base":
+            return ""
+        if command == "diff":
+            return "libs/cua-driver/rust/src/main.rs"
+        raise AssertionError((command, args))
+
+    monkeypatch.setattr(release_channels, "_git", fake_git)
+    monkeypatch.setattr(
+        release_channels.release_attribution,
+        "commits_in_range",
+        lambda *_args: [
+            release_channels.release_attribution.CommitRecord(
+                "deadbeef",
+                "fix: preserve attribution",
+                "Co-authored-by: Local Machine <machine@example.invalid>",
+            )
+        ],
+    )
+    plan = plan_nightly(
+        "cua-driver-rs",
+        source_sha,
+        "20260812",
+        "45",
+        [
+            {
+                "tag_name": "nightly-cua-driver-rs-v0.19.4-nightly.20260811.41",
+                "draft": False,
+                "published_at": "2026-08-11T04:17:00Z",
+            }
+        ],
+        registry_path=REGISTRY,
+        root=ROOT,
+        attribution_config_path=config_path,
+    )
+    assert plan["shouldBuild"] is False
+    assert plan["reason"] == "held-attribution"
+    assert plan["attributionIssues"] == [
+        {"sha": "deadbeef", "name": "Local Machine", "email": "machine@example.invalid"}
+    ]
+
+
 def test_manifest_uses_stable_authority_with_a_separately_versioned_asset_tree(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):

--- a/.github/workflows/nightly-component-plan.yml
+++ b/.github/workflows/nightly-component-plan.yml
@@ -31,9 +31,12 @@ on:
         value: ${{ jobs.plan.outputs.attribution_base_tag }}
       reason:
         value: ${{ jobs.plan.outputs.reason }}
+      attribution_issues:
+        value: ${{ jobs.plan.outputs.attribution_issues }}
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   plan:
@@ -46,6 +49,7 @@ jobs:
       previous_tag: ${{ steps.plan.outputs.previousTag }}
       attribution_base_tag: ${{ steps.plan.outputs.attributionBaseTag }}
       reason: ${{ steps.plan.outputs.reason }}
+      attribution_issues: ${{ steps.plan.outputs.attributionIssues }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -86,6 +90,7 @@ jobs:
             --date "$(date -u +%Y%m%d)" \
             --run "${{ github.run_id }}" \
             --releases "$RUNNER_TEMP/releases.json" \
+            --attribution-config .github/release-attribution-config.json \
             --output "$RUNNER_TEMP/nightly-plan.json" \
             --github-output "$GITHUB_OUTPUT" \
             "${FORCE[@]}"
@@ -98,3 +103,38 @@ jobs:
           path: ${{ runner.temp }}/nightly-plan.json
           if-no-files-found: error
           retention-days: 30
+
+  report-attribution-hold:
+    needs: plan
+    if: needs.plan.outputs.reason == 'held-attribution'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create or refresh the attribution hold
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMPONENT: ${{ inputs.component }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          ATTRIBUTION_ISSUES: ${{ needs.plan.outputs.attribution_issues }}
+        run: |
+          set -euo pipefail
+          TITLE="Nightly ${COMPONENT} held by unresolved contributor attribution"
+          BODY="$RUNNER_TEMP/nightly-attribution-hold.md"
+          {
+            echo "The nightly planner stopped before the cross-platform build because contributor attribution is unresolved."
+            echo
+            echo "Source commit: \`$SOURCE_SHA\`"
+            echo
+            echo "Unresolved identities:"
+            jq -r '.[] | "- `\(.email)` in commit `\(.sha)` (\(.name))"' <<<"$ATTRIBUTION_ISSUES"
+            echo
+            echo "Resolve each identity by linking the email to GitHub, amending the source commit with a recognized email before merge, or adding a verified \`identityOverrides\` mapping. Do not add wildcard or human-email ignores."
+          } > "$BODY"
+          MATCHES=$(gh issue list --repo "${{ github.repository }}" --state open \
+            --search "\"$TITLE\" in:title" --limit 100 --json number,title)
+          NUMBER=$(jq -r --arg title "$TITLE" \
+            'map(select(.title == $title)) | first | .number // empty' <<<"$MATCHES")
+          if [[ -n "$NUMBER" ]]; then
+            gh issue edit "$NUMBER" --repo "${{ github.repository }}" --body-file "$BODY"
+          else
+            gh issue create --repo "${{ github.repository }}" --title "$TITLE" --body-file "$BODY"
+          fi

--- a/.github/workflows/nightly-cua-driver.yml
+++ b/.github/workflows/nightly-cua-driver.yml
@@ -18,7 +18,7 @@ on:
 permissions:
   contents: write
   id-token: write
-  issues: read
+  issues: write
   pull-requests: read
 
 concurrency:

--- a/.github/workflows/nightly-lume.yml
+++ b/.github/workflows/nightly-lume.yml
@@ -17,7 +17,7 @@ on:
 
 permissions:
   contents: write
-  issues: read
+  issues: write
   pull-requests: read
 
 concurrency:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,9 @@ include a `Co-authored-by` trailer with the contributor's GitHub no-reply email
 and link the source pull request in the landing pull request. Use a line such as
 `Salvaged from #123` so release automation can recover the source author.
 Prefer a commit email linked to the contributor's GitHub account, especially a
-GitHub no-reply address. If preserved authorship uses an email GitHub cannot
+GitHub no-reply address. This also applies to the pull request author's own
+commits: GitHub may turn an unlinked commit author into a `Co-authored-by`
+trailer during squash merge. If preserved authorship uses an email GitHub cannot
 resolve, add the verified email-to-login entry to
 `.github/release-attribution-config.json` in the same pull request. The
 contributor-attribution check provides the exact `identityOverrides` JSON when


### PR DESCRIPTION
## What this changes

Nightly attribution failures now stop before platform builds and preserve a clear remediation path.

- PR attribution rejects unlinked commit authors that GitHub would preserve as squash-generated coauthors.
- Nightly planning scans the exact attribution range and returns `reason=held-attribution` with structured unresolved identities before build/signing.
- The reusable planner creates or refreshes one component-specific maintainer issue for a hold; it never publishes partial release state.
- Release-time errors include the exact unresolved email, commit SHA, and remediation options.
- Adds the verified `jf-mac-mini@jf-mac-mini-4.local` -> `0xjohnnydev` mapping, proven by PR #3266's public commit metadata.
- Documents contributor hygiene and the fail-closed hold behavior.

## Verification

- `uv run --frozen pytest -q .github/scripts/tests` (244 passed, 21 subtests)
- Ruff check and format check passed
- JSON validation, workflow YAML parsing, and `git diff --check` passed
- Live planner rehearsal against current checkout returned `attributionIssues: []` and did not mutate stable state

Identity is verified by #3266.

Related: #3266

