### PR TITLE
docs(rfc): define target-addressable KWin input

### DIFF
--- a/rfcs/3506-kwin-target-input.md
+++ b/rfcs/3506-kwin-target-input.md
@@ -1,0 +1,494 @@
+---
+title: Target-addressable KWin input delivery for KDE/Wayland
+authors:
+  - netbospl
+created: 2026-09-01
+last_updated: 2026-09-01
+status: review
+discussion: https://github.com/trycua/cua/issues/3506
+rfc_pr:
+implementation:
+  - https://github.com/trycua/cua/issues/2283
+supersedes:
+superseded_by:
+---
+
+# RFC: Target-addressable KWin input delivery for KDE/Wayland
+
+## Summary
+
+Add a trusted, versioned KWin-side target-input contract that lets Cua Driver
+bind pointer and keyboard delivery to one freshly verified KDE/KWin window.
+When exact delivery cannot be proven, the driver must return a structured
+refusal and must not fall back to focus-bound global portal/libei input.
+
+## Motivation
+
+Cua Driver already has partial KDE/KWin integration for window discovery and
+identity. The current helper exports trusted KWin window metadata and lets the
+driver correlate compositor identity with PID, geometry, activity/stacking, and
+AT-SPI. It intentionally does not expose mutating input operations.
+
+The remaining problem is not discovery but delivery. XDG portal/libei input is
+bound to the surface that is focused when the compositor processes the event,
+not to a Cua-selected KWin window token. An implementation that activates a
+window, verifies focus, and then sends global libei input has a race: focus can
+change between verification and irreversible delivery. A later read-back cannot
+undo a click or key event that reached the wrong application.
+
+KDE therefore needs a target-addressable mutation path whose contract is owned
+at the KWin boundary. The safety requirement is stronger than "the intended
+window was focused shortly before input"; the compositor-side path must either
+associate the event with the exact verified target or refuse it.
+
+## Goals
+
+- Define a versioned KWin target-input contract that binds a short-lived input
+  transaction to one exact verified window identity.
+- Preserve and extend the current trusted identity checks rather than replacing
+  them with title, app-id, geometry, or focus heuristics.
+- Route supported KDE pointer and keyboard mutations through that target-bound
+  contract.
+- Guarantee that a selected KWin target never falls through to global
+  portal/libei delivery when target-bound dispatch is unavailable or becomes
+  unsafe.
+- Expose precise capability and refusal information through doctor/health
+  reporting.
+- Reuse the same KWin routing for existing-profile browser setup so browser
+  setup cannot bypass the target-bound safety boundary.
+- Prove failure isolation with tests that observe both target state and absence
+  of leaked global input.
+
+## Non-goals
+
+- This RFC does not make generic Wayland background input safe.
+- This RFC does not claim equivalent target-addressable semantics for GNOME,
+  wlroots, X11, Windows, or macOS.
+- This RFC does not enable raw background delivery to arbitrary unfocused
+  Wayland surfaces when the compositor cannot prove exact targeting.
+- This RFC does not replace semantic AT-SPI actions where those actions already
+  provide a stronger target-scoped operation.
+- This RFC does not treat focus restoration alone as proof that input was
+  delivered safely.
+
+## Terminology
+
+**KWin target token**
+: The compositor-issued opaque identity currently used by the Cua KWin helper
+  to distinguish one KWin window from another.
+
+**Target generation**
+: A process/helper/compositor generation value that prevents stale tokens or PID
+  reuse from being accepted after restart or recreation.
+
+**Target-bound input**
+: Input delivery for which the KWin-side contract associates the mutation with
+  one exact verified target identity rather than with whichever surface happens
+  to hold focus at processing time.
+
+**Global input**
+: Focus-bound input injection, including portal/libei delivery, where the event
+  is not cryptographically or compositor-contractually associated with the
+  Cua-selected target.
+
+**Structured refusal**
+: A typed failure returned before unsafe mutation when identity, capability, or
+  transaction invariants cannot be proven.
+
+## Current state
+
+The repository already contains a KWin target helper and Rust adapter. Protocol
+v1 is intentionally read-only: it exposes a version and window snapshots but no
+activation or raw input mutation methods. The Rust adapter verifies the D-Bus
+owner, KWin PID/session ownership, UID, protocol version, and correlates KWin
+window identity with AT-SPI.
+
+The current safety posture is deliberate:
+
+- the KWin helper can enumerate trusted windows;
+- `available()` for mutating KWin foreground input remains false;
+- the focused-window mutation wrapper refuses;
+- raw KWin pointer and keyboard actions remain disabled because portal/libei is
+  focus-bound rather than target-bound.
+
+This is preferable to activating a target and then sending global input because
+focus can change between any check and compositor-side event processing.
+
+## Proposal
+
+### Contract ownership
+
+Extend the existing KWin helper contract under the current service namespace:
+
+```text
+D-Bus name:   org.cua.KWinTarget
+Object path:  /org/cua/KWinTarget
+Interface:    org.cua.KWinTarget
+```
+
+The helper remains the authority for compositor window identity. Protocol v2
+(or a later compatible version selected during review) adds target-input
+capabilities while retaining v1 read-only discovery semantics for older clients.
+
+The public contract must expose enough information for the driver to distinguish
+at least these capabilities:
+
+- identity/discovery available;
+- target activation available;
+- target-bound pointer input available;
+- target-bound keyboard input available.
+
+A helper that only implements `GetVersion()` and `GetWindows()` must never be
+reported as mutation-capable.
+
+### Target identity
+
+A target-input transaction is opened only from a fresh snapshot that resolves
+exactly one target using a tuple equivalent to:
+
+```text
+(pid, kwin_token, generation)
+```
+
+The exact wire representation is implementation-defined, but the following
+properties are required:
+
+- the token is opaque to callers;
+- PID ownership is verified and cannot be substituted by title/app-id lookup;
+- the generation changes when token/PID reuse could make an old identity stale;
+- the target is revalidated immediately before each irreversible mutation or
+  input frame;
+- duplicate or ambiguous identities refuse rather than selecting a best match.
+
+Existing owner/session/UID checks remain mandatory.
+
+### Transaction model
+
+The Rust adapter gains a target-input transaction abstraction conceptually like:
+
+```rust
+with_target_input(pid, token, generation, |target| {
+    // bounded pointer/keyboard operations
+})
+```
+
+Opening the transaction must:
+
+1. obtain a fresh KWin snapshot;
+2. resolve exactly one verified target;
+3. negotiate the required target-input capability;
+4. bind the transaction to that identity;
+5. reject stale, ambiguous, missing, or unsupported targets before mutation.
+
+During the transaction the KWin-side path must ensure that delivery remains
+associated with the bound target. If the invariant cannot be maintained across
+multi-frame operations such as drag or type sequences, the transaction must
+stop and return a structured refusal before the next frame.
+
+The implementation may internally activate the target when required by KWin,
+but activation is not itself the safety guarantee. The safety guarantee is that
+the compositor-side input path associates each delivered event with the bound
+target identity or refuses the event.
+
+### Supported operations
+
+Once the contract proves target-bound delivery, KDE routing may use it for:
+
+- click / pointer button actions;
+- pointer movement required by click and drag;
+- scroll;
+- drag;
+- text typing;
+- individual key presses;
+- hotkeys.
+
+Operations that cannot satisfy the same target-binding invariant remain
+structured refusals even if some other KWin mutation path is available.
+
+### No-global-fallback rule
+
+The key safety rule is:
+
+> After cua-driver selects the trusted KWin target route for an operation, any
+> inability to prove or maintain target-bound delivery MUST return a structured
+> refusal. The operation MUST NOT fall back to global portal/libei input.
+
+This includes capability loss, helper restart, target closure, generation
+change, ambiguous identity, user focus takeover where the contract cannot
+preserve target binding, and unsupported input kinds.
+
+A representative refusal code is `target_input_unavailable`; final typed error
+names should follow the existing driver error taxonomy.
+
+### libei relationship
+
+The preferred design does not route KWin target-bound mutation through the
+existing global `libei.rs` worker because those commands do not carry a window
+identity today and because EIS focus-bound delivery does not by itself provide
+target association.
+
+Portal/libei remains valid for other compositors where its documented semantics
+match the accepted operation contract. It may also remain available for
+non-targeted or explicitly global operations that are outside this RFC.
+
+If an implementation later proposes using libei inside the KWin transaction,
+it must first provide compositor-level evidence that every event is target-bound
+before delivery. Pre/post focus checks alone are insufficient.
+
+### Browser existing-profile setup
+
+The browser setup path currently has compositor-specific foreground routing that
+can differ from the general Wayland routing. KDE existing-profile setup must use
+the same KWin target transaction (directly or via the common Wayland target
+routing) rather than bypassing it through a GNOME-oriented shell helper or global
+input fallback.
+
+This keeps browser approval, exact target identity, generation, reconnect, and
+mutation under one safety boundary.
+
+### Doctor and health reporting
+
+Health output must distinguish identity from mutation capability. Representative
+states are:
+
+```text
+KWin identity adapter: available
+KWin target input: unavailable (helper is read-only)
+```
+
+and, once v2 is present and verified:
+
+```text
+KWin identity adapter: available
+KWin target input: pointer and keyboard target-bound delivery available
+Wayland backend: KDE/KWin target-addressable foreground dispatch available
+```
+
+Doctor should distinguish at least:
+
+1. helper absent;
+2. helper present but read-only;
+3. incompatible protocol version;
+4. helper missing required target-input methods/capabilities;
+5. target identity ambiguous or stale;
+6. target-bound transaction unavailable for the requested operation.
+
+The platform support documentation remains experimental until the full live
+acceptance evidence described below is recorded.
+
+### Control flow
+
+The intended flow is:
+
+```text
+cua-driver
+    |
+    | fresh (PID, token, generation) validation
+    v
+KWin target-input transaction
+    |
+    | compositor-bound delivery or refusal
+    v
+exact KWin Window
+```
+
+The disallowed flow is:
+
+```text
+activate target -> check focus -> global libei input
+```
+
+because no amount of pre-delivery focus checking makes a global irreversible
+event target-addressable.
+
+## Alternatives considered
+
+### Activate then use global portal/libei
+
+Rejected as the baseline design. Focus can change after activation or focus
+verification and before compositor-side event delivery. Post-event checks cannot
+undo an event delivered to another application.
+
+### Recheck focus before every libei command or add sleeps
+
+Rejected. This narrows a timing window but does not remove it, and therefore
+cannot support an exact-target safety claim.
+
+### Use title, app-id, or geometry matching
+
+Rejected for authorization. These values are not unique stable identities and
+can collide or change. They may be diagnostic metadata but not the mutation
+selector.
+
+### `wmctrl` / `xdotool`
+
+Rejected for native KWin/Wayland target delivery. These X11-oriented mechanisms
+do not establish a native Wayland target-bound input contract.
+
+### Enable the existing adapter by setting `available() = true`
+
+Rejected while the mutation body remains global/focus-bound. Capability must be
+reported from the actual target-input contract, not helper presence.
+
+### Focus transaction with read-back after each event
+
+Insufficient without compositor-side target binding. It can detect some races
+after the fact but cannot retract an event already delivered to the wrong
+surface.
+
+## Compatibility and migration
+
+The change is additive at the protocol level:
+
+- existing v1 helpers remain valid for identity/discovery;
+- existing clients continue to see KDE raw target input as unavailable;
+- a v2-capable helper advertises target-input capability explicitly;
+- the driver enables KDE mutation only after verifying both protocol/capability
+  and target transaction invariants.
+
+No unsafe fallback is introduced during rollout. If driver and helper versions
+are mismatched, the behavior is a precise refusal rather than degraded global
+input.
+
+Rollback is straightforward: disable/remove the v2 mutation capability and the
+driver returns to the current read-only KWin posture without changing window
+identity discovery.
+
+The first user-visible implementation should use a `feat(cua-driver): ...` pull
+request title because safe target-addressable KDE raw input is a new capability.
+
+## Security, privacy, and telemetry
+
+The KWin helper is part of a privileged desktop trust boundary and must expose
+only the minimum metadata needed for identity and delivery.
+
+Required properties:
+
+- verify the D-Bus service owner and expected KWin session process;
+- verify same-user/session ownership;
+- do not trust caller-provided titles, app IDs, geometry, or PID without a fresh
+  compositor snapshot;
+- bind mutation to an opaque compositor target plus generation;
+- invalidate transactions on helper/compositor restart and stale identity;
+- refuse ambiguous target resolution;
+- never send global raw input as a recovery path after target routing is chosen;
+- avoid telemetry containing typed text, key sequences, window titles, document
+  contents, or target application data.
+
+Permitted telemetry should be limited to capability state, protocol version,
+structured refusal category, operation class, and coarse timing/error counters
+that cannot reconstruct user input.
+
+## Implementation plan
+
+Implementation begins only after this RFC is accepted according to the Cua RFC
+process.
+
+### Increment 1: KWin target-input contract and adapter
+
+- extend the KWin helper with a versioned target-input capability;
+- add generation-aware target validation;
+- add the Rust target transaction abstraction;
+- retain read-only behavior for v1 helpers;
+- add focused contract/unit tests for stale, duplicate, ambiguous and restarted
+  targets.
+
+### Increment 2: pointer/keyboard routing and no-fallback enforcement
+
+- route supported KDE pointer/keyboard operations through the target transaction;
+- hard-block transition from selected KWin routing to global libei;
+- add structured refusal coverage for mid-transaction target changes;
+- verify multi-frame drag/type cancellation behavior.
+
+### Increment 3: browser setup and health reporting
+
+- route existing-profile browser setup through the common KWin target path;
+- distinguish identity-only and target-input capability in doctor/health output;
+- add compatibility/version diagnostics.
+
+### Increment 4: live Plasma 6 evidence and documentation
+
+- run the canonical KDE/Wayland lane on the exact candidate SHA;
+- test representative Chromium, Firefox, GTK, Qt and Electron targets where the
+  existing harness supports them;
+- prove pointer, keyboard, drag, scroll, target closure, focus takeover, and
+  focus restoration behavior;
+- update platform support/roadmap/action-support documentation only to the level
+  demonstrated by the evidence.
+
+These increments may be separate PRs when that keeps review focused. The first
+implementation PR links this RFC and the decision issue.
+
+## Test and acceptance plan
+
+### Contract and unit tests
+
+Cover at least:
+
+- snapshot parsing and protocol negotiation;
+- duplicate tokens;
+- two windows owned by one process;
+- minimized/hidden targets where relevant;
+- ambiguous AT-SPI correlation;
+- stale token after window close;
+- helper/KWin generation change;
+- browser restart and PID reuse;
+- workspace and geometry changes;
+- target loss before mutation;
+- unsupported operation capability.
+
+### Safety tests
+
+Explicitly trigger:
+
+- user focus change immediately before delivery;
+- focus change between drag frames;
+- close target during text typing;
+- helper/KWin restart during a transaction;
+- target replacement with possible PID reuse;
+- another window of the same process becoming active.
+
+For every unsafe case, acceptance requires both:
+
+```text
+structured refusal
+no global input sent
+```
+
+A successful driver response alone is not evidence.
+
+### Live Plasma 6 evidence
+
+Use the repository's compositor-specific Linux desktop harness on the exact
+candidate SHA. At minimum, prove one exact target receives pointer and keyboard
+input while a sentinel/other window proves no leaked input. Expand the matrix to
+representative Chromium/Chrome, Firefox, GTK, Qt, Electron, two-window, covered,
+and alternate-workspace scenarios as supported by the harness.
+
+Evidence must observe fixture-owned state and relevant focus/z-order/no-leak
+oracles. Focus restoration after bounded foreground operations must be verified.
+
+The complete expensive desktop matrix should run only once the implementation
+is stable, consistent with repository agent guidance.
+
+## Unresolved questions
+
+- Which supported KWin extension/plugin API should implement the target-bound
+  delivery primitive on Plasma 6 without relying on private unstable internals?
+- Should protocol v2 expose coarse `BeginTargetInput` / `EndTargetInput`
+  transactions with typed event methods, or one atomic method per operation?
+- What exact generation source most reliably prevents stale token and PID reuse
+  across KWin/helper/browser restarts?
+- Can target-bound delivery preserve user foreground posture without activating
+  the target, or is bounded activation/restoration required for some event
+  classes?
+- Which refusal/error names best align with the current typed driver error
+  contract?
+- Which minimum live application matrix is required before documentation may
+  advance KDE from experimental identity support to target-input support?
+
+## Decision record
+
+Pending maintainer review. Record material feedback, accepted changes, rejected
+alternatives, remaining risks, and final disposition in issue #3506 before
+implementation begins.

--- a/rfcs/3506-kwin-target-input.md
+++ b/rfcs/3506-kwin-target-input.md
@@ -6,9 +6,8 @@ created: 2026-09-01
 last_updated: 2026-09-01
 status: review
 discussion: https://github.com/trycua/cua/issues/3506
-rfc_pr:
+rfc_pr: https://github.com/trycua/cua/pull/3507
 implementation:
-  - https://github.com/trycua/cua/issues/2283
 supersedes:
 superseded_by:
 ---
@@ -17,47 +16,76 @@ superseded_by:
 
 ## Summary
 
-Add a trusted, versioned KWin-side target-input contract that lets Cua Driver
-bind pointer and keyboard delivery to one freshly verified KDE/KWin window.
-When exact delivery cannot be proven, the driver must return a structured
-refusal and must not fall back to focus-bound global portal/libei input.
+Add a trusted KWin-side target-input capability that lets Cua Driver bind
+pointer and keyboard delivery to one freshly verified KDE/KWin window, while
+preserving an explicit user-authorization boundary at least as strong as the
+current RemoteDesktop portal flow. When exact delivery or authorization cannot
+be proven, the driver must return a structured refusal and must not fall back to
+focus-bound global portal/libei input.
+
+This RFC is intentionally gated on two proofs before product implementation:
+
+1. Plasma 6/KWin must expose a supported integration point that can bind the
+   mutation itself to an exact target rather than merely activate a window; and
+2. the KWin helper must not become a generally callable session-bus input
+   injection service. Mutating calls require a scoped, user-authorized
+   capability; same-UID access alone is not an authorization model.
+
+If either proof cannot be established with supported KWin/desktop APIs, KDE raw
+target-addressed input remains refused and the implementation does not proceed.
 
 ## Motivation
 
 Cua Driver already has partial KDE/KWin integration for window discovery and
-identity. The current helper exports trusted KWin window metadata and lets the
-driver correlate compositor identity with PID, geometry, activity/stacking, and
-AT-SPI. It intentionally does not expose mutating input operations.
+identity. The current in-process KWin effect exports a read-only Cua-owned D-Bus
+service. It reports helper-issued opaque tokens associated with live KWin
+windows, PID, geometry, active/minimized state, and stacking order. The Rust
+adapter verifies that the service owner is the running `kwin_wayland` process,
+checks same-user ownership, requires protocol version 1, and correlates KWin
+identity with AT-SPI.
 
-The remaining problem is not discovery but delivery. XDG portal/libei input is
-bound to the surface that is focused when the compositor processes the event,
-not to a Cua-selected KWin window token. An implementation that activates a
-window, verifies focus, and then sends global libei input has a race: focus can
-change between verification and irreversible delivery. A later read-back cannot
-undo a click or key event that reached the wrong application.
+The remaining delivery problem is separate from discovery. XDG
+Desktop Portal/libei input is focus-bound: the event reaches whichever surface
+is focused when KWin processes it. An implementation that activates a target,
+checks focus, and then emits global libei input has a TOCTOU race. Focus may
+change after verification but before an irreversible click or key is processed;
+a later read-back cannot undo an event delivered to the wrong application.
 
-KDE therefore needs a target-addressable mutation path whose contract is owned
-at the KWin boundary. The safety requirement is stronger than "the intended
-window was focused shortly before input"; the compositor-side path must either
-associate the event with the exact verified target or refuse it.
+There is also a permission-boundary problem. The current libei path obtains
+RemoteDesktop portal authorization and persists the user's explicit consent.
+Adding raw mutating methods to the helper's ordinary session-bus interface
+without an equivalent authorization mechanism would create a new desktop input
+capability available outside that portal flow. Verifying that the helper belongs
+to KWin proves the server identity; it does not authorize every client that can
+reach the session bus to request input.
+
+KDE therefore needs both target binding and caller authorization. The safety
+claim is stronger than "the intended window was focused shortly before input"
+and stronger than "the caller has the same UID": the compositor-side path must
+associate each accepted event with the exact verified target and a valid
+user-authorized capability, or refuse it.
 
 ## Goals
 
-- Define a versioned KWin target-input contract that binds a short-lived input
-  transaction to one exact verified window identity.
-- Preserve and extend the current trusted identity checks rather than replacing
-  them with title, app-id, geometry, or focus heuristics.
-- Route supported KDE pointer and keyboard mutations through that target-bound
-  contract.
+- Define a KWin target-input contract that binds a short-lived input transaction
+  to one exact verified window identity.
+- Preserve and extend the current trusted helper-owner, PID, UID, window-token,
+  and AT-SPI correlation checks.
+- Preserve a user-authorization boundary at least as strong as the existing
+  RemoteDesktop portal consent path; same UID, executable path, or process name
+  alone must not authorize raw input.
+- Route supported KDE pointer and keyboard mutations only through a proven
+  target-bound contract.
 - Guarantee that a selected KWin target never falls through to global
-  portal/libei delivery when target-bound dispatch is unavailable or becomes
-  unsafe.
+  portal/libei delivery when target-bound dispatch is unavailable or unsafe.
+- Preserve read-only discovery compatibility for existing v1 drivers/helpers
+  during capability rollout.
 - Expose precise capability and refusal information through doctor/health
   reporting.
 - Reuse the same KWin routing for existing-profile browser setup so browser
   setup cannot bypass the target-bound safety boundary.
-- Prove failure isolation with tests that observe both target state and absence
-  of leaked global input.
+- Prove failure isolation with tests that observe target state, authorization,
+  and absence of leaked global input.
 
 ## Non-goals
 
@@ -70,55 +98,135 @@ associate the event with the exact verified target or refuse it.
   provide a stronger target-scoped operation.
 - This RFC does not treat focus restoration alone as proof that input was
   delivered safely.
+- This RFC does not approve private or unstable KWin internals merely because a
+  prototype can call them.
+- This RFC does not define a generic Linux process-authentication scheme. It
+  requires a concrete desktop/user authorization mechanism for this capability.
 
 ## Terminology
 
 **KWin target token**
-: The compositor-issued opaque identity currently used by the Cua KWin helper
-  to distinguish one KWin window from another.
+: A helper-issued opaque token associated with a live KWin window identity. In
+  the current helper it is allocated from the window's KWin `internalId()` and
+  is valid only within the lifetime/generation in which it was issued.
 
-**Target generation**
-: A process/helper/compositor generation value that prevents stale tokens or PID
-  reuse from being accepted after restart or recreation.
+**Helper generation**
+: An identity that changes whenever a token from an earlier helper/KWin instance
+  could become stale. A captured D-Bus unique service owner may be part of this
+  proof, or the protocol may expose an explicit epoch. The chosen representation
+  must survive review and tests for helper/KWin restart and PID/token reuse.
+
+**Caller authorization**
+: A user-granted capability that permits raw desktop input. The current portal
+  RemoteDesktop authorization is the baseline security property. Same UID,
+  process name, executable path, or knowledge of a window token is not by
+  itself sufficient authorization for a new mutation endpoint.
 
 **Target-bound input**
-: Input delivery for which the KWin-side contract associates the mutation with
-  one exact verified target identity rather than with whichever surface happens
-  to hold focus at processing time.
+: Input delivery for which the compositor-side contract associates the mutation
+  with one exact verified target identity rather than with whichever surface
+  happens to hold focus at processing time.
 
 **Global input**
-: Focus-bound input injection, including portal/libei delivery, where the event
-  is not cryptographically or compositor-contractually associated with the
-  Cua-selected target.
+: Focus-bound input injection, including ordinary portal/libei delivery, where
+  the event is not contractually associated with the Cua-selected target.
 
 **Structured refusal**
-: A typed failure returned before unsafe mutation when identity, capability, or
-  transaction invariants cannot be proven.
+: A typed failure returned before unsafe mutation when identity, authorization,
+  capability, or transaction invariants cannot be proven.
 
 ## Current state
 
-The repository already contains a KWin target helper and Rust adapter. Protocol
-v1 is intentionally read-only: it exposes a version and window snapshots but no
-activation or raw input mutation methods. The Rust adapter verifies the D-Bus
-owner, KWin PID/session ownership, UID, protocol version, and correlates KWin
-window identity with AT-SPI.
+The repository contains `libs/cua-driver/kwin-target-helper`, an optional KWin 6
+effect loaded in the `kwin_wayland` process, and the Rust adapter at
+`platform-linux/src/wayland/kwin_helper.rs`.
 
-The current safety posture is deliberate:
+The helper's current contract is deliberately small:
 
-- the KWin helper can enumerate trusted windows;
-- `available()` for mutating KWin foreground input remains false;
+```text
+D-Bus name:   org.cua.KWinTarget
+Object path:  /org/cua/KWinTarget
+Interface:    org.cua.KWinTarget
+GetVersion() -> 1
+GetWindows() -> JSON window snapshot
+```
+
+Important current properties are:
+
+- protocol v1 is read-only;
+- the helper creates opaque numeric tokens for live KWin window identities;
+- the helper does not expose activation or input mutation methods;
+- the Rust adapter verifies the helper D-Bus owner, KWin process identity and
+  UID, and currently accepts the helper only when `GetVersion() == 1`;
+- `available()` for KWin raw input remains false;
 - the focused-window mutation wrapper refuses;
-- raw KWin pointer and keyboard actions remain disabled because portal/libei is
-  focus-bound rather than target-bound.
+- portal/libei obtains RemoteDesktop portal authorization, but the resulting
+  input is focus-bound rather than target-bound.
 
-This is preferable to activating a target and then sending global input because
-focus can change between any check and compositor-side event processing.
+That strict `GetVersion() == 1` check matters for migration: a simple helper
+upgrade from version 1 to version 2 would cause existing v1 drivers to reject
+the helper entirely, including read-only discovery. A capability rollout must
+therefore avoid describing such a bump as automatically additive.
 
 ## Proposal
 
-### Contract ownership
+### 1. Feasibility gate: supported KWin target-binding primitive
 
-Extend the existing KWin helper contract under the current service namespace:
+Before implementation changes product behavior, the RFC must identify and
+validate a supported Plasma 6/KWin extension point that can associate an input
+mutation with one exact `KWin::Window` (or an equivalent stable compositor
+object) at delivery time.
+
+The proof must demonstrate that the primitive is stronger than:
+
+```text
+activate(window) -> global input
+```
+
+A KWin API that only activates a window, changes focus, or emits compositor-wide
+input does not satisfy this RFC. A private/unstable symbol that cannot be
+supported across the documented KWin/Qt ABI policy also does not satisfy the
+production contract without an explicit maintainer decision.
+
+The feasibility spike should be reviewable evidence, not shipped capability. If
+no supported target-binding primitive exists, the disposition is to keep raw KDE
+input refused and, if useful, pursue an upstream KWin API rather than weaken the
+safety invariant.
+
+### 2. Authorization gate: do not create an ambient input service
+
+The current read-only D-Bus service may remain discoverable on the session bus.
+Mutating target-input capability must not become callable merely because a
+process can address `org.cua.KWinTarget`.
+
+Before any mutation method is enabled, the implementation must establish a
+scoped authorization mechanism with security properties at least as strong as
+the existing user-approved RemoteDesktop portal path. Acceptable design families
+for review include:
+
+- retaining portal-granted authorization and proving that the authorized EIS
+  capability can be bound by KWin to the selected target before delivery;
+- obtaining an explicit user-approved KWin/desktop capability whose scope is the
+  target-input operation; or
+- another maintainer-approved capability design that is non-ambient, revocable,
+  generation-bound, and testable.
+
+The exact mechanism is intentionally a review decision, but the following are
+not sufficient on their own:
+
+- same UID;
+- D-Bus sender PID;
+- process name or executable path;
+- possession of a window token;
+- an unguessable token that is not tied to user authorization and revocation.
+
+The helper must fail closed when authorization is absent, expired, revoked, for
+a different generation, or not valid for the requested operation.
+
+### 3. Contract ownership and compatibility
+
+Keep the current service namespace unless review finds a reason to split the
+mutation surface:
 
 ```text
 D-Bus name:   org.cua.KWinTarget
@@ -126,73 +234,94 @@ Object path:  /org/cua/KWinTarget
 Interface:    org.cua.KWinTarget
 ```
 
-The helper remains the authority for compositor window identity. Protocol v2
-(or a later compatible version selected during review) adds target-input
-capabilities while retaining v1 read-only discovery semantics for older clients.
+Because existing drivers require `GetVersion() == 1`, the preferred additive
+shape is to treat the current value as a wire-compatibility major and negotiate
+new behavior separately, for example with an optional method such as:
 
-The public contract must expose enough information for the driver to distinguish
-at least these capabilities:
+```text
+GetVersion()      -> 1
+GetCapabilities() -> named/typed capabilities
+```
 
-- identity/discovery available;
-- target activation available;
-- target-bound pointer input available;
-- target-bound keyboard input available.
+A v1 driver would continue to call only `GetVersion()` and `GetWindows()` and
+would therefore retain read-only discovery. A new driver talking to an old v1
+helper would observe no target-input capabilities and keep raw input refused.
 
-A helper that only implements `GetVersion()` and `GetWindows()` must never be
-reported as mutation-capable.
+The final capability encoding may differ, but it must distinguish at least:
 
-### Target identity
+- identity/discovery;
+- target activation, if separately meaningful;
+- authorized target-bound pointer input;
+- authorized target-bound keyboard input.
+
+If implementation needs a wire-incompatible protocol change, it must use an
+explicit migration strategy such as a parallel interface/path or dual-version
+support. A bare `GetVersion(): 1 -> 2` change is not considered additive because
+current v1 drivers reject non-1 helpers.
+
+A helper that only implements the current `GetVersion()` and `GetWindows()` must
+never be reported as mutation-capable.
+
+### 4. Target identity and generation
 
 A target-input transaction is opened only from a fresh snapshot that resolves
 exactly one target using a tuple equivalent to:
 
 ```text
-(pid, kwin_token, generation)
+(pid, kwin_token, helper_generation)
 ```
 
-The exact wire representation is implementation-defined, but the following
-properties are required:
+The exact wire representation is implementation-defined, but these properties
+are required:
 
 - the token is opaque to callers;
 - PID ownership is verified and cannot be substituted by title/app-id lookup;
-- the generation changes when token/PID reuse could make an old identity stale;
+- the generation changes whenever an old token could become stale after helper
+  reload, KWin restart, or other identity reset;
+- the authorization capability is bound to the compatible live generation;
 - the target is revalidated immediately before each irreversible mutation or
   input frame;
 - duplicate or ambiguous identities refuse rather than selecting a best match.
 
-Existing owner/session/UID checks remain mandatory.
+The existing helper-owner/session/UID checks remain mandatory. The implementation
+must not assume the monotonic numeric token alone is globally unique or durable.
 
-### Transaction model
+### 5. Target-input transaction
 
 The Rust adapter gains a target-input transaction abstraction conceptually like:
 
 ```rust
-with_target_input(pid, token, generation, |target| {
+with_target_input(pid, token, generation, authorization, |target| {
     // bounded pointer/keyboard operations
 })
 ```
 
-Opening the transaction must:
+The concrete API does not need to match this signature. Opening the transaction
+must:
 
 1. obtain a fresh KWin snapshot;
 2. resolve exactly one verified target;
-3. negotiate the required target-input capability;
-4. bind the transaction to that identity;
-5. reject stale, ambiguous, missing, or unsupported targets before mutation.
+3. validate the live helper/KWin generation;
+4. validate the caller's user-authorized input capability;
+5. negotiate the required target-input capability;
+6. bind the transaction to the target identity and authorization scope;
+7. reject stale, ambiguous, missing, unauthorized, revoked, or unsupported
+   targets before mutation.
 
-During the transaction the KWin-side path must ensure that delivery remains
+During the transaction, the KWin-side path must ensure that delivery remains
 associated with the bound target. If the invariant cannot be maintained across
-multi-frame operations such as drag or type sequences, the transaction must
-stop and return a structured refusal before the next frame.
+multi-frame operations such as drag or type sequences, the transaction stops and
+returns a structured refusal before the next frame.
 
 The implementation may internally activate the target when required by KWin,
-but activation is not itself the safety guarantee. The safety guarantee is that
-the compositor-side input path associates each delivered event with the bound
-target identity or refuses the event.
+but activation is not the safety guarantee. The guarantee is that each accepted
+event is associated with the bound target and valid authorization at delivery
+time, or is refused.
 
-### Supported operations
+### 6. Supported operations
 
-Once the contract proves target-bound delivery, KDE routing may use it for:
+Only operations proven to satisfy the same authorization and target-binding
+contract may be enabled:
 
 - click / pointer button actions;
 - pointer movement required by click and drag;
@@ -202,65 +331,75 @@ Once the contract proves target-bound delivery, KDE routing may use it for:
 - individual key presses;
 - hotkeys.
 
-Operations that cannot satisfy the same target-binding invariant remain
-structured refusals even if some other KWin mutation path is available.
+Capability negotiation may expose pointer and keyboard support separately.
+Operations that cannot satisfy the invariant remain structured refusals even if
+another KWin/global mutation mechanism exists.
 
-### No-global-fallback rule
+### 7. No-global-fallback rule
 
-The key safety rule is:
+The key delivery rule is:
 
 > After cua-driver selects the trusted KWin target route for an operation, any
-> inability to prove or maintain target-bound delivery MUST return a structured
-> refusal. The operation MUST NOT fall back to global portal/libei input.
+> inability to prove or maintain authorization and target-bound delivery MUST
+> return a structured refusal. The operation MUST NOT fall back to global
+> portal/libei input.
 
-This includes capability loss, helper restart, target closure, generation
-change, ambiguous identity, user focus takeover where the contract cannot
-preserve target binding, and unsupported input kinds.
+This includes authorization loss/revocation, capability loss, helper restart,
+target closure, generation change, ambiguous identity, unsupported input kinds,
+or any focus/user-interaction transition that the target-bound primitive cannot
+handle safely.
 
-A representative refusal code is `target_input_unavailable`; final typed error
-names should follow the existing driver error taxonomy.
+Representative refusal categories include `target_input_unavailable`,
+`target_identity_stale`, and `target_input_unauthorized`; final names should
+follow the existing typed driver error taxonomy.
 
-### libei relationship
+### 8. libei relationship
 
-The preferred design does not route KWin target-bound mutation through the
-existing global `libei.rs` worker because those commands do not carry a window
-identity today and because EIS focus-bound delivery does not by itself provide
-target association.
+The existing global `libei.rs` worker carries pointer/keyboard commands but no
+KWin target identity. EIS focus-bound delivery does not by itself establish
+exact-target association.
 
-Portal/libei remains valid for other compositors where its documented semantics
-match the accepted operation contract. It may also remain available for
-non-targeted or explicitly global operations that are outside this RFC.
+Portal/libei remains valid for compositors and operations where its documented
+semantics match the accepted contract. It may also remain valid for explicitly
+global operations outside this RFC.
 
-If an implementation later proposes using libei inside the KWin transaction,
-it must first provide compositor-level evidence that every event is target-bound
-before delivery. Pre/post focus checks alone are insufficient.
+If the accepted KDE design retains libei/EIS, the implementation must prove that
+the already-authorized input capability is bound by KWin to the exact target
+*before delivery*. Pre/post focus checks and post-event read-back are
+insufficient.
 
-### Browser existing-profile setup
+### 9. Browser existing-profile setup
 
-The browser setup path currently has compositor-specific foreground routing that
-can differ from the general Wayland routing. KDE existing-profile setup must use
-the same KWin target transaction (directly or via the common Wayland target
-routing) rather than bypassing it through a GNOME-oriented shell helper or global
-input fallback.
+The browser setup path has compositor-specific foreground routing that can differ
+from the general Wayland path. KDE existing-profile setup must use the same
+accepted KWin authorization/target transaction, directly or through common
+Wayland routing, rather than bypassing it through a GNOME-oriented helper or a
+global input fallback.
 
 This keeps browser approval, exact target identity, generation, reconnect, and
-mutation under one safety boundary.
+mutation under one safety boundary. Related broader browser work is tracked in
+#2283.
 
-### Doctor and health reporting
+### 10. Doctor and health reporting
 
-Health output must distinguish identity from mutation capability. Representative
-states are:
+Health output must distinguish discovery, authorization, and mutation capability.
+Representative states are:
 
 ```text
 KWin identity adapter: available
 KWin target input: unavailable (helper is read-only)
 ```
 
-and, once v2 is present and verified:
+```text
+KWin identity adapter: available
+KWin target input: blocked (user authorization unavailable/revoked)
+```
+
+and, only after all gates pass:
 
 ```text
 KWin identity adapter: available
-KWin target input: pointer and keyboard target-bound delivery available
+KWin target input: authorized pointer and keyboard target-bound delivery available
 Wayland backend: KDE/KWin target-addressable foreground dispatch available
 ```
 
@@ -268,57 +407,48 @@ Doctor should distinguish at least:
 
 1. helper absent;
 2. helper present but read-only;
-3. incompatible protocol version;
-4. helper missing required target-input methods/capabilities;
-5. target identity ambiguous or stale;
-6. target-bound transaction unavailable for the requested operation.
+3. incompatible wire version;
+4. helper missing required target-input capability;
+5. authorization absent/revoked/invalid for the current generation;
+6. target identity ambiguous or stale;
+7. target-bound transaction unavailable for the requested operation.
 
-The platform support documentation remains experimental until the full live
-acceptance evidence described below is recorded.
-
-### Control flow
-
-The intended flow is:
-
-```text
-cua-driver
-    |
-    | fresh (PID, token, generation) validation
-    v
-KWin target-input transaction
-    |
-    | compositor-bound delivery or refusal
-    v
-exact KWin Window
-```
-
-The disallowed flow is:
-
-```text
-activate target -> check focus -> global libei input
-```
-
-because no amount of pre-delivery focus checking makes a global irreversible
-event target-addressable.
+The platform support documentation remains experimental until the live acceptance
+evidence in this RFC is recorded.
 
 ## Alternatives considered
 
 ### Activate then use global portal/libei
 
-Rejected as the baseline design. Focus can change after activation or focus
-verification and before compositor-side event delivery. Post-event checks cannot
-undo an event delivered to another application.
+Rejected. Focus can change after activation or verification and before
+compositor-side delivery. Post-event checks cannot undo an event delivered to
+another application.
 
 ### Recheck focus before every libei command or add sleeps
 
-Rejected. This narrows a timing window but does not remove it, and therefore
-cannot support an exact-target safety claim.
+Rejected. This narrows a timing window but does not remove it.
+
+### Expose target mutation directly on the session bus to same-UID callers
+
+Rejected as the default security model. The current RemoteDesktop path carries
+explicit user authorization. A new ambient same-user input service would widen
+the capability boundary and could allow callers that never obtained that
+authorization to request desktop input.
+
+### Trust D-Bus sender PID, process name, or executable path
+
+Rejected as sufficient authorization. These can contribute to diagnostics or
+defense in depth but do not replace a user-granted, revocable capability.
+
+### Increment `GetVersion()` from 1 to 2 and call the rollout additive
+
+Rejected without a compatibility layer. Current v1 drivers require exact version
+1 and would lose even read-only discovery when presented with version 2.
 
 ### Use title, app-id, or geometry matching
 
-Rejected for authorization. These values are not unique stable identities and
-can collide or change. They may be diagnostic metadata but not the mutation
-selector.
+Rejected for authorization/identity. These values are not unique stable target
+identities and may change or collide.
 
 ### `wmctrl` / `xdotool`
 
@@ -327,8 +457,8 @@ do not establish a native Wayland target-bound input contract.
 
 ### Enable the existing adapter by setting `available() = true`
 
-Rejected while the mutation body remains global/focus-bound. Capability must be
-reported from the actual target-input contract, not helper presence.
+Rejected while the mutation body remains global/focus-bound or authorization is
+unproven. Capability reporting must derive from the actual accepted contract.
 
 ### Focus transaction with read-back after each event
 
@@ -338,95 +468,127 @@ surface.
 
 ## Compatibility and migration
 
-The change is additive at the protocol level:
+The preferred rollout preserves the current wire-compatible discovery surface:
 
-- existing v1 helpers remain valid for identity/discovery;
-- existing clients continue to see KDE raw target input as unavailable;
-- a v2-capable helper advertises target-input capability explicitly;
-- the driver enables KDE mutation only after verifying both protocol/capability
-  and target transaction invariants.
+- old driver + new helper: `GetVersion() == 1` and `GetWindows()` continue to
+  work; the old driver ignores optional capabilities/methods;
+- new driver + old helper: discovery works, target-input capability is absent,
+  and raw KDE input remains refused;
+- new driver + new helper: target input is enabled only after capability,
+  authorization, generation, and target checks pass.
 
-No unsafe fallback is introduced during rollout. If driver and helper versions
-are mismatched, the behavior is a precise refusal rather than degraded global
+If a wire-incompatible change becomes necessary, the RFC must be updated with a
+parallel/dual-version migration before implementation. The design must not
+silently trade away existing read-only discovery compatibility.
+
+No unsafe fallback is introduced during rollout. Mismatch, missing capability,
+or missing authorization produces a precise refusal rather than degraded global
 input.
 
-Rollback is straightforward: disable/remove the v2 mutation capability and the
-driver returns to the current read-only KWin posture without changing window
-identity discovery.
+Rollback is straightforward only if discovery remains separable from mutation:
+disable/remove the new mutation capability and the driver returns to the current
+read-only KWin posture.
 
 The first user-visible implementation should use a `feat(cua-driver): ...` pull
 request title because safe target-addressable KDE raw input is a new capability.
 
 ## Security, privacy, and telemetry
 
-The KWin helper is part of a privileged desktop trust boundary and must expose
-only the minimum metadata needed for identity and delivery.
+The KWin helper runs inside the compositor process and is therefore part of a
+privileged desktop trust boundary. Mutating its API is materially more sensitive
+than the current read-only snapshot surface.
 
 Required properties:
 
 - verify the D-Bus service owner and expected KWin session process;
-- verify same-user/session ownership;
+- verify same-user/session ownership as server-identity evidence;
+- separately validate a user-authorized input capability for every mutation
+  transaction;
+- do not treat same UID, D-Bus sender PID, process name/path, or token possession
+  as sufficient authorization;
 - do not trust caller-provided titles, app IDs, geometry, or PID without a fresh
   compositor snapshot;
-- bind mutation to an opaque compositor target plus generation;
-- invalidate transactions on helper/compositor restart and stale identity;
+- bind mutation to an opaque live target plus generation and authorization scope;
+- invalidate transactions on helper/KWin restart, stale identity, authorization
+  revocation, or capability loss;
 - refuse ambiguous target resolution;
 - never send global raw input as a recovery path after target routing is chosen;
 - avoid telemetry containing typed text, key sequences, window titles, document
-  contents, or target application data.
+  contents, target application data, authorization secrets, or restore tokens.
 
-Permitted telemetry should be limited to capability state, protocol version,
-structured refusal category, operation class, and coarse timing/error counters
-that cannot reconstruct user input.
+Permitted telemetry should be limited to capability/authorization state,
+wire/capability version, structured refusal category, operation class, and
+coarse timing/error counters that cannot reconstruct user input.
 
 ## Implementation plan
 
 Implementation begins only after this RFC is accepted according to the Cua RFC
 process.
 
-### Increment 1: KWin target-input contract and adapter
+### Increment 0: feasibility and authorization spike
 
-- extend the KWin helper with a versioned target-input capability;
+Before production routing changes:
+
+- identify the supported KWin API that can bind delivery to an exact target;
+- demonstrate a positive target-binding canary with two competing windows;
+- define and prototype the user-authorization mechanism without creating an
+  ambient session-bus mutation service;
+- document ABI/support constraints and rollback;
+- return to RFC review if the spike requires private KWin internals, weakens user
+  consent, or changes the public security boundary beyond this proposal.
+
+No raw KDE input support is advertised from this spike alone.
+
+### Increment 1: compatible capability and target identity contract
+
+- preserve v1 read-only discovery for existing clients;
+- add compatible capability negotiation or an explicitly reviewed dual-version
+  interface;
 - add generation-aware target validation;
+- bind authorization to the live helper/target generation;
 - add the Rust target transaction abstraction;
-- retain read-only behavior for v1 helpers;
-- add focused contract/unit tests for stale, duplicate, ambiguous and restarted
-  targets.
+- add contract/unit tests for stale, duplicate, ambiguous, unauthorized and
+  restarted targets.
 
 ### Increment 2: pointer/keyboard routing and no-fallback enforcement
 
-- route supported KDE pointer/keyboard operations through the target transaction;
+- route only proven KDE pointer/keyboard operations through the authorized target
+  transaction;
 - hard-block transition from selected KWin routing to global libei;
-- add structured refusal coverage for mid-transaction target changes;
+- add structured refusal coverage for mid-transaction target or authorization
+  changes;
 - verify multi-frame drag/type cancellation behavior.
 
 ### Increment 3: browser setup and health reporting
 
-- route existing-profile browser setup through the common KWin target path;
-- distinguish identity-only and target-input capability in doctor/health output;
+- route existing-profile browser setup through the common accepted KWin path;
+- distinguish identity-only, authorization, and target-input capability in
+  doctor/health output;
 - add compatibility/version diagnostics.
 
 ### Increment 4: live Plasma 6 evidence and documentation
 
-- run the canonical KDE/Wayland lane on the exact candidate SHA;
+- run the compositor-specific Linux desktop harness on the exact candidate SHA;
 - test representative Chromium, Firefox, GTK, Qt and Electron targets where the
-  existing harness supports them;
-- prove pointer, keyboard, drag, scroll, target closure, focus takeover, and
-  focus restoration behavior;
+  harness supports them;
+- prove pointer, keyboard, drag, scroll, target closure, focus takeover,
+  authorization loss, and focus restoration behavior;
 - update platform support/roadmap/action-support documentation only to the level
-  demonstrated by the evidence.
+  demonstrated by evidence.
 
-These increments may be separate PRs when that keeps review focused. The first
-implementation PR links this RFC and the decision issue.
+These increments may be separate PRs when that keeps review focused. Each
+implementation PR must link this RFC and issue #3506.
 
 ## Test and acceptance plan
 
-### Contract and unit tests
+### Contract and compatibility tests
 
 Cover at least:
 
-- snapshot parsing and protocol negotiation;
-- duplicate tokens;
+- old-driver/new-helper read-only discovery compatibility;
+- new-driver/old-helper read-only discovery and target-input refusal;
+- capability negotiation and malformed/unknown capabilities;
+- snapshot parsing and duplicate tokens;
 - two windows owned by one process;
 - minimized/hidden targets where relevant;
 - ambiguous AT-SPI correlation;
@@ -437,7 +599,21 @@ Cover at least:
 - target loss before mutation;
 - unsupported operation capability.
 
-### Safety tests
+### Authorization tests
+
+Explicitly prove:
+
+- an ordinary session-bus caller without the approved user capability cannot
+  mutate input;
+- authorization revocation stops subsequent operations before delivery;
+- authorization from a previous helper/KWin generation cannot be replayed;
+- capability material is not exposed in logs, health output, or telemetry;
+- the accepted path preserves any required desktop/user consent semantics.
+
+Where the chosen design interacts with sandboxed applications or portal policy,
+include a representative isolation test supported by the repository harness.
+
+### Target-safety tests
 
 Explicitly trigger:
 
@@ -446,39 +622,61 @@ Explicitly trigger:
 - close target during text typing;
 - helper/KWin restart during a transaction;
 - target replacement with possible PID reuse;
-- another window of the same process becoming active.
+- another window of the same process becoming active;
+- authorization loss during a multi-frame operation.
 
-For every unsafe case, acceptance requires both:
+For every unsafe case, acceptance requires:
 
 ```text
 structured refusal
-no global input sent
+no event delivered to a non-target window
+no fallback global input sent
 ```
 
 A successful driver response alone is not evidence.
 
 ### Live Plasma 6 evidence
 
-Use the repository's compositor-specific Linux desktop harness on the exact
-candidate SHA. At minimum, prove one exact target receives pointer and keyboard
-input while a sentinel/other window proves no leaked input. Expand the matrix to
-representative Chromium/Chrome, Firefox, GTK, Qt, Electron, two-window, covered,
-and alternate-workspace scenarios as supported by the harness.
+At minimum, prove one exact target receives pointer and keyboard input while a
+sentinel/second window proves no leaked input. The positive canary must also
+show that deliberately selecting the second target changes only the second
+target; this demonstrates target addressability rather than coincidental focus.
 
-Evidence must observe fixture-owned state and relevant focus/z-order/no-leak
-oracles. Focus restoration after bounded foreground operations must be verified.
+Expand the stable candidate matrix to representative Chromium/Chrome, Firefox,
+GTK, Qt, Electron, two-window, covered, and alternate-workspace scenarios as
+supported by the harness. Evidence must observe fixture-owned state and relevant
+focus/z-order/no-leak/authorization oracles. Focus restoration after bounded
+foreground operations must be verified when activation is part of the accepted
+implementation.
 
-The complete expensive desktop matrix should run only once the implementation
-is stable, consistent with repository agent guidance.
+The expensive desktop matrix should run only after the implementation is stable,
+consistent with repository agent guidance, and must record the exact candidate
+SHA.
+
+## Related work
+
+- #2283 tracks exact existing-profile browser setup across Wayland compositors.
+- #2194 tracks trustworthy Wayland cursor-preservation evidence.
+
+These are related constraints/evidence streams, not substitutes for this RFC's
+authorization and exact-target decision.
 
 ## Unresolved questions
 
-- Which supported KWin extension/plugin API should implement the target-bound
-  delivery primitive on Plasma 6 without relying on private unstable internals?
-- Should protocol v2 expose coarse `BeginTargetInput` / `EndTargetInput`
-  transactions with typed event methods, or one atomic method per operation?
-- What exact generation source most reliably prevents stale token and PID reuse
-  across KWin/helper/browser restarts?
+- Which supported KWin extension/plugin API, if any, can implement exact
+  target-bound delivery on Plasma 6 without relying on private unstable
+  internals?
+- How should user authorization be represented so the helper cannot become an
+  ambient same-user input service and consent/revocation semantics remain at
+  least as strong as the current portal path?
+- Can an authorized EIS/libei capability be bound to an exact KWin target before
+  delivery, or does KDE require a different supported primitive?
+- Should compatible capability negotiation stay on wire version 1, or should a
+  parallel interface/path carry a future incompatible major version?
+- What exact generation source most reliably prevents stale token, authorization
+  and PID reuse across helper/KWin/browser restarts?
+- Should the mutation API expose a bounded transaction or atomic operation calls
+  so partial multi-frame delivery and cancellation semantics are unambiguous?
 - Can target-bound delivery preserve user foreground posture without activating
   the target, or is bounded activation/restoration required for some event
   classes?
@@ -489,6 +687,7 @@ is stable, consistent with repository agent guidance.
 
 ## Decision record
 
-Pending maintainer review. Record material feedback, accepted changes, rejected
-alternatives, remaining risks, and final disposition in issue #3506 before
-implementation begins.
+Pending maintainer review. The decision summary in issue #3506 must record the
+chosen KWin primitive, authorization model, compatibility strategy, rejected
+alternatives, remaining risks, and final disposition before implementation
+begins.


### PR DESCRIPTION
## Summary

Documentation-only RFC for making KDE/KWin pointer and keyboard delivery **target-addressable**: an accepted mutation must be bound to the exact verified KWin target at delivery time, or refuse without falling back to focus-bound global input.

No product behavior changes in this PR. The current KWin helper remains read-only and current `main` still keeps KWin raw target input unavailable.

## Current project context

This branch is synced with current `main` (`39a206e`) at head `db651e1`.

Since this RFC was opened, the project accepted the Hyprland compositor-input design in **#3550 / #3551**. That decision establishes an important shared baseline for compositor integrations:

- normal Cua Driver actions continue through the existing `standard`, `bounded`, and explicitly acknowledged `unrestricted` permission modes;
- policy/manifest/resource/lifecycle checks are performed per action rather than inherited from a cached compositor connection;
- same-desktop-account transport is a trusted-local model, not a sandbox against arbitrary same-user native code; and
- compatibility qualification is not a second permission system.

For this KWin RFC, that means reviewers do **not** need to invent a new mandatory per-window approval UI or standalone signer merely because the mutation path is compositor-specific. The remaining KWin-specific authorization question is narrower: how the mutation transport/interface is owned so an ambient session-bus method cannot bypass the Driver-controlled policy path, and how that authority is invalidated across helper/KWin generation changes.

The RFC document predates the #3550 decision and intentionally remains in `status: review`; its stricter authorization wording is therefore part of the review surface to reconcile before acceptance, not a claim that KWin must introduce a second approval system.

## Maintainer decisions requested

1. **Target delivery primitive** — Is there a supported Plasma 6/KWin API that binds pointer/keyboard mutation to one exact live target at delivery time, rather than `activate(window) + global input`? If not, raw KDE input should remain refused and the missing primitive may need to be pursued upstream.
2. **Mutation transport / ownership** — Should mutation be added through compatible capability negotiation on the existing v1 discovery surface, a parallel D-Bus interface/path, or another Driver-owned channel that preserves the shared per-action authorization model?
3. **Generation / stale authority** — What KWin/helper generation identity should bind target tokens and any mutation authority so restart, reload, stale target, and PID/token reuse fail closed?

Current drivers require `GetVersion() == 1`, so a bare `1 -> 2` bump would break existing read-only discovery.

## Required invariants

Any accepted implementation must:

- bind each mutation to an exact, freshly verified target and live helper/KWin generation;
- run through normal Cua Driver permission/policy admission for each action;
- revalidate before irreversible mutation and during bounded multi-frame operations where necessary;
- refuse ambiguous, stale, unsupported, or policy-denied requests;
- never fall back to global portal/libei after target-bound KWin routing is selected;
- keep existing-profile browser setup on the same accepted KWin safety boundary; and
- require compatibility, no-leak/refusal, recovery, and live Plasma 6 evidence before support claims change.

## Reviewer guide

The highest-value review areas are:

1. **Proposal §§1–3** — whether the KWin primitive and wire/interface direction are supportable.
2. **Target identity / transaction sections** — whether generation, stale-token, and multi-frame failure semantics are strong enough.
3. **Security + acceptance plan** — reconcile the RFC’s original authorization wording with the shared Driver policy selected in #3550 without creating an ambient mutation bypass.
4. **Compatibility** — preserve v1 read-only discovery for old drivers/helpers while adding no unsafe downgrade path.

A maintainer decision in **#3506** is the authoritative disposition; implementation remains blocked until then.

## Validation / CI

- RFC only: **1 Markdown file**, no production-code behavior changes.
- Rechecked against current `main`, the read-only KWin helper, `kwin_helper.rs`, the RFC process, and the later shared-policy decision in #3550/#3551.
- The refreshed head is mergeable. Current fork-triggered `Fleet Mirror Guard` and `CI: Release metadata` runs are `action_required` and need maintainer approval if the repository requires them for RFC processing.
- No unresolved inline review threads or submitted reviews are currently outstanding.

Refs #3506
Refs #3336
Refs #3550
Refs #3551
Refs #2283
Refs #2194