### PR TITLE
fix(fleet): support WASM client credentials

### DIFF
--- a/docs/superpowers/plans/2026-08-27-fleet-wasm-auth-init.md
+++ b/docs/superpowers/plans/2026-08-27-fleet-wasm-auth-init.md
@@ -1,0 +1,234 @@
+# Fleet WASM Authentication and Initialization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make client-credentials OAuth work in the `@trycua/fleet` WASM package and make its synchronous UniFFI API safe immediately after import.
+
+**Architecture:** Add a built-package Node regression that exercises the real WASM artifact through a scripted `HttpClient`. Initialize the WASM at ESM module evaluation and replace `std::time::Instant` with the cross-target `web_time::Instant` while leaving token semantics unchanged.
+
+**Tech Stack:** Rust 1.97.0, UniFFI 0.31.0, `wasm32-unknown-unknown`, `web-time` 1.1.0, TypeScript/ESM, Node test runner, pnpm 10.12.3.
+
+## Global Constraints
+
+- Preserve the generated Rust and TypeScript public APIs.
+- Keep `uniffiInitAsync()` exported and idempotent.
+- Do not change OAuth request semantics, expiry skew, caching, or 401 refresh behavior.
+- Do not require live Fleet credentials or external services in tests.
+- Do not commit changes unless the user explicitly requests a commit.
+
+---
+
+### Task 1: Add Built-Package Regression
+
+**Files:**
+- Create: `libs/typescript/fleet/tests/node-client-credentials.test.mjs`
+- Modify: `libs/typescript/fleet/package.json`
+
+**Interfaces:**
+- Consumes: Existing generated `CyclopsCredentials`, `CyclopsConfiguration`, `CyclopsClient.connect`, and `HttpClient` callback shape.
+- Produces: `pnpm run test:node`, executed automatically after `build:artifacts` by `pnpm run build`.
+
+- [x] **Step 1: Add the failing Node regression**
+
+```js
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  CyclopsClient,
+  CyclopsConfiguration,
+  CyclopsCredentials,
+} from '../dist/node.js';
+
+const encoder = new TextEncoder();
+
+class ScriptedHttpClient {
+  requests = [];
+
+  async execute(request) {
+    this.requests.push(request);
+    if (request.url === 'https://identity.example/oauth/token') {
+      return {
+        status: 200,
+        headers: [],
+        body: encoder.encode(JSON.stringify({ access_token: 'token-a', expires_in: 3600 })).buffer,
+      };
+    }
+    return { status: 200, headers: [], body: encoder.encode('[]').buffer };
+  }
+}
+
+test('initializes before synchronous FFI calls and caches client-credentials tokens', async () => {
+  const httpClient = new ScriptedHttpClient();
+  const credentials = new CyclopsCredentials('client-id', 'client-secret');
+  const configuration = CyclopsConfiguration.create({
+    baseUrl: 'https://run.example',
+    tokenUrl: 'https://identity.example/oauth/token',
+    credentials,
+    poolPollIntervalMs: 1n,
+    poolPollLimit: 1,
+    claimPollIntervalMs: 1n,
+    claimPollLimit: 1,
+  });
+  const client = CyclopsClient.connect(configuration, httpClient);
+
+  await client.listNamespaces();
+  await client.listNamespaces();
+
+  const tokenRequests = httpClient.requests.filter(
+    ({ url }) => url === 'https://identity.example/oauth/token',
+  );
+  assert.equal(tokenRequests.length, 1);
+  assert.equal(tokenRequests[0].method, 'POST');
+
+  const controlPlaneRequests = httpClient.requests.filter(
+    ({ url }) => url === 'https://run.example/api/namespaces',
+  );
+  assert.equal(controlPlaneRequests.length, 2);
+  for (const request of controlPlaneRequests) {
+    assert.equal(
+      request.headers.find(({ name }) => name.toLowerCase() === 'authorization')?.value,
+      'Bearer token-a',
+    );
+  }
+});
+```
+
+- [x] **Step 2: Wire the regression into package builds**
+
+Update `libs/typescript/fleet/package.json` scripts to:
+
+```json
+{
+  "build": "pnpm run build:artifacts && pnpm run test:node",
+  "build:artifacts": "node ./scripts/build.mjs",
+  "test:node": "node --test ./tests/node-client-credentials.test.mjs",
+  "pack:check": "pnpm run build && npm pack --dry-run"
+}
+```
+
+- [x] **Step 3: Run the test to verify the initialization failure**
+
+Run:
+
+```bash
+corepack pnpm --dir libs/typescript install --frozen-lockfile
+corepack pnpm --dir libs/typescript/fleet build
+```
+
+Expected: the Node test fails before making HTTP requests with an uninitialized UniFFI error containing `rustcallstatus_new` or an equivalent undefined WASM binding.
+
+---
+
+### Task 2: Initialize WASM During Module Import
+
+**Files:**
+- Modify: `libs/typescript/fleet/scripts/build.mjs`
+- Test: `libs/typescript/fleet/tests/node-client-credentials.test.mjs`
+
+**Interfaces:**
+- Consumes: Memoized `uniffiInitAsync(): Promise<void>` in each generated package entry.
+- Produces: Both Node and browser ESM entry points finish WASM and UniFFI initialization before importers can use exported synchronous constructors.
+
+- [x] **Step 1: Await initialization in both generated entries**
+
+Append this statement after each `uniffiInitAsync` declaration in `browserSource` and `nodeSource`:
+
+```ts
+await uniffiInitAsync()
+```
+
+Keep `createFleetClient()` unchanged; its explicit await remains an idempotent compatibility path.
+
+- [x] **Step 2: Rebuild and verify the test advances to token timing**
+
+Run:
+
+```bash
+corepack pnpm --dir libs/typescript/fleet build
+```
+
+Expected: constructors and `CyclopsClient.connect()` succeed without an explicit initialization call, and the test now fails when the first OAuth token response reaches the WASM-incompatible `std::time::Instant::now()` path.
+
+---
+
+### Task 3: Use a WASM-Compatible Monotonic Clock
+
+**Files:**
+- Modify: `libs/fleet/Cargo.toml`
+- Modify: `libs/fleet/sdk/Cargo.toml`
+- Modify: `libs/fleet/sdk/src/transport.rs`
+- Modify: `libs/fleet/Cargo.lock` if dependency resolution changes it
+- Test: `libs/fleet/sdk/tests/oauth.rs`
+- Test: `libs/typescript/fleet/tests/node-client-credentials.test.mjs`
+
+**Interfaces:**
+- Consumes: Existing `Instant::now()`, `Instant::checked_add`, and `Instant::checked_sub` token-expiry operations.
+- Produces: The same operations through `web_time::Instant` on native and `wasm32-unknown-unknown` targets.
+
+- [x] **Step 1: Add the workspace dependency**
+
+Add to `[workspace.dependencies]` in `libs/fleet/Cargo.toml`:
+
+```toml
+web-time = "1.1.0"
+```
+
+Add to `[dependencies]` in `libs/fleet/sdk/Cargo.toml`:
+
+```toml
+web-time.workspace = true
+```
+
+- [x] **Step 2: Replace only the Instant import**
+
+Change the imports in `libs/fleet/sdk/src/transport.rs` from:
+
+```rust
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+```
+
+to:
+
+```rust
+use std::{sync::Arc, time::Duration};
+use web_time::Instant;
+```
+
+Do not alter the token cache, expiry skew, refresh, or generation logic.
+
+- [x] **Step 3: Run focused native OAuth compatibility tests**
+
+Run:
+
+```bash
+CARGO_PROFILE_TEST_DEBUG=0 cargo test --manifest-path libs/fleet/Cargo.toml -p cyclops-sdk --test oauth
+```
+
+Expected: all OAuth tests pass, confirming native cache and refresh semantics remain unchanged.
+
+- [x] **Step 4: Build and run the real Node/WASM regression**
+
+Run:
+
+```bash
+corepack pnpm --dir libs/typescript/fleet build
+```
+
+Expected: the built package test passes; it constructs the raw API without `uniffiInitAsync()`, performs one token request, performs two authenticated control-plane requests, and reuses `token-a`.
+
+- [x] **Step 5: Run package and diff validation**
+
+Run:
+
+```bash
+corepack pnpm --dir libs/typescript/fleet build
+npm pack --dry-run
+git diff --check
+git status --short
+```
+
+Expected: the package dry-run succeeds, the diff has no whitespace errors, and only the planned source, test, dependency, lockfile, spec, and plan files are modified.

--- a/docs/superpowers/specs/2026-08-27-fleet-wasm-auth-init-design.md
+++ b/docs/superpowers/specs/2026-08-27-fleet-wasm-auth-init-design.md
@@ -1,0 +1,46 @@
+# Fleet WASM Authentication and Initialization Design
+
+**Goal:** Make `@trycua/fleet` client-credentials authentication work in Node/WASM and make all exported synchronous UniFFI constructors safe immediately after importing the package.
+
+## Scope
+
+- Replace the WASM-incompatible `std::time::Instant` used by OAuth token caching.
+- Initialize the package's WASM module once during ESM module evaluation.
+- Preserve the existing generated Rust and TypeScript public APIs.
+- Keep `uniffiInitAsync()` exported and idempotent for existing callers.
+- Add local Node regression coverage without requiring live Fleet credentials.
+
+## Token Timing
+
+Use `web_time::Instant` with `std::time::Duration` in the Fleet SDK transport. `web-time` delegates to the standard library on native targets and provides a browser-compatible monotonic clock on `wasm32-unknown-unknown`, so the existing expiry, skew, cache, and 401 refresh logic remains structurally unchanged.
+
+This is preferable to maintaining a custom `js_sys` clock shim because it preserves the current `Instant` API, supports checked arithmetic, and keeps target-specific JavaScript details outside the SDK.
+
+## Package Initialization
+
+Keep the existing memoized `uniffiInitAsync()` implementation, then await it at the top level of both generated package entry points before exports become usable. Static and dynamic ESM imports therefore complete only after the WASM module and both UniFFI binding tables are initialized.
+
+This covers every synchronous generated FFI surface, including credentials, configuration record factories, and client constructors. It avoids patching generated classes individually and leaves explicit `await uniffiInitAsync()` calls harmless.
+
+The accepted tradeoff is that importing `@trycua/fleet/node` or `@trycua/fleet/browser` always loads the WASM artifact and import failures surface during module evaluation.
+
+## Regression Coverage
+
+Add a Node test that imports the built package and immediately constructs `CyclopsCredentials` and a `CyclopsConfiguration` record without calling `uniffiInitAsync()`. A scripted `HttpClient` returns a local OAuth token response and a control-plane response, exercising token acquisition, expiry creation, caching, and authenticated request execution inside the WASM module.
+
+The test asserts:
+
+- synchronous constructors work directly after import;
+- the token endpoint receives one client-credentials request;
+- two authenticated calls reuse the valid token;
+- the Authorization header contains the minted bearer token;
+- no `Instant::now()` or `rustcallstatus_new` panic occurs.
+
+Run the focused native OAuth tests as a compatibility check, then build and execute the package-level Node regression test. Browser artifact coverage remains responsible for validating browser bundling and loading.
+
+## Non-Goals
+
+- Changing OAuth request semantics or token refresh policy.
+- Changing the static-token or access-token-provider APIs.
+- Adding a second client-credentials wrapper API.
+- Running a live Fleet lifecycle test with real credentials.

--- a/libs/fleet/Cargo.lock
+++ b/libs/fleet/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "web-time",
 ]
 
 [[package]]

--- a/libs/fleet/Cargo.toml
+++ b/libs/fleet/Cargo.toml
@@ -22,4 +22,5 @@ thiserror = "2.0"
 tokio = { version = "1.0", features = ["macros", "rt", "sync"] }
 uniffi = { version = "=0.31.0", features = ["tokio", "wasm-unstable-single-threaded"] }
 url = "2.5"
+web-time = "1.1.0"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots"] }

--- a/libs/fleet/sdk/Cargo.toml
+++ b/libs/fleet/sdk/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { workspace = true, features = ["sync"] }
 uniffi.workspace = true
 uniffi-builder-derive = { path = "../uniffi-builder-derive" }
 url.workspace = true
+web-time.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 reqwest.workspace = true

--- a/libs/fleet/sdk/src/transport.rs
+++ b/libs/fleet/sdk/src/transport.rs
@@ -6,12 +6,10 @@ use base64::{Engine, engine::general_purpose::STANDARD};
 use serde::Deserialize;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::OnceLock;
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 use url::Url;
+use web_time::Instant;
 
 const TOKEN_EXPIRY_SKEW: Duration = Duration::from_secs(30);
 const AUTHENTICATED_REQUEST_OPERATION: &str = "authenticated request";

--- a/libs/typescript/fleet/README.md
+++ b/libs/typescript/fleet/README.md
@@ -4,6 +4,10 @@ Browser and Node.js WebAssembly bindings for the Cua Fleet control plane. Both
 entry points expose the generated lifecycle client used to create templates,
 pools, claims, and authenticated requests to sandbox services.
 
+Both entry points initialize their WASM module during import, so generated
+constructors and static client methods are ready immediately. The exported
+`uniffiInitAsync()` function remains available and idempotent for compatibility.
+
 The package is built from the public Fleet mirror in
 [`libs/fleet`](../../fleet). That mirror is synchronized from the canonical
 Fleet repository, so the npm release and public SDK source share one repository

--- a/libs/typescript/fleet/package.json
+++ b/libs/typescript/fleet/package.json
@@ -50,7 +50,9 @@
     "access": "public"
   },
   "scripts": {
-    "build": "node ./scripts/build.mjs",
+    "build": "pnpm run build:artifacts && pnpm run test:node",
+    "build:artifacts": "node ./scripts/build.mjs",
+    "test:node": "node --test ./tests/node-client-credentials.test.mjs",
     "pack:check": "pnpm run build && npm pack --dry-run"
   },
   "dependencies": {

--- a/libs/typescript/fleet/scripts/build.mjs
+++ b/libs/typescript/fleet/scripts/build.mjs
@@ -53,6 +53,8 @@ export function uniffiInitAsync(): Promise<void> {
   })()
   return initialization
 }
+
+await uniffiInitAsync()
 `;
 
 const nodeSource = `
@@ -91,6 +93,8 @@ export function uniffiInitAsync(): Promise<void> {
   })()
   return initialization
 }
+
+await uniffiInitAsync()
 
 export async function createFleetClient(
   configuration: fleet_sdk.CyclopsTokenProviderConfiguration,

--- a/libs/typescript/fleet/tests/node-client-credentials.test.mjs
+++ b/libs/typescript/fleet/tests/node-client-credentials.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { CyclopsClient, CyclopsConfiguration, CyclopsCredentials } from '../dist/node.js';
+
+const encoder = new TextEncoder();
+
+class ScriptedHttpClient {
+  requests = [];
+
+  async execute(request) {
+    this.requests.push(request);
+    if (request.url === 'https://identity.example/oauth/token') {
+      return {
+        status: 200,
+        headers: [],
+        body: encoder.encode(JSON.stringify({ access_token: 'token-a', expires_in: 3600 })).buffer,
+      };
+    }
+    return { status: 200, headers: [], body: encoder.encode('[]').buffer };
+  }
+}
+
+test('initializes synchronous FFI calls and caches client-credentials tokens', async () => {
+  const httpClient = new ScriptedHttpClient();
+  const credentials = new CyclopsCredentials('client-id', 'client-secret');
+  const configuration = CyclopsConfiguration.create({
+    baseUrl: 'https://run.example',
+    tokenUrl: 'https://identity.example/oauth/token',
+    credentials,
+    poolPollIntervalMs: 1n,
+    poolPollLimit: 1,
+    claimPollIntervalMs: 1n,
+    claimPollLimit: 1,
+  });
+  const client = CyclopsClient.connect(configuration, httpClient);
+
+  await client.listNamespaces();
+  await client.listNamespaces();
+
+  const tokenRequests = httpClient.requests.filter(
+    ({ url }) => url === 'https://identity.example/oauth/token'
+  );
+  assert.equal(tokenRequests.length, 1);
+  assert.equal(tokenRequests[0].method, 'POST');
+
+  const controlPlaneRequests = httpClient.requests.filter(
+    ({ url }) => url === 'https://run.example/api/namespaces'
+  );
+  assert.equal(controlPlaneRequests.length, 2);
+  for (const request of controlPlaneRequests) {
+    assert.equal(
+      request.headers.find(({ name }) => name.toLowerCase() === 'authorization')?.value,
+      'Bearer token-a'
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- replace `std::time::Instant` with `web_time::Instant` for OAuth token expiry on `wasm32-unknown-unknown`
- initialize the Node and browser WASM entry points during ESM module evaluation while keeping `uniffiInitAsync()` idempotent
- add a built-package Node regression covering raw synchronous constructors, client-credentials token acquisition, and token caching
- document the import-time initialization behavior

Follow-up to #3408.

## Test plan

- `pnpm --dir libs/typescript/fleet build`
- `cargo test --manifest-path libs/fleet/Cargo.toml -p cyclops-sdk --test oauth` — 13 passed
- Node `20.20.2`: `node --test libs/typescript/fleet/tests/node-client-credentials.test.mjs` — 1 passed
- `cargo fmt --manifest-path libs/fleet/Cargo.toml --all -- --check`
- `pnpm --dir libs/typescript exec prettier --check fleet/README.md fleet/package.json fleet/scripts/build.mjs fleet/tests/node-client-credentials.test.mjs`
- `npm pack --dry-run` from `libs/typescript/fleet`
