### PR TITLE
fix(computer-server): recover idle driver sessions

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/cua_driver.py
+++ b/libs/python/computer-server/computer_server/handlers/cua_driver.py
@@ -147,7 +147,6 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
         if selected_scope not in {"auto", "window", "desktop"}:
             raise ValueError("CUA_DRIVER_CAPTURE_SCOPE must be auto, window, or desktop")
         self._capture_scope = selected_scope
-        self._session_started = False
         self._session_lock = asyncio.Lock()
         self._closed = False
 
@@ -183,13 +182,11 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
         return target_type.DESKTOP(display_id="primary"), None
 
     async def _ensure_session(self) -> None:
-        if self._closed:
-            raise RuntimeError("Cua Driver automation handler is closed")
-        if self._session_started:
-            return
+        """Declare or revive the process-owned session before each driver call."""
+
         async with self._session_lock:
-            if self._session_started:
-                return
+            if self._closed:
+                raise RuntimeError("Cua Driver automation handler is closed")
             started = await self._driver.start_session(
                 self._sdk.StartSessionInput(
                     session=self._session_id,
@@ -203,7 +200,6 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
             )
             if not started.active:
                 raise RuntimeError("Cua Driver did not activate the compatibility session")
-            self._session_started = True
 
     @staticmethod
     def _structured(result: DriverResult) -> Dict[str, Any]:
@@ -285,11 +281,7 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
             if self._closed:
                 return
             try:
-                if self._session_started:
-                    await self._driver.end_session(
-                        self._sdk.EndSessionInput(session=self._session_id)
-                    )
-                    self._session_started = False
+                await self._driver.end_session(self._sdk.EndSessionInput(session=self._session_id))
             finally:
                 await self._driver.shutdown()
                 self._closed = True
@@ -362,8 +354,8 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
         self, x: Optional[int], y: Optional[int], *, button: str, count: int
     ) -> Dict[str, Any]:
         try:
-            await self._ensure_session()
             px, py = await self._point(x, y)
+            await self._ensure_session()
             target, scope = self._desktop_target()
             result = await self._driver.click(
                 self._sdk.ClickInput(
@@ -547,8 +539,8 @@ class CuaDriverAutomationHandler(BaseAutomationHandler):
 
     async def _scroll(self, direction: str, amount: int) -> Dict[str, Any]:
         try:
-            await self._ensure_session()
             x, y = await self._point(None, None)
+            await self._ensure_session()
             target, scope = self._desktop_target()
             result = await self._driver.scroll(
                 self._sdk.ScrollInput(

--- a/libs/python/computer-server/tests/test_cua_driver_handler.py
+++ b/libs/python/computer-server/tests/test_cua_driver_handler.py
@@ -239,7 +239,7 @@ def fallback():
 
 
 @pytest.mark.asyncio
-async def test_desktop_actions_share_one_typed_session(sdk, fallback):
+async def test_desktop_actions_redeclare_one_typed_session(sdk, fallback):
     driver = _Driver()
     handler = CuaDriverAutomationHandler(
         fallback,
@@ -260,15 +260,31 @@ async def test_desktop_actions_share_one_typed_session(sdk, fallback):
     assert click["effect"] == "unverifiable"
     assert click["verified"] is False
     assert scroll["success"] is True
-    assert [name for name, _ in driver.calls].count("start_session") == 1
-    start = next(value for name, value in driver.calls if name == "start_session")
-    assert start.session == "server-a"
-    assert start.capture_scope is _CaptureScope.DESKTOP
-    assert start.cursor_theme is None
+    starts = [value for name, value in driver.calls if name == "start_session"]
+    assert len(starts) == 5
+    assert {start.session for start in starts} == {"server-a"}
+    assert {start.capture_scope for start in starts} == {_CaptureScope.DESKTOP}
+    assert all(start.cursor_theme is None for start in starts)
     clicked = next(value for name, value in driver.calls if name == "click")
     assert (clicked.x, clicked.y) == (12.0, 34.0)
     assert clicked.target.display_id == "primary"
     assert clicked.scope is None
+
+
+@pytest.mark.asyncio
+async def test_each_call_redeclares_the_session_after_possible_idle_expiry(sdk, fallback):
+    driver = _Driver()
+    handler = CuaDriverAutomationHandler(fallback, driver=driver, sdk=sdk, session_id="idle-server")
+
+    assert (await handler.get_screen_size())["success"] is True
+    assert (await handler.get_screen_size())["success"] is True
+
+    assert [name for name, _ in driver.calls] == [
+        "start_session",
+        "get_screen_size",
+        "start_session",
+        "get_screen_size",
+    ]
 
 
 @pytest.mark.asyncio
@@ -388,9 +404,12 @@ async def test_close_ends_owned_session_and_shuts_down_once(sdk, fallback):
 
     await handler.close()
     await handler.close()
+    closed = await handler.get_cursor_position()
 
     assert [value.session for value in driver.ended] == ["owned-session"]
     assert driver.shutdown_count == 1
+    assert closed["success"] is False
+    assert "closed" in closed["error"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## problem

computer-server cached one successful `start_session` as valid for the rest of the process. cua-driver correctly tombstones that named session after its idle TTL, so every later action reused an ended label and failed until computer-server restarted.

## change

- declare the same process-owned session idempotently before each driver-backed call
- let `start_session` revive an idle-ended label before the action reaches it
- remove the stale process-lifetime `_session_started` cache
- keep the existing named-session, capture-policy compatibility, and explicit shutdown ownership contracts unchanged
- avoid retry state, generation counters, and daemon error-text matching

## validation

- [x] `CUA_TELEMETRY_ENABLED=false uv run --extra driver --with pytest --with pytest-asyncio pytest tests -q` — 80 passed
- [x] `ruff check computer_server/handlers/cua_driver.py tests/test_cua_driver_handler.py`
- [x] `ruff format --check computer_server/handlers/cua_driver.py tests/test_cua_driver_handler.py`
- [x] cua-driver 0.22.2 embedded smoke with a 1-second session TTL and the real 30-second lifecycle sweep — the first and post-idle `get_screen_size` calls succeeded
- [x] cua-driver 0.22.2 daemon smoke over an isolated socket with the same forced expiry — the first and post-idle `get_screen_size` calls succeeded

## known gaps

none. the shared Python lifecycle adapter owns this behavior; the real embedded and daemon paths cover both runtime modes without changing driver behavior.

Fixes #3433