### PR TITLE
fix(cua-driver): make agent plugin use bundled MCP

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -24,6 +24,7 @@
     "f@trycua.com": "f-trycua",
     "fbonacci@fbonacci-xfce-vm.b40fumexvs1ujlod2ppcyfh5qa.bx.internal.cloudapp.net": "f-trycua",
     "i@jyunko.cn": "HsiangNianian",
+    "jf-mac-mini@jf-mac-mini-4.local": "0xjohnnydev",
     "klymenko@adobe.com": "pavelklymenko",
     "m.fuechtenkoetter@posteo.de": "ai-ag2026",
     "manfred@ubuntu26.04-vm": "ai-ag2026",

--- a/.prettierignore
+++ b/.prettierignore
@@ -31,6 +31,11 @@ venv/
 pnpm-lock.yaml
 uv.lock
 
+# Generated Cua Driver agent plugin payload (README remains hand-written)
+libs/cua-driver/plugins/cua-driver/.*-plugin/
+libs/cua-driver/plugins/cua-driver/.mcp.json
+libs/cua-driver/plugins/cua-driver/skills/
+
 # Auto-generated docs source
 docs/.source/
 docs/next-env.d.ts

--- a/libs/cua-driver/plugins/cua-driver/README.md
+++ b/libs/cua-driver/plugins/cua-driver/README.md
@@ -25,11 +25,14 @@ The plugin does not install or update the native `cua-driver` executable.
   embedding references
 - Manifests for Claude Code, Grok Build, and Codex CLI
 
+The plugin uses the bundled MCP server and does not fall back to shell commands
+or another computer-use provider when that server is unavailable.
+
 Start a new agent session after installing or updating the plugin. Begin with a
 read-only prompt such as:
 
 ```text
-Use Cua Driver to list the visible applications and windows. Do not interact
+Use $cua-driver to list the visible applications and windows. Do not interact
 with them yet.
 ```
 

--- a/libs/cua-driver/plugins/cua-driver/skills/cua-driver/BROWSER.md
+++ b/libs/cua-driver/plugins/cua-driver/skills/cua-driver/BROWSER.md
@@ -1,3 +1,7 @@
+> **Plugin transport rule:** Use the bundled `cua-driver` MCP tools for every operation in this file.
+> Treat any `cua-driver ...` shell command as standalone documentation only; do not execute it from the plugin.
+> If a matching MCP tool is unavailable, stop instead of falling back to a shell command or another provider.
+
 # Browser automation
 
 Use this guide for page content in Chromium-family browsers and Electron.

--- a/libs/cua-driver/plugins/cua-driver/skills/cua-driver/EMBEDDING.md
+++ b/libs/cua-driver/plugins/cua-driver/skills/cua-driver/EMBEDDING.md
@@ -1,3 +1,7 @@
+> **Plugin transport rule:** Use the bundled `cua-driver` MCP tools for every operation in this file.
+> Treat any `cua-driver ...` shell command as standalone documentation only; do not execute it from the plugin.
+> If a matching MCP tool is unavailable, stop instead of falling back to a shell command or another provider.
+
 # Embedding cua-driver in your application without introducing new permissions
 
 This guide is for teams shipping a macOS app (an "agent harness") that wants

--- a/libs/cua-driver/plugins/cua-driver/skills/cua-driver/LINUX.md
+++ b/libs/cua-driver/plugins/cua-driver/skills/cua-driver/LINUX.md
@@ -1,3 +1,7 @@
+> **Plugin transport rule:** Use the bundled `cua-driver` MCP tools for every operation in this file.
+> Treat any `cua-driver ...` shell command as standalone documentation only; do not execute it from the plugin.
+> If a matching MCP tool is unavailable, stop instead of falling back to a shell command or another provider.
+
 # cua-driver — Linux
 
 The Linux backend drives X11 apps **in the background**: clicks and

--- a/libs/cua-driver/plugins/cua-driver/skills/cua-driver/MACOS.md
+++ b/libs/cua-driver/plugins/cua-driver/skills/cua-driver/MACOS.md
@@ -1,3 +1,7 @@
+> **Plugin transport rule:** Use the bundled `cua-driver` MCP tools for every operation in this file.
+> Treat any `cua-driver ...` shell command as standalone documentation only; do not execute it from the plugin.
+> If a matching MCP tool is unavailable, stop instead of falling back to a shell command or another provider.
+
 # cua-driver — macOS specifics
 
 This file is the macOS-specific extension to `SKILL.md`.

--- a/libs/cua-driver/plugins/cua-driver/skills/cua-driver/RECORDING.md
+++ b/libs/cua-driver/plugins/cua-driver/skills/cua-driver/RECORDING.md
@@ -1,3 +1,7 @@
+> **Plugin transport rule:** Use the bundled `cua-driver` MCP tools for every operation in this file.
+> Treat any `cua-driver ...` shell command as standalone documentation only; do not execute it from the plugin.
+> If a matching MCP tool is unavailable, stop instead of falling back to a shell command or another provider.
+
 # Recording & replaying trajectories
 
 > **Cross-platform.** Recording is available on macOS (native

--- a/libs/cua-driver/plugins/cua-driver/skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/plugins/cua-driver/skills/cua-driver/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cua-driver
-description: Drive a native GUI app (macOS, Windows, Linux) via the cua-driver CLI (default) or MCP server; snapshot its accessibility tree, act through snapshot-bound element tokens, native menu paths, exact window geometry, or pixel coordinates, and verify from fresh state. Use when the user asks you to operate, drive, automate, or perform a GUI task in a real application on the host, or to continue, resume, or recall recent Cua activity.
+description: Use the bundled Cua Driver MCP server only when explicitly invoked as `$cua-driver` or selected through the Cua Driver plugin. Do not use for generic or plain-language computer-use requests.
 metadata:
   openclaw:
     requires:
@@ -28,12 +28,16 @@ metadata:
     homepage: https://cua.ai/docs/cua-driver
 ---
 
+> **Plugin transport rule:** Use the bundled `cua-driver` MCP tools for every operation in this file.
+> Treat any `cua-driver ...` shell command as standalone documentation only; do not execute it from the plugin.
+> If a matching MCP tool is unavailable, stop instead of falling back to a shell command or another provider.
+
 # cua-driver
 
-Orchestrates cross-platform app automation via `cua-driver`. Whenever
-a user asks to drive a native app, follow the loop in this skill
-rather than calling tools ad-hoc — the snapshot-before-action
-invariant is not optional and silently breaks if you skip it.
+Orchestrates cross-platform app automation via the bundled `cua-driver`
+MCP server. After this Skill has been explicitly invoked, follow the loop below
+rather than calling tools ad-hoc — the snapshot-before-action invariant is not
+optional and silently breaks if you skip it.
 
 ## Consult recent Cua activity only for continuation
 
@@ -107,11 +111,10 @@ before stopping or advancing:
 5. **Desktop fallback.** Select an exact desktop target for that call only.
    Later calls may return to an exact window target in the same session.
 
-Use Cua Driver when the outcome lives in an application's UI or window state,
-or when the user explicitly asks to operate that GUI. Once the task crosses
-that boundary, do not replace Cua's targeted and verified actions with shell
-scripts that mutate the app UI. A shell is a capability of the calling agent,
-not of the Cua Driver MCP server; an MCP-only client must not assume one exists.
+After this Skill has been explicitly invoked, use Cua Driver for outcomes in
+an application's UI or window state. Do not treat a generic GUI request as
+authorization to load or route through this Skill. Do not replace Cua's
+targeted and verified actions with shell scripts that mutate the app UI.
 
 ### Filesystem outcomes and GUI fallbacks
 
@@ -182,23 +185,22 @@ window ladder has been attempted and verified. Permission policy must still
 admit the display resource. Never infer desktop permission from a failed action
 or a public session label.
 
-## GUI transport defaults — prefer cua-driver over GUI shell shims
+## GUI transport defaults — use the bundled MCP server
 
-**Default transport is the `cua-driver` CLI** — `Bash` shelling out
-to `cua-driver <tool-name> '<JSON-args>'`. MCP tools (prefix
-`mcp__cua-driver__*`) only when the user explicitly asks for them.
-CLI wins because it picks up rebuilds instantly, failures are
-easier to diagnose, and there's no per-tool schema-load overhead.
+**Default transport is the bundled `cua-driver` MCP server.** Use its exposed
+tools for every Cua Driver operation in this skill.
+Do not shell out to `cua-driver`.
 
-Every reference to `click(...)`, `get_window_state(...)` etc. in this
-skill means `cua-driver click '{...}'` — translate to MCP form only
-when MCP is requested.
+If the bundled MCP tools are unavailable or the server cannot start, report the
+exact installation or connection failure and stop. Do not silently fall back
+to the host's built-in computer-use provider (including Codex Computer Use or
+`@oai/sky`), AppleScript, another MCP server, or any other provider.
 
 ### Claude Code computer-use compatibility mode
 
-For normal Claude Code use, keep the default CLI or `cua-driver` MCP
-server path above. If the user explicitly wants Claude Code's
-vision/computer-use-style flow, they can register:
+For normal Claude Code plugin use, keep the bundled `cua-driver` MCP server
+path above. The compatibility registration command below is standalone setup
+for users configuring Claude Code outside the plugin:
 
 ```bash
 cua-driver mcp-config --client claude   # then paste + run the printed line
@@ -219,7 +221,10 @@ still work as CuaDriver calls, but they do not expose the
 `mcp__cua-computer-use__screenshot` tool name that Claude Code
 appears to use as the image-grounding cue.
 
-## Using cua-driver from the shell
+## Standalone CLI reference — not for plugin execution
+
+The commands below document standalone Cua Driver use. Plugin workflows must
+use the bundled MCP tools and must not execute these shell forms.
 
 Tool names are `snake_case`, management subcommands are
 `kebab-case` — no ambiguity. Tools invoked as `cua-driver
@@ -556,7 +561,7 @@ Use the `effect`, `route`, optional `delivery`, `evidence`, and
 success” above. The old `verified`, `path`, coordinates, scope, and
 `escalation.recommended` response fields no longer exist.
 The full wire contract and 0.14 migration notes are in
-`../../../docs/action-result-contract.md`.
+[`action-result-contract.md`](action-result-contract.md).
 
 A successful accessibility value write can still return
 `effect:"unverifiable"` when the provider publishes its new value only after

--- a/libs/cua-driver/plugins/cua-driver/skills/cua-driver/WINDOWS.md
+++ b/libs/cua-driver/plugins/cua-driver/skills/cua-driver/WINDOWS.md
@@ -1,9 +1,13 @@
+> **Plugin transport rule:** Use the bundled `cua-driver` MCP tools for every operation in this file.
+> Treat any `cua-driver ...` shell command as standalone documentation only; do not execute it from the plugin.
+> If a matching MCP tool is unavailable, stop instead of falling back to a shell command or another provider.
+
 # cua-driver — Windows
 
-Orchestrates Windows app automation via the `cua-driver` binary (`cua-driver.exe`). Whenever a user
-asks to drive a native Windows app, follow the loop in this doc
-rather than calling tools ad-hoc — the snapshot-before-action
-invariant is not optional and silently breaks if you skip it.
+Extends an explicitly invoked Cua Driver plugin task with Windows-specific
+automation guidance. Follow the loop in this document rather than calling tools
+ad-hoc — the snapshot-before-action invariant is not optional and silently
+breaks if you skip it.
 
 `SKILL.md` in this directory describes the cross-platform core;
 this file is the Windows-specific extension. Read both:
@@ -318,21 +322,16 @@ on a Chromium target falls through to `send_click_synthesized`
   so the tool response is not proof that the previous foreground has already
   been restored.
 
-## Defaults — always prefer cua-driver over shell shims
+## Defaults — use the bundled MCP server
 
-**Default transport is the `cua-driver` CLI** — `Bash` shelling out
-to `cua-driver <tool-name>` with JSON piped via stdin (avoids
-PowerShell 5.1's argv quoting quirks for strings containing both
-quotes and spaces). MCP tools (prefix `mcp__cua-driver__*`) only when
-the user explicitly asks for them. CLI wins because it picks up
-rebuilds instantly, failures are easier to diagnose, and there's no
-per-tool schema-load overhead.
+The plugin's default transport is the bundled `cua-driver` MCP server. Use its
+exposed tools for every Cua Driver operation in this document. Do not shell out
+to `cua-driver`, and apply the same no-fallback rule from `SKILL.md`.
 
-Every reference to `click(...)`, `get_window_state(...)` etc. in this
-doc means `cua-driver <name>` with JSON piped via stdin — translate
-to MCP form only when MCP is requested.
+### Standalone CLI argument reference
 
-### CLI argument plumbing on Windows
+The forms below are for users configuring Cua Driver outside the plugin.
+Plugin workflows must keep using the bundled MCP tools.
 
 Three equivalent shapes for passing JSON to `cua-driver <tool>`:
 
@@ -497,7 +496,10 @@ your prior tool calls earned.
      may flag the unsigned binary on first run. Click "More info →
      Run anyway" once.
 
-## Using cua-driver from the shell
+## Standalone CLI reference — not for plugin execution
+
+The commands below document standalone Cua Driver use. Plugin workflows must
+use the bundled MCP tools and must not execute these shell forms.
 
 Tool names are `snake_case`, management subcommands are
 `kebab-case` — no ambiguity. Tools invoked as `cua-driver call

--- a/libs/cua-driver/plugins/cua-driver/skills/cua-driver/action-result-contract.md
+++ b/libs/cua-driver/plugins/cua-driver/skills/cua-driver/action-result-contract.md
@@ -1,0 +1,145 @@
+# Action results and postcondition verification
+
+Cua Driver 0.15 separates two facts that earlier releases mixed together:
+
+- `ActionResult` says what route the driver used and how strongly it can
+  account for the action itself.
+- `VerifyStateOutput` says whether a caller-defined postcondition is
+  `satisfied`, `unsatisfied`, or `unknown`.
+
+The driver reports these facts. The agent harness owns task meaning, visual
+reading, stop/retry decisions, and movement through the action ladder.
+
+## MCP action result
+
+Every successful action returns a closed `structuredContent` object:
+
+```json
+{
+  "effect": "confirmed",
+  "route": "accessibility",
+  "delivery": {"mode": "background"},
+  "evidence": [{"kind": "value_readback"}]
+}
+```
+
+`effect` and `route` are required.
+
+| Field | Values |
+| --- | --- |
+| `effect` | `confirmed`, `partial`, `unverifiable`, `suspected_noop`, `refused` |
+| `route` | `accessibility`, `synthetic_events`, `global_input`, `dom`, `trusted_input` |
+| `delivery.mode` | `background`, `foreground`, `not_applicable`, `unknown` |
+| `evidence[].kind` | `value_readback`, `window_change` |
+| `escalation.target` | `pixel`, `foreground`, `page`, `session` |
+| `escalation.reason` | `route_unavailable`, `delivery_failed`, `effect_unconfirmed`, `suspected_noop`, `permission_required` |
+
+The action-result tools are:
+
+`click`, `double_click`, `right_click`, `scroll`, `drag`, `mouse_drag`,
+`parallel_mouse_drag`, `move_cursor`, `mouse_button_down`, `mouse_button_up`,
+`type_text`, `type_text_chars`, `press_key`, `hotkey`, `set_value`,
+`set_window_frame`, `invoke_menu`, `browser_click`, `browser_pointer`, and
+`browser_type`.
+
+Other mutating tools such as application launch, window activation, browser
+navigation, dialogs, uploads, and downloads retain their own typed results.
+
+The contract is deliberately closed. It does not echo selectors, coordinates,
+scope, targets, platform transport names, diagnostic pointers, or the old
+`verified` boolean.
+
+The invariants are:
+
+- `confirmed` has publishable readback or window-change evidence;
+- `partial` has `delivery.delivered_count`;
+- `refused` has neither delivery nor evidence.
+
+## Window target resolution
+
+Window-scoped actions accept a PID without `window_id` only when that process
+has exactly one eligible top-level window. The driver promotes that unique
+match to an exact `(pid, window_id)` target before dispatch. If the PID owns
+multiple eligible windows, the action fails before sending input with
+`code: "ambiguous_window_target"`, `effect: "refused"`, and a `candidates`
+array containing each candidate's `window_id`, title, application name when
+available, and on-screen state. Call `list_windows({pid})`, select the intended
+candidate, and retry with its explicit `window_id`.
+
+A PID with no eligible windows fails with `code: "window_target_not_found"`.
+Explicit `window_id` targets and `element_token` targets retain their exact
+resolution semantics; the guard does not replace or reinterpret them.
+
+An action that reached an actuator but lacks a trusted readback is
+`unverifiable`, not `confirmed`. Screenshot change, native API acceptance,
+event receipt, and operator observation may remain useful internal diagnostics,
+but they do not independently justify `confirmed`.
+
+## Verification remains separate
+
+After an action, use `verify_state` for a bounded structured postcondition.
+`satisfied` is the only successful terminal status. `unsatisfied` can justify a
+retry or another ladder route. `unknown` means the available observation could
+not prove either answer and must never be promoted to success.
+
+When `include_screenshot` is enabled, the screenshot is uninterpreted evidence.
+A multimodal harness reads it and decides whether to stop, retry, or advance.
+
+## SDK access
+
+Rust, Python, and TypeScript keep the transport-neutral `ToolResult` envelope:
+text, images, structured JSON, error state/code, degraded state, and raw JSON.
+The ambiguous `verified` field is removed.
+
+Successful action calls expose the typed value at `result.action`; successful
+`verify_state` calls expose it at `result.verification`. In Rust the equivalent
+borrow accessors are `result.action()` and `result.verification()`.
+
+```python
+result = await driver.click(click_input)
+if result.action.effect is ActionEffect.CONFIRMED:
+    verification = await driver.verify_state(expectation)
+    if verification.verification.status is VerificationStatus.SATISFIED:
+        return "done"
+```
+
+```ts
+const result = await driver.click(input)
+if (result.action?.effect === ActionEffect.Confirmed) {
+  const checked = await driver.verifyState(expectation)
+  if (checked.verification?.status === VerificationStatus.Satisfied) {
+    return "done"
+  }
+}
+```
+
+## Escalation belongs to the harness
+
+An optional escalation is advice, not an automatic retry:
+
+| Target | Harness action |
+| --- | --- |
+| `pixel` | refresh visual state and choose an exact pixel target |
+| `foreground` | explicitly select foreground delivery when session policy permits |
+| `page` | bind the native window to a supported browser page route |
+| `session` | prepare or explicitly widen the session only when policy permits |
+
+SDK integrators, OpenClaw, Hermes, and other agent hosts can implement different
+policies above this same narrow fact contract without duplicating platform
+actuator details.
+
+## Migration from 0.14
+
+- Replace `result.verified` checks with `result.action.effect` for action facts.
+- Use `result.verification.status` only for `verify_state` postconditions.
+- Replace imports of the removed `ClickOutput`, `DesktopActionOutput`, and
+  `MoveCursorOutput` types with `ActionResult`.
+- Do not read coordinates, `scope`, `path`, `transport`, or request targets from
+  an action response; retain request context in the caller if it is needed.
+- `move_cursor` no longer echoes `x`/`y`; call `get_cursor_position` when the
+  observed pointer location is needed.
+- Treat `unverifiable` as unknown action effect, not failure and not success.
+- Treat MCP `isError` as transport/tool failure; inspect a successful
+  `ActionResult` separately.
+- Upgrade daemon and SDK together. A 0.15 SDK intentionally rejects legacy
+  0.14 action payloads instead of guessing at their meaning.

--- a/libs/cua-driver/plugins/cua-driver/skills/cua-driver/agents/openai.yaml
+++ b/libs/cua-driver/plugins/cua-driver/skills/cua-driver/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Cua Driver"
+  short_description: "Drive native apps through bundled Cua Driver MCP"
+  default_prompt: "Use $cua-driver to inspect the selected app without interacting yet."
+policy:
+  allow_implicit_invocation: false

--- a/libs/cua-driver/scripts/generate-agent-plugin.py
+++ b/libs/cua-driver/scripts/generate-agent-plugin.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shutil
 import sys
 import tempfile
 from pathlib import Path
-
 
 ROOT = Path(__file__).resolve().parents[3]
 DRIVER_ROOT = ROOT / "libs/cua-driver"
@@ -37,6 +37,152 @@ LONG_DESCRIPTION = (
     "teaches the snapshot, action, and verification workflow for safe desktop "
     "automation across macOS, Windows, and Linux."
 )
+
+PLUGIN_SKILL_DESCRIPTION = (
+    "Use the bundled Cua Driver MCP server only when explicitly invoked as "
+    "`$cua-driver` or selected through the Cua Driver plugin. Do not use for "
+    "generic or plain-language computer-use requests."
+)
+
+PLUGIN_TRANSPORT_NOTICE = """> **Plugin transport rule:** Use the bundled `cua-driver` MCP tools for every operation in this file.
+> Treat any `cua-driver ...` shell command as standalone documentation only; do not execute it from the plugin.
+> If a matching MCP tool is unavailable, stop instead of falling back to a shell command or another provider.
+
+"""
+
+SKILL_BODY_START = """---
+
+# cua-driver
+"""
+PLUGIN_SKILL_BODY_START = f"""---
+
+{PLUGIN_TRANSPORT_NOTICE}# cua-driver
+"""
+
+GENERIC_SKILL_INTRO = """Orchestrates cross-platform app automation via `cua-driver`. Whenever
+a user asks to drive a native app, follow the loop in this skill
+rather than calling tools ad-hoc — the snapshot-before-action
+invariant is not optional and silently breaks if you skip it.
+"""
+PLUGIN_SKILL_INTRO = """Orchestrates cross-platform app automation via the bundled `cua-driver`
+MCP server. After this Skill has been explicitly invoked, follow the loop below
+rather than calling tools ad-hoc — the snapshot-before-action invariant is not
+optional and silently breaks if you skip it.
+"""
+
+GENERIC_GUI_ROUTING_BLOCK = """Use Cua Driver when the outcome lives in an application's UI or window state,
+or when the user explicitly asks to operate that GUI. Once the task crosses
+that boundary, do not replace Cua's targeted and verified actions with shell
+scripts that mutate the app UI. A shell is a capability of the calling agent,
+not of the Cua Driver MCP server; an MCP-only client must not assume one exists.
+"""
+PLUGIN_GUI_ROUTING_BLOCK = """After this Skill has been explicitly invoked, use Cua Driver for outcomes in
+an application's UI or window state. Do not treat a generic GUI request as
+authorization to load or route through this Skill. Do not replace Cua's
+targeted and verified actions with shell scripts that mutate the app UI.
+"""
+
+GENERIC_WINDOWS_INTRO = """Orchestrates Windows app automation via the `cua-driver` binary (`cua-driver.exe`). Whenever a user
+asks to drive a native Windows app, follow the loop in this doc
+rather than calling tools ad-hoc — the snapshot-before-action
+invariant is not optional and silently breaks if you skip it.
+"""
+PLUGIN_WINDOWS_INTRO = """Extends an explicitly invoked Cua Driver plugin task with Windows-specific
+automation guidance. Follow the loop in this document rather than calling tools
+ad-hoc — the snapshot-before-action invariant is not optional and silently
+breaks if you skip it.
+"""
+
+CLI_TRANSPORT_BLOCK = """## GUI transport defaults — prefer cua-driver over GUI shell shims
+
+**Default transport is the `cua-driver` CLI** — `Bash` shelling out
+to `cua-driver <tool-name> '<JSON-args>'`. MCP tools (prefix
+`mcp__cua-driver__*`) only when the user explicitly asks for them.
+CLI wins because it picks up rebuilds instantly, failures are
+easier to diagnose, and there's no per-tool schema-load overhead.
+
+Every reference to `click(...)`, `get_window_state(...)` etc. in this
+skill means `cua-driver click '{...}'` — translate to MCP form only
+when MCP is requested.
+"""
+
+PLUGIN_MCP_TRANSPORT_BLOCK = """## GUI transport defaults — use the bundled MCP server
+
+**Default transport is the bundled `cua-driver` MCP server.** Use its exposed
+tools for every Cua Driver operation in this skill.
+Do not shell out to `cua-driver`.
+
+If the bundled MCP tools are unavailable or the server cannot start, report the
+exact installation or connection failure and stop. Do not silently fall back
+to the host's built-in computer-use provider (including Codex Computer Use or
+`@oai/sky`), AppleScript, another MCP server, or any other provider.
+"""
+
+CLAUDE_DEFAULT_TRANSPORT_REFERENCE = """For normal Claude Code use, keep the default CLI or `cua-driver` MCP
+server path above. If the user explicitly wants Claude Code's
+vision/computer-use-style flow, they can register:
+"""
+PLUGIN_CLAUDE_TRANSPORT_REFERENCE = """For normal Claude Code plugin use, keep the bundled `cua-driver` MCP server
+path above. The compatibility registration command below is standalone setup
+for users configuring Claude Code outside the plugin:
+"""
+
+WINDOWS_CLI_TRANSPORT_BLOCK = """## Defaults — always prefer cua-driver over shell shims
+
+**Default transport is the `cua-driver` CLI** — `Bash` shelling out
+to `cua-driver <tool-name>` with JSON piped via stdin (avoids
+PowerShell 5.1's argv quoting quirks for strings containing both
+quotes and spaces). MCP tools (prefix `mcp__cua-driver__*`) only when
+the user explicitly asks for them. CLI wins because it picks up
+rebuilds instantly, failures are easier to diagnose, and there's no
+per-tool schema-load overhead.
+
+Every reference to `click(...)`, `get_window_state(...)` etc. in this
+doc means `cua-driver <name>` with JSON piped via stdin — translate
+to MCP form only when MCP is requested.
+"""
+
+WINDOWS_PLUGIN_MCP_TRANSPORT_BLOCK = """## Defaults — use the bundled MCP server
+
+The plugin's default transport is the bundled `cua-driver` MCP server. Use its
+exposed tools for every Cua Driver operation in this document. Do not shell out
+to `cua-driver`, and apply the same no-fallback rule from `SKILL.md`.
+"""
+
+WINDOWS_CLI_ARGUMENT_HEADING = """### CLI argument plumbing on Windows
+
+"""
+WINDOWS_PLUGIN_CLI_ARGUMENT_HEADING = """### Standalone CLI argument reference
+
+The forms below are for users configuring Cua Driver outside the plugin.
+Plugin workflows must keep using the bundled MCP tools.
+
+"""
+
+SHELL_REFERENCE_HEADING = """## Using cua-driver from the shell
+
+"""
+PLUGIN_SHELL_REFERENCE_HEADING = """## Standalone CLI reference — not for plugin execution
+
+The commands below document standalone Cua Driver use. Plugin workflows must
+use the bundled MCP tools and must not execute these shell forms.
+
+"""
+
+ACTION_RESULT_REFERENCE = """The full wire contract and 0.14 migration notes are in
+`../../../docs/action-result-contract.md`.
+"""
+PORTABLE_ACTION_RESULT_REFERENCE = """The full wire contract and 0.14 migration notes are in
+[`action-result-contract.md`](action-result-contract.md).
+"""
+
+OPENAI_SKILL_CONFIG = """interface:
+  display_name: "Cua Driver"
+  short_description: "Drive native apps through bundled Cua Driver MCP"
+  default_prompt: "Use $cua-driver to inspect the selected app without interacting yet."
+policy:
+  allow_implicit_invocation: false
+"""
 
 WINDOWS_INSTALL_BLOCK = """   If missing, point the user at:
    ```powershell
@@ -99,23 +245,104 @@ def portable_skill_contents(filename: str) -> str:
         )
         if replacements != 1:
             raise SystemExit(f"expected one release version in {source}")
+        contents, replacements = re.subn(
+            r"(?m)^description: .*\n",
+            f"description: {PLUGIN_SKILL_DESCRIPTION}\n",
+            contents,
+        )
+        if replacements != 1:
+            raise SystemExit(f"expected one skill description in {source}")
+        if contents.count(SKILL_BODY_START) != 1:
+            raise SystemExit(f"expected one skill body start in {source}")
+        contents = contents.replace(
+            SKILL_BODY_START,
+            PLUGIN_SKILL_BODY_START,
+        )
+        if contents.count(GENERIC_SKILL_INTRO) != 1:
+            raise SystemExit(f"expected one generic skill intro in {source}")
+        contents = contents.replace(GENERIC_SKILL_INTRO, PLUGIN_SKILL_INTRO)
+        if contents.count(GENERIC_GUI_ROUTING_BLOCK) != 1:
+            raise SystemExit(f"expected one generic GUI routing block in {source}")
+        contents = contents.replace(
+            GENERIC_GUI_ROUTING_BLOCK,
+            PLUGIN_GUI_ROUTING_BLOCK,
+        )
+        if contents.count(CLI_TRANSPORT_BLOCK) != 1:
+            raise SystemExit(f"expected one CLI transport block in {source}")
+        contents = contents.replace(
+            CLI_TRANSPORT_BLOCK,
+            PLUGIN_MCP_TRANSPORT_BLOCK,
+        )
+        if contents.count(ACTION_RESULT_REFERENCE) != 1:
+            raise SystemExit(f"expected one action-result reference in {source}")
+        contents = contents.replace(
+            ACTION_RESULT_REFERENCE,
+            PORTABLE_ACTION_RESULT_REFERENCE,
+        )
+        if contents.count(CLAUDE_DEFAULT_TRANSPORT_REFERENCE) != 1:
+            raise SystemExit(f"expected one Claude transport reference in {source}")
+        contents = contents.replace(
+            CLAUDE_DEFAULT_TRANSPORT_REFERENCE,
+            PLUGIN_CLAUDE_TRANSPORT_REFERENCE,
+        )
     if filename == "WINDOWS.md":
+        if contents.count(GENERIC_WINDOWS_INTRO) != 1:
+            raise SystemExit(f"expected one generic Windows intro in {source}")
+        contents = contents.replace(GENERIC_WINDOWS_INTRO, PLUGIN_WINDOWS_INTRO)
         if contents.count(WINDOWS_INSTALL_BLOCK) != 1:
             raise SystemExit(f"expected one installer block in {source}")
         contents = contents.replace(
             WINDOWS_INSTALL_BLOCK,
             WINDOWS_PORTABLE_INSTALL_BLOCK,
         )
+        if contents.count(WINDOWS_CLI_TRANSPORT_BLOCK) != 1:
+            raise SystemExit(f"expected one Windows CLI transport block in {source}")
+        contents = contents.replace(
+            WINDOWS_CLI_TRANSPORT_BLOCK,
+            WINDOWS_PLUGIN_MCP_TRANSPORT_BLOCK,
+        )
+        if contents.count(WINDOWS_CLI_ARGUMENT_HEADING) != 1:
+            raise SystemExit(f"expected one Windows CLI argument heading in {source}")
+        contents = contents.replace(
+            WINDOWS_CLI_ARGUMENT_HEADING,
+            WINDOWS_PLUGIN_CLI_ARGUMENT_HEADING,
+        )
+    if filename in {"SKILL.md", "WINDOWS.md"}:
+        if contents.count(SHELL_REFERENCE_HEADING) != 1:
+            raise SystemExit(f"expected one shell reference heading in {source}")
+        contents = contents.replace(
+            SHELL_REFERENCE_HEADING,
+            PLUGIN_SHELL_REFERENCE_HEADING,
+        )
+    if filename != "SKILL.md":
+        contents = PLUGIN_TRANSPORT_NOTICE + contents
     return contents
 
 
 def render_package(destination: Path) -> None:
     version = read_version()
+    skill_contents = {filename: portable_skill_contents(filename) for filename in SKILL_FILES}
+    action_result_contract = (DRIVER_ROOT / "docs/action-result-contract.md").read_bytes()
+
+    # 插件目录除手写 README 外均由生成器拥有；先清空，避免重命名后残留旧文件。
+    if destination.exists():
+        for child in destination.iterdir():
+            if child.name == "README.md":
+                continue
+            if child.is_dir() and not child.is_symlink():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+
     skill_destination = destination / "skills/cua-driver"
     skill_destination.mkdir(parents=True, exist_ok=True)
-    for filename in SKILL_FILES:
+    for filename, contents in skill_contents.items():
         target = skill_destination / filename
-        target.write_text(portable_skill_contents(filename), encoding="utf-8")
+        target.write_text(contents, encoding="utf-8")
+    (skill_destination / "action-result-contract.md").write_bytes(action_result_contract)
+    openai_policy = skill_destination / "agents/openai.yaml"
+    openai_policy.parent.mkdir(parents=True, exist_ok=True)
+    openai_policy.write_text(OPENAI_SKILL_CONFIG, encoding="utf-8")
 
     mcp_manifest = {
         "mcpServers": {
@@ -162,7 +389,7 @@ def files_under(root: Path) -> dict[str, bytes]:
     return {
         path.relative_to(root).as_posix(): path.read_bytes()
         for path in sorted(root.rglob("*"))
-        if path.is_file() and path.name != "README.md"
+        if path.is_file() and path != root / "README.md"
     }
 
 

--- a/libs/cua-driver/scripts/tests/test_generate_agent_plugin.py
+++ b/libs/cua-driver/scripts/tests/test_generate_agent_plugin.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import yaml
-
 
 ROOT = Path(__file__).resolve().parents[4]
 DRIVER_ROOT = ROOT / "libs/cua-driver"
 PLUGIN_ROOT = DRIVER_ROOT / "plugins/cua-driver"
 SKILL_SOURCE = DRIVER_ROOT / "rust/Skills/cua-driver"
+GENERATOR_PATH = DRIVER_ROOT / "scripts/generate-agent-plugin.py"
 
 
 def read_json(path: Path) -> dict[str, object]:
@@ -20,13 +22,38 @@ def read_json(path: Path) -> dict[str, object]:
 def test_generated_agent_plugin_is_current() -> None:
     subprocess.run(
         [
-            "python3",
+            sys.executable,
             "libs/cua-driver/scripts/generate-agent-plugin.py",
             "--check",
         ],
         cwd=ROOT,
         check=True,
     )
+
+
+def test_render_package_removes_stale_generated_files(tmp_path: Path) -> None:
+    spec = importlib.util.spec_from_file_location("generate_agent_plugin", GENERATOR_PATH)
+    assert spec is not None and spec.loader is not None
+    generator = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(generator)
+
+    destination = tmp_path / "cua-driver"
+    destination.mkdir()
+    readme = destination / "README.md"
+    readme.write_text("hand-written\n", encoding="utf-8")
+    stale = destination / "skills/cua-driver/obsolete.md"
+    stale.parent.mkdir(parents=True)
+    stale.write_text("obsolete\n", encoding="utf-8")
+    stale_readme = stale.parent / "README.md"
+    stale_readme.write_text("obsolete readme\n", encoding="utf-8")
+
+    assert "skills/cua-driver/README.md" in generator.files_under(destination)
+
+    generator.render_package(destination)
+
+    assert not stale.exists()
+    assert not stale_readme.exists()
+    assert readme.read_text(encoding="utf-8") == "hand-written\n"
 
 
 def test_vendor_manifests_share_identity_and_release_version() -> None:
@@ -59,6 +86,56 @@ def test_plugin_uses_local_cua_driver_stdio_mcp() -> None:
     }
 
 
+def test_plugin_skill_uses_bundled_mcp_without_fallback() -> None:
+    packaged_skill = PLUGIN_ROOT / "skills/cua-driver"
+    packaged_contents = (packaged_skill / "SKILL.md").read_text(encoding="utf-8")
+    frontmatter = yaml.safe_load(packaged_contents.split("---", 2)[1])
+    openai = yaml.safe_load((packaged_skill / "agents/openai.yaml").read_text(encoding="utf-8"))
+    package_skill_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in sorted(packaged_skill.rglob("*.md"))
+    )
+    normalized_skill_text = " ".join(package_skill_text.split())
+
+    assert "explicitly invoked as `$cua-driver`" in frontmatter["description"]
+    assert "plain-language computer-use requests" in frontmatter["description"]
+    assert openai["interface"]["display_name"] == "Cua Driver"
+    assert openai["policy"]["allow_implicit_invocation"] is False
+    assert "Default transport is the bundled `cua-driver` MCP server" in packaged_contents
+    assert "Do not shell out to `cua-driver`" in packaged_contents
+    assert "Do not silently fall back" in packaged_contents
+    assert "Default transport is the `cua-driver` CLI" not in package_skill_text
+    assert "MCP tools (prefix `mcp__cua-driver__*`) only when" not in package_skill_text
+    assert "Whenever a user asks to drive a native app" not in normalized_skill_text
+    assert "Whenever a user asks to drive a native Windows app" not in normalized_skill_text
+    assert (
+        "Use Cua Driver when the outcome lives in an application's UI" not in normalized_skill_text
+    )
+    assert "After this Skill has been explicitly invoked" in normalized_skill_text
+    assert "Extends an explicitly invoked Cua Driver plugin task" in normalized_skill_text
+    assert package_skill_text.count("## Standalone CLI reference — not for plugin execution") == 2
+    transport_notice = "Treat any `cua-driver ...` shell command as standalone documentation only"
+    for filename in {
+        "BROWSER.md",
+        "EMBEDDING.md",
+        "LINUX.md",
+        "MACOS.md",
+        "RECORDING.md",
+        "SKILL.md",
+        "WINDOWS.md",
+    }:
+        assert transport_notice in (packaged_skill / filename).read_text(encoding="utf-8")
+
+
+def test_plugin_skill_bundles_action_result_contract() -> None:
+    packaged_skill = PLUGIN_ROOT / "skills/cua-driver"
+    packaged_contents = (packaged_skill / "SKILL.md").read_text(encoding="utf-8")
+    contract = packaged_skill / "action-result-contract.md"
+
+    assert "[`action-result-contract.md`](action-result-contract.md)" in packaged_contents
+    assert "../../../docs/action-result-contract.md" not in packaged_contents
+    assert contract.read_bytes() == (DRIVER_ROOT / "docs/action-result-contract.md").read_bytes()
+
+
 def test_plugin_skill_is_generated_from_canonical_skill() -> None:
     packaged_skill = PLUGIN_ROOT / "skills/cua-driver"
     expected_files = {
@@ -69,18 +146,16 @@ def test_plugin_skill_is_generated_from_canonical_skill() -> None:
         "BROWSER.md",
         "RECORDING.md",
         "EMBEDDING.md",
+        "action-result-contract.md",
+        "agents/openai.yaml",
     }
-    assert {path.name for path in packaged_skill.iterdir()} == expected_files
+    assert {
+        path.relative_to(packaged_skill).as_posix()
+        for path in packaged_skill.rglob("*")
+        if path.is_file()
+    } == expected_files
 
-    canonical_skill = (SKILL_SOURCE / "SKILL.md").read_text(encoding="utf-8")
     packaged_contents = (packaged_skill / "SKILL.md").read_text(encoding="utf-8")
-    canonical_without_version = "\n".join(
-        line
-        for line in canonical_skill.splitlines()
-        if not line.startswith("version: ")
-    ) + "\n"
-    assert packaged_contents == canonical_without_version
-
     frontmatter = yaml.safe_load(packaged_contents.split("---", 2)[1])
     assert set(frontmatter) <= {
         "name",
@@ -91,10 +166,17 @@ def test_plugin_skill_is_generated_from_canonical_skill() -> None:
     }
     assert frontmatter["name"] == "cua-driver"
 
-    for filename in expected_files - {"SKILL.md", "WINDOWS.md"}:
-        assert (packaged_skill / filename).read_bytes() == (
-            SKILL_SOURCE / filename
-        ).read_bytes()
+    for filename in expected_files - {
+        "SKILL.md",
+        "WINDOWS.md",
+        "action-result-contract.md",
+        "agents/openai.yaml",
+    }:
+        assert (
+            (packaged_skill / filename)
+            .read_bytes()
+            .endswith((SKILL_SOURCE / filename).read_bytes())
+        )
 
     packaged_windows = (packaged_skill / "WINDOWS.md").read_text(encoding="utf-8")
     assert "https://cua.ai/docs/how-to-guides/driver/install" in packaged_windows
@@ -104,13 +186,13 @@ def test_plugin_skill_is_generated_from_canonical_skill() -> None:
 def test_marketplace_readme_requires_separate_native_install() -> None:
     readme = (PLUGIN_ROOT / "README.md").read_text(encoding="utf-8")
     assert "does not install or update" in readme
+    assert "does not fall back" in readme
+    assert "Use $cua-driver" in readme
     assert "curl" not in readme
     assert "cua-driver doctor" in readme
 
     package_text = "\n".join(
-        path.read_text(encoding="utf-8")
-        for path in PLUGIN_ROOT.rglob("*")
-        if path.is_file()
+        path.read_text(encoding="utf-8") for path in PLUGIN_ROOT.rglob("*") if path.is_file()
     )
     assert "curl" not in package_text
     assert "irm https://cua.ai/driver/install.ps1 | iex" not in package_text


### PR DESCRIPTION
## Summary

- make the generated Cua Driver plugin explicit-only and route plugin workflows through the bundled `cua-driver` MCP server
- mark CLI examples as standalone documentation, refuse silent fallback to Codex Computer Use or another provider, and keep the canonical standalone Skill unchanged
- bundle the action-result contract, make regeneration remove stale generated files while preserving the hand-written README, and add regression coverage

## Related work

Refs #2813
Unblocks #3387

This is a stacked PR targeting `feat/cua-driver-agent-plugin`; it does not replace or compete with #3387.

## Compatibility and scope

- no native Cua Driver runtime, MCP wire schema, permission model, or marketplace publication changes
- standalone CLI and standalone MCP installation remain supported by the canonical Skill
- Codex loads the packaged Skill only through explicit `$cua-driver` or plugin selection (`allow_implicit_invocation: false`)

## Validation

- `uvx --with pyyaml --with jsonschema --with toml pytest -q libs/cua-driver/scripts/tests/test_generate_agent_plugin.py .github/scripts/tests/test_release_channels.py .github/scripts/tests/test_validate_release_versions.py` — 32 passed
- `py -3.13 libs/cua-driver/scripts/generate-agent-plugin.py --check`
- `py -3.13 .github/scripts/validate_release_versions.py --product driver`
- Codex plugin validator and Skill quick validator
- repository pre-commit hooks: Prettier, isort, Black, and Ruff passed; TypeScript skipped because no TypeScript files changed
- `cua-driver list-tools` read-only transport preflight

The broader cross-platform script suite on this native Windows host reported 130 passed, 23 skipped, and 31 platform-environment failures because `/bin/bash` is unavailable and Windows symlink creation lacks privilege. Those failing tests do not cover this generator change. Full desktop E2E was not run because this PR does not change runtime behavior or the MCP schema.

## Stacked-base sync

- includes the single contributor identity override already present on current `main` from `b589a6b8f`, because the #3387 base branch predates that required attribution entry

