### PR TITLE
fix(cua-driver): make Agent View opt-in by default

### DIFF
--- a/libs/cua-driver/docs/agent-view.md
+++ b/libs/cua-driver/docs/agent-view.md
@@ -2,16 +2,17 @@
 
 Agent View is an optional, always-on-top miniature desktop that shows the exact
 application windows and browser tabs traversed by one Cua Driver agent session.
-It is enabled by default on supported interactive desktops. Disable it for one
-daemon invocation with:
+It is disabled by default. Enable it for one daemon invocation with:
 
 ```console
-cua-driver --no-agent-view
+cua-driver --agent-view
 ```
 
-`--agent-view` remains accepted as an explicit enable for compatibility. The
-durable config equivalent is `{"agent_view": false}` in
+The durable config equivalent is `{"agent_view": true}` in
 `~/.cua-driver/config.json`.
+
+`--no-agent-view` remains available to override a persisted enable for one
+daemon invocation.
 
 Use `--agent-view-geometry WxH[+X+Y]` to override its initial size and optional
 top-left position. The default is `640x420` near the top-right of the main

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -641,7 +641,7 @@ pub fn parse_command() -> Command {
         );
         println!("  cua-driver history enable   Opt in and initialize encrypted local history.");
         println!("  cua-driver history status|pause|resume|flush|list|show|disable|delete");
-        println!("  --agent-view                Show the Agent View (enabled by default).");
+        println!("  --agent-view                Enable the optional Agent View.");
         println!("                              Exact native windows and");
         println!(
             "                              Chrome tabs traversed through Cua Driver become cards."
@@ -662,7 +662,7 @@ pub fn parse_command() -> Command {
             "                              Native presentation is available on macOS, Windows,"
         );
         println!("                              and Linux (X11/XWayland).");
-        println!("  --no-agent-view             Disable Agent View for this daemon invocation.");
+        println!("  --no-agent-view             Disable Agent View, including a persisted enable.");
         println!("  --agent-view-geometry WxH[+X+Y]   Override window size (and optional top-left");
         println!("                                          origin). Defaults to 640x420 in the top-right");
         println!("                                          corner of the main display.");

--- a/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
@@ -1168,6 +1168,20 @@ mod tests {
     }
 
     #[test]
+    fn agent_view_cli_overrides_disabled_config_file() {
+        let path = std::env::temp_dir().join(format!(
+            "cua-agent-view-config-{}-cli-enable.json",
+            std::process::id()
+        ));
+        std::fs::write(&path, r#"{"agent_view":false}"#).unwrap();
+
+        let cfg = PipConfig::from_file_and_args(&path, &["--agent-view".to_owned()]);
+        assert!(cfg.enabled);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn cli_flags_override_config_file_values() {
         let path = std::env::temp_dir().join(format!(
             "cua-agent-view-config-{}-cli-precedence.json",

--- a/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
@@ -21,7 +21,7 @@ pub use desktop_layout::{
 };
 pub use session_tabs::{layout_session_tabs, session_accent, SessionTab, SessionTabsLayout};
 
-pub const AGENT_VIEW_DEFAULT_ENABLED: bool = true;
+pub const AGENT_VIEW_DEFAULT_ENABLED: bool = false;
 
 /// Canonical `~/.cua-driver/config.json` path matching what the per-platform
 /// `set_config` tools write to. Resolves `$HOME` first (Unix/macOS) and falls
@@ -1104,10 +1104,10 @@ mod tests {
     }
 
     #[test]
-    fn explicit_no_agent_view_overrides_the_default() {
-        let cfg = PipConfig::parse(&["--no-agent-view".to_owned()]);
+    fn agent_view_is_disabled_by_default() {
+        let cfg = PipConfig::parse(&[]);
         assert!(!cfg.enabled);
-        assert!(PipConfig::default().enabled);
+        assert!(!PipConfig::default().enabled);
     }
 
     #[test]
@@ -1118,7 +1118,7 @@ mod tests {
             "640x420".to_owned(),
             "--pip".to_owned(),
         ]);
-        assert!(cfg.enabled);
+        assert!(!cfg.enabled);
         assert_eq!(cfg.geometry.width, PipGeometry::default().width);
         assert_eq!(cfg.geometry.height, PipGeometry::default().height);
     }
@@ -1209,7 +1209,7 @@ mod tests {
         .unwrap();
 
         let cfg = PipConfig::from_args_and_file(&path);
-        assert!(cfg.enabled);
+        assert!(!cfg.enabled);
         assert_eq!(cfg.geometry.width, PipGeometry::default().width);
         assert_eq!(cfg.geometry.height, PipGeometry::default().height);
 


### PR DESCRIPTION
## Scope

- Change the shared cross-platform Agent View fallback from enabled to disabled.
- Preserve explicit opt-in through `--agent-view` and `{"agent_view": true}`.
- Preserve `--no-agent-view` as a per-run override for persisted enables.
- Update CLI help, product docs, and precedence/default tests.

Follow-up to #3431.

## Validation

- [x] `cargo test --locked -p pip-preview` (42 passed)
- [x] `cargo run --locked -p cua-driver-contract --bin cua-contract-gen -- all --check`
- [x] `cargo test --locked -p cua-driver-contract` (33 passed)
- [x] `cargo test --locked -p cua-driver macos_main_loop` (2 selected tests passed)
- [x] Source-built macOS CLI help reflects opt-in behavior
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

## Desktop acceptance

Exact candidate: `d342a0fc84f1bd2e57f91c656b18d54ed6d8f010`

- [x] [Windows interactive matrix](https://github.com/trycua/cua/actions/runs/33196287956) (native, capture, shared, installer passed)
- [x] [Linux X11 interactive matrix](https://github.com/trycua/cua/actions/runs/33196289751) (native, capture, shared, installer passed)
- [x] [Linux pure Wayland matrix](https://github.com/trycua/cua/actions/runs/33196291496) (capture/shared passed; native limitation documented below)

## Known gaps

- Pure Wayland/Sway native lane has a pre-existing harness limitation: the base SHA `57981a16f8c16a72955ac06d3a98dbcc0f9ca4b6` and candidate SHA `d342a0fc84f1bd2e57f91c656b18d54ed6d8f010` fail identically in X11-dependent cursor showcase and GTK3 pixel-background evidence cells (`DISPLAY: NotPresent` / missing screenshot dimensions). Candidate replay: https://github.com/trycua/cua/actions/runs/33197563054; base replay: https://github.com/trycua/cua/actions/runs/33197564963. Wayland capture/shared behavior and GTK4 target selection pass. This follow-up does not change the affected code paths.
