### PR TITLE
Remove warning about image digest usage

### DIFF
--- a/docs/content/docs/how-to-guides/sandbox/run-omarchy-on-cloud-fleet.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/run-omarchy-on-cloud-fleet.mdx
@@ -16,12 +16,6 @@ as a KubeVirt `containerDisk`; the guest starts Hyprland and exposes both the
   does not run on Fleet.
 </Callout>
 
-<Callout type="warn">
-  Use an immutable image digest. The example digest below passed two fresh Fleet claims with
-  screenshot, shell, mouse, keyboard, clipboard, window discovery, and workspace hotkey checks.
-  Fleet admission and image availability must be enabled for your account before a claim can start.
-  Do not replace the digest with `latest` in production automation.
-</Callout>
 
 ## Before you start
 


### PR DESCRIPTION
Removed warning about using an immutable image digest for production automation.

<!--
Keep this description current as scope and evidence change. Do not include
credentials, private user data, sensitive screenshots, or vulnerability details.
Preserve external contributor authorship when their code or design ships.
While this pull request is a draft, use this description as the live record of
scope, progress, blockers, and evidence rather than posting periodic status comments.
-->

## Summary

- Problem this solves:
- What changed:

<!-- Describe observable behavior. Do not narrate the diff file by file. -->

## Related work

<!-- Use Fixes only when this PR fully resolves the issue. Otherwise use Refs. -->

Refs #

RFC (required for a public SDK, CLI, MCP, protocol, compatibility, permission,
or cross-component contract change):

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact:
- Risk and rollback:

## Validation

- Focused tests and checks:
- Manual or platform evidence:
- Known gaps or CI still required:

## Contributor and release checks

- [ ] The PR is focused and the description matches the final diff.
- [ ] This change does not require an RFC, or the accepted RFC is linked above.
- [ ] Tests, documentation, and platform evidence are included or the gap is explained.
- [ ] The PR title is a Conventional Commit describing the production change.
- [ ] External contributor authorship is preserved, or no external contribution is included.
- [ ] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.
