### PR TITLE
feat(cua-driver): make proxy PiP live and dismissible

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/pip_hook.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/pip_hook.rs
@@ -21,7 +21,6 @@ use std::sync::OnceLock;
 /// platform backends pull both crates in).
 pub struct PipHookFrame {
     pub png_bytes: Vec<u8>,
-    pub action_label: String,
     pub timestamp_ms: u64,
 }
 

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -1656,10 +1656,8 @@ impl ToolRegistry {
             let window_id = args.opt_u64("window_id");
             let pid = args.opt_i64("pid");
             if let Some(png_bytes) = screenshot_for(window_id, pid) {
-                let label = synthesize_action_label(name, &public_args);
                 pip_hook::push_pip_frame(pip_hook::PipHookFrame {
                     png_bytes,
-                    action_label: label,
                     timestamp_ms: now_ms(),
                 });
             }
@@ -4728,53 +4726,6 @@ fn recording_args_for(tool_name: &str, args: &Value) -> Value {
 impl Default for ToolRegistry {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-/// Build a short, human-friendly label for the PiP overlay from the
-/// tool name + raw args. Kept under ~60 chars so the macOS NSTextField
-/// has room without truncation at default geometry.
-fn synthesize_action_label(tool_name: &str, args: &Value) -> String {
-    let arg = |k: &str| -> Option<String> {
-        args.get(k).map(|v| match v {
-            Value::String(s) => s.clone(),
-            other => other.to_string(),
-        })
-    };
-    let summary = match tool_name {
-        "click" | "double_click" | "right_click" => {
-            if let Some(idx) = args.opt_u64("element_index") {
-                format!("element_index={idx}")
-            } else if let (Some(x), Some(y)) = (args.opt_f64("x"), args.opt_f64("y")) {
-                format!("({x:.0}, {y:.0})")
-            } else {
-                "".into()
-            }
-        }
-        "type_text" => {
-            let text = arg("text").unwrap_or_default();
-            let trimmed: String = text.chars().take(40).collect();
-            if text.chars().count() > 40 {
-                format!("\"{trimmed}…\"")
-            } else {
-                format!("\"{trimmed}\"")
-            }
-        }
-        "press_key" | "hotkey" => arg("key").or_else(|| arg("keys")).unwrap_or_default(),
-        "scroll" => format!(
-            "dx={} dy={}",
-            arg("dx").unwrap_or_else(|| "0".into()),
-            arg("dy").unwrap_or_else(|| "0".into())
-        ),
-        "drag" => "drag".into(),
-        "set_value" => arg("value").unwrap_or_default(),
-        "launch_app" => arg("bundle_id").or_else(|| arg("name")).unwrap_or_default(),
-        _ => String::new(),
-    };
-    if summary.is_empty() {
-        tool_name.to_owned()
-    } else {
-        format!("{tool_name}: {summary}")
     }
 }
 

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -33,6 +33,9 @@ pub enum Command {
         /// Repeatable trusted launch grants for residual standard-mode
         /// boundaries, for example `--grant existing-profile`.
         grants: Vec<String>,
+        /// Forward the process-local experimental PiP request to a daemon
+        /// launched by the MCP proxy.
+        experimental_pip: bool,
     },
     ListTools,
     Describe(String),
@@ -475,6 +478,11 @@ fn finite_tool_name_from_args(args: &[String]) -> Option<String> {
     }
 }
 
+fn experimental_pip_requested(args: &[String]) -> bool {
+    args.iter()
+        .any(|arg| arg == "--experimental-pip" || arg == "--pip")
+}
+
 /// Parse the first non-flag positional argument from argv to determine which
 /// subcommand to run.  Cursor-overlay flags are consumed by `CursorConfig`
 /// independently; we only care about the first non-`--` arg here.
@@ -711,6 +719,7 @@ pub fn parse_command() -> Command {
     let claude_code_compat = args
         .iter()
         .any(|a| a == "--claude-code-computer-use-compat");
+    let experimental_pip = experimental_pip_requested(&args);
 
     let mut pos = positionals.into_iter();
     match pos.next() {
@@ -741,6 +750,7 @@ pub fn parse_command() -> Command {
                 direct: args.iter().any(|a| a == "--direct"),
                 claude_code_compat,
                 grants: grants.clone(),
+                experimental_pip,
             }
         }
         Some("mcp") => Command::Mcp {
@@ -748,6 +758,7 @@ pub fn parse_command() -> Command {
             direct: args.iter().any(|a| a == "--direct"),
             claude_code_compat,
             grants: grants.clone(),
+            experimental_pip,
         },
         Some("list-tools") => Command::ListTools,
         Some("mcp-config") => Command::McpConfig { client: mcp_client },
@@ -1205,6 +1216,7 @@ pub fn launch_daemon_and_wait(
     claude_code_compat: bool,
     grants: &[String],
     experimental_history: bool,
+    experimental_pip: bool,
 ) -> Result<(), LaunchDaemonError> {
     let state = crate::history_runtime::DaemonLaunchState {
         claude_code_compat,
@@ -1216,6 +1228,7 @@ pub fn launch_daemon_and_wait(
         timeout_secs,
         &state,
         experimental_history,
+        experimental_pip,
         true,
     )
 }
@@ -1226,6 +1239,7 @@ fn launch_daemon_with_state_and_wait(
     timeout_secs: u64,
     state: &crate::history_runtime::DaemonLaunchState,
     experimental_history: bool,
+    experimental_pip: bool,
     _allow_managed_restart: bool,
 ) -> Result<(), LaunchDaemonError> {
     use std::process::{Command as Cmd, Stdio};
@@ -1241,7 +1255,13 @@ fn launch_daemon_with_state_and_wait(
     let app_name = crate::bundle::app_name();
     let app_path = crate::bundle::app_bundle_path();
     let pass_socket = socket_path != crate::serve::default_socket_path();
-    let open_args = daemon_launch_arguments(app_name, socket_path, state, experimental_history);
+    let open_args = daemon_launch_arguments(
+        app_name,
+        socket_path,
+        state,
+        experimental_history,
+        experimental_pip,
+    );
     // Thread the Claude-Code compat flag through to the daemon. Without this
     // the proxy-spawned daemon always called build_macos_registry() (compat
     // hardcoded false), so `cua-driver mcp --claude-code-computer-use-compat`
@@ -1313,6 +1333,7 @@ pub fn launch_daemon_and_wait(
     claude_code_compat: bool,
     grants: &[String],
     experimental_history: bool,
+    experimental_pip: bool,
 ) -> Result<(), LaunchDaemonError> {
     let state = crate::history_runtime::DaemonLaunchState {
         claude_code_compat,
@@ -1324,6 +1345,7 @@ pub fn launch_daemon_and_wait(
         timeout_secs,
         &state,
         experimental_history,
+        experimental_pip,
         true,
     )
 }
@@ -1334,6 +1356,7 @@ fn launch_daemon_with_state_and_wait(
     timeout_secs: u64,
     state: &crate::history_runtime::DaemonLaunchState,
     experimental_history: bool,
+    experimental_pip: bool,
     allow_managed_restart: bool,
 ) -> Result<(), LaunchDaemonError> {
     use std::time::{Duration, Instant};
@@ -1346,7 +1369,8 @@ fn launch_daemon_with_state_and_wait(
         && socket_path == crate::serve::default_socket_path()
         && restart_managed_daemon_if_present(&executable);
     if !managed {
-        let arguments = daemon_process_arguments(socket_path, state, experimental_history);
+        let arguments =
+            daemon_process_arguments(socket_path, state, experimental_history, experimental_pip);
         #[cfg(unix)]
         {
             use std::os::unix::process::CommandExt as _;
@@ -1484,12 +1508,13 @@ fn daemon_process_arguments(
     socket_path: &str,
     state: &crate::history_runtime::DaemonLaunchState,
     experimental_history: bool,
+    experimental_pip: bool,
 ) -> Vec<String> {
     let mut args = vec!["serve".to_owned()];
     if socket_path != crate::serve::default_socket_path() {
         args.extend(["--socket".to_owned(), socket_path.to_owned()]);
     }
-    append_daemon_launch_state(&mut args, state, experimental_history);
+    append_daemon_launch_state(&mut args, state, experimental_history, experimental_pip);
     args
 }
 
@@ -1541,6 +1566,7 @@ fn daemon_launch_arguments(
     socket_path: &str,
     state: &crate::history_runtime::DaemonLaunchState,
     experimental_history: bool,
+    experimental_pip: bool,
 ) -> Vec<String> {
     let mut args = vec![
         "-n".to_owned(),
@@ -1553,7 +1579,7 @@ fn daemon_launch_arguments(
     if socket_path != crate::serve::default_socket_path() {
         args.extend(["--socket".to_owned(), socket_path.to_owned()]);
     }
-    append_daemon_launch_state(&mut args, state, experimental_history);
+    append_daemon_launch_state(&mut args, state, experimental_history, experimental_pip);
     args
 }
 
@@ -1561,6 +1587,7 @@ fn append_daemon_launch_state(
     args: &mut Vec<String>,
     state: &crate::history_runtime::DaemonLaunchState,
     experimental_history: bool,
+    experimental_pip: bool,
 ) {
     if let Some(mode) = &state.permission_mode {
         args.extend(["--permission-mode".to_owned(), mode.clone()]);
@@ -1582,6 +1609,9 @@ fn append_daemon_launch_state(
     }
     if experimental_history {
         args.push("--experimental-history".to_owned());
+    }
+    if experimental_pip {
+        args.push("--experimental-pip".to_owned());
     }
     for grant in &state.grants {
         args.extend(["--grant".to_owned(), grant.clone()]);
@@ -1620,6 +1650,7 @@ pub fn run_mcp_via_daemon_proxy<F>(
     socket: Option<String>,
     claude_code_compat: bool,
     grants: &[String],
+    experimental_pip: bool,
     on_startup: F,
 ) -> anyhow::Result<()>
 where
@@ -1662,9 +1693,14 @@ where
             } else {
                 String::new()
             };
+            let pip_suffix = if experimental_pip {
+                " --experimental-pip"
+            } else {
+                ""
+            };
             eprintln!(
                 "{}: mcp launched without {app_name}.app's TCC grants; \
-                 auto-launching the daemon via `open -n -g -a {app_name} --args serve{socket_suffix}` \
+                 auto-launching the daemon via `open -n -g -a {app_name} --args serve{socket_suffix}{pip_suffix}` \
                  and proxying MCP requests through it.",
                 crate::bundle::cli_name()
             );
@@ -1674,6 +1710,7 @@ where
                 claude_code_compat,
                 grants,
                 crate::history_runtime::preview_admitted_preference(),
+                experimental_pip,
             ) {
                 if let Some(on_startup) = on_startup.take() {
                     on_startup(
@@ -1703,9 +1740,14 @@ where
                      Then re-run `cua-driver mcp`."
                 );
             }
-            if let Err(error) =
-                launch_daemon_and_wait(&socket_path, 10, claude_code_compat, grants, true)
-            {
+            if let Err(error) = launch_daemon_and_wait(
+                &socket_path,
+                10,
+                claude_code_compat,
+                grants,
+                true,
+                experimental_pip,
+            ) {
                 if let Some(on_startup) = on_startup.take() {
                     on_startup(
                         if error.kind == LaunchDaemonErrorKind::Timeout {
@@ -2500,6 +2542,7 @@ pub fn run_history_cmd(
                 &prior_daemon_state,
                 true,
                 false,
+                false,
             ) {
                 rollback_history_preview(
                     &socket_path,
@@ -2645,8 +2688,14 @@ fn rollback_history_preview(
         crate::history_runtime::set_preview_admitted_preference(prior_preview_admitted_preference);
     let _ = stop_history_daemon(socket_path);
     if prior_daemon_was_running && !crate::serve::is_daemon_listening(socket_path) {
-        let _ =
-            launch_daemon_with_state_and_wait(socket_path, 15, prior_daemon_state, false, false);
+        let _ = launch_daemon_with_state_and_wait(
+            socket_path,
+            15,
+            prior_daemon_state,
+            false,
+            false,
+            false,
+        );
     }
 }
 
@@ -3564,6 +3613,7 @@ fn run_permissions_grant() {
                 false,
                 &[],
                 crate::history_runtime::preview_admitted_preference(),
+                false,
             ) {
                 eprintln!("\nDidn't detect the {app_name} daemon: {e}");
                 eprintln!(
@@ -4738,9 +4788,10 @@ mod tests {
             grants,
         };
         #[cfg(target_os = "macos")]
-        let launch = daemon_launch_arguments("CuaDriver", "/tmp/history-test.sock", &state, true);
+        let launch =
+            daemon_launch_arguments("CuaDriver", "/tmp/history-test.sock", &state, true, false);
         #[cfg(not(target_os = "macos"))]
-        let launch = daemon_process_arguments("history-test.sock", &state, true);
+        let launch = daemon_process_arguments("history-test.sock", &state, true, false);
         assert!(launch
             .windows(2)
             .any(|pair| pair == ["--permission-mode", "bounded"]));
@@ -4771,11 +4822,44 @@ mod tests {
             ..Default::default()
         };
         let mut launch = vec!["serve".to_owned()];
-        append_daemon_launch_state(&mut launch, &state, true);
+        append_daemon_launch_state(&mut launch, &state, true, false);
         assert!(launch
             .windows(2)
             .any(|pair| { pair == ["--permission-mode", "unrestricted"] }));
         assert!(launch.contains(&"--dangerously-bypass-approvals".to_owned()));
+    }
+
+    #[test]
+    fn fresh_daemon_launch_forwards_only_an_explicit_pip_request() {
+        let state = crate::history_runtime::DaemonLaunchState::default();
+        #[cfg(target_os = "macos")]
+        let enabled =
+            daemon_launch_arguments("CuaDriver", "/tmp/pip-test.sock", &state, false, true);
+        #[cfg(not(target_os = "macos"))]
+        let enabled = daemon_process_arguments("pip-test.sock", &state, false, true);
+        assert!(enabled.contains(&"--experimental-pip".to_owned()));
+
+        #[cfg(target_os = "macos")]
+        let disabled =
+            daemon_launch_arguments("CuaDriver", "/tmp/pip-test.sock", &state, false, false);
+        #[cfg(not(target_os = "macos"))]
+        let disabled = daemon_process_arguments("pip-test.sock", &state, false, false);
+        assert!(!disabled.contains(&"--experimental-pip".to_owned()));
+    }
+
+    #[test]
+    fn pip_request_parser_accepts_only_the_two_explicit_flags() {
+        assert!(experimental_pip_requested(&args(&[
+            "mcp",
+            "--experimental-pip"
+        ])));
+        assert!(experimental_pip_requested(&args(&["--pip", "mcp"])));
+        assert!(!experimental_pip_requested(&args(&["mcp"])));
+        assert!(!experimental_pip_requested(&args(&[
+            "mcp",
+            "--experimental-pip-geometry",
+            "480x360"
+        ])));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -651,12 +651,12 @@ pub fn parse_command() -> Command {
         );
         println!("  cua-driver history enable   Opt in and initialize encrypted local history.");
         println!("  cua-driver history status|pause|resume|flush|list|show|disable|delete");
-        println!("  --experimental-pip          Show a small always-on-top window with the latest");
+        println!("  --experimental-pip          Show a small always-on-top live screen preview.");
         println!(
-            "                              post-action screenshot + a 1-line label. macOS only"
+            "                              The window is movable, resizable, minimizable, and closable."
         );
         println!(
-            "                              today; Win/Linux print a not-yet-implemented notice."
+            "                              macOS only today; Win/Linux print a not-yet-implemented notice."
         );
         println!(
             "  --experimental-pip-geometry WxH[+X+Y]   Override window size (and optional top-left"

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -261,7 +261,6 @@ fn maybe_init_pip() {
                     if let Some(b) = slot.lock().unwrap().as_ref() {
                         b.push_frame(pip_preview::PipFrame {
                             png_bytes: frame.png_bytes,
-                            action_label: frame.action_label,
                             timestamp_ms: frame.timestamp_ms,
                         });
                     }

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -832,6 +832,7 @@ fn main() {
             direct,
             claude_code_compat,
             grants,
+            experimental_pip,
         } => {
             let startup_started = std::time::Instant::now();
             // Long-running MCP proxy — kick off the background update check
@@ -858,6 +859,7 @@ fn main() {
                     socket,
                     claude_code_compat,
                     &grants,
+                    experimental_pip,
                     |daemon, success| {
                         telemetry::capture_mcp_startup_completed(
                             "daemon_proxy",
@@ -1122,6 +1124,7 @@ fn main() -> anyhow::Result<()> {
             direct,
             claude_code_compat,
             grants,
+            experimental_pip,
         } => {
             let startup_started = std::time::Instant::now();
             // Long-running MCP proxy — kick off the background update check
@@ -1143,6 +1146,7 @@ fn main() -> anyhow::Result<()> {
                     socket,
                     claude_code_compat,
                     &grants,
+                    experimental_pip,
                     |daemon, success| {
                         telemetry::capture_mcp_startup_completed(
                             "daemon_proxy",

--- a/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
@@ -3,8 +3,8 @@
 //!
 //! The PiP window is an opt-in, always-on-top floating window that
 //! shows what the cua-driver agent just did: a post-action screenshot
-//! of the target window plus a one-line label summarising the tool
-//! call. It mirrors the architecture used by `cursor-overlay` (shared
+//! of the target window. It mirrors the architecture used by
+//! `cursor-overlay` (shared
 //! config/types here, platform-specific renderer in each `platform-*`
 //! crate) and the registration pattern used by `cua_driver_core::video`
 //! (a `OnceLock` factory set once at startup by `main.rs`).
@@ -259,9 +259,6 @@ impl PipConfig {
 #[derive(Debug, Clone)]
 pub struct PipFrame {
     pub png_bytes: Vec<u8>,
-    /// One-line summary shown overlayed on the frame, e.g.
-    /// `click element_index=2` or `type_text "hello world"`.
-    pub action_label: String,
     /// Wall-clock timestamp (ms since Unix epoch) — used by backends
     /// that want to show "last update Xs ago" in the title bar.
     pub timestamp_ms: u64,

--- a/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
+++ b/libs/cua-driver/rust/crates/pip-preview/src/lib.rs
@@ -1,9 +1,9 @@
 //! pip-preview — shared types + trait for the experimental
 //! picture-in-picture agent preview window.
 //!
-//! The PiP window is an opt-in, always-on-top floating window that
-//! shows what the cua-driver agent just did: a post-action screenshot
-//! of the target window. It mirrors the architecture used by
+//! The PiP window is an opt-in, always-on-top floating window. Platform
+//! backends may provide a live preview; the shared post-action frame hook
+//! remains available as a compatibility fallback. It mirrors the architecture used by
 //! `cursor-overlay` (shared
 //! config/types here, platform-specific renderer in each `platform-*`
 //! crate) and the registration pattern used by `cua_driver_core::video`
@@ -250,12 +250,12 @@ impl PipConfig {
     }
 }
 
-/// A single frame pushed into the PiP window after a tool call lands.
+/// A single fallback frame pushed into the PiP window after a tool call lands.
 ///
 /// `png_bytes` are the raw PNG bytes produced by the platform
 /// screenshot callback — the same path that powers `screenshot.png`
-/// in the recording pipeline, so PiP shows exactly what the recorder
-/// sees.
+/// in the recording pipeline. Platforms with native live capture may
+/// ignore these frames while their stream is active.
 #[derive(Debug, Clone)]
 pub struct PipFrame {
     pub png_bytes: Vec<u8>,

--- a/libs/cua-driver/rust/crates/platform-macos/Cargo.toml
+++ b/libs/cua-driver/rust/crates/platform-macos/Cargo.toml
@@ -46,9 +46,8 @@ objc2-app-kit = { version = "0.2", features = [
     "NSEvent", "NSRunningApplication", "NSWorkspace",
     "NSView", "NSGraphicsContext", "NSResponder",
     # Picture-in-picture preview window (experimental) — NSImageView /
-    # NSImage for the post-action screenshot, NSTextField for the
-    # one-line action label, NSPanel/NSImageCell are reachable via
-    # transitive deps.
+    # NSImage for live and fallback screenshots; NSPanel/NSImageCell are
+    # reachable via transitive deps.
     "NSImage", "NSImageView", "NSTextField", "NSControl", "NSCell",
     "block2", "libc",
 ] }

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -1,8 +1,7 @@
 //! macOS picture-in-picture preview window.
 //!
 //! Floating NSWindow with an NSImageView showing the most recent
-//! post-action screenshot and an NSTextField with a one-line label
-//! describing the action that produced it.
+//! post-action screenshot.
 //!
 //! ## Threading model
 //!
@@ -15,19 +14,19 @@
 //!   the frame into a heap-allocated `Box` and posts the actual UI
 //!   update onto the main queue via `dispatch_async_f`. The block
 //!   then constructs an `NSImage` from the PNG bytes and calls
-//!   `[imageView setImage:]` + `[label setStringValue:]`.
+//!   `[imageView setImage:]`.
 //!
 //! ## Window properties
 //!
-//! - `NSWindowCollectionBehaviorCanJoinAllSpaces | FullScreenAuxiliary |
-//!    Stationary | Transient | IgnoresCycle`
+//! - Standard titled, closable, miniaturizable, resizable window chrome.
+//! - Default collection behavior, so the preview stays on the Space where the
+//!   user opened it instead of following them across every desktop.
 //! - `level = .floating` (kCGFloatingWindowLevel, between normal apps
 //!   and dock; high enough to stay visible, low enough not to obscure
 //!   menus or accessibility overlays).
-//! - `setIgnoresMouseEvents(false)` — user can click the red close
-//!   button. Backend cleanup happens on `shutdown()`; closing the
-//!   window manually decouples it from the session as the spec
-//!   requires.
+//! - `setIgnoresMouseEvents(false)` and
+//!   `setMovableByWindowBackground(true)` — the user can move, resize,
+//!   minimize, or close the preview without affecting the daemon.
 //! - No activation: `setHidesOnDeactivate(false)` and
 //!   `setBecomesKeyOnlyIfNeeded(true)` so the window never steals
 //!   keyboard focus from the user's frontmost app.
@@ -71,7 +70,7 @@ unsafe impl objc2::RefEncode for CGColor {
 
 // ── Native AppKit pointer cell ─────────────────────────────────────────────
 //
-// Window, image view, and label pointers are stashed as `usize` so
+// Window and image-view pointers are stashed as `usize` so
 // `Send` works (raw `*mut AnyObject` is `!Send`). The actual deref +
 // `msg_send!` happens only on the main queue inside the dispatched
 // block, so there is no thread-safety hazard from the Send promise.
@@ -79,7 +78,6 @@ unsafe impl objc2::RefEncode for CGColor {
 struct NativeHandles {
     window: usize,
     image_view: usize,
-    label: usize,
 }
 
 static HANDLES: Mutex<Option<NativeHandles>> = Mutex::new(None);
@@ -130,10 +128,10 @@ unsafe extern "C" fn push_frame_cb(ctx: *mut c_void) {
 
     let frame: PipFrame = *Box::from_raw(ctx as *mut PipFrame);
 
-    let (image_view_ptr, label_ptr) = {
+    let image_view_ptr = {
         let guard = HANDLES.lock().unwrap();
         match guard.as_ref() {
-            Some(h) => (h.image_view, h.label),
+            Some(h) => h.image_view,
             None => return,
         }
     };
@@ -158,19 +156,6 @@ unsafe extern "C" fn push_frame_cb(ctx: *mut c_void) {
     if !img.is_null() {
         let image_view = image_view_ptr as *mut AnyObject;
         let _: () = msg_send![image_view, setImage: img];
-    }
-
-    // Update the label. NSString::stringWithUTF8String requires NUL
-    // termination; copy into a CString so we hand a clean buffer.
-    if let Ok(cstr) = std::ffi::CString::new(frame.action_label) {
-        let ns_str: *mut AnyObject = msg_send![
-            class!(NSString),
-            stringWithUTF8String: cstr.as_ptr() as *const u8
-        ];
-        if !ns_str.is_null() {
-            let label = label_ptr as *mut AnyObject;
-            let _: () = msg_send![label, setStringValue: ns_str];
-        }
     }
 }
 
@@ -273,13 +258,12 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     let rect = NSRect::new(NSPoint::new(top_left_x, bottom_y), NSSize::new(w, h));
 
     // ── NSWindow ──
-    // Borderless so the image owns the whole rectangle. No close button
-    // / title bar — the window is owned by the daemon session lifecycle.
-    // The rounded-corner look comes from a CALayer-backed content view
-    // with cornerRadius + masksToBounds; the window itself stays
-    // transparent outside the rounded rect.
-    //   NSWindowStyleMaskBorderless = 0
-    let style_mask: u64 = 0;
+    // Use ordinary macOS window affordances. The preview is auxiliary, but it
+    // must never trap the user behind an immovable borderless always-on-top
+    // surface.
+    //   Titled = 1<<0 | Closable = 1<<1 | Miniaturizable = 1<<2 |
+    //   Resizable = 1<<3
+    let style_mask: u64 = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3);
     let backing_store_buffered: u64 = 2;
     let win: *mut AnyObject = {
         let alloc: *mut AnyObject = msg_send![class!(NSWindow), alloc];
@@ -295,45 +279,38 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
         return;
     }
 
-    // Transparent backing so the corners outside the CALayer-clipped
-    // content view show whatever's underneath — gives the floating-pill
-    // look. The shadow comes from AppKit's default `hasShadow: true`.
-    let clear: *mut AnyObject = msg_send![class!(NSColor), clearColor];
-    let _: () = msg_send![win, setBackgroundColor: clear];
-    let _: () = msg_send![win, setOpaque: false];
+    if let Ok(cstr) = std::ffi::CString::new(cfg.title) {
+        let title: *mut AnyObject = msg_send![
+            class!(NSString),
+            stringWithUTF8String: cstr.as_ptr() as *const u8
+        ];
+        if !title.is_null() {
+            let _: () = msg_send![win, setTitle: title];
+        }
+    }
+    let black: *mut AnyObject = msg_send![class!(NSColor), blackColor];
+    let _: () = msg_send![win, setBackgroundColor: black];
+    let _: () = msg_send![win, setOpaque: true];
     let _: () = msg_send![win, setHasShadow: true];
-    // Draggable from anywhere since there's no title bar.
+    let _: () = msg_send![win, setIgnoresMouseEvents: false];
+    // In addition to the title bar, allow grabbing unused image background.
     let _: () = msg_send![win, setMovableByWindowBackground: true];
 
     // Floating window level (NSFloatingWindowLevel = 3).
     let _: () = msg_send![win, setLevel: 3i64];
 
-    // Collection behavior: visible across all spaces, no Mission
-    // Control affordance, never the main / key window.
-    // 1<<0 CanJoinAllSpaces | 1<<4 Stationary | 1<<8 FullScreenAuxiliary
-    // 1<<6 Transient | 1<<7 IgnoresCycle
-    let behavior: u64 = (1 << 0) | (1 << 4) | (1 << 8) | (1 << 6) | (1 << 7);
-    let _: () = msg_send![win, setCollectionBehavior: behavior];
+    // Keep the default collection behavior. In particular, do not join every
+    // Space or opt out of normal window cycling: those choices made the
+    // preview feel permanently glued to the screen.
+    let _: () = msg_send![win, setCollectionBehavior: 0u64];
 
     let _: () = msg_send![win, setReleasedWhenClosed: false];
     let _: () = msg_send![win, setHidesOnDeactivate: false];
 
-    // ── Content view: rounded-corner black backing ──
-    // wantsLayer + masksToBounds clips the image view to the rounded
-    // rect. The backing CALayer color shows wherever the (proportionally
-    // scaled) image leaves gaps above/below or left/right.
+    // ── Content view: black backing behind proportional screenshots ──
     let content_view: *mut AnyObject = msg_send![win, contentView];
     let _: () = msg_send![content_view, setWantsLayer: true];
     let content_layer: *mut AnyObject = msg_send![content_view, layer];
-    let _: () = msg_send![content_layer, setCornerRadius: 12.0_f64];
-    let _: () = msg_send![content_layer, setMasksToBounds: true];
-    let black: *mut AnyObject = msg_send![
-        class!(NSColor),
-        colorWithCalibratedRed: 0.0_f64
-        green: 0.0_f64
-        blue: 0.0_f64
-        alpha: 1.0_f64
-    ];
     let black_cg: *mut CGColor = msg_send![black, CGColor];
     let _: () = msg_send![content_layer, setBackgroundColor: black_cg];
 
@@ -347,70 +324,10 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     // AppKit types this as NSUInteger — passing signed i64 triggers
     // an objc2 type-encoding panic on macOS 26+.
     let _: () = msg_send![image_view, setImageScaling: 3u64];
-
-    // ── Label overlay: pill at bottom-center ──
-    // Container NSView with semi-transparent black backing + rounded
-    // corners (half its height for a fully rounded pill). NSTextField
-    // sits inside, centered, white text on the dark backing.
-    let pill_height = 22.0_f64;
-    let pill_inset_x = 16.0_f64;
-    let pill_inset_bottom = 10.0_f64;
-    let pill_w = (w - pill_inset_x * 2.0).max(60.0);
-    let pill_rect = NSRect::new(
-        NSPoint::new(pill_inset_x, pill_inset_bottom),
-        NSSize::new(pill_w, pill_height),
-    );
-    let pill: *mut AnyObject = {
-        let alloc: *mut AnyObject = msg_send![class!(NSView), alloc];
-        msg_send![alloc, initWithFrame: pill_rect]
-    };
-    let _: () = msg_send![pill, setWantsLayer: true];
-    let pill_layer: *mut AnyObject = msg_send![pill, layer];
-    let _: () = msg_send![pill_layer, setCornerRadius: pill_height / 2.0];
-    let _: () = msg_send![pill_layer, setMasksToBounds: true];
-    let pill_bg: *mut AnyObject = msg_send![
-        class!(NSColor),
-        colorWithCalibratedRed: 0.0_f64
-        green: 0.0_f64
-        blue: 0.0_f64
-        alpha: 0.62_f64
-    ];
-    let pill_bg_cg: *mut CGColor = msg_send![pill_bg, CGColor];
-    let _: () = msg_send![pill_layer, setBackgroundColor: pill_bg_cg];
-
-    // NSTextField inside the pill — horizontal padding via frame inset.
-    let label_rect = NSRect::new(
-        NSPoint::new(10.0, 0.0),
-        NSSize::new(pill_w - 20.0, pill_height),
-    );
-    let label: *mut AnyObject = {
-        let alloc: *mut AnyObject = msg_send![class!(NSTextField), alloc];
-        msg_send![alloc, initWithFrame: label_rect]
-    };
-    let _: () = msg_send![label, setBezeled: false];
-    let _: () = msg_send![label, setDrawsBackground: false];
-    let _: () = msg_send![label, setEditable: false];
-    let _: () = msg_send![label, setSelectable: false];
-    // NSTextAlignment.center = 2 (NSInteger).
-    let _: () = msg_send![label, setAlignment: 2i64];
-    let white: *mut AnyObject = msg_send![class!(NSColor), whiteColor];
-    let _: () = msg_send![label, setTextColor: white];
-    let font: *mut AnyObject = msg_send![class!(NSFont), systemFontOfSize: 11.0_f64];
-    let _: () = msg_send![label, setFont: font];
-    // Initial placeholder text — overwritten on the first frame.
-    if let Ok(cstr) = std::ffi::CString::new("waiting for first action…") {
-        let ns_str: *mut AnyObject = msg_send![
-            class!(NSString),
-            stringWithUTF8String: cstr.as_ptr() as *const u8
-        ];
-        if !ns_str.is_null() {
-            let _: () = msg_send![label, setStringValue: ns_str];
-        }
-    }
+    // Follow user-initiated resize operations.
+    let _: () = msg_send![image_view, setAutoresizingMask: 18u64];
 
     let _: () = msg_send![content_view, addSubview: image_view];
-    let _: () = msg_send![pill, addSubview: label];
-    let _: () = msg_send![content_view, addSubview: pill];
 
     // Show the window without making it key or activating the app.
     let _: () = msg_send![win, orderFrontRegardless];
@@ -418,7 +335,6 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     *HANDLES.lock().unwrap() = Some(NativeHandles {
         window: win as usize,
         image_view: image_view as usize,
-        label: label as usize,
     });
 
     tracing::info!(target: "pip", "PiP window initialised ({}x{})", cfg.geometry.width, cfg.geometry.height);

--- a/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/pip/mod.rs
@@ -1,7 +1,8 @@
 //! macOS picture-in-picture preview window.
 //!
-//! Floating NSWindow with an NSImageView showing the most recent
-//! post-action screenshot.
+//! Floating NSWindow with an NSImageView showing a low-frame-rate live
+//! preview of the main display. The preview window itself is excluded
+//! from ScreenCaptureKit so it never produces a recursive mirror.
 //!
 //! ## Threading model
 //!
@@ -10,11 +11,13 @@
 //! - The MCP/tokio server runs on a background thread.
 //! - AppKit MUST run on the main thread, which `cua-driver/src/main.rs`
 //!   parks in `NSApplication.run()` for the cursor overlay.
-//! - `push_frame()` is called from arbitrary tokio tasks. It packages
-//!   the frame into a heap-allocated `Box` and posts the actual UI
-//!   update onto the main queue via `dispatch_async_f`. The block
-//!   then constructs an `NSImage` from the PNG bytes and calls
-//!   `[imageView setImage:]`.
+//! - A ScreenCaptureKit stream runs on its own callback queue and sends
+//!   retained `CGImage`s to the AppKit main queue via `dispatch_async_f`.
+//! - At most one frame may be waiting for AppKit. Newer frames are dropped
+//!   while that slot is occupied so a busy main thread cannot accumulate
+//!   an unbounded queue.
+//! - `push_frame()` remains as a post-action PNG fallback when live capture
+//!   cannot start.
 //!
 //! ## Window properties
 //!
@@ -41,9 +44,15 @@
 //! `Mutex<Option<usize>>` and silently no-ops until init finishes.
 
 use std::ffi::c_void;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use pip_preview::{PipBackend, PipBackendFactory, PipConfig, PipFrame};
+use screencapturekit::prelude::{
+    CMSampleBufferExt, CMSampleBufferSCExt, CMTime, SCContentFilter, SCShareableContent, SCStream,
+    SCStreamConfiguration, SCStreamOutputType,
+};
 
 // ── CGColor objc2 encoding shim ────────────────────────────────────────────
 //
@@ -58,6 +67,11 @@ struct CGColor {
     _opaque: [u8; 0],
 }
 
+#[repr(C)]
+struct NativeCGImage {
+    _opaque: [u8; 0],
+}
+
 // RefEncode supplies an automatic Encode impl for `*mut CGColor` /
 // `*const CGColor` via objc2's blanket — that's the route msg_send! needs
 // for both setting layer.backgroundColor and reading [NSColor CGColor].
@@ -66,6 +80,11 @@ struct CGColor {
 unsafe impl objc2::RefEncode for CGColor {
     const ENCODING_REF: objc2::Encoding =
         objc2::Encoding::Pointer(&objc2::Encoding::Struct("CGColor", &[]));
+}
+
+unsafe impl objc2::RefEncode for NativeCGImage {
+    const ENCODING_REF: objc2::Encoding =
+        objc2::Encoding::Pointer(&objc2::Encoding::Struct("CGImage", &[]));
 }
 
 // ── Native AppKit pointer cell ─────────────────────────────────────────────
@@ -81,6 +100,19 @@ struct NativeHandles {
 }
 
 static HANDLES: Mutex<Option<NativeHandles>> = Mutex::new(None);
+
+const LIVE_CAPTURE_FPS: i32 = 8;
+const LIVE_CAPTURE_MAX_SIDE: f64 = 1280.0;
+const LIVE_CAPTURE_WINDOW_LOOKUP_TIMEOUT: Duration = Duration::from_secs(3);
+
+static LIVE_STREAM: Mutex<Option<SCStream>> = Mutex::new(None);
+static LIVE_CAPTURE_ACTIVE: AtomicBool = AtomicBool::new(false);
+static LIVE_CAPTURE_CANCELLED: AtomicBool = AtomicBool::new(false);
+static LIVE_FRAME_PENDING: AtomicBool = AtomicBool::new(false);
+
+struct LiveFrame {
+    image: screencapturekit::CGImage,
+}
 
 // ── libdispatch glue — same shape as cursor::overlay ──────────────────────
 
@@ -108,6 +140,12 @@ pub struct MacosPipBackend;
 
 impl PipBackend for MacosPipBackend {
     fn push_frame(&self, frame: PipFrame) {
+        // A live ScreenCaptureKit stream is the primary presentation path on
+        // macOS. Keep the existing post-action PNG bridge as a fallback for
+        // machines where live capture could not be established.
+        if LIVE_CAPTURE_ACTIVE.load(Ordering::Acquire) {
+            return;
+        }
         // No window yet? Drop the frame silently — start() dispatches
         // the create block onto the main queue and the very first
         // tool call can race that block.
@@ -118,7 +156,178 @@ impl PipBackend for MacosPipBackend {
     }
 
     fn shutdown(self: Box<Self>) {
+        stop_live_capture();
         dispatch_to_main((), shutdown_cb);
+    }
+}
+
+fn live_capture_dimensions(width_points: u32, height_points: u32, scale: f64) -> (u32, u32) {
+    let mut width = (f64::from(width_points) * scale.max(1.0)).max(1.0);
+    let mut height = (f64::from(height_points) * scale.max(1.0)).max(1.0);
+    let longest = width.max(height);
+    if longest > LIVE_CAPTURE_MAX_SIDE {
+        let shrink = LIVE_CAPTURE_MAX_SIDE / longest;
+        width *= shrink;
+        height *= shrink;
+    }
+    (width.round() as u32, height.round() as u32)
+}
+
+fn stop_live_capture() {
+    LIVE_CAPTURE_CANCELLED.store(true, Ordering::Release);
+    LIVE_CAPTURE_ACTIVE.store(false, Ordering::Release);
+    LIVE_FRAME_PENDING.store(false, Ordering::Release);
+    let stream = LIVE_STREAM
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .take();
+    if let Some(stream) = stream {
+        if let Err(error) = stream.stop_capture() {
+            tracing::debug!(target: "pip", %error, "failed to stop live PiP capture cleanly");
+        }
+    }
+}
+
+fn start_live_capture(window_id: u32, output_width: u32, output_height: u32) {
+    LIVE_CAPTURE_CANCELLED.store(false, Ordering::Release);
+    if let Err(error) = std::thread::Builder::new()
+        .name("cua-pip-live-capture".into())
+        .spawn(move || match build_live_capture(window_id, output_width, output_height) {
+            Ok(stream) => {
+                if LIVE_CAPTURE_CANCELLED.load(Ordering::Acquire) {
+                    let _ = stream.stop_capture();
+                    return;
+                }
+                *LIVE_STREAM
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(stream);
+                LIVE_CAPTURE_ACTIVE.store(true, Ordering::Release);
+                tracing::info!(
+                    target: "pip",
+                    fps = LIVE_CAPTURE_FPS,
+                    width = output_width,
+                    height = output_height,
+                    "live PiP capture started"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(target: "pip", %error, "live PiP capture unavailable; using post-action screenshots");
+            }
+        })
+    {
+        tracing::warn!(target: "pip", %error, "failed to spawn live PiP capture worker");
+    }
+}
+
+fn build_live_capture(
+    window_id: u32,
+    output_width: u32,
+    output_height: u32,
+) -> anyhow::Result<SCStream> {
+    let deadline = Instant::now() + LIVE_CAPTURE_WINDOW_LOOKUP_TIMEOUT;
+    let (display, pip_window) = loop {
+        let content = SCShareableContent::get()
+            .map_err(|error| anyhow::anyhow!("SCShareableContent::get failed: {error}"))?;
+        let main_display_id = unsafe { core_graphics::display::CGMainDisplayID() };
+        let display = content
+            .displays()
+            .into_iter()
+            .find(|display| display.display_id() == main_display_id)
+            .or_else(|| content.displays().into_iter().next())
+            .ok_or_else(|| anyhow::anyhow!("no displays available for live PiP capture"))?;
+        if let Some(window) = content
+            .windows()
+            .into_iter()
+            .find(|window| window.window_id() == window_id)
+        {
+            break (display, window);
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("PiP window {window_id} was not visible to ScreenCaptureKit");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    };
+
+    let filter = SCContentFilter::create()
+        .with_display(&display)
+        .with_excluding_windows(&[&pip_window])
+        .build();
+    let frame_interval = CMTime::new(1, LIVE_CAPTURE_FPS);
+    let config = SCStreamConfiguration::new()
+        .with_width(output_width)
+        .with_height(output_height)
+        .with_scales_to_fit(true)
+        .with_preserves_aspect_ratio(true)
+        .with_queue_depth(3)
+        .with_minimum_frame_interval(&frame_interval)
+        .with_shows_cursor(true);
+
+    let mut stream = SCStream::new(&filter, &config);
+    stream
+        .add_output_handler(
+            |sample: screencapturekit::cm::CMSampleBuffer, output_type: SCStreamOutputType| {
+                if output_type != SCStreamOutputType::Screen
+                    || LIVE_CAPTURE_CANCELLED.load(Ordering::Acquire)
+                    || sample
+                        .frame_status()
+                        .is_some_and(|status| !status.has_content())
+                    || LIVE_FRAME_PENDING.swap(true, Ordering::AcqRel)
+                {
+                    return;
+                }
+
+                match sample.cg_image() {
+                    Ok(image) => dispatch_to_main(LiveFrame { image }, push_live_frame_cb),
+                    Err(error) => {
+                        LIVE_FRAME_PENDING.store(false, Ordering::Release);
+                        tracing::debug!(target: "pip", error, "live PiP frame had no image");
+                    }
+                }
+            },
+            SCStreamOutputType::Screen,
+        )
+        .ok_or_else(|| anyhow::anyhow!("ScreenCaptureKit rejected the PiP output handler"))?;
+    stream
+        .start_capture()
+        .map_err(|error| anyhow::anyhow!("SCStream::start_capture failed: {error}"))?;
+    Ok(stream)
+}
+
+unsafe extern "C" fn push_live_frame_cb(ctx: *mut c_void) {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+    use objc2_foundation::NSSize;
+
+    let frame: LiveFrame = *Box::from_raw(ctx as *mut LiveFrame);
+    LIVE_FRAME_PENDING.store(false, Ordering::Release);
+
+    let (window_ptr, image_view_ptr) = {
+        let guard = HANDLES.lock().unwrap();
+        match guard.as_ref() {
+            Some(handles) => (handles.window, handles.image_view),
+            None => return,
+        }
+    };
+    let window = window_ptr as *mut AnyObject;
+    let minimized: bool = msg_send![window, isMiniaturized];
+    if minimized {
+        return;
+    }
+    let visible: bool = msg_send![window, isVisible];
+    if !visible {
+        stop_live_capture();
+        return;
+    }
+
+    let cg_image = frame.image.as_ptr() as *mut NativeCGImage;
+    let image: *mut AnyObject = {
+        let alloc: *mut AnyObject = msg_send![class!(NSImage), alloc];
+        msg_send![alloc, initWithCGImage: cg_image size: NSSize::new(0.0, 0.0)]
+    };
+    if !image.is_null() {
+        let image_view = image_view_ptr as *mut AnyObject;
+        let _: () = msg_send![image_view, setImage: image];
+        let _: () = msg_send![image, release];
     }
 }
 
@@ -156,6 +365,7 @@ unsafe extern "C" fn push_frame_cb(ctx: *mut c_void) {
     if !img.is_null() {
         let image_view = image_view_ptr as *mut AnyObject;
         let _: () = msg_send![image_view, setImage: img];
+        let _: () = msg_send![img, release];
     }
 }
 
@@ -243,6 +453,7 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
         return;
     }
     let screen_frame: NSRect = msg_send![screen, frame];
+    let backing_scale: f64 = msg_send![screen, backingScaleFactor];
 
     let w = cfg.geometry.width as f64;
     let h = cfg.geometry.height as f64;
@@ -332,10 +543,36 @@ unsafe extern "C" fn init_cb(ctx: *mut c_void) {
     // Show the window without making it key or activating the app.
     let _: () = msg_send![win, orderFrontRegardless];
 
+    let window_number: i64 = msg_send![win, windowNumber];
+
     *HANDLES.lock().unwrap() = Some(NativeHandles {
         window: win as usize,
         image_view: image_view as usize,
     });
 
+    if let Ok(window_id) = u32::try_from(window_number) {
+        let (output_width, output_height) =
+            live_capture_dimensions(cfg.geometry.width, cfg.geometry.height, backing_scale);
+        start_live_capture(window_id, output_width, output_height);
+    } else {
+        tracing::warn!(target: "pip", window_number, "cannot start live PiP capture without a valid window id");
+    }
+
     tracing::info!(target: "pip", "PiP window initialised ({}x{})", cfg.geometry.width, cfg.geometry.height);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn live_capture_dimensions_follow_backing_scale() {
+        assert_eq!(live_capture_dimensions(320, 200, 2.0), (640, 400));
+        assert_eq!(live_capture_dimensions(320, 200, 1.0), (320, 200));
+    }
+
+    #[test]
+    fn live_capture_dimensions_bound_large_windows_without_changing_aspect_ratio() {
+        assert_eq!(live_capture_dimensions(4000, 2000, 2.0), (1280, 640));
+    }
 }


### PR DESCRIPTION
## Summary

- preserve an explicit `--experimental-pip` / `--pip` request when the MCP proxy auto-launches a fresh daemon
- stream a low-frame-rate live macOS preview with ScreenCaptureKit instead of waiting for agent actions
- exclude the PiP window from capture so the preview cannot recursively mirror itself
- bound capture resolution and coalesce pending frames to keep the preview lightweight
- retain post-action screenshots as a fallback when live capture is unavailable
- use standard movable, resizable, minimizable, and closable macOS window chrome
- remove the synthesized action label and keep the preview on its originating Space

Fixes #3496.
Fixes #3498.
Fixes #3499.
Supports mslsrc/tbh#26292.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p platform-macos -p pip-preview -p cua-driver`
- `cargo test -p platform-macos live_capture_dimensions -- --nocapture` (2 passed)
- `cargo test -p pip-preview`
- `cargo test -p cua-driver --bin cua-driver pip_ -- --nocapture` (2 passed)
- release-built and stable-signed `CuaDriverLocal.app`
- user-visible macOS E2E against the signed release bundle:
  - PiP content changed without any CUA tool action
  - the PiP window was absent from its own captured image
  - a real title-bar drag moved the window from `(1384,33)` to `(1000,173)`
  - native minimize succeeded while the daemon remained running
  - restoring the window produced a new live frame rather than a frozen pre-minimize frame
  - native close removed the on-screen window while leaving the daemon alive
  - the test daemon and local screenshots were removed afterward

The signed staging bundle was used for E2E because this execution environment is not allowed to replace the existing `/Applications/CuaDriverLocal.app` bundle.