### PR TITLE
docs(cua-driver): add MiniMax provider guide

### DIFF
--- a/docs/content/docs/use-cua-with/index.mdx
+++ b/docs/content/docs/use-cua-with/index.mdx
@@ -6,6 +6,7 @@ description: Choose a model provider, agent harness, or local runtime for Cua Dr
 import { Card, Cards } from 'fumadocs-ui/components/card';
 import { SiAnthropic, SiGooglegemini, SiMeta, SiOllama, SiOpenai } from 'react-icons/si';
 import {
+  AudioWaveform,
   Bot,
   BrainCircuit,
   Cpu,
@@ -44,6 +45,9 @@ These pages show the verified harnesses and local runtimes that can put each mod
   </Card>
   <Card icon={<MoonStar />} title="Kimi" href="/use-cua-with/kimi">
     Connect Kimi Code CLI through its MCP support.
+  </Card>
+  <Card icon={<AudioWaveform />} title="MiniMax" href="/use-cua-with/minimax">
+    Use MiniMax M-series models through Codex or Claude Code.
   </Card>
 </Cards>
 

--- a/docs/content/docs/use-cua-with/meta.json
+++ b/docs/content/docs/use-cua-with/meta.json
@@ -11,6 +11,7 @@
     "meta",
     "qwen",
     "kimi",
+    "minimax",
     "---Agent harnesses---",
     "claude-code",
     "codex",

--- a/docs/content/docs/use-cua-with/minimax.mdx
+++ b/docs/content/docs/use-cua-with/minimax.mdx
@@ -1,0 +1,19 @@
+---
+title: MiniMax
+description: Use MiniMax M-series models with Cua Driver through Codex or Claude Code.
+icon: AudioWaveform
+---
+
+MiniMax documents M-series model configurations for both Codex and Claude Code. Configure the harness to use MiniMax, then connect that same harness to Cua Driver over MCP.
+
+Choose the path for your harness:
+
+| Start here when…                    | Recommended path                                                                                                                                                                                         |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| You use Codex                       | Follow MiniMax's [Codex setup](https://platform.minimax.io/docs/token-plan/codex), then [connect Codex to Cua Driver](/use-cua-with/codex)                                                               |
+| You use Claude Code                 | Follow MiniMax's [Claude Code setup](https://platform.minimax.io/docs/token-plan/claude-code), then [connect Claude Code to Cua Driver](/use-cua-with/claude-code)                                       |
+| You use another MCP-capable harness | Configure MiniMax using its [model invocation guide](https://platform.minimax.io/docs/guides/text-generation), then [add Cua Driver over MCP](/how-to-guides/driver/connect-your-agent#generic-mcp-json) |
+
+Cua Driver supplies desktop state and actions. The harness owns the MiniMax model connection, reasoning loop, and tool selection.
+
+MiniMax recommends its Anthropic-compatible API for direct model calls and also provides an OpenAI-compatible API. Use the upstream guides above for the supported endpoints, model names, and authentication settings.


### PR DESCRIPTION
## Summary

- add a MiniMax provider page under **Use Cua with**
- route Codex and Claude Code users through MiniMax's official setup guides before connecting Cua Driver over MCP
- add MiniMax to the provider navigation and landing-page cards

## Scope

This is a docs-only provider guide. It does not add the separate native MiniMax Code client support proposed in #2978.

## Validation

- `prettier --check`
- `docs:check-hygiene`
- `docs:check-links` (0 errors)
- Next.js production build (129 static pages)
- local route verified at `/docs/use-cua-with/minimax`