### PR TITLE
fix(release): publish workspace packages with pnpm

### DIFF
--- a/.github/workflows/ts-reusable-publish.yml
+++ b/.github/workflows/ts-reusable-publish.yml
@@ -104,6 +104,12 @@ jobs:
       - name: Publish to npm
         if: steps.verify-version.outputs.should_publish == 'true' || steps.check-version.outputs.changed == 'true'
         working-directory: ./${{ inputs.package_dir }}
-        run: npm publish --access public --provenance
+        run: |
+          if [ "${{ inputs.package_manager }}" = "pnpm" ]; then
+            # pnpm rewrites workspace protocol dependencies to registry semver ranges.
+            pnpm publish --access public --provenance
+          else
+            npm publish --access public --provenance
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/content/docs/how-to-guides/sandbox/create-pool-with-typescript.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/create-pool-with-typescript.mdx
@@ -4,6 +4,7 @@ description: Create a reusable Fleet pool and capture a sandbox screenshot from 
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
 Use `@trycua/fleet` to create a reusable sandbox pool from TypeScript. This
 guide creates a one-replica Linux pool, claims a sandbox, captures a screenshot,

--- a/libs/typescript/computer/package.json
+++ b/libs/typescript/computer/package.json
@@ -42,11 +42,11 @@
     "pretypecheck": "pnpm --filter @trycua/core build && pnpm --filter @trycua/fleet build"
   },
   "dependencies": {
-    "@trycua/core": "^0.1.4",
+    "@trycua/core": "workspace:^",
     "pino": "^9.7.0",
     "uuid": "^11.1.1",
     "ws": "^8.21.0",
-    "@trycua/fleet": "^0.1.0"
+    "@trycua/fleet": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "^22.15.17",

--- a/libs/typescript/computer/package.json
+++ b/libs/typescript/computer/package.json
@@ -42,7 +42,7 @@
     "pretypecheck": "pnpm --filter @trycua/core build && pnpm --filter @trycua/fleet build"
   },
   "dependencies": {
-    "@trycua/core": "workspace:^",
+    "@trycua/core": "workspace:^0.1.4",
     "pino": "^9.7.0",
     "uuid": "^11.1.1",
     "ws": "^8.21.0",

--- a/libs/typescript/computer/package.json
+++ b/libs/typescript/computer/package.json
@@ -42,11 +42,11 @@
     "pretypecheck": "pnpm --filter @trycua/core build && pnpm --filter @trycua/fleet build"
   },
   "dependencies": {
-    "@trycua/core": "workspace:^",
+    "@trycua/core": "^0.1.4",
     "pino": "^9.7.0",
     "uuid": "^11.1.1",
     "ws": "^8.21.0",
-    "@trycua/fleet": "workspace:^"
+    "@trycua/fleet": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.17",

--- a/libs/typescript/pnpm-lock.yaml
+++ b/libs/typescript/pnpm-lock.yaml
@@ -60,11 +60,11 @@ importers:
   computer:
     dependencies:
       "@trycua/core":
-        specifier: ^0.1.4
-        version: 0.1.4
+        specifier: workspace:^
+        version: link:../core
       "@trycua/fleet":
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: workspace:^
+        version: link:../fleet
       pino:
         specifier: ^9.7.0
         version: 9.14.0

--- a/libs/typescript/pnpm-lock.yaml
+++ b/libs/typescript/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
   computer:
     dependencies:
       "@trycua/core":
-        specifier: workspace:^
+        specifier: workspace:^0.1.4
         version: link:../core
       "@trycua/fleet":
         specifier: workspace:^

--- a/libs/typescript/pnpm-lock.yaml
+++ b/libs/typescript/pnpm-lock.yaml
@@ -60,11 +60,11 @@ importers:
   computer:
     dependencies:
       "@trycua/core":
-        specifier: workspace:^
-        version: link:../core
+        specifier: ^0.1.4
+        version: 0.1.4
       "@trycua/fleet":
-        specifier: workspace:^
-        version: link:../fleet
+        specifier: ^0.1.0
+        version: 0.1.0
       pino:
         specifier: ^9.7.0
         version: 9.14.0


### PR DESCRIPTION
## What changed
- publish pnpm-managed TypeScript packages with `pnpm publish` so `workspace:^` dependencies become registry semver ranges
- keep Computer linked to local Core and Fleet packages during workspace development
- import the Tabs components used by the new TypeScript guide so production SSR succeeds

## Why
The shared release workflow used `npm publish`, which published literal `workspace:^` dependencies in `@trycua/computer@0.2.0`. The new TypeScript guide also rendered HTTP 500 because its Tabs components were not imported.

## Validation
- Computer test suite: 57 tests passed
- Computer build passed
- pnpm 10.12.3 frozen install passed
- `pnpm pack` rewrites dependencies to `@trycua/core: ^0.1.5` and `@trycua/fleet: ^0.1.0`
- TypeScript formatting and `git diff --check` passed