### PR TITLE
perf(cua-driver): extend configurable pacing to mouse, WebKit settle, and type_text default

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/embedded.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/embedded.rs
@@ -862,6 +862,11 @@ pub(crate) fn allowed_environment_name(name: &str) -> bool {
                 | "CUA_LOG"
                 | "CUA_DRIVER_RS_TELEMETRY_ENABLED"
                 | "CUA_TELEMETRY_ENABLED"
+                | "CUA_DRIVER_RS_MOUSE_PRIMER_MS"
+                | "CUA_DRIVER_RS_CLICK_GAP_MS"
+                | "CUA_DRIVER_RS_MULTI_CLICK_GAP_MS"
+                | "CUA_DRIVER_RS_WEBKIT_SETTLE_MS"
+                | "CUA_DRIVER_RS_TYPE_TEXT_DELAY_MS"
         )
 }
 
@@ -1423,5 +1428,51 @@ mod tests {
 
         assert_eq!(host.state(), EmbeddedDriverHostState::Stopped);
         assert!(!socket_path.exists());
+    }
+
+    /// The pacing knobs must survive both propagation paths into a child
+    /// launch — inherited from the parent environment and supplied as
+    /// explicit overrides. An allowlist miss silently strips a
+    /// deployment's pacing configuration in embedded/worker modes.
+    #[test]
+    fn pacing_knobs_propagate_inherited_and_explicit() {
+        let names = [
+            "CUA_DRIVER_RS_MOUSE_PRIMER_MS",
+            "CUA_DRIVER_RS_CLICK_GAP_MS",
+            "CUA_DRIVER_RS_MULTI_CLICK_GAP_MS",
+            "CUA_DRIVER_RS_WEBKIT_SETTLE_MS",
+            "CUA_DRIVER_RS_TYPE_TEXT_DELAY_MS",
+        ];
+        for name in names {
+            assert!(allowed_environment_name(name), "{name} not allowlisted");
+        }
+        // Inherited: the parent's value rides into the child set.
+        let inherited = names.map(|n| (n.to_owned(), "7".to_owned()));
+        let merged = merge_safe_environment(inherited, &[]);
+        for name in names {
+            assert!(
+                merged
+                    .iter()
+                    .any(|v| v.name.eq_ignore_ascii_case(name) && v.value == "7"),
+                "{name} stripped from the inherited environment"
+            );
+        }
+        // Explicit: an override supplied at launch is accepted.
+        let overrides: Vec<EmbeddedEnvironmentVariable> = names
+            .iter()
+            .map(|n| EmbeddedEnvironmentVariable {
+                name: (*n).to_owned(),
+                value: "3".to_owned(),
+            })
+            .collect();
+        let merged = merge_safe_environment(std::iter::empty(), &overrides);
+        for name in names {
+            assert!(
+                merged
+                    .iter()
+                    .any(|v| v.name.eq_ignore_ascii_case(name) && v.value == "3"),
+                "{name} rejected as an explicit override"
+            );
+        }
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/mod.rs
@@ -12,6 +12,7 @@ pub mod ax_actions;
 pub mod interactive;
 pub mod keyboard;
 pub mod mouse;
+pub(crate) mod pacing;
 pub mod skylight;
 
 pub use ax_actions::perform_ax_action;

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs
@@ -129,7 +129,7 @@ fn click_at_xy_desktop_inner(
                 (pair_index + 1) as i64,
             );
             down.post(CGEventTapLocation::HID);
-            std::thread::sleep(std::time::Duration::from_millis(28));
+            std::thread::sleep(super::pacing::click_gap());
             let up = CGEvent::new_mouse_event(source.clone(), up_ty, point, btn)
                 .map_err(|_| anyhow::anyhow!("CGEvent::new_mouse_event(up) failed"))?;
             up.set_flags(flags);
@@ -139,7 +139,7 @@ fn click_at_xy_desktop_inner(
             );
             up.post(CGEventTapLocation::HID);
             if count > 1 {
-                std::thread::sleep(std::time::Duration::from_millis(80));
+                std::thread::sleep(super::pacing::multi_click_gap());
             }
         }
         Ok(())
@@ -312,7 +312,7 @@ fn click_at_xy_inner(
             // 28 ms down→up gap: an NSButton's mouseDown enters a modal
             // tracking loop that polls for the matching mouseUp; too tight a
             // gap can race the loop's first poll and the click is dropped.
-            std::thread::sleep(std::time::Duration::from_millis(28));
+            std::thread::sleep(super::pacing::click_gap());
 
             let up = CGEvent::new_mouse_event(
                 source.clone(),
@@ -337,7 +337,7 @@ fn click_at_xy_inner(
             );
 
             if count > 1 {
-                std::thread::sleep(std::time::Duration::from_millis(80));
+                std::thread::sleep(super::pacing::multi_click_gap());
             }
         }
         Ok(())
@@ -513,7 +513,7 @@ pub fn click_at_xy_chromium(
         if pair_index < click_pairs {
             // ~80 ms between pairs — under the system double-click threshold,
             // clear of coalescing back into pair N.
-            std::thread::sleep(std::time::Duration::from_millis(80));
+            std::thread::sleep(super::pacing::multi_click_gap());
         }
     }
 
@@ -991,7 +991,7 @@ fn right_click_at_xy_inner(
     // button_number = 1 (right). Stamping 0 here routes the event as a left
     // button-number on the receiving side even though the type is rightMouseDown.
     post_mouse_event(pid, &down, window_local, wid, click_group_id, 1, 1, 3);
-    std::thread::sleep(std::time::Duration::from_millis(28));
+    std::thread::sleep(super::pacing::click_gap());
 
     let up = CGEvent::new_mouse_event(
         source,

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs
@@ -283,7 +283,7 @@ fn click_at_xy_inner(
         // right point. Without it the synthetic mouseDown on a backgrounded
         // AppKit control is silently ignored.
         post_mouse_moved_primer(pid, &source, point, window_local, wid, click_group_id);
-        std::thread::sleep(std::time::Duration::from_millis(12));
+        std::thread::sleep(super::pacing::mouse_primer_settle());
 
         for pair_index in 0..count {
             let click_state = (pair_index + 1) as i64;
@@ -976,7 +976,7 @@ fn right_click_at_xy_inner(
     // Prime cursor-tracking state at the target so AppKit hit-tests the
     // right-down at the right NSView (same rationale as the left path).
     post_mouse_moved_primer(pid, &source, point, window_local, wid, click_group_id);
-    std::thread::sleep(std::time::Duration::from_millis(12));
+    std::thread::sleep(super::pacing::mouse_primer_settle());
 
     let down = CGEvent::new_mouse_event(
         source.clone(),
@@ -1171,7 +1171,7 @@ pub fn scroll_wheel_at_xy(
                 .subsec_nanos() as i64,
         ),
     );
-    std::thread::sleep(std::time::Duration::from_millis(12));
+    std::thread::sleep(super::pacing::mouse_primer_settle());
 
     for _ in 0..ticks.max(1) {
         // Fresh source per event, matching the click primitives.

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/pacing.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/pacing.rs
@@ -1,0 +1,77 @@
+//! Deploy-time input pacing knobs.
+//!
+//! Every gap here defaults to the previously hardcoded constant — zero
+//! out-of-the-box behavior change — and is overridable via a
+//! `CUA_DRIVER_RS_*` env var for latency-sensitive deployments, following
+//! the crate's existing override pattern (`CUA_DRIVER_RS_DRAW_SYSTEM_CURSOR`
+//! et al.). Read once per process: pacing is a deploy-time knob, not a
+//! per-call one.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// The duration for `env_value`, falling back to `default_ms` when unset
+/// or unparseable. Pure so the fallback contract is unit-testable without
+/// process-global env mutation.
+fn ms_from(env_value: Option<&str>, default_ms: u64) -> Duration {
+    env_value
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(Duration::from_millis(default_ms))
+}
+
+fn env_ms(cell: &'static OnceLock<Duration>, name: &str, default_ms: u64) -> Duration {
+    *cell.get_or_init(|| ms_from(std::env::var(name).ok().as_deref(), default_ms))
+}
+
+/// Settle after the leading mouseMoved primer.
+/// `CUA_DRIVER_RS_MOUSE_PRIMER_MS`, default 12 (the previous constant).
+pub(crate) fn mouse_primer_settle() -> Duration {
+    static CELL: OnceLock<Duration> = OnceLock::new();
+    env_ms(&CELL, "CUA_DRIVER_RS_MOUSE_PRIMER_MS", 12)
+}
+
+/// Mouse down→up gap within one click.
+/// `CUA_DRIVER_RS_CLICK_GAP_MS`, default 28 (the previous constant).
+pub(crate) fn click_gap() -> Duration {
+    static CELL: OnceLock<Duration> = OnceLock::new();
+    env_ms(&CELL, "CUA_DRIVER_RS_CLICK_GAP_MS", 28)
+}
+
+/// Gap between the down/up pairs of a multi-click.
+/// `CUA_DRIVER_RS_MULTI_CLICK_GAP_MS`, default 80 (the previous constant).
+pub(crate) fn multi_click_gap() -> Duration {
+    static CELL: OnceLock<Duration> = OnceLock::new();
+    env_ms(&CELL, "CUA_DRIVER_RS_MULTI_CLICK_GAP_MS", 80)
+}
+
+/// WebKit DOM focus settle after clicking a text input.
+/// `CUA_DRIVER_RS_WEBKIT_SETTLE_MS`, default 800 (the previous constant).
+pub(crate) fn webkit_settle() -> Duration {
+    static CELL: OnceLock<Duration> = OnceLock::new();
+    env_ms(&CELL, "CUA_DRIVER_RS_WEBKIT_SETTLE_MS", 800)
+}
+
+/// `type_text`'s default inter-character delay in whole ms (feeds the
+/// tool's `delay_ms` argument when the caller omits it).
+/// `CUA_DRIVER_RS_TYPE_TEXT_DELAY_MS`, default 30 (the previous constant).
+pub(crate) fn type_text_default_delay_ms() -> u64 {
+    static CELL: OnceLock<Duration> = OnceLock::new();
+    env_ms(&CELL, "CUA_DRIVER_RS_TYPE_TEXT_DELAY_MS", 30).as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every knob honors its env value and falls back to the default on
+    /// unset or unparseable input.
+    #[test]
+    fn ms_from_parses_and_falls_back() {
+        assert_eq!(ms_from(Some("4"), 28), Duration::from_millis(4));
+        assert_eq!(ms_from(Some("0"), 28), Duration::from_millis(0));
+        assert_eq!(ms_from(Some("junk"), 28), Duration::from_millis(28));
+        assert_eq!(ms_from(Some(""), 28), Duration::from_millis(28));
+        assert_eq!(ms_from(None, 28), Duration::from_millis(28));
+    }
+}

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/click.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/click.rs
@@ -700,10 +700,11 @@ impl Tool for ClickTool {
                     ),
                     fronted,
                 ))) => {
-                    // For text inputs, wait 800ms for WebKit DOM focus to settle
+                    // For text inputs, wait for WebKit DOM focus to settle
+                    // (default 800ms; CUA_DRIVER_RS_WEBKIT_SETTLE_MS overrides)
                     // before returning — matches the Swift reference behaviour.
                     if needs_webkit_delay {
-                        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+                        tokio::time::sleep(crate::input::pacing::webkit_settle()).await;
                     }
                     msg.push_str(&changes.result_suffix());
                     // AX dispatch went through, but AXPerformAction returning

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/type_text.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/type_text.rs
@@ -169,7 +169,12 @@ impl Tool for TypeTextTool {
             let text =
                 cua_driver_core::text_sanitize::strip_trailing_agent_protocol_tags(&input.text)
                     .into_owned();
-            let delay_ms = args.u64_or("delay_ms", 30).min(200);
+            let delay_ms = args
+                .u64_or(
+                    "delay_ms",
+                    crate::input::pacing::type_text_default_delay_ms(),
+                )
+                .min(200);
             if let Some(refusal) = synthesis_preflight(
                 TextDeliveryRoute::UnicodeSynthesis,
                 text.chars().count(),
@@ -229,7 +234,10 @@ impl Tool for TypeTextTool {
                 via_token: _,
             } => (Some(idx), wid),
         };
-        let delay_ms = args.u64_or("delay_ms", 30);
+        let delay_ms = args.u64_or(
+            "delay_ms",
+            crate::input::pacing::type_text_default_delay_ms(),
+        );
         let delivery_mode = super::DeliveryMode::parse(args.opt_str("delivery_mode").as_deref());
         if let Some(error) = screen_sharing_delivery_error(
             crate::input::keyboard::is_screen_sharing_pid(pid),


### PR DESCRIPTION
Companion to #3489 (keyboard key gap): the remaining hardcoded input pacing constants on macOS move behind read-once `CUA_DRIVER_RS_*` env overrides. **Every default is unchanged — zero out-of-the-box behavior change.**

| Constant | Sites | Knob | Default |
|---|---|---|---|
| mouseMoved-primer settle 12ms | 3 (left, right, scroll primer) | `CUA_DRIVER_RS_MOUSE_PRIMER_MS` | 12 |
| click down→up gap 28ms | 3 (warp path, pid path, right-click) | `CUA_DRIVER_RS_CLICK_GAP_MS` | 28 |
| multi-click pair gap 80ms | 3 | `CUA_DRIVER_RS_MULTI_CLICK_GAP_MS` | 80 |
| WebKit DOM-focus settle 800ms | 1 (`click.rs`) | `CUA_DRIVER_RS_WEBKIT_SETTLE_MS` | 800 |
| `type_text` default `delay_ms` 30 | 2 (`type_text.rs`) | `CUA_DRIVER_RS_TYPE_TEXT_DELAY_MS` | 30 (per-call `delay_ms` still wins) |

All knobs share one `ms_from`/`env_ms` helper in a new `input/pacing.rs`, read once per process, with the parse-and-fallback contract unit-tested (`ms_from_parses_and_falls_back`). The 40-100ms warp/settle sleeps on the foreground path are deliberately untouched — those pace cursor restore and AppKit event consumption, not the click itself.

Evidence that tighter pacing holds up where deployments choose it (Swift driver this Rust tree mirrors, measured live against Safari): primer 4ms + click gap 8ms delivered focus-correct clicks with a typed marker read back through an independent AX referee, and inter-character delay 0 with a 2ms key gap typed 136/136 characters exactly.

`cargo test -p platform-macos` — 353 passed. `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)