### PR TITLE
chore: ignore local pi state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ env.bak/
 venv.bak/
 # Git worktrees
 .worktrees/
+.pi/
 # Spyder project settings
 .spyderproject
 .spyproject


### PR DESCRIPTION
## summary

- ignore the repository-local `.pi/` state directory
- keep pi session data out of contributor diffs

## validation

- `git check-ignore -v .pi/example`
- `git diff --check`