### PR TITLE
fix(computer-server): run cua-driver actions in process

### DIFF
--- a/libs/python/computer-server/README.md
+++ b/libs/python/computer-server/README.md
@@ -66,6 +66,10 @@ portable desktop capture, pointer, scroll, and keyboard actions through the
 generated `cua-driver` Python SDK. The default `embedded` mode loads the Rust
 runtime into computer-server and does not require a daemon. `daemon` mode is a
 compatibility option for deployments that already own a long-lived driver.
+The driver backend never falls back to OS-native input injection. Separate
+`mouse_down`, `mouse_up`, `key_down`, and `key_up` calls return an explicit
+unsupported-operation error; use `drag`, `click`, `press_key`, or `hotkey`
+instead.
 
 Each computer-server process opens a distinct driver session. Its capture scope
 defaults to `desktop`, which enables the `get_desktop_state` command and

--- a/libs/python/computer-server/computer_server/handlers/cua_driver.py
+++ b/libs/python/computer-server/computer_server/handlers/cua_driver.py
@@ -20,7 +20,30 @@ from typing import Any, Dict, List, Optional, Protocol, Tuple
 
 from PIL import Image
 
-from .base import BaseAutomationHandler, normalize_screenshot_format
+from .base import BaseAccessibilityHandler, BaseAutomationHandler, normalize_screenshot_format
+
+
+class CuaDriverAccessibilityHandler(BaseAccessibilityHandler):
+    """Refuse accessibility calls the portable driver contract does not expose."""
+
+    @staticmethod
+    def _unsupported() -> Dict[str, Any]:
+        return {
+            "success": False,
+            "code": "unsupported_in_cua_driver",
+            "error": "Accessibility queries are unavailable with the Cua Driver backend",
+        }
+
+    async def get_accessibility_tree(self) -> Dict[str, Any]:
+        return self._unsupported()
+
+    async def find_element(
+        self,
+        role: Optional[str] = None,
+        title: Optional[str] = None,
+        value: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        return self._unsupported()
 
 
 class DriverImage(Protocol):

--- a/libs/python/computer-server/computer_server/handlers/cua_driver.py
+++ b/libs/python/computer-server/computer_server/handlers/cua_driver.py
@@ -2,9 +2,8 @@
 
 The compatibility server keeps its remote HTTP/WebSocket, shell, file, PTY,
 and authentication surfaces while delegating the portable desktop action space
-to the generated ``cua-driver`` Python SDK. Operations that are not part of the
-portable driver contract remain on the supplied legacy handler until they have
-an equivalent Rust implementation.
+to the generated ``cua-driver`` Python SDK. Unsupported input primitives fail
+explicitly instead of falling back to a platform-native automation backend.
 """
 
 from __future__ import annotations
@@ -39,6 +38,8 @@ class DriverResult(Protocol):
 
 
 class DriverClient(Protocol):
+    async def call_tool(self, name: str, arguments_json: str) -> DriverResult: ...
+
     async def start_session(self, input: Any) -> Any: ...
 
     async def end_session(self, input: Any) -> Any: ...
@@ -81,7 +82,7 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
 
     def __init__(
         self,
-        fallback: BaseAutomationHandler,
+        fallback: Optional[BaseAutomationHandler] = None,
         *,
         driver: Optional[DriverClient] = None,
         sdk: Optional[ModuleType] = None,
@@ -156,6 +157,7 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
                         "window": self._sdk.CaptureScope.WINDOW,
                         "desktop": self._sdk.CaptureScope.DESKTOP,
                     }[self._capture_scope],
+                    cursor_theme=None,
                 )
             )
             if not started.active:
@@ -303,12 +305,16 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
     async def mouse_down(
         self, x: Optional[int] = None, y: Optional[int] = None, button: str = "left"
     ) -> Dict[str, Any]:
-        return await self._fallback.mouse_down(x, y, button)
+        return self._error(
+            NotImplementedError("Cua Driver does not support separate mouse-down actions")
+        )
 
     async def mouse_up(
         self, x: Optional[int] = None, y: Optional[int] = None, button: str = "left"
     ) -> Dict[str, Any]:
-        return await self._fallback.mouse_up(x, y, button)
+        return self._error(
+            NotImplementedError("Cua Driver does not support separate mouse-up actions")
+        )
 
     async def _click(
         self, x: Optional[int], y: Optional[int], *, button: str, count: int
@@ -320,6 +326,7 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
                 self._sdk.ClickInput(
                     x=float(px),
                     y=float(py),
+                    target=None,
                     scope=self._sdk.DesktopScope.DESKTOP,
                     session=self._session_id,
                     button={
@@ -357,6 +364,7 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
                 self._sdk.MoveCursorInput(
                     x=float(x),
                     y=float(y),
+                    target=None,
                     scope=self._sdk.DesktopScope.DESKTOP,
                     session=self._session_id,
                 )
@@ -394,6 +402,7 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
                 from_y=float(start_y),
                 to_x=float(end_x),
                 to_y=float(end_y),
+                target=None,
                 scope=self._sdk.DesktopScope.DESKTOP,
                 session=self._session_id,
                 duration_ms=min(10000, max(0, int(duration * 1000))),
@@ -429,10 +438,14 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
             return self._error(error)
 
     async def key_down(self, key: str) -> Dict[str, Any]:
-        return await self._fallback.key_down(key)
+        return self._error(
+            NotImplementedError("Cua Driver does not support separate key-down actions")
+        )
 
     async def key_up(self, key: str) -> Dict[str, Any]:
-        return await self._fallback.key_up(key)
+        return self._error(
+            NotImplementedError("Cua Driver does not support separate key-up actions")
+        )
 
     async def type_text(self, text: str) -> Dict[str, Any]:
         try:
@@ -440,6 +453,7 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
             result = await self._driver.type_text(
                 self._sdk.TypeTextInput(
                     text=text,
+                    target=None,
                     scope=self._sdk.DesktopScope.DESKTOP,
                     session=self._session_id,
                 )
@@ -454,6 +468,7 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
             result = await self._driver.press_key(
                 self._sdk.PressKeyInput(
                     key=key,
+                    target=None,
                     scope=self._sdk.DesktopScope.DESKTOP,
                     session=self._session_id,
                     modifiers=None,
@@ -473,6 +488,7 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
             result = await self._driver.hotkey(
                 self._sdk.HotkeyInput(
                     keys=keys,
+                    target=None,
                     scope=self._sdk.DesktopScope.DESKTOP,
                     session=self._session_id,
                 )
@@ -495,6 +511,7 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
                         "left": self._sdk.ScrollDirection.LEFT,
                         "right": self._sdk.ScrollDirection.RIGHT,
                     }[direction],
+                    target=None,
                     scope=self._sdk.DesktopScope.DESKTOP,
                     session=self._session_id,
                     by=self._sdk.ScrollBy.LINE,
@@ -591,10 +608,41 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
             return self._error(error)
 
     async def copy_to_clipboard(self) -> Dict[str, Any]:
-        return await self._fallback.copy_to_clipboard()
+        try:
+            await self._ensure_session()
+            result = await self._driver.call_tool(
+                "clipboard_read",
+                json.dumps({"include_text": True, "session": self._session_id}),
+            )
+            data = self._result_data(result)
+            if not data.get("supported", False):
+                raise RuntimeError("Cua Driver clipboard read is not supported")
+            return self._ok({"content": data.get("text") or ""})
+        except Exception as error:
+            return self._error(error)
 
     async def set_clipboard(self, text: str) -> Dict[str, Any]:
-        return await self._fallback.set_clipboard(text)
+        try:
+            await self._ensure_session()
+            result = await self._driver.call_tool(
+                "clipboard_write",
+                json.dumps(
+                    {
+                        "text": text,
+                        "image_path": None,
+                        "file_path": None,
+                        "session": self._session_id,
+                    }
+                ),
+            )
+            data = self._result_data(result)
+            if not data.get("supported", False):
+                raise RuntimeError("Cua Driver clipboard write is not supported")
+            return self._ok(data)
+        except Exception as error:
+            return self._error(error)
 
     async def run_command(self, command: str, timeout: Optional[float] = None) -> Dict[str, Any]:
-        return await self._fallback.run_command(command, timeout)
+        if self._fallback is not None:
+            return await self._fallback.run_command(command, timeout)
+        return await super().run_command(command, timeout)

--- a/libs/python/computer-server/computer_server/handlers/cua_driver.py
+++ b/libs/python/computer-server/computer_server/handlers/cua_driver.py
@@ -20,7 +20,11 @@ from typing import Any, Dict, List, Optional, Protocol, Tuple
 
 from PIL import Image
 
-from .base import BaseAccessibilityHandler, BaseAutomationHandler, normalize_screenshot_format
+from .base import (
+    BaseAccessibilityHandler,
+    BaseAutomationHandler,
+    normalize_screenshot_format,
+)
 
 
 class CuaDriverAccessibilityHandler(BaseAccessibilityHandler):

--- a/libs/python/computer-server/computer_server/handlers/factory.py
+++ b/libs/python/computer-server/computer_server/handlers/factory.py
@@ -19,23 +19,6 @@ logger = logging.getLogger(__name__)
 
 OS_TYPE = get_current_os()
 
-if OS_TYPE == "android":
-    from .android import (
-        AndroidAccessibilityHandler,
-        AndroidAutomationHandler,
-        AndroidDesktopHandler,
-        AndroidFileHandler,
-        AndroidWindowHandler,
-    )
-elif OS_TYPE == "darwin":
-    from computer_server.diorama.macos import MacOSDioramaHandler
-
-    from .macos import MacOSAccessibilityHandler, MacOSAutomationHandler
-elif OS_TYPE == "linux":
-    from .linux import LinuxAccessibilityHandler, LinuxAutomationHandler
-elif OS_TYPE == "windows":
-    from .windows import WindowsAccessibilityHandler, WindowsAutomationHandler
-
 from .generic import GenericDesktopHandler, GenericFileHandler, GenericWindowHandler
 
 HandlerTuple = Tuple[
@@ -91,14 +74,32 @@ class HandlerFactory:
             raise RuntimeError("CUA_BACKEND must be native, vnc, or cua-driver")
         if backend == "cua-driver" and OS_TYPE == "android":
             raise RuntimeError("CUA_BACKEND=cua-driver is not supported on Android")
-
-        driver_automation: Optional[BaseAutomationHandler] = None
         if backend == "cua-driver":
-            from .cua_driver import CuaDriverAutomationHandler
+            from .cua_driver import (
+                CuaDriverAccessibilityHandler,
+                CuaDriverAutomationHandler,
+            )
 
-            driver_automation = CuaDriverAutomationHandler()
+            automation = CuaDriverAutomationHandler()
+            logger.info("Using Cua Driver automation backend (%s mode)", automation.mode)
+            return (
+                CuaDriverAccessibilityHandler(),
+                automation,
+                BaseDioramaHandler(),
+                GenericFileHandler(),
+                GenericDesktopHandler(),
+                GenericWindowHandler(),
+            )
 
         if OS_TYPE == "android":
+            from .android import (
+                AndroidAccessibilityHandler,
+                AndroidAutomationHandler,
+                AndroidDesktopHandler,
+                AndroidFileHandler,
+                AndroidWindowHandler,
+            )
+
             handlers: HandlerTuple = (
                 AndroidAccessibilityHandler(),
                 AndroidAutomationHandler(),
@@ -108,31 +109,35 @@ class HandlerFactory:
                 AndroidWindowHandler(),
             )
         elif OS_TYPE == "darwin":
+            from computer_server.diorama.macos import MacOSDioramaHandler
+
+            from .macos import MacOSAccessibilityHandler, MacOSAutomationHandler
+
             handlers = (
                 MacOSAccessibilityHandler(),
-                (driver_automation if driver_automation is not None else MacOSAutomationHandler()),
+                MacOSAutomationHandler(),
                 MacOSDioramaHandler(),
                 GenericFileHandler(),
                 GenericDesktopHandler(),
                 GenericWindowHandler(),
             )
         elif OS_TYPE == "linux":
+            from .linux import LinuxAccessibilityHandler, LinuxAutomationHandler
+
             handlers = (
                 LinuxAccessibilityHandler(),
-                (driver_automation if driver_automation is not None else LinuxAutomationHandler()),
+                LinuxAutomationHandler(),
                 BaseDioramaHandler(),
                 GenericFileHandler(),
                 GenericDesktopHandler(),
                 GenericWindowHandler(),
             )
         elif OS_TYPE == "windows":
+            from .windows import WindowsAccessibilityHandler, WindowsAutomationHandler
+
             handlers = (
                 WindowsAccessibilityHandler(),
-                (
-                    driver_automation
-                    if driver_automation is not None
-                    else WindowsAutomationHandler()
-                ),
+                WindowsAutomationHandler(),
                 BaseDioramaHandler(),
                 GenericFileHandler(),
                 GenericDesktopHandler(),
@@ -140,9 +145,6 @@ class HandlerFactory:
             )
         else:
             raise NotImplementedError(f"OS '{OS_TYPE}' is not supported")
-
-        if driver_automation is not None:
-            logger.info("Using Cua Driver automation backend (%s mode)", handlers[1].mode)
 
         return handlers
 

--- a/libs/python/computer-server/computer_server/handlers/factory.py
+++ b/libs/python/computer-server/computer_server/handlers/factory.py
@@ -89,6 +89,14 @@ class HandlerFactory:
             )
         if backend not in {"native", "cua-driver"}:
             raise RuntimeError("CUA_BACKEND must be native, vnc, or cua-driver")
+        if backend == "cua-driver" and OS_TYPE == "android":
+            raise RuntimeError("CUA_BACKEND=cua-driver is not supported on Android")
+
+        driver_automation: Optional[BaseAutomationHandler] = None
+        if backend == "cua-driver":
+            from .cua_driver import CuaDriverAutomationHandler
+
+            driver_automation = CuaDriverAutomationHandler()
 
         if OS_TYPE == "android":
             handlers: HandlerTuple = (
@@ -102,7 +110,7 @@ class HandlerFactory:
         elif OS_TYPE == "darwin":
             handlers = (
                 MacOSAccessibilityHandler(),
-                MacOSAutomationHandler(),
+                (driver_automation if driver_automation is not None else MacOSAutomationHandler()),
                 MacOSDioramaHandler(),
                 GenericFileHandler(),
                 GenericDesktopHandler(),
@@ -111,7 +119,7 @@ class HandlerFactory:
         elif OS_TYPE == "linux":
             handlers = (
                 LinuxAccessibilityHandler(),
-                LinuxAutomationHandler(),
+                (driver_automation if driver_automation is not None else LinuxAutomationHandler()),
                 BaseDioramaHandler(),
                 GenericFileHandler(),
                 GenericDesktopHandler(),
@@ -120,7 +128,11 @@ class HandlerFactory:
         elif OS_TYPE == "windows":
             handlers = (
                 WindowsAccessibilityHandler(),
-                WindowsAutomationHandler(),
+                (
+                    driver_automation
+                    if driver_automation is not None
+                    else WindowsAutomationHandler()
+                ),
                 BaseDioramaHandler(),
                 GenericFileHandler(),
                 GenericDesktopHandler(),
@@ -129,19 +141,7 @@ class HandlerFactory:
         else:
             raise NotImplementedError(f"OS '{OS_TYPE}' is not supported")
 
-        if backend == "cua-driver":
-            if OS_TYPE == "android":
-                raise RuntimeError("CUA_BACKEND=cua-driver is not supported on Android")
-            from .cua_driver import CuaDriverAutomationHandler
-
-            handlers = (
-                handlers[0],
-                CuaDriverAutomationHandler(handlers[1]),
-                handlers[2],
-                handlers[3],
-                handlers[4],
-                handlers[5],
-            )
+        if driver_automation is not None:
             logger.info("Using Cua Driver automation backend (%s mode)", handlers[1].mode)
 
         return handlers

--- a/libs/python/computer-server/pyproject.toml
+++ b/libs/python/computer-server/pyproject.toml
@@ -55,7 +55,7 @@ vnc = [
     "vncdotool>=1.2.0"
 ]
 driver = [
-    "cua-driver>=0.12.2,<0.13.0"
+    "cua-driver>=0.22.2,<0.23.0"
 ]
 
 [project.urls]

--- a/libs/python/computer-server/tests/test_cua_driver_handler.py
+++ b/libs/python/computer-server/tests/test_cua_driver_handler.py
@@ -72,6 +72,30 @@ class _Driver:
         self.calls.append(("start_session", input))
         return SimpleNamespace(active=True)
 
+    async def call_tool(self, name, arguments_json):
+        self.calls.append(("call_tool", (name, json.loads(arguments_json))))
+        if name == "clipboard_read":
+            return _Result(
+                {
+                    "supported": True,
+                    "types": ["text"],
+                    "text": "driver clipboard",
+                    "privacy_sensitive": True,
+                    "content_redacted_from_telemetry": True,
+                }
+            )
+        if name == "clipboard_write":
+            return _Result(
+                {
+                    "supported": True,
+                    "written_type": "text",
+                    "types": ["text"],
+                    "privacy_sensitive": True,
+                    "content_redacted_from_telemetry": True,
+                }
+            )
+        return _Result(error=f"unsupported tool: {name}")
+
     async def end_session(self, input):
         self.ended.append(input)
         return SimpleNamespace(active=False)
@@ -227,8 +251,10 @@ async def test_desktop_actions_share_one_typed_session(sdk, fallback):
     start = next(value for name, value in driver.calls if name == "start_session")
     assert start.session == "server-a"
     assert start.capture_scope is _CaptureScope.DESKTOP
+    assert start.cursor_theme is None
     clicked = next(value for name, value in driver.calls if name == "click")
     assert (clicked.x, clicked.y) == (12.0, 34.0)
+    assert clicked.target is None
     assert clicked.scope is _DesktopScope.DESKTOP
 
 
@@ -266,13 +292,37 @@ async def test_adapter_uses_the_generated_python_contract(fallback):
     )
 
     result = await handler.get_screen_size()
+    await handler.move_cursor(20, 30)
+    await handler.left_click(20, 30)
+    await handler.drag([(20, 30), (40, 50)])
+    await handler.scroll_down()
+    await handler.type_text("hello")
+    await handler.press_key("enter")
+    await handler.hotkey(["ctrl", "a"])
+    await handler.copy_to_clipboard()
+    await handler.set_clipboard("updated")
 
     assert result == {"success": True, "size": {"width": 1280, "height": 720}}
     start = next(value for name, value in driver.calls if name == "start_session")
     assert isinstance(start, cua_driver.StartSessionInput)
     assert start.capture_scope is cua_driver.CaptureScope.DESKTOP
+    assert start.cursor_theme is None
     request = next(value for name, value in driver.calls if name == "get_screen_size")
     assert isinstance(request, cua_driver.GetScreenSizeInput)
+    expected_types = {
+        "move_cursor": cua_driver.MoveCursorInput,
+        "click": cua_driver.ClickInput,
+        "drag": cua_driver.DragInput,
+        "scroll": cua_driver.ScrollInput,
+        "type_text": cua_driver.TypeTextInput,
+        "press_key": cua_driver.PressKeyInput,
+        "hotkey": cua_driver.HotkeyInput,
+    }
+    for name, expected_type in expected_types.items():
+        request = next(value for call, value in driver.calls if call == name)
+        assert isinstance(request, expected_type)
+        if hasattr(request, "target"):
+            assert request.target is None
 
 
 @pytest.mark.asyncio
@@ -328,16 +378,39 @@ async def test_close_ends_owned_session_and_shuts_down_once(sdk, fallback):
 
 
 @pytest.mark.asyncio
-async def test_non_portable_actions_remain_on_legacy_handler(sdk, fallback):
-    handler = CuaDriverAutomationHandler(fallback, driver=_Driver(), sdk=sdk)
+async def test_foreground_actions_never_fall_back_to_legacy_input(sdk, fallback):
+    driver = _Driver()
+    handler = CuaDriverAutomationHandler(fallback, driver=driver, sdk=sdk, session_id="foreground")
 
-    assert await handler.mouse_down(1, 2, "left") == {"success": True}
-    assert await handler.key_down("shift") == {"success": True}
-    assert await handler.copy_to_clipboard() == {"success": True, "content": "x"}
+    mouse_down = await handler.mouse_down(1, 2, "left")
+    key_down = await handler.key_down("shift")
+    clipboard = await handler.copy_to_clipboard()
+    clipboard_write = await handler.set_clipboard("updated")
 
-    fallback.mouse_down.assert_awaited_once_with(1, 2, "left")
-    fallback.key_down.assert_awaited_once_with("shift")
-    fallback.copy_to_clipboard.assert_awaited_once_with()
+    assert mouse_down["success"] is False
+    assert "separate mouse-down" in mouse_down["error"]
+    assert key_down["success"] is False
+    assert "separate key-down" in key_down["error"]
+    assert clipboard == {"success": True, "content": "driver clipboard"}
+    assert clipboard_write["success"] is True
+    fallback.mouse_down.assert_not_awaited()
+    fallback.key_down.assert_not_awaited()
+    fallback.copy_to_clipboard.assert_not_awaited()
+    fallback.set_clipboard.assert_not_awaited()
+    calls = [value for name, value in driver.calls if name == "call_tool"]
+    assert calls[0] == (
+        "clipboard_read",
+        {"include_text": True, "session": "foreground"},
+    )
+    assert calls[1] == (
+        "clipboard_write",
+        {
+            "text": "updated",
+            "image_path": None,
+            "file_path": None,
+            "session": "foreground",
+        },
+    )
 
 
 def test_invalid_driver_configuration_is_rejected(sdk, fallback):
@@ -345,6 +418,32 @@ def test_invalid_driver_configuration_is_rejected(sdk, fallback):
         CuaDriverAutomationHandler(fallback, driver=_Driver(), sdk=sdk, mode="rpc")
     with pytest.raises(ValueError, match="CUA_DRIVER_CAPTURE_SCOPE"):
         CuaDriverAutomationHandler(fallback, driver=_Driver(), sdk=sdk, capture_scope="everything")
+
+
+def test_factory_selects_driver_without_constructing_native_automation(monkeypatch):
+    monkeypatch.setenv("CUA_BACKEND", "cua-driver")
+    monkeypatch.setenv("PYNPUT_BACKEND", "dummy")
+
+    from computer_server.handlers import cua_driver as driver_module
+    from computer_server.handlers import factory
+
+    driver = SimpleNamespace(mode="embedded")
+
+    def fail_native():
+        raise AssertionError("native automation must not be constructed")
+
+    monkeypatch.setattr(factory, "OS_TYPE", "linux")
+    monkeypatch.setattr(factory, "LinuxAccessibilityHandler", object, raising=False)
+    monkeypatch.setattr(factory, "LinuxAutomationHandler", fail_native, raising=False)
+    monkeypatch.setattr(factory, "BaseDioramaHandler", object)
+    monkeypatch.setattr(factory, "GenericFileHandler", object)
+    monkeypatch.setattr(factory, "GenericDesktopHandler", object)
+    monkeypatch.setattr(factory, "GenericWindowHandler", object)
+    monkeypatch.setattr(driver_module, "CuaDriverAutomationHandler", lambda: driver)
+
+    handlers = factory.HandlerFactory.create_handlers()
+
+    assert handlers[1] is driver
 
 
 @pytest.mark.asyncio

--- a/libs/python/computer-server/tests/test_cua_driver_handler.py
+++ b/libs/python/computer-server/tests/test_cua_driver_handler.py
@@ -1,10 +1,14 @@
 import json
+import sys
 from enum import Enum
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from computer_server.handlers.cua_driver import CuaDriverAutomationHandler
+from computer_server.handlers.cua_driver import (
+    CuaDriverAccessibilityHandler,
+    CuaDriverAutomationHandler,
+)
 
 
 class _Record:
@@ -429,21 +433,19 @@ def test_factory_selects_driver_without_constructing_native_automation(monkeypat
 
     driver = SimpleNamespace(mode="embedded")
 
-    def fail_native():
-        raise AssertionError("native automation must not be constructed")
-
     monkeypatch.setattr(factory, "OS_TYPE", "linux")
-    monkeypatch.setattr(factory, "LinuxAccessibilityHandler", object, raising=False)
-    monkeypatch.setattr(factory, "LinuxAutomationHandler", fail_native, raising=False)
     monkeypatch.setattr(factory, "BaseDioramaHandler", object)
     monkeypatch.setattr(factory, "GenericFileHandler", object)
     monkeypatch.setattr(factory, "GenericDesktopHandler", object)
     monkeypatch.setattr(factory, "GenericWindowHandler", object)
     monkeypatch.setattr(driver_module, "CuaDriverAutomationHandler", lambda: driver)
+    sys.modules.pop("computer_server.handlers.linux", None)
 
     handlers = factory.HandlerFactory.create_handlers()
 
     assert handlers[1] is driver
+    assert isinstance(handlers[0], CuaDriverAccessibilityHandler)
+    assert "computer_server.handlers.linux" not in sys.modules
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -229,15 +229,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asyncio"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/ea/26c489a11f7ca862d5705db67683a7361ce11c23a7b98fc6c2deaeccede2/asyncio-4.0.0.tar.gz", hash = "sha256:570cd9e50db83bc1629152d4d0b7558d6451bb1bfd5dfc2e935d96fc2f40329b", size = 5371, upload-time = "2025-08-05T02:51:46.605Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/64/eff2564783bd650ca25e15938d1c5b459cda997574a510f7de69688cb0b4/asyncio-4.0.0-py3-none-any.whl", hash = "sha256:c1eddb0659231837046809e68103969b2bef8b0400d59cfa6363f6b5ed8cc88b", size = 5555, upload-time = "2025-08-05T02:51:45.767Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -825,7 +816,6 @@ source = { editable = "libs/python/agent" }
 dependencies = [
     { name = "aiohttp" },
     { name = "anyio" },
-    { name = "asyncio" },
     { name = "certifi" },
     { name = "cua-core" },
     { name = "httpx" },
@@ -930,7 +920,6 @@ requires-dist = [
     { name = "accelerate", marker = "extra == 'uitars-hf'" },
     { name = "aiohttp", specifier = ">=3.9.3" },
     { name = "anyio", specifier = ">=4.4.1" },
-    { name = "asyncio" },
     { name = "blobfile", marker = "extra == 'all'", specifier = ">=3.0.0" },
     { name = "blobfile", marker = "extra == 'opencua-hf'", specifier = ">=3.0.0" },
     { name = "certifi", specifier = ">=2024.2.2" },
@@ -1128,7 +1117,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.1" },
     { name = "cua-auto", editable = "libs/python/cua-auto" },
     { name = "cua-core", editable = "libs/python/core" },
-    { name = "cua-driver", marker = "extra == 'driver'", specifier = ">=0.12.2,<0.13.0" },
+    { name = "cua-driver", marker = "extra == 'driver'", specifier = ">=0.22.2,<0.23.0" },
     { name = "fastapi", specifier = ">=0.111.0" },
     { name = "fastmcp", specifier = ">=3.2.0,<3.3.0" },
     { name = "grpcio", specifier = "==1.78.0" },
@@ -1198,14 +1187,14 @@ dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
 name = "cua-driver"
-version = "0.12.2"
+version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/9a/b77097f4dd4ee0f0a6a92ea9fb9bd7acabdeb134fe10a76440ebe3cccb8e/cua_driver-0.12.2-py3-none-macosx_13_0_universal2.whl", hash = "sha256:be45a102f92031b424e84dbfeba7afa3fcc6cd957bee0276f0e3a26f2d3efc58", size = 32083206, upload-time = "2026-07-23T05:33:11.238Z" },
-    { url = "https://files.pythonhosted.org/packages/32/c5/65facce8ae822e9c756a0aa4339496f88bb2a708ce7b40786b4da8673797/cua_driver-0.12.2-py3-none-manylinux_2_31_aarch64.whl", hash = "sha256:dc494710c3cf13139d715f3c117be46fabf6a388afdad71cb9a4f08ee8b2b4e5", size = 22983041, upload-time = "2026-07-23T05:33:13.654Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/34/6f4ba52bbc23f114546987c7e59851769af334e6e70975a3616f5c82e017/cua_driver-0.12.2-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:ce58c405f677d73f34f60c5e5f622a4426225517c15e55094f145b1f1e47a7db", size = 22840183, upload-time = "2026-07-23T05:33:16.195Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9a/f9280da9bbdad5e7596e1ab7e77bcb8f18efe71ee2d33cfe3aa278cfa57a/cua_driver-0.12.2-py3-none-win_amd64.whl", hash = "sha256:f1b5f05174720fd63a8797ab34d4227f1169a59ef1e04c54d1db2596a8e10f55", size = 21756824, upload-time = "2026-07-23T05:33:18.864Z" },
-    { url = "https://files.pythonhosted.org/packages/35/e5/98707a7d45744510c863417d2b859aaab9d35e6bc18e6e4660e52ab2cdee/cua_driver-0.12.2-py3-none-win_arm64.whl", hash = "sha256:69ce4c5c54c54a70e3fb7e8baeb8b476cc151277a6ba6dab0eda052faf2918ff", size = 19943506, upload-time = "2026-07-23T05:33:21.521Z" },
+    { url = "https://files.pythonhosted.org/packages/56/23/e5f4a6d9a799a3fd73c5ff8dd88de377f97864b344493afa5c6c5b409539/cua_driver-0.22.2-py3-none-macosx_13_0_universal2.whl", hash = "sha256:954ad2fc57049abe8117f82ef8f2a7e23aa71f0bf102023c6885baed2468b257", size = 38859550, upload-time = "2026-08-27T18:48:14.272Z" },
+    { url = "https://files.pythonhosted.org/packages/49/86/efc63a991104f051b6b16bcee5c5af169e75b7bb11e2216bfd556ec13e89/cua_driver-0.22.2-py3-none-manylinux_2_31_aarch64.whl", hash = "sha256:aceec765940a4bcfb68891a0642ff8072f5fd220c66fa3fe113a4b1f8c71d1ea", size = 27575564, upload-time = "2026-08-27T18:48:17.136Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6d/ec8b2dcbd5a59c0597ea4b20c50f63ca96ed6b29e7cf34b16847c244cc23/cua_driver-0.22.2-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:19f1124ab2670335ca272b66c15c59b12f7579d1e463c422fb2cd5d58c08d0d2", size = 27550099, upload-time = "2026-08-27T18:48:19.729Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/89/97f6bbd9e672c619ef661ac9982f8f46353f877c43df3e8fda4bd63743ce/cua_driver-0.22.2-py3-none-win_amd64.whl", hash = "sha256:93909184d515e3eac9e6a0651731e930b1a9ee6218b6a0aaa8897ea592dee8fa", size = 25363707, upload-time = "2026-08-27T18:48:22.825Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b8/635c087292f33342206276617d3fe4499b27d6ddf171019d6557bc57e5a3/cua_driver-0.22.2-py3-none-win_arm64.whl", hash = "sha256:2a037886a57765c486d4915c28099857bc5b16c0ab09c209068f6bffc69c90fe", size = 23672187, upload-time = "2026-08-27T18:48:25.586Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- construct the current generated `cua-driver` inputs correctly for foreground desktop actions
- select the embedded SDK backend directly without constructing native `pynput` automation first
- route clipboard reads and writes through the in-process SDK
- fail explicitly for separate hold/release primitives that the driver contract does not expose
- require the published `cua-driver` 0.22.x SDK and exercise its real wheel contract in tests

## Validation

- `79 passed` across `libs/python/computer-server/tests` with the `driver` extra
- `14 passed` in the focused generated-SDK/backend suite
- Ruff check and format pass
- uv lock check passes with the repository-compatible uv version

## Remaining delivery verification

- publish the patch release after merge
- consume it in the Omarchy image and run screenshot plus foreground input smoke on Wayland

Closes #3424
