### PR TITLE
fix(cua-driver): authenticate history requests lazily

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
@@ -203,9 +203,9 @@ fn is_session_lifecycle_tool(tool_name: &str) -> bool {
 fn history_control_response(
     registry: &crate::sdk_adapter::SdkAdapter,
     request: &DaemonRequest,
-    trusted_cli_connection: bool,
+    trusted_cli_request: bool,
 ) -> DaemonResponse {
-    if !trusted_cli_connection
+    if !trusted_cli_request
         || request.client_kind != Some(cua_driver_core::daemon::DaemonClientKind::Cli)
         || request.observation_origin != Some(ToolObservationOrigin::Direct)
     {
@@ -319,7 +319,7 @@ fn history_control_response(
 async fn history_control_response_async(
     registry: std::sync::Arc<crate::sdk_adapter::SdkAdapter>,
     request: DaemonRequest,
-    trusted_cli_connection: bool,
+    trusted_cli_request: bool,
 ) -> DaemonResponse {
     // Native credential stores are synchronous at this boundary. Linux's
     // Secret Service adapter may drive its own async runtime internally, which
@@ -327,7 +327,7 @@ async fn history_control_response_async(
     // deletion, and encrypted-store I/O off the daemon's async executor on all
     // platforms so one control request cannot stall unrelated clients.
     tokio::task::spawn_blocking(move || {
-        history_control_response(&registry, &request, trusted_cli_connection)
+        history_control_response(&registry, &request, trusted_cli_request)
     })
     .await
     .unwrap_or_else(|error| {
@@ -337,9 +337,9 @@ async fn history_control_response_async(
 
 fn history_relaunch_state_response(
     request: &DaemonRequest,
-    trusted_cli_connection: bool,
+    trusted_cli_request: bool,
 ) -> DaemonResponse {
-    if !trusted_cli_connection
+    if !trusted_cli_request
         || request.client_kind != Some(cua_driver_core::daemon::DaemonClientKind::Cli)
         || request.observation_origin != Some(ToolObservationOrigin::Direct)
     {
@@ -763,7 +763,9 @@ fn authenticate_embedded_host_connection(stream: &tokio::net::UnixStream) -> any
 }
 
 #[cfg(target_os = "macos")]
-fn authenticate_history_cli_connection(stream: &tokio::net::UnixStream) -> anyhow::Result<()> {
+fn history_cli_executable_path(
+    stream: &tokio::net::UnixStream,
+) -> anyhow::Result<std::path::PathBuf> {
     use std::os::unix::ffi::OsStringExt as _;
 
     let peer_pid = stream
@@ -782,21 +784,46 @@ fn authenticate_history_cli_connection(stream: &tokio::net::UnixStream) -> anyho
         .position(|byte| *byte == 0)
         .unwrap_or(length as usize);
     buffer.truncate(path_length);
-    let path = std::path::PathBuf::from(std::ffi::OsString::from_vec(buffer));
-    crate::history_runtime::verify_history_cli_executable_path(&path)
+    Ok(std::path::PathBuf::from(std::ffi::OsString::from_vec(
+        buffer,
+    )))
 }
 
 #[cfg(target_os = "linux")]
-fn authenticate_history_cli_connection(stream: &tokio::net::UnixStream) -> anyhow::Result<()> {
+fn history_cli_executable_path(
+    stream: &tokio::net::UnixStream,
+) -> anyhow::Result<std::path::PathBuf> {
     let peer_pid = stream
         .peer_cred()
         .map_err(|error| anyhow::anyhow!("read history control peer credentials: {error}"))?
         .pid()
         .ok_or_else(|| anyhow::anyhow!("history control peer PID is unavailable"))?;
-    let path = std::fs::read_link(format!("/proc/{peer_pid}/exe")).map_err(|error| {
-        anyhow::anyhow!("history control peer executable is unavailable: {error}")
-    })?;
-    crate::history_runtime::verify_history_cli_executable_path(&path)
+    std::fs::read_link(format!("/proc/{peer_pid}/exe"))
+        .map_err(|error| anyhow::anyhow!("history control peer executable is unavailable: {error}"))
+}
+
+fn history_cli_authentication_path(
+    method: &str,
+    executable_path: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
+    if !matches!(method, "history_control" | "history_relaunch_state") {
+        return None;
+    }
+    executable_path.map(std::path::Path::to_path_buf)
+}
+
+async fn authenticate_history_cli_request(
+    method: &str,
+    executable_path: Option<&std::path::Path>,
+) -> bool {
+    let Some(executable_path) = history_cli_authentication_path(method, executable_path) else {
+        return false;
+    };
+    tokio::task::spawn_blocking(move || {
+        crate::history_runtime::verify_history_cli_executable_path(&executable_path).is_ok()
+    })
+    .await
+    .unwrap_or(false)
 }
 
 fn service_authorization_status(trusted_host_connection: bool) -> serde_json::Value {
@@ -828,8 +855,8 @@ fn service_authorization_status(trusted_host_connection: bool) -> serde_json::Va
 #[cfg(all(test, unix))]
 mod peer_authentication_tests {
     use super::{
-        authenticate_unix_peer, authenticate_unix_uid, history_relaunch_state_response,
-        shutdown_response, DaemonRequest, ToolObservationOrigin,
+        authenticate_unix_peer, authenticate_unix_uid, history_cli_authentication_path,
+        history_relaunch_state_response, shutdown_response, DaemonRequest, ToolObservationOrigin,
     };
 
     #[tokio::test]
@@ -843,6 +870,27 @@ mod peer_authentication_tests {
     fn foreign_unix_uid_is_rejected_before_request_parsing() {
         let error = authenticate_unix_uid(501, 502).unwrap_err();
         assert!(error.to_string().contains("reject Unix peer uid 502"));
+    }
+
+    #[test]
+    fn only_history_methods_select_the_peer_for_authentication() {
+        let path = std::path::Path::new("/installed/cua-driver");
+        for method in [
+            "list",
+            "metadata",
+            "authorization_status",
+            "call",
+            "shutdown",
+        ] {
+            assert_eq!(history_cli_authentication_path(method, Some(path)), None);
+        }
+        for method in ["history_control", "history_relaunch_state"] {
+            assert_eq!(
+                history_cli_authentication_path(method, Some(path)).as_deref(),
+                Some(path)
+            );
+            assert_eq!(history_cli_authentication_path(method, None), None);
+        }
     }
 
     #[test]
@@ -969,8 +1017,7 @@ pub async fn run_serve(
                 }
                 let trusted_host_connection =
                     authenticate_embedded_host_connection(&stream).is_ok();
-                let trusted_history_cli_connection =
-                    authenticate_history_cli_connection(&stream).is_ok();
+                let history_cli_executable_path = history_cli_executable_path(&stream).ok();
                 let reg = sdk.clone();
                 let shutdown_tx2 = shutdown_tx.clone();
                 let trusted_resume_registry = trusted_resume_registry.clone();
@@ -1002,6 +1049,11 @@ pub async fn run_serve(
                             }
                         };
 
+                        let trusted_history_cli_request = authenticate_history_cli_request(
+                            &req.method,
+                            history_cli_executable_path.as_deref(),
+                        ).await;
+
                         match req.method.as_str() {
                             "metadata" => {
                                 let resp = daemon_metadata_response();
@@ -1012,7 +1064,7 @@ pub async fn run_serve(
                             "history_relaunch_state" => {
                                 let resp = history_relaunch_state_response(
                                     &req,
-                                    trusted_history_cli_connection,
+                                    trusted_history_cli_request,
                                 );
                                 let _ = writer.write_all(
                                     (serde_json::to_string(&resp).unwrap() + "\n").as_bytes()
@@ -1080,7 +1132,7 @@ pub async fn run_serve(
                                 let resp = history_control_response_async(
                                     reg.clone(),
                                     req,
-                                    trusted_history_cli_connection,
+                                    trusted_history_cli_request,
                                 ).await;
                                 let _ = writer.write_all(
                                     (serde_json::to_string(&resp).unwrap() + "\n").as_bytes()
@@ -1709,11 +1761,8 @@ pub async fn run_serve(
                         expected_host_process_id,
                         client_process_id,
                     );
-                let trusted_history_cli_connection = client_process_id
-                    .and_then(platform_windows::history::process_executable_path)
-                    .is_some_and(|path| {
-                        crate::history_runtime::verify_history_cli_executable_path(&path).is_ok()
-                    });
+                let history_cli_executable_path =
+                    client_process_id.and_then(platform_windows::history::process_executable_path);
 
                 let reg = sdk.clone();
                 let shutdown_tx2 = shutdown_tx.clone();
@@ -1743,6 +1792,11 @@ pub async fn run_serve(
                             }
                         };
 
+                        let trusted_history_cli_request = authenticate_history_cli_request(
+                            &req.method,
+                            history_cli_executable_path.as_deref(),
+                        ).await;
+
                         match req.method.as_str() {
                             "metadata" => {
                                 let resp = daemon_metadata_response();
@@ -1753,7 +1807,7 @@ pub async fn run_serve(
                             "history_relaunch_state" => {
                                 let resp = history_relaunch_state_response(
                                     &req,
-                                    trusted_history_cli_connection,
+                                    trusted_history_cli_request,
                                 );
                                 let _ = writer.write_all(
                                     (serde_json::to_string(&resp).unwrap() + "\n").as_bytes()
@@ -1804,7 +1858,7 @@ pub async fn run_serve(
                                 let resp = history_control_response_async(
                                     reg.clone(),
                                     req,
-                                    trusted_history_cli_connection,
+                                    trusted_history_cli_request,
                                 ).await;
                                 let _ = writer.write_all(
                                     (serde_json::to_string(&resp).unwrap() + "\n").as_bytes()


### PR DESCRIPTION
## summary

- keep cheap peer identity capture at connection acceptance
- select a peer for full Computer History attestation only after parsing `history_control` or `history_relaunch_state`
- run blocking signature verification outside the async worker
- apply the same request-scoped rule to Unix sockets and Windows named pipes

## root cause

#3347 established that 0.21 moved installed-helper attestation into the macOS Unix-socket accept loop. The exact installed helper then ran five synchronous `codesign` subprocesses before the daemon knew the request method. `status --socket` performs a liveness request followed by `authorization_status`, so both ordinary connections paid the privileged History cost and the accept loop could not serve another client while attestation ran.

## scope

This keeps the existing peer path and signature checks unchanged. It separates cheap peer identity capture from expensive verification and selects verification only for the two privileged History methods. It does not add a cache or change `status`, which overlaps #3318.

The issue reporter supplied the cross-version isolation and identified the eager attestation path that this change corrects.

Fixes #3347.

## validation

candidate: `6cf704eef66b1f30ac7befe0771a935ac94f113d`

completed:

- `cargo fmt --all -- --check`
- `git diff --check`
- deterministic routing coverage proves only the two History methods select the peer for verification and missing peer identity fails closed
- existing forged-CLI refusal coverage retained
- Linux, Windows, and Nix Rust unit and compile checks passed
- portable contract parity passed on macOS, Windows, and Linux
- non-publishing cross-platform packaging passed, including both macOS architectures and the universal app bundle: https://github.com/trycua/cua/actions/runs/33703512759
- all ordinary pull request checks passed

pending:

- exact installed macOS reproduction proving `status --socket` avoids `codesign` and completes below the downstream 2-second deadline
- exact-candidate macOS Cua Driver E2E before readiness

local focused Rust execution remains unavailable because this Linux workspace lacks `pkg-config` and X11 development metadata.
