### PR TITLE
fix(linux): round-trip native Wayland window identities

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
@@ -3148,11 +3148,9 @@ pub fn list_windows_dispatch(filter_pid: Option<u32>) -> Vec<WindowInfo> {
         // only consulted when wlroots yields no windows (including when its
         // manager global is absent).
         let native = match list_windows() {
-            Ok(ws) if !ws.is_empty() => Ok(enrich_native_windows(
-                ws,
-                wayland_atspi_windows(filter_pid),
-                is_inject_mode(),
-            )),
+            Ok(ws) if !ws.is_empty() => {
+                Ok(enrich_native_windows(ws, wayland_atspi_windows(filter_pid)))
+            }
             Ok(_) => ext_toplevel::list_windows(),
             Err(wlr_error) => ext_toplevel::list_windows().map_err(|ext_error| {
                 anyhow::anyhow!(
@@ -3242,67 +3240,66 @@ fn merge_atspi_windows(
     }
 }
 
-fn enrich_native_windows(
-    mut native: Vec<WindowInfo>,
-    atspi: Vec<WindowInfo>,
-    adopt_atspi_ids: bool,
-) -> Vec<WindowInfo> {
+fn enrich_native_windows(mut native: Vec<WindowInfo>, atspi: Vec<WindowInfo>) -> Vec<WindowInfo> {
     let mut claimed = std::collections::HashSet::new();
     for window in &mut native {
         if window.pid.is_some() {
             continue;
         }
         let native_title = undecorated_native_title(window);
-        let title_match = atspi.iter().enumerate().find_map(|(index, candidate)| {
-            (!claimed.contains(&index)
-                && !native_title.is_empty()
-                && candidate.title == native_title)
-                .then_some(index)
+        let title_match = unique_unclaimed_match(&atspi, &claimed, |candidate| {
+            !native_title.is_empty() && candidate.title == native_title
         });
         let app_match = title_match.or_else(|| {
-            let matches = atspi
-                .iter()
-                .enumerate()
-                .filter(|(index, candidate)| {
-                    !claimed.contains(index)
-                        && !window.app_name.is_empty()
-                        && candidate.app_name == window.app_name
-                })
-                .map(|(index, _)| index)
-                .collect::<Vec<_>>();
-            (matches.len() == 1).then(|| matches[0])
+            unique_unclaimed_match(&atspi, &claimed, |candidate| {
+                !window.app_name.is_empty()
+                    && candidate.app_name.eq_ignore_ascii_case(&window.app_name)
+            })
         });
         let Some(index) = app_match else { continue };
-        claimed.insert(index);
         let candidate = &atspi[index];
-        window.pid = candidate.pid;
-        if adopt_atspi_ids {
-            let toplevel = Toplevel {
-                title: undecorated_native_title(window).to_owned(),
-                app_id: window.app_name.clone(),
-                closed: false,
-                activated: false,
-            };
-            window.xid = candidate.xid;
-            remember_identity(window.xid, &toplevel);
+        if candidate.pid.is_none() || candidate.xid == 0 {
+            continue;
         }
+        claimed.insert(index);
+        window.pid = candidate.pid;
+        let toplevel = Toplevel {
+            title: undecorated_native_title(window).to_owned(),
+            app_id: window.app_name.clone(),
+            closed: false,
+            activated: false,
+        };
+        window.xid = candidate.xid;
+        remember_identity(window.xid, &toplevel);
         if window.width == 0 || window.height == 0 {
             window.x = candidate.x;
             window.y = candidate.y;
             window.width = candidate.width;
             window.height = candidate.height;
         }
-        if adopt_atspi_ids {
-            if let Some(pid) = candidate.pid {
-                if let Some((window_x, window_y)) = inject_window_origin(pid) {
-                    window.x = window_x;
-                    window.y = window_y;
-                }
+        if let Some(pid) = candidate.pid {
+            if let Some((window_x, window_y)) = inject_window_origin(pid) {
+                window.x = window_x;
+                window.y = window_y;
             }
         }
         window.is_on_screen = candidate.is_on_screen;
     }
     native
+}
+
+fn unique_unclaimed_match(
+    windows: &[WindowInfo],
+    claimed: &std::collections::HashSet<usize>,
+    matches: impl Fn(&WindowInfo) -> bool,
+) -> Option<usize> {
+    let mut matching = windows
+        .iter()
+        .enumerate()
+        .filter(|(index, window)| !claimed.contains(index) && matches(window))
+        .map(|(index, _)| index);
+    let index = matching.next()?;
+    matching.next().is_none().then_some(index)
 }
 
 fn undecorated_native_title(window: &WindowInfo) -> &str {
@@ -3485,21 +3482,25 @@ mod tests {
     }
 
     #[test]
-    fn native_enrichment_matches_plain_atspi_title() {
+    fn native_enrichment_adopts_atspi_target_for_exact_title() {
         let mut native = window(42, None, "CUA Fixture [cua-fixture]");
         native.app_name = "cua-fixture".into();
-        let mut accessible = window(123 << 16, Some(123), "CUA Fixture");
+        let mut accessible = window(41_001 << 16, Some(41_001), "CUA Fixture");
+        accessible.app_name = "Cua Fixture".into();
         accessible.x = 20;
         accessible.y = 30;
         accessible.width = 800;
         accessible.height = 600;
 
-        let enriched = enrich_native_windows(vec![native], vec![accessible], false);
+        let enriched = enrich_native_windows(vec![native], vec![accessible]);
 
-        assert_eq!(enriched[0].xid, 42);
-        assert_eq!(enriched[0].pid, Some(123));
+        assert_eq!(enriched[0].xid, 41_001 << 16);
+        assert_eq!(enriched[0].pid, Some(41_001));
         assert_eq!((enriched[0].x, enriched[0].y), (20, 30));
         assert_eq!((enriched[0].width, enriched[0].height), (800, 600));
+        let activation_identity = identity_for(enriched[0].xid).unwrap();
+        assert_eq!(activation_identity.title, "CUA Fixture");
+        assert_eq!(activation_identity.app_id, "cua-fixture");
     }
 
     #[test]
@@ -3509,16 +3510,18 @@ mod tests {
     }
 
     #[test]
-    fn native_title_match_recovers_pid_without_replacing_native_id() {
-        let native = vec![window(77, None, "CuaTestHarness")];
-        let mut accessible = window(123 << 16, Some(123), "CuaTestHarness");
+    fn native_enrichment_matches_unique_app_id_case_insensitively() {
+        let mut native = window(77, None, "New Tab [chromium]");
+        native.app_name = "chromium".into();
+        let mut accessible = window(41_002 << 16, Some(41_002), "Chromium");
+        accessible.app_name = "Chromium".into();
         accessible.x = 20;
         accessible.y = 30;
         accessible.width = 800;
         accessible.height = 600;
-        let enriched = enrich_native_windows(native, vec![accessible], false);
-        assert_eq!(enriched[0].xid, 77);
-        assert_eq!(enriched[0].pid, Some(123));
+        let enriched = enrich_native_windows(vec![native], vec![accessible]);
+        assert_eq!(enriched[0].xid, 41_002 << 16);
+        assert_eq!(enriched[0].pid, Some(41_002));
         assert_eq!(
             (
                 enriched[0].x,
@@ -3531,15 +3534,34 @@ mod tests {
     }
 
     #[test]
-    fn nested_enrichment_adopts_stable_atspi_id() {
-        let native = vec![window(77, None, "CuaTestHarness")];
-        let accessible = window(123 << 16, Some(123), "CuaTestHarness");
-        let enriched = enrich_native_windows(native, vec![accessible], true);
-        assert_eq!(enriched[0].xid, 123 << 16);
-        assert_eq!(enriched[0].pid, Some(123));
+    fn native_enrichment_refuses_ambiguous_app_identity() {
+        let mut native = window(77, None, "New Tab [chromium]");
+        native.app_name = "chromium".into();
+        let mut first = window(41_003 << 16, Some(41_003), "First Chromium window");
+        first.app_name = "Chromium".into();
+        first.x = 20;
+        first.y = 30;
+        first.width = 800;
+        first.height = 600;
+        let mut second = window(41_004 << 16, Some(41_004), "Second Chromium window");
+        second.app_name = "chromium".into();
+        second.x = 40;
+        second.y = 50;
+        second.width = 1024;
+        second.height = 768;
+
+        let enriched = enrich_native_windows(vec![native], vec![first, second]);
+
+        assert_eq!(enriched[0].xid, 77);
+        assert_eq!(enriched[0].pid, None);
         assert_eq!(
-            identity_for(enriched[0].xid).unwrap().title,
-            "CuaTestHarness"
+            (
+                enriched[0].x,
+                enriched[0].y,
+                enriched[0].width,
+                enriched[0].height
+            ),
+            (0, 0, 0, 0)
         );
     }
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
@@ -3242,18 +3242,35 @@ fn merge_atspi_windows(
 
 fn enrich_native_windows(mut native: Vec<WindowInfo>, atspi: Vec<WindowInfo>) -> Vec<WindowInfo> {
     let mut claimed = std::collections::HashSet::new();
-    for window in &mut native {
-        if window.pid.is_some() {
+    let needs_correlation: Vec<_> = native.iter().map(|window| window.pid.is_none()).collect();
+    for native_index in 0..native.len() {
+        if !needs_correlation[native_index] {
             continue;
         }
-        let native_title = undecorated_native_title(window);
+        let native_title = undecorated_native_title(&native[native_index]);
         let title_match = unique_unclaimed_match(&atspi, &claimed, |candidate| {
             !native_title.is_empty() && candidate.title == native_title
+        })
+        .filter(|&atspi_index| {
+            unique_native_match(&native, |index, window| {
+                let title = undecorated_native_title(window);
+                needs_correlation[index] && !title.is_empty() && title == atspi[atspi_index].title
+            }) == Some(native_index)
         });
         let app_match = title_match.or_else(|| {
+            let native_app_name = &native[native_index].app_name;
             unique_unclaimed_match(&atspi, &claimed, |candidate| {
-                !window.app_name.is_empty()
-                    && candidate.app_name.eq_ignore_ascii_case(&window.app_name)
+                !native_app_name.is_empty()
+                    && candidate.app_name.eq_ignore_ascii_case(native_app_name)
+            })
+            .filter(|&atspi_index| {
+                unique_native_match(&native, |index, window| {
+                    needs_correlation[index]
+                        && !window.app_name.is_empty()
+                        && window
+                            .app_name
+                            .eq_ignore_ascii_case(&atspi[atspi_index].app_name)
+                }) == Some(native_index)
             })
         });
         let Some(index) = app_match else { continue };
@@ -3262,6 +3279,7 @@ fn enrich_native_windows(mut native: Vec<WindowInfo>, atspi: Vec<WindowInfo>) ->
             continue;
         }
         claimed.insert(index);
+        let window = &mut native[native_index];
         window.pid = candidate.pid;
         let toplevel = Toplevel {
             title: undecorated_native_title(window).to_owned(),
@@ -3286,6 +3304,19 @@ fn enrich_native_windows(mut native: Vec<WindowInfo>, atspi: Vec<WindowInfo>) ->
         window.is_on_screen = candidate.is_on_screen;
     }
     native
+}
+
+fn unique_native_match(
+    windows: &[WindowInfo],
+    matches: impl Fn(usize, &WindowInfo) -> bool,
+) -> Option<usize> {
+    let mut matching = windows
+        .iter()
+        .enumerate()
+        .filter(|(index, window)| matches(*index, window))
+        .map(|(index, _)| index);
+    let index = matching.next()?;
+    matching.next().is_none().then_some(index)
 }
 
 fn unique_unclaimed_match(
@@ -3563,6 +3594,31 @@ mod tests {
             ),
             (0, 0, 0, 0)
         );
+    }
+
+    #[test]
+    fn native_enrichment_refuses_one_atspi_candidate_for_two_native_rows() {
+        let mut first = window(77, None, "First tab [chromium]");
+        first.app_name = "chromium".into();
+        let mut second = window(78, None, "Second tab [chromium]");
+        second.app_name = "chromium".into();
+        let mut accessible = window(41_005 << 16, Some(41_005), "Chromium");
+        accessible.app_name = "Chromium".into();
+        accessible.x = 20;
+        accessible.y = 30;
+        accessible.width = 800;
+        accessible.height = 600;
+
+        let enriched = enrich_native_windows(vec![first, second], vec![accessible]);
+
+        assert_eq!((enriched[0].xid, enriched[1].xid), (77, 78));
+        for window in enriched {
+            assert_eq!(window.pid, None);
+            assert_eq!(
+                (window.x, window.y, window.width, window.height),
+                (0, 0, 0, 0)
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Repairs the native Wayland `list_windows -> get_window_state` chain when wlroots foreign-toplevel discovery and AT-SPI observe the same window through different identifier spaces.

When a native Wayland row can be correlated **uniquely in both directions** with an AT-SPI top-level, `list_windows` now returns the already-supported, stable AT-SPI target ID together with its PID and bounds. That ID is accepted by the existing semantic path, while the original foreign-toplevel identity is retained for Wayland activation.

## Safety contract

Correlation fails closed. No AT-SPI ID/PID/bounds are adopted unless:

1. exactly one unclaimed AT-SPI candidate matches; and
2. exactly one native Wayland row matches that same candidate.

This prevents two same-app native windows from being accidentally associated with one AT-SPI tree. The regression suite covers both `2 AT-SPI -> 1 native` and `2 native -> 1 AT-SPI` ambiguity.

## Scope

- Case-insensitive app-id correlation only as a unique fallback (`chromium` / `Chromium`).
- Exact title correlation remains preferred.
- No new API fields, Hyprland helper, shell integration, or host-side workaround.

## Validation

```text
cargo fmt --check --package platform-linux
cargo test -p platform-linux --lib
# 312 passed, 8 ignored
```

Relates to #3247.
