### PR TITLE
perf(cua-driver): memoize the installed-app scan behind a root-mtime key

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
@@ -426,7 +426,7 @@ fn bundle_id_for_app_path(app_path: &str) -> Option<String> {
 ///   * `kind` (`"desktop"` on macOS).
 pub fn list_all_apps() -> Vec<AppInfo> {
     let mut running = list_running_apps();
-    let installed = scan_installed_apps();
+    let installed = scan_installed_apps_cached();
     // Lookup: bundle_id → (launch_path, last_used) from the installed scan.
     let installed_by_bundle: std::collections::HashMap<String, (Option<String>, Option<String>)> =
         installed
@@ -467,22 +467,75 @@ pub fn list_all_apps() -> Vec<AppInfo> {
     all
 }
 
-fn scan_installed_apps() -> Vec<AppInfo> {
-    let dirs = [
-        "/Applications",
-        "/Applications/Utilities",
-        "/System/Applications",
-        "/System/Applications/Utilities",
-    ];
+/// The app roots `scan_installed_apps` walks, in scan order.
+fn installed_scan_roots() -> Vec<String> {
     let home = std::env::var("HOME").unwrap_or_default();
-    let user_apps = format!("{home}/Applications");
+    vec![
+        "/Applications".to_owned(),
+        "/Applications/Utilities".to_owned(),
+        "/System/Applications".to_owned(),
+        "/System/Applications/Utilities".to_owned(),
+        format!("{home}/Applications"),
+    ]
+}
 
+/// How long a cached installed-app scan stays valid when the root
+/// mtimes still match. The mtime key catches an install/uninstall
+/// instantly (adding or removing a bundle touches its parent
+/// directory); the TTL bounds drift in the per-bundle `last_used`
+/// timestamps, which can change without any root directory noticing.
+const INSTALLED_CACHE_TTL: Duration = Duration::from_secs(30);
+
+/// Whether a cached scan may be served: the root-mtime key must match
+/// and the entry must be younger than the TTL. Pure for unit tests.
+fn installed_cache_is_fresh(
+    cached_key: &[Option<std::time::SystemTime>],
+    key: &[Option<std::time::SystemTime>],
+    age: Duration,
+) -> bool {
+    cached_key == key && age < INSTALLED_CACHE_TTL
+}
+
+/// The mtime of each scan root (`None` for an unreadable root — two
+/// `None`s compare equal, so a permanently missing root still caches).
+fn installed_scan_key(roots: &[String]) -> Vec<Option<std::time::SystemTime>> {
+    roots
+        .iter()
+        .map(|d| std::fs::metadata(d).and_then(|m| m.modified()).ok())
+        .collect()
+}
+
+/// `scan_installed_apps`, memoized. The uncached scan reads every
+/// bundle's Info.plist on every call — hundreds of file reads that
+/// dominate `list_apps` latency (seconds under load) for an answer that
+/// changes only when something is installed or removed.
+fn scan_installed_apps_cached() -> Vec<AppInfo> {
+    struct InstalledCache {
+        key: Vec<Option<std::time::SystemTime>>,
+        at: std::time::Instant,
+        apps: Vec<AppInfo>,
+    }
+    static CACHE: std::sync::Mutex<Option<InstalledCache>> = std::sync::Mutex::new(None);
+
+    let roots = installed_scan_roots();
+    let key = installed_scan_key(&roots);
+    if let Some(cached) = CACHE.lock().unwrap().as_ref() {
+        if installed_cache_is_fresh(&cached.key, &key, cached.at.elapsed()) {
+            return cached.apps.clone();
+        }
+    }
+    let apps = scan_installed_apps();
+    *CACHE.lock().unwrap() = Some(InstalledCache {
+        key,
+        at: std::time::Instant::now(),
+        apps: apps.clone(),
+    });
+    apps
+}
+
+fn scan_installed_apps() -> Vec<AppInfo> {
     let mut result = Vec::new();
-    let mut all_dirs: Vec<&str> = dirs.to_vec();
-    let user_apps_str: &str = user_apps.as_str();
-    all_dirs.push(user_apps_str);
-
-    for dir in all_dirs {
+    for dir in installed_scan_roots() {
         let Ok(entries) = std::fs::read_dir(dir) else {
             continue;
         };
@@ -716,7 +769,9 @@ pub fn format_app_list(apps: &[AppInfo]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{finder_folder_handoff, unix_secs_to_rfc3339};
+    use super::{
+        finder_folder_handoff, installed_cache_is_fresh, unix_secs_to_rfc3339, INSTALLED_CACHE_TTL,
+    };
 
     #[test]
     fn finder_folder_handoff_is_narrowly_selected() {
@@ -781,5 +836,35 @@ mod tests {
     fn rfc3339_known_pre_2000_timestamp() {
         // 1990-07-04T15:30:00Z → 647105400.
         assert_eq!(unix_secs_to_rfc3339(647_105_400), "1990-07-04T15:30:00Z");
+    }
+
+    /// The installed-scan cache serves only a matching root-mtime key
+    /// within the TTL; a changed mtime, an appearing/disappearing root,
+    /// or an expired entry all force a rescan. Two unreadable roots
+    /// (`None` mtimes) compare equal, so a permanently missing root
+    /// still caches.
+    #[test]
+    fn installed_cache_freshness_contract() {
+        use std::time::{Duration, SystemTime};
+        let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+        let t1 = SystemTime::UNIX_EPOCH + Duration::from_secs(2_000);
+        let key = vec![Some(t0), None];
+        let fresh_age = Duration::from_secs(1);
+        assert!(installed_cache_is_fresh(&key, &key.clone(), fresh_age));
+        assert!(!installed_cache_is_fresh(
+            &key,
+            &[Some(t1), None],
+            fresh_age
+        ));
+        assert!(!installed_cache_is_fresh(
+            &key,
+            &[Some(t0), Some(t1)],
+            fresh_age
+        ));
+        assert!(!installed_cache_is_fresh(
+            &key,
+            &key.clone(),
+            INSTALLED_CACHE_TTL
+        ));
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
@@ -509,28 +509,44 @@ fn installed_scan_key(roots: &[String]) -> Vec<Option<std::time::SystemTime>> {
 /// bundle's Info.plist on every call — hundreds of file reads that
 /// dominate `list_apps` latency (seconds under load) for an answer that
 /// changes only when something is installed or removed.
-fn scan_installed_apps_cached() -> Vec<AppInfo> {
-    struct InstalledCache {
-        key: Vec<Option<std::time::SystemTime>>,
-        at: std::time::Instant,
-        apps: Vec<AppInfo>,
-    }
-    static CACHE: std::sync::Mutex<Option<InstalledCache>> = std::sync::Mutex::new(None);
+struct InstalledCache {
+    key: Vec<Option<std::time::SystemTime>>,
+    at: std::time::Instant,
+    apps: Vec<AppInfo>,
+}
 
-    let roots = installed_scan_roots();
-    let key = installed_scan_key(&roots);
-    if let Some(cached) = CACHE.lock().unwrap().as_ref() {
+/// Serve from `cache` or refresh it via `scan`. The lock is held ACROSS
+/// the scan — single-flight: concurrent misses on a cold or expired
+/// cache block behind the one running scan and then serve its result,
+/// instead of each running the expensive walk themselves. The freshness
+/// check re-runs after the lock is acquired, so a waiter that queued
+/// behind a refresh takes the fresh entry without scanning again.
+/// Generic over `scan` so the single-flight contract is testable with a
+/// counting closure.
+fn cached_installed_scan(
+    cache: &std::sync::Mutex<Option<InstalledCache>>,
+    key: Vec<Option<std::time::SystemTime>>,
+    scan: impl FnOnce() -> Vec<AppInfo>,
+) -> Vec<AppInfo> {
+    let mut guard = cache.lock().unwrap();
+    if let Some(cached) = guard.as_ref() {
         if installed_cache_is_fresh(&cached.key, &key, cached.at.elapsed()) {
             return cached.apps.clone();
         }
     }
-    let apps = scan_installed_apps();
-    *CACHE.lock().unwrap() = Some(InstalledCache {
+    let apps = scan();
+    *guard = Some(InstalledCache {
         key,
         at: std::time::Instant::now(),
         apps: apps.clone(),
     });
     apps
+}
+
+fn scan_installed_apps_cached() -> Vec<AppInfo> {
+    static CACHE: std::sync::Mutex<Option<InstalledCache>> = std::sync::Mutex::new(None);
+    let key = installed_scan_key(&installed_scan_roots());
+    cached_installed_scan(&CACHE, key, scan_installed_apps)
 }
 
 fn scan_installed_apps() -> Vec<AppInfo> {
@@ -866,5 +882,43 @@ mod tests {
             &key.clone(),
             INSTALLED_CACHE_TTL
         ));
+    }
+
+    /// Concurrent misses on a cold cache must run exactly one scan
+    /// (single-flight): the lock is held across the refresh, so racers
+    /// queue behind it and serve the fresh entry. The previous shape —
+    /// lock released before scanning — let every racer run the
+    /// expensive walk; under this test that reports 8 scans, not 1
+    /// (verified by mutating the implementation back).
+    #[test]
+    fn concurrent_cold_misses_scan_once() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Mutex};
+        let cache: Arc<Mutex<Option<super::InstalledCache>>> = Arc::new(Mutex::new(None));
+        let scans = Arc::new(AtomicUsize::new(0));
+        let key: Vec<Option<std::time::SystemTime>> = vec![Some(std::time::SystemTime::UNIX_EPOCH)];
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let cache = cache.clone();
+            let scans = scans.clone();
+            let key = key.clone();
+            handles.push(std::thread::spawn(move || {
+                super::cached_installed_scan(&cache, key, || {
+                    scans.fetch_add(1, Ordering::SeqCst);
+                    // Widen the race window: a non-single-flight
+                    // implementation lets every racer enter here.
+                    std::thread::sleep(std::time::Duration::from_millis(30));
+                    Vec::new()
+                })
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(
+            scans.load(Ordering::SeqCst),
+            1,
+            "cold cache scanned more than once"
+        );
     }
 }


### PR DESCRIPTION
## Problem

`list_all_apps` re-walks five app directories and re-reads every bundle's `Info.plist` on **every call** — hundreds of file reads for an answer that changes only when something is installed or removed. Measured against the 0.16 binary under adversarial load (6 CPU spinners, fresh connection per request): `list_apps` p50 **1.2–2.6 s**, dominated by this scan.

## Change

`scan_installed_apps` is memoized behind a two-part key:

- **Root mtimes** — adding or removing a `.app` bundle touches its parent directory, so an install/uninstall invalidates the cache instantly.
- **30s TTL** — per-bundle `last_used` timestamps (filesystem mtime heuristic) can change without any root directory noticing; the TTL bounds that drift.

An unreadable root keys as `None`, and two `None`s compare equal — a permanently missing root (e.g. no `~/Applications`) still caches instead of rescanning forever. Running apps are untouched: `list_running_apps` still runs live on every call, and running entries are still backfilled from the (now cached) installed scan.

The freshness contract (`installed_cache_is_fresh`) is a pure function with a unit test covering: matching key within TTL → serve; changed mtime, appearing/disappearing root, or expired TTL → rescan.

## Numbers

With the equivalent mtime-keyed cache in the Swift driver this Rust tree mirrors, the same adversarial bench answered `list_apps` in **~15–23 ms** (vs 1.2–2.6 s), with correctness checked against `NSWorkspace` ground truth (21/21 running apps, all bundle ids present).

`cargo test -p platform-macos` — 353 passed. `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)