### PR TITLE
fix(cua-driver): drop schemars uint/float formats from contract schema

### DIFF
--- a/libs/cua-driver/contract/manifest.json
+++ b/libs/cua-driver/contract/manifest.json
@@ -67,12 +67,10 @@
                         "type": "string"
                       },
                       "pid": {
-                        "format": "uint32",
                         "minimum": 0,
                         "type": "integer"
                       },
                       "window_id": {
-                        "format": "uint64",
                         "minimum": 0,
                         "type": "integer"
                       }
@@ -128,7 +126,6 @@
             "additionalProperties": false,
             "properties": {
               "delivered_count": {
-                "format": "uint32",
                 "minimum": 0,
                 "type": [
                   "integer",
@@ -468,12 +465,10 @@
                         "type": "string"
                       },
                       "pid": {
-                        "format": "uint32",
                         "minimum": 0,
                         "type": "integer"
                       },
                       "window_id": {
-                        "format": "uint64",
                         "minimum": 0,
                         "type": "integer"
                       }
@@ -531,7 +526,6 @@
             "additionalProperties": false,
             "properties": {
               "delivered_count": {
-                "format": "uint32",
                 "minimum": 0,
                 "type": [
                   "integer",
@@ -843,39 +837,30 @@
           "motion": {
             "properties": {
               "arc_flow": {
-                "format": "double",
                 "type": "number"
               },
               "arc_size": {
-                "format": "double",
                 "type": "number"
               },
               "dwell_after_click_ms": {
-                "format": "double",
                 "type": "number"
               },
               "end_handle": {
-                "format": "double",
                 "type": "number"
               },
               "glide_duration_ms": {
-                "format": "double",
                 "type": "number"
               },
               "idle_hide_ms": {
-                "format": "double",
                 "type": "number"
               },
               "spring": {
-                "format": "double",
                 "type": "number"
               },
               "start_handle": {
-                "format": "double",
                 "type": "number"
               },
               "turn_radius": {
-                "format": "double",
                 "type": "number"
               }
             },
@@ -895,11 +880,9 @@
           "position": {
             "properties": {
               "x": {
-                "format": "double",
                 "type": "number"
               },
               "y": {
-                "format": "double",
                 "type": "number"
               }
             },
@@ -954,7 +937,6 @@
           "visual_state": {
             "properties": {
               "frame": {
-                "format": "uint64",
                 "minimum": 0,
                 "type": "integer"
               },
@@ -968,7 +950,6 @@
                 "type": "string"
               },
               "preempted_count": {
-                "format": "uint64",
                 "minimum": 0,
                 "type": "integer"
               },
@@ -1268,12 +1249,10 @@
             "type": "boolean"
           },
           "expires_in_seconds": {
-            "format": "uint64",
             "minimum": 0,
             "type": "integer"
           },
           "idle_seconds": {
-            "format": "uint64",
             "minimum": 0,
             "type": "integer"
           },
@@ -1475,12 +1454,10 @@
                         "type": "string"
                       },
                       "pid": {
-                        "format": "uint32",
                         "minimum": 0,
                         "type": "integer"
                       },
                       "window_id": {
-                        "format": "uint64",
                         "minimum": 0,
                         "type": "integer"
                       }
@@ -1529,7 +1506,6 @@
             "additionalProperties": false,
             "properties": {
               "delivered_count": {
-                "format": "uint32",
                 "minimum": 0,
                 "type": [
                   "integer",
@@ -1700,7 +1676,6 @@
             "additionalProperties": false,
             "properties": {
               "delivered_count": {
-                "format": "uint32",
                 "minimum": 0,
                 "type": [
                   "integer",
@@ -1838,7 +1813,6 @@
           },
           "limit": {
             "description": "Maximum number of content-free summaries to return (default 50, max\n100). Ordinary agent transports are scoped to their own lease.",
-            "format": "uint32",
             "minimum": 0,
             "type": [
               "integer",
@@ -1879,12 +1853,10 @@
                   "type": "boolean"
                 },
                 "expires_in_seconds": {
-                  "format": "uint64",
                   "minimum": 0,
                   "type": "integer"
                 },
                 "idle_seconds": {
-                  "format": "uint64",
                   "minimum": 0,
                   "type": "integer"
                 },
@@ -1990,12 +1962,10 @@
                         "type": "string"
                       },
                       "pid": {
-                        "format": "uint32",
                         "minimum": 0,
                         "type": "integer"
                       },
                       "window_id": {
-                        "format": "uint64",
                         "minimum": 0,
                         "type": "integer"
                       }
@@ -2052,7 +2022,6 @@
             "additionalProperties": false,
             "properties": {
               "delivered_count": {
-                "format": "uint32",
                 "minimum": 0,
                 "type": [
                   "integer",
@@ -2215,12 +2184,10 @@
                         "type": "string"
                       },
                       "pid": {
-                        "format": "uint32",
                         "minimum": 0,
                         "type": "integer"
                       },
                       "window_id": {
-                        "format": "uint64",
                         "minimum": 0,
                         "type": "integer"
                       }
@@ -2269,7 +2236,6 @@
             "additionalProperties": false,
             "properties": {
               "delivered_count": {
-                "format": "uint32",
                 "minimum": 0,
                 "type": [
                   "integer",
@@ -2444,12 +2410,10 @@
                         "type": "string"
                       },
                       "pid": {
-                        "format": "uint32",
                         "minimum": 0,
                         "type": "integer"
                       },
                       "window_id": {
-                        "format": "uint64",
                         "minimum": 0,
                         "type": "integer"
                       }
@@ -2506,7 +2470,6 @@
             "additionalProperties": false,
             "properties": {
               "delivered_count": {
-                "format": "uint32",
                 "minimum": 0,
                 "type": [
                   "integer",
@@ -2687,42 +2650,36 @@
         "additionalProperties": false,
         "properties": {
           "arc_flow": {
-            "format": "double",
             "type": [
               "number",
               "null"
             ]
           },
           "arc_size": {
-            "format": "double",
             "type": [
               "number",
               "null"
             ]
           },
           "dwell_after_click_ms": {
-            "format": "double",
             "type": [
               "number",
               "null"
             ]
           },
           "end_handle": {
-            "format": "double",
             "type": [
               "number",
               "null"
             ]
           },
           "glide_duration_ms": {
-            "format": "double",
             "type": [
               "number",
               "null"
             ]
           },
           "idle_hide_ms": {
-            "format": "double",
             "type": [
               "number",
               "null"
@@ -2732,21 +2689,18 @@
             "type": "string"
           },
           "spring": {
-            "format": "double",
             "type": [
               "number",
               "null"
             ]
           },
           "start_handle": {
-            "format": "double",
             "type": [
               "number",
               "null"
             ]
           },
           "turn_radius": {
-            "format": "double",
             "type": [
               "number",
               "null"
@@ -2764,39 +2718,30 @@
           "motion": {
             "properties": {
               "arc_flow": {
-                "format": "double",
                 "type": "number"
               },
               "arc_size": {
-                "format": "double",
                 "type": "number"
               },
               "dwell_after_click_ms": {
-                "format": "double",
                 "type": "number"
               },
               "end_handle": {
-                "format": "double",
                 "type": "number"
               },
               "glide_duration_ms": {
-                "format": "double",
                 "type": "number"
               },
               "idle_hide_ms": {
-                "format": "double",
                 "type": "number"
               },
               "spring": {
-                "format": "double",
                 "type": "number"
               },
               "start_handle": {
-                "format": "double",
                 "type": "number"
               },
               "turn_radius": {
-                "format": "double",
                 "type": "number"
               }
             },
@@ -2990,7 +2935,6 @@
             "additionalProperties": false,
             "properties": {
               "delivered_count": {
-                "format": "uint32",
                 "minimum": 0,
                 "type": [
                   "integer",
@@ -3286,12 +3230,10 @@
                         "type": "string"
                       },
                       "pid": {
-                        "format": "uint32",
                         "minimum": 0,
                         "type": "integer"
                       },
                       "window_id": {
-                        "format": "uint64",
                         "minimum": 0,
                         "type": "integer"
                       }
@@ -3343,7 +3285,6 @@
             "additionalProperties": false,
             "properties": {
               "delivered_count": {
-                "format": "uint32",
                 "minimum": 0,
                 "type": [
                   "integer",
@@ -3633,7 +3574,6 @@
         "additionalProperties": true,
         "properties": {
           "elapsed_ms": {
-            "format": "uint64",
             "minimum": 0,
             "type": "integer"
           },
@@ -3641,7 +3581,6 @@
             "items": {
               "properties": {
                 "index": {
-                  "format": "uint64",
                   "minimum": 0,
                   "type": "integer"
                 },
@@ -3694,7 +3633,6 @@
             "type": "array"
           },
           "samples": {
-            "format": "uint64",
             "minimum": 0,
             "type": "integer"
           },

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/inputs.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/inputs.rs
@@ -30,6 +30,12 @@ fn normalize_schema(value: &mut Value) {
     match value {
         Value::Object(object) => {
             object.remove("title");
+            if matches!(
+                object.get("format").and_then(Value::as_str),
+                Some("uint32" | "uint64" | "double")
+            ) {
+                object.remove("format");
+            }
             if object.get("type").and_then(Value::as_str) == Some("object") {
                 object
                     .entry("properties")
@@ -819,5 +825,29 @@ mod tests {
         }))
         .expect_err("portable input must reject runtime-only fields");
         assert!(error.to_string().contains("unknown field `pid`"));
+    }
+
+    #[test]
+    fn input_normalization_drops_only_schemars_numeric_formats() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "count": {"type": "integer", "format": "uint32"},
+                "frame": {"type": "integer", "format": "uint64"},
+                "ratio": {"type": "number", "format": "double"},
+                "created_at": {"type": "string", "format": "date-time"},
+                "format": {"type": "string"}
+            },
+            "required": ["format"]
+        });
+
+        normalize_schema(&mut schema);
+
+        for property in ["count", "frame", "ratio"] {
+            assert!(schema["properties"][property].get("format").is_none());
+        }
+        assert_eq!(schema["properties"]["created_at"]["format"], "date-time");
+        assert_eq!(schema["properties"]["format"], json!({"type": "string"}));
+        assert_eq!(schema["required"], json!(["format"]));
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/inputs.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/inputs.rs
@@ -6,7 +6,7 @@
 //! These types are transport-free. The contract generator derives JSON Schema
 //! from them, and live Rust handlers deserialize the same types before acting.
 
-use crate::CursorThemeSelection;
+use crate::{schema_settings, CursorThemeSelection};
 use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
@@ -15,11 +15,9 @@ pub trait ToolInput: Serialize + DeserializeOwned + JsonSchema {
     const TOOL_NAME: &'static str;
 
     fn input_schema() -> Value {
-        let settings = schemars::generate::SchemaSettings::draft2020_12().with(|settings| {
-            settings.meta_schema = None;
-            settings.inline_subschemas = true;
-        });
-        let schema = settings.into_generator().into_root_schema_for::<Self>();
+        let schema = schema_settings()
+            .into_generator()
+            .into_root_schema_for::<Self>();
         let mut value = serde_json::to_value(schema).expect("tool input schema serializes");
         normalize_schema(&mut value);
         value
@@ -30,12 +28,6 @@ fn normalize_schema(value: &mut Value) {
     match value {
         Value::Object(object) => {
             object.remove("title");
-            if matches!(
-                object.get("format").and_then(Value::as_str),
-                Some("uint32" | "uint64" | "double")
-            ) {
-                object.remove("format");
-            }
             if object.get("type").and_then(Value::as_str) == Some("object") {
                 object
                     .entry("properties")
@@ -224,11 +216,7 @@ pub enum ActionTarget {
 }
 
 pub fn action_target_schema() -> Value {
-    let settings = schemars::generate::SchemaSettings::draft2020_12().with(|settings| {
-        settings.meta_schema = None;
-        settings.inline_subschemas = true;
-    });
-    let schema = settings
+    let schema = schema_settings()
         .into_generator()
         .into_root_schema_for::<ActionTarget>();
     let mut value = serde_json::to_value(schema).expect("action target schema serializes");
@@ -825,29 +813,5 @@ mod tests {
         }))
         .expect_err("portable input must reject runtime-only fields");
         assert!(error.to_string().contains("unknown field `pid`"));
-    }
-
-    #[test]
-    fn input_normalization_drops_only_schemars_numeric_formats() {
-        let mut schema = json!({
-            "type": "object",
-            "properties": {
-                "count": {"type": "integer", "format": "uint32"},
-                "frame": {"type": "integer", "format": "uint64"},
-                "ratio": {"type": "number", "format": "double"},
-                "created_at": {"type": "string", "format": "date-time"},
-                "format": {"type": "string"}
-            },
-            "required": ["format"]
-        });
-
-        normalize_schema(&mut schema);
-
-        for property in ["count", "frame", "ratio"] {
-            assert!(schema["properties"][property].get("format").is_none());
-        }
-        assert_eq!(schema["properties"]["created_at"]["format"], "date-time");
-        assert_eq!(schema["properties"]["format"], json!({"type": "string"}));
-        assert_eq!(schema["required"], json!(["format"]));
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/lib.rs
@@ -8,6 +8,7 @@
 //! typed inputs/results and versioned declarations used by the live runtime
 //! and to generate experimental client SDKs.
 
+use schemars::{generate::SchemaSettings, transform::RecursiveTransform, Schema};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};
@@ -21,6 +22,24 @@ mod inputs;
 mod outputs;
 mod session;
 mod verification;
+
+pub(crate) fn schema_settings() -> SchemaSettings {
+    SchemaSettings::draft2020_12()
+        .with(|settings| {
+            settings.meta_schema = None;
+            settings.inline_subschemas = true;
+        })
+        .with_transform(RecursiveTransform(drop_schemars_numeric_format))
+}
+
+fn drop_schemars_numeric_format(schema: &mut Schema) {
+    if matches!(
+        schema.get("format").and_then(Value::as_str),
+        Some("uint32" | "uint64" | "double")
+    ) {
+        schema.remove("format");
+    }
+}
 
 pub use cursor::{
     classify_cursor_semantics, CursorAction, CursorDelivery, CursorPlayback, CursorReducedMotion,
@@ -285,6 +304,72 @@ pub fn validate_success_output(name: &str, value: Value) -> Result<bool, String>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Serialize, Deserialize)]
+    struct NumericFormatFixture;
+
+    impl schemars::JsonSchema for NumericFormatFixture {
+        fn schema_name() -> std::borrow::Cow<'static, str> {
+            "NumericFormatFixture".into()
+        }
+
+        fn json_schema(_: &mut schemars::SchemaGenerator) -> Schema {
+            schemars::json_schema!({
+                "type": "object",
+                "properties": {
+                    "count": {"type": "integer", "format": "uint32"},
+                    "frame": {"type": "integer", "format": "uint64"},
+                    "ratio": {"type": "number", "format": "double"},
+                    "created_at": {"type": "string", "format": "date-time"},
+                    "format": {"type": "string"},
+                    "annotation": {
+                        "const": {"format": "uint32"},
+                        "default": {"format": "uint64"},
+                        "examples": [{"format": "double"}]
+                    }
+                },
+                "required": ["format"]
+            })
+        }
+    }
+
+    impl ToolInput for NumericFormatFixture {
+        const TOOL_NAME: &'static str = "numeric_format_fixture";
+    }
+
+    impl ToolOutput for NumericFormatFixture {}
+
+    #[test]
+    fn input_and_output_schemas_drop_only_schemars_numeric_formats() {
+        let schemas = [
+            <NumericFormatFixture as ToolInput>::input_schema(),
+            <NumericFormatFixture as ToolOutput>::output_schema(),
+        ];
+
+        for schema in schemas {
+            for property in ["count", "frame", "ratio"] {
+                assert!(schema["properties"][property].get("format").is_none());
+            }
+            assert_eq!(schema["properties"]["created_at"]["format"], "date-time");
+            assert_eq!(
+                schema["properties"]["format"],
+                serde_json::json!({"type": "string"})
+            );
+            assert_eq!(schema["required"], serde_json::json!(["format"]));
+            assert_eq!(
+                schema["properties"]["annotation"]["const"],
+                serde_json::json!({"format": "uint32"})
+            );
+            assert_eq!(
+                schema["properties"]["annotation"]["default"],
+                serde_json::json!({"format": "uint64"})
+            );
+            assert_eq!(
+                schema["properties"]["annotation"]["examples"],
+                serde_json::json!([{"format": "double"}])
+            );
+        }
+    }
 
     #[test]
     fn manifest_is_sorted_and_versioned() {

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/outputs.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/outputs.rs
@@ -79,6 +79,12 @@ fn strip_schema_titles(value: &mut Value) {
         Value::Object(object) => {
             object.remove("title");
             object.remove("description");
+            if matches!(
+                object.get("format").and_then(Value::as_str),
+                Some("uint32" | "uint64" | "double")
+            ) {
+                object.remove("format");
+            }
             for child in object.values_mut() {
                 strip_schema_titles(child);
             }
@@ -606,6 +612,30 @@ fn nullable_escalation_reason_schema(_: &mut schemars::SchemaGenerator) -> schem
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn output_normalization_drops_only_schemars_numeric_formats() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "count": {"type": "integer", "format": "uint32"},
+                "frame": {"type": "integer", "format": "uint64"},
+                "ratio": {"type": "number", "format": "double"},
+                "created_at": {"type": "string", "format": "date-time"},
+                "format": {"type": "string"}
+            },
+            "required": ["format"]
+        });
+
+        strip_schema_titles(&mut schema);
+
+        for property in ["count", "frame", "ratio"] {
+            assert!(schema["properties"][property].get("format").is_none());
+        }
+        assert_eq!(schema["properties"]["created_at"]["format"], "date-time");
+        assert_eq!(schema["properties"]["format"], json!({"type": "string"}));
+        assert_eq!(schema["required"], json!(["format"]));
+    }
 
     fn object_variant(schema: &Value) -> &Value {
         if schema.get("properties").is_some() {

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/outputs.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/outputs.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Cua AI, Inc.
 
-use crate::{CaptureScope, EscalationReason, Platform};
-use schemars::{generate::SchemaSettings, JsonSchema};
+use crate::{schema_settings, CaptureScope, EscalationReason, Platform};
+use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::BTreeMap;
@@ -56,11 +56,12 @@ pub fn advertised_output_schema(success: Value) -> Value {
 }
 
 fn output_schema_with_additional_properties<T: JsonSchema>(additional_properties: bool) -> Value {
-    let mut settings = SchemaSettings::draft2020_12();
-    settings.inline_subschemas = true;
-    settings.meta_schema = None;
-    let mut schema = serde_json::to_value(settings.into_generator().into_root_schema_for::<T>())
-        .expect("JSON Schema serializes");
+    let mut schema = serde_json::to_value(
+        schema_settings()
+            .into_generator()
+            .into_root_schema_for::<T>(),
+    )
+    .expect("JSON Schema serializes");
     strip_schema_titles(&mut schema);
     if let Some(object) = schema.as_object_mut() {
         object.insert(
@@ -79,12 +80,6 @@ fn strip_schema_titles(value: &mut Value) {
         Value::Object(object) => {
             object.remove("title");
             object.remove("description");
-            if matches!(
-                object.get("format").and_then(Value::as_str),
-                Some("uint32" | "uint64" | "double")
-            ) {
-                object.remove("format");
-            }
             for child in object.values_mut() {
                 strip_schema_titles(child);
             }
@@ -612,30 +607,6 @@ fn nullable_escalation_reason_schema(_: &mut schemars::SchemaGenerator) -> schem
 mod tests {
     use super::*;
     use serde_json::json;
-
-    #[test]
-    fn output_normalization_drops_only_schemars_numeric_formats() {
-        let mut schema = json!({
-            "type": "object",
-            "properties": {
-                "count": {"type": "integer", "format": "uint32"},
-                "frame": {"type": "integer", "format": "uint64"},
-                "ratio": {"type": "number", "format": "double"},
-                "created_at": {"type": "string", "format": "date-time"},
-                "format": {"type": "string"}
-            },
-            "required": ["format"]
-        });
-
-        strip_schema_titles(&mut schema);
-
-        for property in ["count", "frame", "ratio"] {
-            assert!(schema["properties"][property].get("format").is_none());
-        }
-        assert_eq!(schema["properties"]["created_at"]["format"], "date-time");
-        assert_eq!(schema["properties"]["format"], json!({"type": "string"}));
-        assert_eq!(schema["required"], json!(["format"]));
-    }
 
     fn object_variant(schema: &Value) -> &Value {
         if schema.get("properties").is_some() {


### PR DESCRIPTION
## Summary

- Problem this solves: strict JSON Schema clients reject or log every non-standard `uint32`, `uint64`, and `double` format emitted by schemars in `cua-driver`'s MCP `tools/list` response.
- What changed: one shared schemars `RecursiveTransform` removes only those three numeric hints from actual schema nodes for input, output, and action-target generation. Standard formats, properties named `format`, and annotation data under `const`, `default`, and `examples` are preserved. The checked-in manifest is regenerated.

## Related work

No linked issue. This is the focused fix for the client-visible MCP initialization noise reproduced below.

## Compatibility and risk

- User-visible impact: MCP clients no longer receive unsupported schemars numeric format annotations. Existing `type`, `minimum`, and runtime validation remain unchanged.
- API/SDK impact: no UniFFI ABI, Python/TypeScript SDK, tool roster, or platform behavior changes.
- Risk and rollback: limited to generated schema annotations; revert this PR to restore the prior schemas.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p cua-driver-contract --all-targets -- -D warnings`
- `cargo test --locked -p cua-driver-contract` — 33 library tests and 1 generator test passed
- `cargo run --locked -p cua-driver-contract --bin cua-contract-gen -- all --check`
- `cargo test --locked -p cua-driver --test schema_consistency_test portable_desktop_contracts_are_accepted_by_active_backend` — passed against the active macOS backend
- Focused input/output regression proves numeric hints are removed while `date-time`, `properties.format`, `required: ["format"]`, and object values under `const`, `default`, and `examples` survive.

The earlier implementation at `9fc7abb1d` recursively walked annotation data and changed `{"const":{"format":"uint32"}}` to `{"const":{}}`. The candidate at `85d1505fd` applies the rule only to schema nodes and passes the preservation regression.

## Proof

Real transport proof used locally built `cua-driver 0.23.2 mcp --direct`, sent JSON-RPC `initialize` and `tools/list`, then compiled every returned input/output schema with AJV 8.17.1's draft-2020 compiler and strict schema checks (`strictTypes` disabled to isolate keyword/format compatibility).

| Build | Tools returned | Schemas compiled | Numeric `format` annotations | AJV strict-schema result | AJV unknown-format log lines |
| --- | ---: | ---: | ---: | --- | ---: |
| Current `main` `605ce1aec` | 56 | — | 68 (`uint32`: 23, `uint64`: 16, `double`: 29) | Failed on the first `uint64` | 136 |
| PR head `85d1505fd` | 56 | 88 | 0 | All schemas compiled | 0 |

AJV 8.17.1 logs each unknown numeric annotation twice in its non-throwing mode; strict-schema mode fails on the first one. The PR head has neither behavior because the wire response contains none of the unsupported values.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This annotation-only compatibility fix does not require an RFC.
- [x] Tests and real MCP transport evidence are included; no desktop action behavior changed.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] No external contribution is included.
- [x] This is a user-visible Cua Driver fix and should receive the normal patch release; `no-release` is not applicable.
