### PR TITLE
docs: fix TypeScript create-pool Node setup

### DIFF
--- a/docs/content/docs/how-to-guides/sandbox/create-pool-with-typescript.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/create-pool-with-typescript.mdx
@@ -44,6 +44,7 @@ Install the Fleet lifecycle SDK and a TypeScript runner:
 ```bash
 npm install @trycua/fleet
 npm install --save-dev tsx typescript
+npm pkg set type=module
 ```
 
 Set the token and a unique pool name:
@@ -68,6 +69,7 @@ import {
   SandboxTemplateRefBuilder,
   VmTemplateBuilder,
   createFleetClient,
+  uniffiInitAsync,
   type Claim,
 } from '@trycua/fleet/node';
 
@@ -97,6 +99,8 @@ function screenshotBase64(responseBody: ArrayBuffer): string {
   if (typeof encoded !== 'string') throw new Error('Screenshot response has no image data');
   return encoded;
 }
+
+await uniffiInitAsync();
 
 const configuration = new CyclopsTokenProviderConfigurationBuilder()
   .baseUrl(BASE_URL)


### PR DESCRIPTION
## Summary

- configure the Node.js example project as ESM so top-level await and the ESM-only Fleet package run correctly
- import and await `uniffiInitAsync()` before constructing the first SDK builder
- keep the Node example self-contained with the complete Fleet import block and `writeFile` import already present on `main`

## Test plan

- [x] Extract the Node.js `create-pool.ts` block and type-check it against published `@trycua/fleet@0.1.0` with NodeNext module resolution
- [x] `corepack pnpm docs:check-hygiene`
- [x] `corepack pnpm docs:check-links`
- [x] `corepack pnpm build`
- [x] Confirm the corrected example matches the successful live E2E flow validated on August 27, 2026: pool/template creation, claim, screenshot capture, claim deletion, and pool/template cleanup

Prettier still reports the page's pre-existing code-fence formatting differences; formatting the entire page would introduce unrelated browser-tab churn, so this PR leaves those lines unchanged.
