### PR TITLE
ci: resolve Cua Driver release attribution identity

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -34,6 +34,7 @@
     "rwendt1337@gmail.com": "r33drichards",
     "rsyuzyov@gmail.com": "rsyuzyov",
     "sarinajin.li@gmail.com": "sarinali",
+    "umtcgnd@gmail.com": "c8dhjp4tyv-bit",
     "zane.chee.2023@scis.smu.edu.sg": "injaneity",
     "zongxin_yang@hms.harvard.edu": "z-x-yang"
   },


### PR DESCRIPTION
## Problem

The Cua Driver 0.23.0 Release Please metadata gate cannot resolve the preserved coauthor email from merged PR #3340.

## Change

- Map umtcgnd@gmail.com to @c8dhjp4tyv-bit in the trusted release attribution configuration.
- Preserve the contributor credit already present in the squash commit instead of ignoring or rewriting it.

Identity is verified by #3340: that pull request is authored by @c8dhjp4tyv-bit and contains commits using the exact umtcgnd@gmail.com author email.

## Validation

- 41 focused attribution and release-version tests pass.
- The previously failing merge commit resolves with no unresolved coauthor identities.
- Release versions agree for all components.
- JSON validation and git diff checks pass.

Refs #3340