### PR TITLE
fix(release): allow generated publish artifacts

### DIFF
--- a/.github/workflows/ts-reusable-publish.yml
+++ b/.github/workflows/ts-reusable-publish.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           if [ "${{ inputs.package_manager }}" = "pnpm" ]; then
             # pnpm rewrites workspace protocol dependencies to registry semver ranges.
-            pnpm publish --access public --provenance
+            pnpm publish --access public --provenance --no-git-checks
           else
             npm publish --access public --provenance
           fi


### PR DESCRIPTION
## What changed
- disable pnpm git cleanliness checks in the CI publish step

## Why
Computer builds regenerate Fleet binding artifacts before publish. `pnpm publish` correctly rewrites workspace dependencies, but otherwise refuses the intentionally dirty CI checkout.

## Validation
- change is limited to the shared pnpm publish command
- package build and pack behavior already passed on PR #3417