### PR TITLE
docs(sandbox): use fleet claims for dynamic queues

### DIFF
--- a/docs/content/docs/how-to-guides/sandbox/scale-out.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/scale-out.mdx
@@ -59,26 +59,45 @@ asyncio.run(main())
 
 ## Process a dynamic queue of tasks
 
-Use `asyncio.Queue` when tasks arrive at runtime.
+Use `asyncio.Queue` when tasks arrive at runtime. For maximum throughput, have
+each worker claim a sandbox from an existing Fleet pool and reuse it across
+tasks. Claims assign warm or autoscaled Fleet capacity to workers without
+launching a new sandbox for every task.
+
+Before running this example, create a Fleet pool whose replica count or
+autoscaling maximum can support `num_workers`, authenticate with
+`FLEETS_TOKEN` or OAuth client credentials, and set `CUA_POOL_NAME` to the pool
+name. Each worker releases its claim when it exits, returning the sandbox to
+the pool.
 
 ```python
 import asyncio
-from cua import Sandbox, Image
+import os
 
-async def worker(queue: asyncio.Queue, worker_id: int):
-    while True:
-        task = await queue.get()
-        if task is None:
-            break
-        async with Sandbox.ephemeral(Image.linux(), local=True) as sb:
-            result = await sb.shell.run(task)
-            print(f'[worker-{worker_id}] {result.stdout.strip()}')
-        queue.task_done()
+from cua import Pool
 
-async def main():
-    queue: asyncio.Queue = asyncio.Queue()
+async def worker(queue: asyncio.Queue[str | None], pool: Pool, worker_id: int) -> None:
+    async with pool.claim(time_to_start=900) as sb:
+        while True:
+            task = await queue.get()
+            try:
+                if task is None:
+                    return
+                result = await sb.shell.run(task)
+                if result.success:
+                    print(f'[worker-{worker_id}] {result.stdout.strip()}')
+                else:
+                    print(f'[worker-{worker_id}] FAILED: {result.stderr.strip()}')
+            finally:
+                queue.task_done()
+
+async def main() -> None:
+    pool = await Pool.get(os.environ['CUA_POOL_NAME'])
+    queue: asyncio.Queue[str | None] = asyncio.Queue()
     num_workers = 4
-    workers = [asyncio.create_task(worker(queue, i)) for i in range(num_workers)]
+    workers = [
+        asyncio.create_task(worker(queue, pool, i)) for i in range(num_workers)
+    ]
     for i in range(10):
         await queue.put(f"echo 'job {i}'")
     for _ in range(num_workers):

--- a/docs/content/docs/how-to-guides/sandbox/scale-out.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/scale-out.mdx
@@ -73,7 +73,7 @@ each task releases its claim and returns the sandbox to the pool.
 import asyncio
 import os
 
-from cua import Pool
+from cua_sandbox import Pool
 
 async def worker(queue: asyncio.Queue[str | None], pool: Pool, worker_id: int) -> None:
     while True:

--- a/docs/content/docs/how-to-guides/sandbox/scale-out.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/scale-out.mdx
@@ -60,15 +60,14 @@ asyncio.run(main())
 ## Process a dynamic queue of tasks
 
 Use `asyncio.Queue` when tasks arrive at runtime. For maximum throughput, have
-each worker claim a sandbox from an existing Fleet pool and reuse it across
-tasks. Claims assign warm or autoscaled Fleet capacity to workers without
-launching a new sandbox for every task.
+each worker dequeue a task and then claim a sandbox from an existing Fleet
+pool. Claims are effectively instant when warm capacity is available, so each
+task can start without launching a new ephemeral sandbox.
 
-Before running this example, create a Fleet pool whose replica count or
-autoscaling maximum can support `num_workers`, authenticate with
-`FLEETS_TOKEN` or OAuth client credentials, and set `CUA_POOL_NAME` to the pool
-name. Each worker releases its claim when it exits, returning the sandbox to
-the pool.
+Before running this example, create a Fleet pool with enough warm capacity for
+`num_workers`, authenticate with `FLEETS_TOKEN` or OAuth client credentials,
+and set `CUA_POOL_NAME` to the pool name. Exiting the `async with` block after
+each task releases its claim and returns the sandbox to the pool.
 
 ```python
 import asyncio
@@ -77,19 +76,19 @@ import os
 from cua import Pool
 
 async def worker(queue: asyncio.Queue[str | None], pool: Pool, worker_id: int) -> None:
-    async with pool.claim(time_to_start=900) as sb:
-        while True:
-            task = await queue.get()
-            try:
-                if task is None:
-                    return
+    while True:
+        task = await queue.get()
+        try:
+            if task is None:
+                return
+            async with pool.claim(time_to_start=900) as sb:
                 result = await sb.shell.run(task)
                 if result.success:
                     print(f'[worker-{worker_id}] {result.stdout.strip()}')
                 else:
                     print(f'[worker-{worker_id}] FAILED: {result.stderr.strip()}')
-            finally:
-                queue.task_done()
+        finally:
+            queue.task_done()
 
 async def main() -> None:
     pool = await Pool.get(os.environ['CUA_POOL_NAME'])


### PR DESCRIPTION
## Summary
- update the dynamic queue example so each worker dequeues a task before claiming a sandbox from an existing Fleet pool
- import `Pool` from its public `cua_sandbox` package
- explain that claims are effectively instant with warm capacity and document per-task claim release and queue bookkeeping

## Test plan
- [x] Execute the import line extracted from the MDX snippet in the local `cua-sandbox` project and assert it resolves to `cua_sandbox.pool.Pool`
- [x] Assert `queue.get()` precedes the exact `pool.claim(time_to_start=900)` call
- [x] `pnpm docs:check-hygiene`
- [x] `pnpm docs:check-links`
- [x] `pnpm build`

## Notes
- `prettier --check content/docs/how-to-guides/sandbox/scale-out.mdx` reports the same pre-existing formatting warning on `origin/main`; this PR avoids out-of-scope formatting changes.