### PR TITLE
fix(cua-driver): make transport-failure envelopes match the advertised outputSchema

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/lib.rs
@@ -37,15 +37,16 @@ pub use inputs::{
     MULTI_CALL_SESSION_DESCRIPTION,
 };
 pub use outputs::{
-    advertised_output_schema, refusal_envelope_schema, ActionDelivery, ActionDeliveryMode,
-    ActionEffect, ActionEscalation, ActionEscalationReason, ActionEscalationTarget, ActionEvidence,
-    ActionEvidenceKind, ActionResult, ActionResultValidationError, ActionRoute,
-    ClipboardReadOutput, ClipboardWriteOutput, CursorMotionOutput, CursorPointOutput,
-    CursorPositionOutput, CursorThemeOutput, CursorVisualOutput, DesktopStateOutput,
-    EffectiveScope, EndSessionOutput, GetAgentCursorStateOutput, ListSessionsOutput,
-    ScreenSizeOutput, SessionClientKindOutput, SessionLifecycleState, SessionOutput,
-    SessionStateOutput, SessionTransportOutput, SetAgentCursorEnabledOutput,
-    SetAgentCursorMotionOutput, SetAgentCursorThemeOutput, StartSessionOutput, ToolOutput,
+    advertised_output_schema, conforming_error_envelope, refusal_envelope_schema, ActionDelivery,
+    ActionDeliveryMode, ActionEffect, ActionEscalation, ActionEscalationReason,
+    ActionEscalationTarget, ActionEvidence, ActionEvidenceKind, ActionResult,
+    ActionResultValidationError, ActionRoute, ClipboardReadOutput, ClipboardWriteOutput,
+    CursorMotionOutput, CursorPointOutput, CursorPositionOutput, CursorThemeOutput,
+    CursorVisualOutput, DesktopStateOutput, EffectiveScope, EndSessionOutput,
+    GetAgentCursorStateOutput, ListSessionsOutput, ScreenSizeOutput, SessionClientKindOutput,
+    SessionLifecycleState, SessionOutput, SessionStateOutput, SessionTransportOutput,
+    SetAgentCursorEnabledOutput, SetAgentCursorMotionOutput, SetAgentCursorThemeOutput,
+    StartSessionOutput, ToolOutput, TOOL_INVOCATION_FAILED_CODE,
 };
 pub use verification::{
     BoundsExpectation, ElementPredicate, ElementSelector, PredicateOutcome, StatePredicate,

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/lib.rs
@@ -37,12 +37,12 @@ pub use inputs::{
     MULTI_CALL_SESSION_DESCRIPTION,
 };
 pub use outputs::{
-    advertised_output_schema, conforming_error_envelope, refusal_envelope_schema, ActionDelivery,
-    ActionDeliveryMode, ActionEffect, ActionEscalation, ActionEscalationReason,
-    ActionEscalationTarget, ActionEvidence, ActionEvidenceKind, ActionResult,
-    ActionResultValidationError, ActionRoute, ClipboardReadOutput, ClipboardWriteOutput,
-    CursorMotionOutput, CursorPointOutput, CursorPositionOutput, CursorThemeOutput,
-    CursorVisualOutput, DesktopStateOutput, EffectiveScope, EndSessionOutput,
+    advertised_output_schema, conforming_error_envelope, is_refusal_envelope,
+    refusal_envelope_schema, ActionDelivery, ActionDeliveryMode, ActionEffect, ActionEscalation,
+    ActionEscalationReason, ActionEscalationTarget, ActionEvidence, ActionEvidenceKind,
+    ActionResult, ActionResultValidationError, ActionRoute, ClipboardReadOutput,
+    ClipboardWriteOutput, CursorMotionOutput, CursorPointOutput, CursorPositionOutput,
+    CursorThemeOutput, CursorVisualOutput, DesktopStateOutput, EffectiveScope, EndSessionOutput,
     GetAgentCursorStateOutput, ListSessionsOutput, ScreenSizeOutput, SessionClientKindOutput,
     SessionLifecycleState, SessionOutput, SessionStateOutput, SessionTransportOutput,
     SetAgentCursorEnabledOutput, SetAgentCursorMotionOutput, SetAgentCursorThemeOutput,
@@ -211,6 +211,7 @@ struct ToolIndexEntry {
     capabilities: Vec<String>,
     input_fields: BTreeSet<String>,
     output_validator: OutputValidator,
+    advertises_output_schema: bool,
 }
 
 fn tool_index() -> &'static BTreeMap<String, ToolIndexEntry> {
@@ -228,12 +229,14 @@ fn tool_index() -> &'static BTreeMap<String, ToolIndexEntry> {
                     .flatten()
                     .map(|(name, _)| name.clone())
                     .collect();
+                let advertises_output_schema = tool.success_output_schema.is_some();
                 (
                     tool.name,
                     ToolIndexEntry {
                         capabilities: tool.capabilities,
                         input_fields,
                         output_validator: tool.output_validator,
+                        advertises_output_schema,
                     },
                 )
             })
@@ -262,6 +265,37 @@ pub fn tool_success_output_schema(name: &str) -> Option<Value> {
         return Some(desktop::list_windows_success_output_schema());
     }
     tool_contract(name).and_then(|contract| contract.success_output_schema)
+}
+
+/// The `outputSchema` one tool advertises on `tools/list`, or `None` when it
+/// advertises none.
+///
+/// Action tools answer with the shared `ActionResult` shape; everything else
+/// uses its own success schema when it has one. Both are wrapped by
+/// [`advertised_output_schema`] so the refusal arm rides along, because MCP
+/// holds every `structuredContent` a tool emits — refusals included — to this
+/// schema.
+pub fn advertised_tool_output_schema(name: &str) -> Option<Value> {
+    let success = if is_action_result_tool(name) {
+        Some(<ActionResult as ToolOutput>::output_schema())
+    } else {
+        tool_success_output_schema(name)
+    };
+    success.map(advertised_output_schema)
+}
+
+/// Whether [`advertised_tool_output_schema`] would answer with a schema.
+///
+/// The `tools/call` boundary asks this once per call, so it reads the cached
+/// tool index instead of rebuilding the manifest and its schemas.
+/// `advertised_schema_presence_matches_the_cheap_predicate` pins the two
+/// against each other across the whole manifest.
+pub fn advertises_output_schema(name: &str) -> bool {
+    is_action_result_tool(name)
+        || name == "list_windows"
+        || tool_index()
+            .get(name)
+            .is_some_and(|entry| entry.advertises_output_schema)
 }
 
 /// Validate a successful structured payload against the Rust output type that
@@ -300,6 +334,26 @@ mod tests {
         assert_eq!(names, sorted);
         assert_eq!(manifest.contract_version, "0.7.0");
         assert!(manifest.experimental);
+    }
+
+    /// The `tools/call` boundary decides whether a client will validate a
+    /// payload from the cheap predicate, so a tool it disagrees with on would
+    /// be checked against a schema it never advertises, or skipped while a
+    /// client still validates it.
+    #[test]
+    fn advertised_schema_presence_matches_the_cheap_predicate() {
+        let mut names: Vec<String> = manifest().tools.into_iter().map(|tool| tool.name).collect();
+        names.extend(ACTION_RESULT_TOOLS.iter().map(|name| (*name).to_owned()));
+        names.push("list_windows".to_owned());
+        names.push("no_such_tool".to_owned());
+
+        for name in names {
+            assert_eq!(
+                advertised_tool_output_schema(&name).is_some(),
+                advertises_output_schema(&name),
+                "`{name}` disagrees on whether it advertises an output schema"
+            );
+        }
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/outputs.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/outputs.rs
@@ -38,6 +38,48 @@ pub fn refusal_envelope_schema() -> Value {
     })
 }
 
+/// Marker code for structured error envelopes that carry no tool-specific
+/// refusal shape.
+///
+/// The transport and daemon failure paths answer with diagnostics like
+/// `{"exit_code": 1}` rather than a tool refusal. That payload satisfies
+/// neither arm of [`advertised_output_schema`]: it is missing the success
+/// arm's required keys while carrying a key the success arm does not allow,
+/// and it has none of the refusal arm's marker keys. Strict MCP clients then
+/// reject the whole response, so the error text in `content` never reaches the
+/// agent.
+pub const TOOL_INVOCATION_FAILED_CODE: &str = "tool_invocation_failed";
+
+/// Guarantee a structured error payload is recognisable as a refusal.
+///
+/// Inserts [`TOOL_INVOCATION_FAILED_CODE`] when the payload carries none of the
+/// refusal marker keys, so any diagnostic an error path invents still validates
+/// against the advertised `outputSchema`. Payloads that already carry a marker
+/// are returned untouched.
+pub fn conforming_error_envelope(structured: Value) -> Value {
+    // Both arms require `type: object`, so a non-object diagnostic is kept as a
+    // value inside the envelope rather than being emitted as the envelope.
+    let mut object = match structured {
+        Value::Object(object) => object,
+        Value::Null => Map::new(),
+        other => {
+            let mut object = Map::new();
+            object.insert("detail".into(), other);
+            object
+        }
+    };
+    if !["refusal", "status", "code"]
+        .iter()
+        .any(|marker| object.contains_key(*marker))
+    {
+        object.insert(
+            "code".into(),
+            Value::String(TOOL_INVOCATION_FAILED_CODE.into()),
+        );
+    }
+    Value::Object(object)
+}
+
 /// Wrap a success schema into the shape advertised as the MCP `outputSchema`.
 ///
 /// MCP requires every `structuredContent` a tool emits to validate against its
@@ -813,5 +855,48 @@ mod tests {
         );
         result.evidence = None;
         assert_eq!(result.validate_invariants(), Ok(()));
+    }
+}
+
+#[cfg(test)]
+mod error_envelope_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn a_diagnostic_without_a_marker_gains_one() {
+        let envelope = conforming_error_envelope(json!({"exit_code": 1}));
+
+        assert_eq!(envelope["code"], TOOL_INVOCATION_FAILED_CODE);
+        assert_eq!(envelope["exit_code"], 1);
+    }
+
+    #[test]
+    fn each_existing_marker_is_left_alone() {
+        for marker in ["refusal", "status", "code"] {
+            let envelope = conforming_error_envelope(json!({marker: "already-named"}));
+
+            assert_eq!(
+                envelope,
+                json!({marker: "already-named"}),
+                "guard rewrote a payload that already carries `{marker}`"
+            );
+        }
+    }
+
+    #[test]
+    fn a_non_object_diagnostic_becomes_an_object() {
+        let envelope = conforming_error_envelope(json!("daemon transport closed"));
+
+        assert_eq!(envelope["code"], TOOL_INVOCATION_FAILED_CODE);
+        assert_eq!(envelope["detail"], "daemon transport closed");
+    }
+
+    #[test]
+    fn an_absent_diagnostic_still_produces_a_refusal() {
+        assert_eq!(
+            conforming_error_envelope(Value::Null),
+            json!({"code": TOOL_INVOCATION_FAILED_CODE})
+        );
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/outputs.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/outputs.rs
@@ -50,6 +50,22 @@ pub fn refusal_envelope_schema() -> Value {
 /// agent.
 pub const TOOL_INVOCATION_FAILED_CODE: &str = "tool_invocation_failed";
 
+/// Keys that make a payload recognisable to the refusal arm of
+/// [`advertised_output_schema`].
+const REFUSAL_MARKER_KEYS: [&str; 3] = ["refusal", "status", "code"];
+
+/// Whether a payload already satisfies the refusal arm of
+/// [`advertised_output_schema`].
+pub fn is_refusal_envelope(value: &Value) -> bool {
+    value.as_object().is_some_and(has_refusal_marker)
+}
+
+fn has_refusal_marker(object: &Map<String, Value>) -> bool {
+    REFUSAL_MARKER_KEYS
+        .iter()
+        .any(|marker| object.contains_key(*marker))
+}
+
 /// Guarantee a structured error payload is recognisable as a refusal.
 ///
 /// Inserts [`TOOL_INVOCATION_FAILED_CODE`] when the payload carries none of the
@@ -68,10 +84,7 @@ pub fn conforming_error_envelope(structured: Value) -> Value {
             object
         }
     };
-    if !["refusal", "status", "code"]
-        .iter()
-        .any(|marker| object.contains_key(*marker))
-    {
+    if !has_refusal_marker(&object) {
         object.insert(
             "code".into(),
             Value::String(TOOL_INVOCATION_FAILED_CODE.into()),

--- a/libs/cua-driver/rust/crates/cua-driver-core/Cargo.toml
+++ b/libs/cua-driver/rust/crates/cua-driver-core/Cargo.toml
@@ -48,6 +48,8 @@ time = { workspace = true }
 getrandom = { workspace = true }
 fs2 = { workspace = true }
 hmac = { workspace = true }
+# Validate the raw wire payload; serde permits some shapes the schema rejects.
+jsonschema = { version = "0.46", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -57,13 +59,6 @@ libc = "0.2"
 # a duplicate crate version.
 [dev-dependencies]
 tempfile = "3"
-# Test-only. Asserts the advertised `outputSchema` the way a strict MCP client
-# does — by validating real payloads against it. The runtime itself validates
-# success output by deserialising into the Rust type, so this stays out of the
-# shipped dependency graph.
-# Version matches the one regorus already pulls into this crate's graph, so
-# the test dependency reuses that build instead of adding a second copy.
-jsonschema = { version = "0.46", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.58", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/lib.rs
@@ -90,5 +90,7 @@ pub mod video_ffmpeg;
 pub mod window_inspection;
 pub mod window_target;
 
-pub use cua_driver_contract::{CaptureScope, EscalationReason};
+pub use cua_driver_contract::{
+    conforming_error_envelope, CaptureScope, EscalationReason, TOOL_INVOCATION_FAILED_CODE,
+};
 pub use recording::RecordingSession;

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/lib.rs
@@ -66,6 +66,7 @@ pub mod ffmpeg_install;
 pub mod health_report;
 pub mod history;
 pub mod image_utils;
+pub mod mcp_result;
 pub mod page;
 pub mod pip_hook;
 pub mod policy;
@@ -90,7 +91,5 @@ pub mod video_ffmpeg;
 pub mod window_inspection;
 pub mod window_target;
 
-pub use cua_driver_contract::{
-    conforming_error_envelope, CaptureScope, EscalationReason, TOOL_INVOCATION_FAILED_CODE,
-};
+pub use cua_driver_contract::{CaptureScope, EscalationReason, TOOL_INVOCATION_FAILED_CODE};
 pub use recording::RecordingSession;

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/mcp_result.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/mcp_result.rs
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Cua AI, Inc.
+
+//! The one place a `tools/call` result is held to the contract the driver
+//! advertises.
+//!
+//! MCP validates every `structuredContent` a tool emits against that tool's
+//! advertised `outputSchema` — payloads sent with `isError: true` included —
+//! and rejects a response whose payload matches neither arm (`-32602`), or a
+//! successful response that declares a schema and carries no structured
+//! payload at all (`-32600`). Either way the client discards the whole
+//! response, so the message the driver placed in `content` never reaches the
+//! agent.
+//!
+//! Individual result constructors cannot enforce that: `ToolResult::error`
+//! leaves `structuredContent` unset, the transport paths invent diagnostics
+//! like `{"exit_code": 1}`, and the proxy synthesises an empty success when the
+//! daemon answers `ok` with no result. So the rule lives here instead, on the
+//! single path every direct and daemon-backed `tools/call` result passes
+//! through.
+
+use serde_json::{json, Value};
+use tracing::warn;
+
+use cua_driver_contract::{
+    advertises_output_schema, conforming_error_envelope, is_refusal_envelope,
+    validate_success_output,
+};
+
+/// Marker code for a result the driver replaced because the tool's own payload
+/// could not be advertised under its `outputSchema`.
+pub const TOOL_OUTPUT_INVALID_CODE: &str = "tool_output_invalid";
+
+/// Hold one `tools/call` result to the tool's advertised `outputSchema`.
+///
+/// - An error result keeps its diagnostic, normalized into the refusal arm so
+///   a strict client accepts it and reads the `content` message.
+/// - A successful result for a tool that advertises a schema must carry a
+///   structured payload that the schema accepts. A missing or rejected payload
+///   becomes a conforming internal-error result, because the alternative is a
+///   response the client drops entirely.
+/// - A successful result for a tool that advertises no schema is returned
+///   unchanged: there is nothing for a client to validate it against.
+pub fn conforming_tool_result(tool: &str, result: Value) -> Value {
+    let Value::Object(mut result) = result else {
+        return internal_error_result(format!(
+            "internal result mismatch for {tool}: tool result is not an object"
+        ));
+    };
+
+    if result.get("isError").and_then(Value::as_bool) == Some(true) {
+        let structured = result.remove("structuredContent").unwrap_or(Value::Null);
+        result.insert(
+            "structuredContent".to_owned(),
+            conforming_error_envelope(structured),
+        );
+        return Value::Object(result);
+    }
+
+    if !advertises_output_schema(tool) {
+        return Value::Object(result);
+    }
+
+    match result.get("structuredContent") {
+        None | Some(Value::Null) => {
+            warn!(
+                tool,
+                "successful tool result declared an output schema but carried no structured content"
+            );
+            internal_error_result(format!(
+                "internal output mismatch for {tool}: tool advertises an output schema but returned no structured content"
+            ))
+        }
+        // A refusal payload satisfies the advertised schema's other arm. The
+        // typed success validator would reject it, so ask the arm it belongs
+        // to rather than replacing a payload a client accepts.
+        Some(structured) if is_refusal_envelope(structured) => Value::Object(result),
+        Some(structured) => match validate_success_output(tool, structured.clone()) {
+            Ok(_) => Value::Object(result),
+            Err(error) => {
+                warn!(
+                    tool,
+                    "successful tool result carried structured content its output schema rejects"
+                );
+                internal_error_result(format!("internal output mismatch for {tool}: {error}"))
+            }
+        },
+    }
+}
+
+/// Build the `isError: true` result for a call that produced no usable tool
+/// payload, already normalized into the refusal arm.
+pub fn internal_error_result(message: impl Into<String>) -> Value {
+    let message = message.into();
+    json!({
+        "content": [{"type": "text", "text": message}],
+        "isError": true,
+        "structuredContent": {"code": TOOL_OUTPUT_INVALID_CODE},
+    })
+}
+
+/// Build a tool-level error result carrying a caller-supplied diagnostic.
+///
+/// The diagnostic is passed through untouched here; [`conforming_tool_result`]
+/// is what normalizes it, so every error path gets the same treatment whether
+/// or not it went through this constructor.
+pub fn tool_error_result(message: impl Into<String>, structured: Value) -> Value {
+    let message = message.into();
+    json!({
+        "content": [{"type": "text", "text": message}],
+        "isError": true,
+        "structuredContent": structured,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    //! The boundary is asserted the way a strict MCP client sees it: every
+    //! payload leaving it is validated against the schema the tool actually
+    //! advertises.
+
+    use super::*;
+    use cua_driver_contract::{advertised_tool_output_schema, TOOL_INVOCATION_FAILED_CODE};
+
+    /// An action tool, so the advertised schema is the shared `ActionResult`
+    /// one plus the refusal arm.
+    const ACTION_TOOL: &str = "click";
+    /// Advertises no `outputSchema` at all.
+    const UNSCHEMED_TOOL: &str = "no_such_tool";
+
+    #[track_caller]
+    fn assert_conforms(tool: &str, result: &Value) {
+        let schema = advertised_tool_output_schema(tool).expect("tool advertises a schema");
+        let compiled = jsonschema::validator_for(&schema).expect("schema compiles");
+        let structured = &result["structuredContent"];
+
+        assert!(
+            compiled.is_valid(structured),
+            "advertised schema rejected {structured}"
+        );
+    }
+
+    /// The shape this boundary exists for: the bare diagnostic the transport
+    /// paths invent satisfies neither arm, which is what produced the `-32602`
+    /// reports.
+    #[test]
+    fn a_bare_exit_code_diagnostic_does_not_validate() {
+        let schema = advertised_tool_output_schema(ACTION_TOOL).expect("schema");
+        let compiled = jsonschema::validator_for(&schema).expect("schema compiles");
+
+        assert!(!compiled.is_valid(&json!({"exit_code": 1})));
+    }
+
+    #[test]
+    fn an_error_diagnostic_gains_a_refusal_marker() {
+        let result = conforming_tool_result(
+            ACTION_TOOL,
+            tool_error_result("daemon transport closed", json!({"exit_code": 1})),
+        );
+
+        assert_conforms(ACTION_TOOL, &result);
+        // The diagnostic survives; only the marker is added.
+        assert_eq!(result["structuredContent"]["exit_code"], 1);
+        assert_eq!(
+            result["structuredContent"]["code"],
+            TOOL_INVOCATION_FAILED_CODE
+        );
+        assert_eq!(result["content"][0]["text"], "daemon transport closed");
+    }
+
+    /// `ToolResult::error` leaves `structuredContent` unset, and every tool
+    /// that refuses through it lands here.
+    #[test]
+    fn an_error_without_any_payload_gains_one() {
+        let result = conforming_tool_result(
+            ACTION_TOOL,
+            json!({"content": [{"type": "text", "text": "Unknown tool: nope"}], "isError": true}),
+        );
+
+        assert_conforms(ACTION_TOOL, &result);
+        assert_eq!(
+            result["structuredContent"]["code"],
+            TOOL_INVOCATION_FAILED_CODE
+        );
+    }
+
+    /// The guard adds a marker; it does not relabel a payload that already
+    /// names its own refusal.
+    #[test]
+    fn an_existing_refusal_code_is_preserved() {
+        let result = conforming_tool_result(
+            ACTION_TOOL,
+            tool_error_result("denied", json!({"code": "permission_denied"})),
+        );
+
+        assert_conforms(ACTION_TOOL, &result);
+        assert_eq!(result["structuredContent"]["code"], "permission_denied");
+    }
+
+    /// The proxy's empty-success fallback: a client that was promised a schema
+    /// rejects this response outright rather than reading it as an error.
+    #[test]
+    fn a_success_missing_its_structured_payload_becomes_an_error() {
+        let result = conforming_tool_result(ACTION_TOOL, json!({"content": [], "isError": false}));
+
+        assert_conforms(ACTION_TOOL, &result);
+        assert_eq!(result["isError"], true);
+        assert_eq!(
+            result["structuredContent"]["code"],
+            TOOL_OUTPUT_INVALID_CODE
+        );
+    }
+
+    #[test]
+    fn a_success_whose_payload_the_schema_rejects_becomes_an_error() {
+        let result = conforming_tool_result(
+            ACTION_TOOL,
+            json!({
+                "content": [],
+                "isError": false,
+                "structuredContent": {"clicked": true},
+            }),
+        );
+
+        assert_conforms(ACTION_TOOL, &result);
+        assert_eq!(result["isError"], true);
+        assert_eq!(
+            result["structuredContent"]["code"],
+            TOOL_OUTPUT_INVALID_CODE
+        );
+    }
+
+    #[test]
+    fn a_conforming_success_is_returned_untouched() {
+        let structured = json!({
+            "effect": "confirmed",
+            "route": "accessibility",
+            "delivery": {"mode": "background"},
+            "evidence": [{"kind": "value_readback"}],
+        });
+        let success = json!({
+            "content": [{"type": "text", "text": "clicked"}],
+            "isError": false,
+            "structuredContent": structured,
+        });
+
+        let result = conforming_tool_result(ACTION_TOOL, success.clone());
+
+        assert_conforms(ACTION_TOOL, &result);
+        assert_eq!(result, success);
+    }
+
+    /// A tool with no advertised schema has no contract to violate, so its
+    /// successful payload must not be second-guessed here.
+    #[test]
+    fn a_success_from_a_tool_without_a_schema_is_untouched() {
+        let success = json!({
+            "content": [{"type": "text", "text": "ok"}],
+            "isError": false,
+            "structuredContent": {"anything": "goes"},
+        });
+
+        assert_eq!(
+            conforming_tool_result(UNSCHEMED_TOOL, success.clone()),
+            success
+        );
+    }
+
+    #[test]
+    fn a_result_that_is_not_an_object_becomes_a_conforming_error() {
+        let result = conforming_tool_result(ACTION_TOOL, json!("not a result"));
+
+        assert_conforms(ACTION_TOOL, &result);
+        assert_eq!(result["isError"], true);
+    }
+}

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/mcp_result.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/mcp_result.rs
@@ -20,16 +20,45 @@
 //! through.
 
 use serde_json::{json, Value};
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock, Mutex},
+};
 use tracing::warn;
 
 use cua_driver_contract::{
-    advertises_output_schema, conforming_error_envelope, is_refusal_envelope,
-    validate_success_output,
+    advertised_tool_output_schema, advertises_output_schema, conforming_error_envelope,
+    is_refusal_envelope, validate_success_output,
 };
 
 /// Marker code for a result the driver replaced because the tool's own payload
 /// could not be advertised under its `outputSchema`.
 pub const TOOL_OUTPUT_INVALID_CODE: &str = "tool_output_invalid";
+
+type CachedValidator = Result<Arc<jsonschema::Validator>, String>;
+static OUTPUT_VALIDATORS: LazyLock<Mutex<HashMap<String, CachedValidator>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn validate_wire_output(tool: &str, structured: &Value) -> Result<(), String> {
+    // Only published tools reach this cache, so arbitrary client names cannot grow it.
+    let validator = OUTPUT_VALIDATORS
+        .lock()
+        .map_err(|_| "output schema cache unavailable".to_owned())?
+        .entry(tool.to_owned())
+        .or_insert_with(|| {
+            let schema = advertised_tool_output_schema(tool)
+                .ok_or_else(|| "advertised output schema unavailable".to_owned())?;
+            jsonschema::validator_for(&schema)
+                .map(Arc::new)
+                .map_err(|error| format!("invalid advertised output schema: {error}"))
+        })
+        .clone()?;
+    if validator.is_valid(structured) {
+        Ok(())
+    } else {
+        Err("structured content does not match the advertised output schema".to_owned())
+    }
+}
 
 /// Hold one `tools/call` result to the tool's advertised `outputSchema`.
 ///
@@ -67,7 +96,7 @@ pub fn conforming_tool_result(tool: &str, result: Value) -> Value {
                 tool,
                 "successful tool result declared an output schema but carried no structured content"
             );
-            internal_error_result(format!(
+            invalid_output_result(result, format!(
                 "internal output mismatch for {tool}: tool advertises an output schema but returned no structured content"
             ))
         }
@@ -75,27 +104,50 @@ pub fn conforming_tool_result(tool: &str, result: Value) -> Value {
         // typed success validator would reject it, so ask the arm it belongs
         // to rather than replacing a payload a client accepts.
         Some(structured) if is_refusal_envelope(structured) => Value::Object(result),
-        Some(structured) => match validate_success_output(tool, structured.clone()) {
+        Some(structured) => match validate_wire_output(tool, structured)
+            .and_then(|()| validate_success_output(tool, structured.clone()))
+        {
             Ok(_) => Value::Object(result),
             Err(error) => {
                 warn!(
                     tool,
                     "successful tool result carried structured content its output schema rejects"
                 );
-                internal_error_result(format!("internal output mismatch for {tool}: {error}"))
+                invalid_output_result(
+                    result,
+                    format!("internal output mismatch for {tool}: {error}"),
+                )
             }
         },
     }
 }
 
+fn invalid_output_result(original: serde_json::Map<String, Value>, message: String) -> Value {
+    let mut result = internal_error_result(message);
+    if let Some(Value::Array(content)) = original.get("content") {
+        result["content"]
+            .as_array_mut()
+            .unwrap()
+            .extend(content.clone());
+    }
+    if let Some(structured) = original.get("structuredContent") {
+        // Preserve evidence as an explicitly invalid diagnostic, never as success.
+        result["structuredContent"]["invalid_output"] = structured.clone();
+    }
+    result
+}
+
 /// Build the `isError: true` result for a call that produced no usable tool
 /// payload, already normalized into the refusal arm.
 pub fn internal_error_result(message: impl Into<String>) -> Value {
-    let message = message.into();
+    let message = format!(
+        "{}; the tool may have executed. Verify state before retrying.",
+        message.into()
+    );
     json!({
         "content": [{"type": "text", "text": message}],
         "isError": true,
-        "structuredContent": {"code": TOOL_OUTPUT_INVALID_CODE},
+        "structuredContent": {"code": TOOL_OUTPUT_INVALID_CODE, "execution_state": "unknown"},
     })
 }
 
@@ -248,6 +300,44 @@ mod tests {
 
         assert_conforms(ACTION_TOOL, &result);
         assert_eq!(result, success);
+    }
+
+    #[test]
+    fn a_success_missing_required_nullable_fields_becomes_a_conforming_error() {
+        let structured = json!({
+            "session": "schema-test",
+            "capture_scope": "window",
+            "effective_scope": "window",
+            "desktop_capture_authorized": false,
+            "desktop_unlocked": false,
+        });
+        let tool = "get_session_state";
+        assert!(validate_success_output(tool, structured.clone()).is_ok());
+        let result = conforming_tool_result(
+            tool,
+            json!({
+                "content": [{"type": "text", "text": "action completed"}],
+                "isError": false,
+                "structuredContent": structured,
+            }),
+        );
+
+        assert_conforms(tool, &result);
+        assert_eq!(result["isError"], true);
+        assert_eq!(
+            result["structuredContent"]["code"],
+            TOOL_OUTPUT_INVALID_CODE
+        );
+        assert_eq!(result["structuredContent"]["execution_state"], "unknown");
+        assert_eq!(
+            result["structuredContent"]["invalid_output"]["session"],
+            "schema-test"
+        );
+        assert!(result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("Verify state before retrying"));
+        assert_eq!(result["content"][1]["text"], "action completed");
     }
 
     /// A tool with no advertised schema has no contract to violate, so its

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
@@ -944,12 +944,121 @@ async fn handle_request_inner(
     }
 }
 
+/// Build the `isError: true` result for a call that never produced a tool
+/// payload.
+///
+/// MCP holds every `structuredContent` to the tool's advertised `outputSchema`,
+/// refusals included, so the diagnostic is normalized into the refusal arm
+/// before it goes on the wire. Without that, a strict client rejects the whole
+/// response and the message below never reaches the agent.
 fn tool_error_result(message: String, structured: serde_json::Value) -> serde_json::Value {
     serde_json::json!({
         "content": [{"type": "text", "text": message}],
         "isError": true,
-        "structuredContent": structured,
+        "structuredContent": cua_driver_contract::conforming_error_envelope(structured),
     })
+}
+
+#[cfg(test)]
+mod error_envelope_tests {
+    //! Every `structuredContent` the driver emits — refusals and transport
+    //! failures included — is validated by strict MCP clients against the
+    //! tool's advertised `outputSchema`. A payload matching neither arm makes
+    //! the client raise `-32602` and discard the response, so the error text
+    //! the driver put in `content` never reaches the agent.
+
+    use super::*;
+    use cua_driver_contract::{
+        advertised_output_schema, ActionResult, ToolOutput, TOOL_INVOCATION_FAILED_CODE,
+    };
+
+    struct FailingProvider;
+
+    #[async_trait::async_trait]
+    impl ToolProvider for FailingProvider {
+        fn tools_list(&self) -> serde_json::Value {
+            serde_json::json!({"tools": []})
+        }
+
+        async fn invoke_tool(
+            &self,
+            _name: &str,
+            _arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, String> {
+            Err("daemon transport closed".to_owned())
+        }
+    }
+
+    fn advertised_action_schema() -> serde_json::Value {
+        advertised_output_schema(ActionResult::output_schema())
+    }
+
+    fn call_request(name: &str) -> Request {
+        serde_json::from_value(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": name, "arguments": {} }
+        }))
+        .expect("request parses")
+    }
+
+    fn structured_content(response: Response) -> serde_json::Value {
+        match response.body {
+            ResponseBody::Result { result } => result["structuredContent"].clone(),
+            ResponseBody::Error { error } => panic!("expected a result, got {}", error.message),
+        }
+    }
+
+    /// The shape this guard exists for: a bare diagnostic satisfies neither
+    /// arm, so advertising it is what produced the `-32602` reports.
+    #[test]
+    fn a_bare_exit_code_diagnostic_does_not_validate() {
+        let compiled =
+            jsonschema::validator_for(&advertised_action_schema()).expect("schema compiles");
+
+        assert!(!compiled.is_valid(&serde_json::json!({"exit_code": 1})));
+    }
+
+    #[tokio::test]
+    async fn invocation_failure_emits_a_payload_the_advertised_schema_accepts() {
+        let response = handle_request(
+            call_request("click"),
+            serde_json::json!(1),
+            &FailingProvider,
+        )
+        .await;
+        let structured = structured_content(response);
+        let compiled =
+            jsonschema::validator_for(&advertised_action_schema()).expect("schema compiles");
+
+        assert!(
+            compiled.is_valid(&structured),
+            "advertised schema rejected {structured}"
+        );
+        // The diagnostic survives the normalization; only the marker is added.
+        assert_eq!(structured["exit_code"], 1);
+        assert_eq!(structured["code"], TOOL_INVOCATION_FAILED_CODE);
+    }
+
+    /// A payload that already names its own refusal keeps it: the guard adds a
+    /// marker, it does not relabel diagnostics that have one.
+    #[test]
+    fn an_existing_refusal_code_is_preserved() {
+        let result = tool_error_result(
+            "denied".to_owned(),
+            serde_json::json!({"code": "permission_denied"}),
+        );
+        let structured = &result["structuredContent"];
+
+        assert_eq!(structured["code"], "permission_denied");
+        assert!(
+            jsonschema::validator_for(&advertised_action_schema())
+                .expect("schema compiles")
+                .is_valid(structured),
+            "advertised schema rejected {structured}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 use tracing::warn;
 
 use crate::authorization::authorize_tool_call;
+use crate::mcp_result::{conforming_tool_result, tool_error_result};
 use crate::protocol::{initialize_result, InitializeMetadata, Request, Response, ResponseBody};
 use crate::tool::ToolRegistry;
 
@@ -891,9 +892,12 @@ async fn handle_request_inner(
                 if let Err(error) = authorize_tool_call(&call.name, &call.args) {
                     return Response::ok(
                         id,
-                        tool_error_result(
-                            error.to_string(),
-                            serde_json::json!({"code": "permission_denied"}),
+                        conforming_tool_result(
+                            &call.name,
+                            tool_error_result(
+                                error.to_string(),
+                                serde_json::json!({"code": "permission_denied"}),
+                            ),
                         ),
                     );
                 }
@@ -927,13 +931,14 @@ async fn handle_request_inner(
                     }
                 }
 
-                match provider.invoke_tool(&call.name, call.args).await {
-                    Ok(result) => Response::ok(id, result),
-                    Err(error) => Response::ok(
-                        id,
-                        tool_error_result(error, serde_json::json!({"exit_code": 1})),
-                    ),
-                }
+                // Both arms answer through the shared boundary, so a tool
+                // payload and an invocation failure are held to the same
+                // advertised `outputSchema`.
+                let result = match provider.invoke_tool(&call.name, call.args).await {
+                    Ok(result) => result,
+                    Err(error) => tool_error_result(error, serde_json::json!({"exit_code": 1})),
+                };
+                Response::ok(id, conforming_tool_result(&call.name, result))
             }
         },
 
@@ -944,38 +949,19 @@ async fn handle_request_inner(
     }
 }
 
-/// Build the `isError: true` result for a call that never produced a tool
-/// payload.
-///
-/// MCP holds every `structuredContent` to the tool's advertised `outputSchema`,
-/// refusals included, so the diagnostic is normalized into the refusal arm
-/// before it goes on the wire. Without that, a strict client rejects the whole
-/// response and the message below never reaches the agent.
-fn tool_error_result(message: String, structured: serde_json::Value) -> serde_json::Value {
-    serde_json::json!({
-        "content": [{"type": "text", "text": message}],
-        "isError": true,
-        "structuredContent": cua_driver_contract::conforming_error_envelope(structured),
-    })
-}
-
 #[cfg(test)]
-mod error_envelope_tests {
-    //! Every `structuredContent` the driver emits — refusals and transport
-    //! failures included — is validated by strict MCP clients against the
-    //! tool's advertised `outputSchema`. A payload matching neither arm makes
-    //! the client raise `-32602` and discard the response, so the error text
-    //! the driver put in `content` never reaches the agent.
+mod dispatch_contract_tests {
+    //! The boundary itself is unit-tested in `crate::mcp_result`; these pin
+    //! that `tools/call` dispatch actually routes through it, on the path a
+    //! strict MCP client exercises.
 
     use super::*;
-    use cua_driver_contract::{
-        advertised_output_schema, ActionResult, ToolOutput, TOOL_INVOCATION_FAILED_CODE,
-    };
+    use cua_driver_contract::{advertised_tool_output_schema, TOOL_INVOCATION_FAILED_CODE};
 
-    struct FailingProvider;
+    struct StubProvider(Result<serde_json::Value, String>);
 
     #[async_trait::async_trait]
-    impl ToolProvider for FailingProvider {
+    impl ToolProvider for StubProvider {
         fn tools_list(&self) -> serde_json::Value {
             serde_json::json!({"tools": []})
         }
@@ -985,12 +971,8 @@ mod error_envelope_tests {
             _name: &str,
             _arguments: serde_json::Value,
         ) -> Result<serde_json::Value, String> {
-            Err("daemon transport closed".to_owned())
+            self.0.clone()
         }
-    }
-
-    fn advertised_action_schema() -> serde_json::Value {
-        advertised_output_schema(ActionResult::output_schema())
     }
 
     fn call_request(name: &str) -> Request {
@@ -1003,60 +985,57 @@ mod error_envelope_tests {
         .expect("request parses")
     }
 
-    fn structured_content(response: Response) -> serde_json::Value {
+    fn result_of(response: Response) -> serde_json::Value {
         match response.body {
-            ResponseBody::Result { result } => result["structuredContent"].clone(),
+            ResponseBody::Result { result } => result,
             ResponseBody::Error { error } => panic!("expected a result, got {}", error.message),
         }
     }
 
-    /// The shape this guard exists for: a bare diagnostic satisfies neither
-    /// arm, so advertising it is what produced the `-32602` reports.
-    #[test]
-    fn a_bare_exit_code_diagnostic_does_not_validate() {
-        let compiled =
-            jsonschema::validator_for(&advertised_action_schema()).expect("schema compiles");
-
-        assert!(!compiled.is_valid(&serde_json::json!({"exit_code": 1})));
-    }
-
-    #[tokio::test]
-    async fn invocation_failure_emits_a_payload_the_advertised_schema_accepts() {
-        let response = handle_request(
-            call_request("click"),
-            serde_json::json!(1),
-            &FailingProvider,
-        )
-        .await;
-        let structured = structured_content(response);
-        let compiled =
-            jsonschema::validator_for(&advertised_action_schema()).expect("schema compiles");
-
+    #[track_caller]
+    fn assert_conforms(tool: &str, structured: &serde_json::Value) {
+        let schema = advertised_tool_output_schema(tool).expect("tool advertises a schema");
         assert!(
-            compiled.is_valid(&structured),
-            "advertised schema rejected {structured}"
-        );
-        // The diagnostic survives the normalization; only the marker is added.
-        assert_eq!(structured["exit_code"], 1);
-        assert_eq!(structured["code"], TOOL_INVOCATION_FAILED_CODE);
-    }
-
-    /// A payload that already names its own refusal keeps it: the guard adds a
-    /// marker, it does not relabel diagnostics that have one.
-    #[test]
-    fn an_existing_refusal_code_is_preserved() {
-        let result = tool_error_result(
-            "denied".to_owned(),
-            serde_json::json!({"code": "permission_denied"}),
-        );
-        let structured = &result["structuredContent"];
-
-        assert_eq!(structured["code"], "permission_denied");
-        assert!(
-            jsonschema::validator_for(&advertised_action_schema())
+            jsonschema::validator_for(&schema)
                 .expect("schema compiles")
                 .is_valid(structured),
             "advertised schema rejected {structured}"
+        );
+    }
+
+    /// Reverting the boundary call fails this with the bug as the message:
+    /// the advertised schema rejects the bare `{"exit_code": 1}` diagnostic.
+    #[tokio::test]
+    async fn an_invocation_failure_is_dispatched_as_a_conforming_refusal() {
+        let provider = StubProvider(Err("daemon transport closed".to_owned()));
+
+        let result =
+            result_of(handle_request(call_request("click"), serde_json::json!(1), &provider).await);
+
+        assert_conforms("click", &result["structuredContent"]);
+        // The diagnostic survives the normalization; only the marker is added.
+        assert_eq!(result["structuredContent"]["exit_code"], 1);
+        assert_eq!(
+            result["structuredContent"]["code"],
+            TOOL_INVOCATION_FAILED_CODE
+        );
+    }
+
+    /// The class of failure the two `exit_code` paths were only one instance
+    /// of: a provider result that is invalid under the advertised schema no
+    /// longer reaches the client as a success.
+    #[tokio::test]
+    async fn a_provider_success_that_violates_the_schema_is_replaced() {
+        let provider = StubProvider(Ok(serde_json::json!({"content": [], "isError": false})));
+
+        let result =
+            result_of(handle_request(call_request("click"), serde_json::json!(1), &provider).await);
+
+        assert_conforms("click", &result["structuredContent"]);
+        assert_eq!(result["isError"], true);
+        assert_eq!(
+            result["structuredContent"]["code"],
+            crate::mcp_result::TOOL_OUTPUT_INVALID_CODE
         );
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -179,26 +179,18 @@ impl ToolDef {
             "capabilities": caps,
             "risk": risk,
         });
-        let output_schema = if crate::action_record::is_action_tool(&self.name) {
-            Some(
-                <cua_driver_contract::ActionResult as cua_driver_contract::ToolOutput>::output_schema(
-                ),
-            )
-        } else {
-            cua_driver_contract::tool_success_output_schema(&self.name)
-        };
-        if let Some(output_schema) = output_schema {
-            // Advertise the refusal envelope alongside the success shape. MCP
-            // holds every `structuredContent` we emit — refusals included — to
-            // the advertised schema, and a success-only schema made strict
-            // clients discard our refusal message in favour of a schema error.
+        // Advertise the refusal envelope alongside the success shape. MCP
+        // holds every `structuredContent` we emit — refusals included — to
+        // the advertised schema, and a success-only schema made strict
+        // clients discard our refusal message in favour of a schema error.
+        // The `tools/call` boundary answers from the same lookup, so what a
+        // client is promised and what it is held to cannot drift.
+        if let Some(output_schema) = cua_driver_contract::advertised_tool_output_schema(&self.name)
+        {
             entry
                 .as_object_mut()
                 .expect("tool list entry is an object")
-                .insert(
-                    "outputSchema".into(),
-                    cua_driver_contract::advertised_output_schema(output_schema),
-                );
+                .insert("outputSchema".into(), output_schema);
         }
         entry
     }

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -1576,10 +1576,11 @@ impl ToolRegistry {
         if result.is_error != Some(true) && crate::action_record::is_action_tool(resolved_name) {
             if let Err(error) = publish_action_result(&mut result) {
                 result = ToolResult::error(format!(
-                    "internal action outcome mismatch for {resolved_name}: {error}"
+                    "internal action outcome mismatch for {resolved_name}: {error}; the tool may have executed. Verify state before retrying."
                 ))
                 .with_structured(serde_json::json!({
                     "code": "action_outcome_mismatch",
+                    "execution_state": "unknown",
                     "tool": resolved_name,
                     "detail": error,
                 }));
@@ -1591,10 +1592,11 @@ impl ToolRegistry {
                     cua_driver_contract::validate_success_output(resolved_name, structured)
                 {
                     result = ToolResult::error(format!(
-                        "internal typed output mismatch for {resolved_name}: {error}"
+                        "internal typed output mismatch for {resolved_name}: {error}; the tool may have executed. Verify state before retrying."
                     ))
                     .with_structured(serde_json::json!({
                         "code": "typed_output_mismatch",
+                        "execution_state": "unknown",
                         "tool": resolved_name,
                         "detail": error,
                     }));

--- a/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
@@ -27,7 +27,9 @@ use cua_driver_core::server::{
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tracing::{debug, error, warn};
 
-use crate::serve::{is_daemon_listening, send_request, DaemonRequest, ToolObservationOrigin};
+use crate::serve::{
+    is_daemon_listening, send_request, DaemonRequest, DaemonResponse, ToolObservationOrigin,
+};
 
 /// Run stdio MCP directly over an SDK-owned runtime.
 ///
@@ -774,46 +776,48 @@ async fn forward_tool_call(
         Ok(Ok(r)) => r,
     };
 
-    if !resp.ok {
-        // MCP separates two failure modes:
-        //   - JSON-RPC errors → `Response::error(...)`, used for
-        //     transport / protocol failures (unknown method, bad
-        //     params shape, server crash).
-        //   - Tool-level errors → `Response::ok(...)` carrying a
-        //     `CallTool.Result` with `isError: true` and the error
-        //     message in `content[]`. The tool ran, returned a
-        //     well-formed result that says "I failed."
-        //
-        // A non-`ok` daemon response means the tool call reached the
-        // daemon and the daemon decided the tool returned an error
-        // (or rejected the call). That's tool-level, not transport-
-        // level, so the core protocol surfaces it as `Response::ok` with
-        // `isError: true`. Mirror that shape here — CodeRabbit #2.
+    Response::ok(id, daemon_response_to_tool_result(&name, resp))
+}
+
+/// Translate one `DaemonResponse` into the `CallTool.Result` the MCP client
+/// receives.
+///
+/// MCP separates two failure modes:
+///   - JSON-RPC errors → `Response::error(...)`, used for transport /
+///     protocol failures (unknown method, bad params shape, server crash).
+///     Those are handled by the caller, above.
+///   - Tool-level errors → `Response::ok(...)` carrying a `CallTool.Result`
+///     with `isError: true` and the error message in `content[]`. The tool
+///     ran, returned a well-formed result that says "I failed."
+///
+/// A non-`ok` daemon response means the tool call reached the daemon and the
+/// daemon decided the tool returned an error (or rejected the call). That's
+/// tool-level, not transport-level, so the core protocol surfaces it as
+/// `Response::ok` with `isError: true`. Mirror that shape here — CodeRabbit #2.
+///
+/// Every branch — including the empty result synthesised for an `ok` response
+/// that carries none — leaves through the same boundary the direct dispatch
+/// uses, so a daemon-backed call is held to the tool's advertised
+/// `outputSchema` exactly as a direct one is.
+fn daemon_response_to_tool_result(name: &str, resp: DaemonResponse) -> serde_json::Value {
+    let result = if resp.ok {
+        resp.result.unwrap_or_else(|| {
+            serde_json::json!({
+                "content": [],
+                "isError": false
+            })
+        })
+    } else {
         let msg = resp
             .error
             .unwrap_or_else(|| "daemon reported failure".into());
         let exit_code = resp.exit_code.unwrap_or(1);
-        // MCP validates this payload against the tool's advertised
-        // `outputSchema`, so the bare `exit_code` diagnostic is normalized into
-        // the refusal arm. Otherwise a strict client rejects the response and
-        // `msg` never reaches the agent.
-        let result = serde_json::json!({
-            "content": [{ "type": "text", "text": msg }],
-            "isError": true,
-            "structuredContent": cua_driver_core::conforming_error_envelope(
-                serde_json::json!({ "exit_code": exit_code })
-            )
-        });
-        return Response::ok(id, result);
-    }
-
-    let result = resp.result.unwrap_or_else(|| {
-        serde_json::json!({
-            "content": [],
-            "isError": false
-        })
-    });
-    Response::ok(id, result)
+        cua_driver_core::mcp_result::tool_error_result(
+            msg,
+            serde_json::json!({ "exit_code": exit_code }),
+        )
+    };
+    cua_driver_core::mcp_result::conforming_tool_result(name, result)
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -825,7 +829,6 @@ async fn forward_tool_call(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::serve::DaemonResponse;
 
     #[tokio::test]
     async fn proxy_loop_returns_promptly_on_clean_eof() {
@@ -882,22 +885,11 @@ mod tests {
         assert!(response.get("result").is_some());
     }
 
-    /// Reconstruct the `!resp.ok` branch in isolation so we can assert
-    /// on the serialized shape without spinning up a real daemon /
-    /// tokio runtime. Keep this in sync with `forward_tool_call`.
-    fn build_tool_error_response(id: serde_json::Value, resp: DaemonResponse) -> Response {
-        let msg = resp
-            .error
-            .unwrap_or_else(|| "daemon reported failure".into());
-        let exit_code = resp.exit_code.unwrap_or(1);
-        let result = serde_json::json!({
-            "content": [{ "type": "text", "text": msg }],
-            "isError": true,
-            "structuredContent": cua_driver_core::conforming_error_envelope(
-                serde_json::json!({ "exit_code": exit_code })
-            )
-        });
-        Response::ok(id, result)
+    /// Serialize the production conversion the way the proxy answers it, so
+    /// these assertions run against `forward_tool_call`'s own branch without
+    /// spinning up a real daemon.
+    fn tool_call_response(id: serde_json::Value, resp: DaemonResponse) -> Response {
+        Response::ok(id, daemon_response_to_tool_result("click", resp))
     }
 
     #[test]
@@ -908,7 +900,7 @@ mod tests {
             error: Some("missing required field `pid`".into()),
             exit_code: Some(64),
         };
-        let resp = build_tool_error_response(serde_json::json!(7), daemon_resp);
+        let resp = tool_call_response(serde_json::json!(7), daemon_resp);
         let value = serde_json::to_value(&resp).expect("serialize");
 
         // Top-level JSON-RPC envelope: success (`result`), not error.
@@ -946,7 +938,7 @@ mod tests {
             error: None,
             exit_code: None,
         };
-        let resp = build_tool_error_response(serde_json::json!("abc"), daemon_resp);
+        let resp = tool_call_response(serde_json::json!("abc"), daemon_resp);
         let value = serde_json::to_value(&resp).expect("serialize");
         assert_eq!(value["result"]["isError"], serde_json::json!(true));
         assert_eq!(
@@ -958,6 +950,51 @@ mod tests {
             value["result"]["structuredContent"]["code"],
             cua_driver_core::TOOL_INVOCATION_FAILED_CODE
         );
+    }
+
+    /// An `ok` daemon response that carries no result used to be forwarded as
+    /// an empty success. For a tool that declares an `outputSchema` that is a
+    /// response a strict client rejects outright (`-32600`), so the boundary
+    /// converts it into an error the client can actually read.
+    #[test]
+    fn an_ok_daemon_response_with_no_result_becomes_a_conforming_error() {
+        let daemon_resp = DaemonResponse {
+            ok: true,
+            result: None,
+            error: None,
+            exit_code: None,
+        };
+
+        let result = daemon_response_to_tool_result("click", daemon_resp);
+
+        assert_eq!(result["isError"], serde_json::json!(true));
+        assert_eq!(
+            result["structuredContent"]["code"],
+            cua_driver_core::mcp_result::TOOL_OUTPUT_INVALID_CODE
+        );
+    }
+
+    /// A daemon result that already conforms is forwarded untouched.
+    #[test]
+    fn a_conforming_daemon_success_is_forwarded_unchanged() {
+        let result = serde_json::json!({
+            "content": [{ "type": "text", "text": "clicked" }],
+            "isError": false,
+            "structuredContent": {
+                "effect": "confirmed",
+                "route": "accessibility",
+                "delivery": { "mode": "background" },
+                "evidence": [{ "kind": "value_readback" }],
+            },
+        });
+        let daemon_resp = DaemonResponse {
+            ok: true,
+            result: Some(result.clone()),
+            error: None,
+            exit_code: None,
+        };
+
+        assert_eq!(daemon_response_to_tool_result("click", daemon_resp), result);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
@@ -793,10 +793,16 @@ async fn forward_tool_call(
             .error
             .unwrap_or_else(|| "daemon reported failure".into());
         let exit_code = resp.exit_code.unwrap_or(1);
+        // MCP validates this payload against the tool's advertised
+        // `outputSchema`, so the bare `exit_code` diagnostic is normalized into
+        // the refusal arm. Otherwise a strict client rejects the response and
+        // `msg` never reaches the agent.
         let result = serde_json::json!({
             "content": [{ "type": "text", "text": msg }],
             "isError": true,
-            "structuredContent": { "exit_code": exit_code }
+            "structuredContent": cua_driver_core::conforming_error_envelope(
+                serde_json::json!({ "exit_code": exit_code })
+            )
         });
         return Response::ok(id, result);
     }
@@ -887,7 +893,9 @@ mod tests {
         let result = serde_json::json!({
             "content": [{ "type": "text", "text": msg }],
             "isError": true,
-            "structuredContent": { "exit_code": exit_code }
+            "structuredContent": cua_driver_core::conforming_error_envelope(
+                serde_json::json!({ "exit_code": exit_code })
+            )
         });
         Response::ok(id, result)
     }
@@ -921,6 +929,13 @@ mod tests {
         assert_eq!(result["content"][0]["type"], "text");
         assert_eq!(result["content"][0]["text"], "missing required field `pid`");
         assert_eq!(result["structuredContent"]["exit_code"], 64);
+        // Strict MCP clients validate this payload against the tool's
+        // advertised `outputSchema`. The refusal marker is what keeps the
+        // response readable instead of being discarded as `-32602`.
+        assert_eq!(
+            result["structuredContent"]["code"],
+            cua_driver_core::TOOL_INVOCATION_FAILED_CODE
+        );
     }
 
     #[test]
@@ -939,6 +954,10 @@ mod tests {
             "daemon reported failure"
         );
         assert_eq!(value["result"]["structuredContent"]["exit_code"], 1);
+        assert_eq!(
+            value["result"]["structuredContent"]["code"],
+            cua_driver_core::TOOL_INVOCATION_FAILED_CODE
+        );
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
@@ -700,7 +700,16 @@ async fn handle_proxy_request(
             Err(e) => Response::error(id, -32602, format!("Invalid params: {e}")),
             Ok(call) => {
                 if let Err(error) = authorize_tool_call(&call.name, &call.args) {
-                    return Response::error(id, -32603, error.to_string());
+                    return Response::ok(
+                        id,
+                        cua_driver_core::mcp_result::conforming_tool_result(
+                            &call.name,
+                            cua_driver_core::mcp_result::tool_error_result(
+                                error.to_string(),
+                                serde_json::json!({"code": "permission_denied"}),
+                            ),
+                        ),
+                    );
                 }
                 forward_tool_call(
                     id,
@@ -829,6 +838,76 @@ fn daemon_response_to_tool_result(name: &str, resp: DaemonResponse) -> serde_jso
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn proxy_authorization_refusal_is_a_tool_error_without_forwarding() {
+        const CHILD_ENV: &str = "CUA_DRIVER_PROXY_REFUSAL_TEST_CHILD";
+        if std::env::var_os(CHILD_ENV).is_none() {
+            // Policy configuration is process-wide and immutable; keep this
+            // denial out of other tests without mutating the parent environment.
+            let directory = tempfile::tempdir().expect("temporary policy directory");
+            let policy = directory.path().join("deny.yaml");
+            std::fs::write(&policy, "deny:\n  tools: [click]\n").expect("write policy");
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "proxy::tests::proxy_authorization_refusal_is_a_tool_error_without_forwarding",
+                    "--nocapture",
+                ])
+                .env(CHILD_ENV, "1")
+                .env(cua_driver_core::policy::POLICY_FILE_ENV, &policy)
+                .env_remove(cua_driver_core::policy::MANAGED_POLICY_FILE_ENV)
+                .output()
+                .expect("run isolated refusal test");
+            assert!(
+                output.status.success(),
+                "isolated refusal test failed: {}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+
+        let directory = tempfile::tempdir().expect("temporary socket directory");
+        let socket = directory.path().join("daemon.sock");
+        #[cfg(unix)]
+        let listener = tokio::net::UnixListener::bind(&socket).expect("bind test daemon");
+        let request = serde_json::from_value(serde_json::json!({
+            "jsonrpc": "2.0", "id": 19, "method": "tools/call",
+            "params": {"name": "click", "arguments": {"pid": 42, "x": 10, "y": 20}}
+        }))
+        .expect("valid tool request");
+        let cached_tools = Arc::new(serde_json::json!({"tools": [{"name": "click"}]}));
+        let response = handle_proxy_request(
+            request,
+            serde_json::json!(19),
+            socket.to_str().unwrap(),
+            &cached_tools,
+            "refusal-test-session",
+            false,
+        );
+        #[cfg(unix)]
+        let response = tokio::select! {
+            response = response => response,
+            connection = listener.accept() => {
+                drop(connection);
+                panic!("a locally denied call must never connect to the daemon");
+            }
+        };
+        #[cfg(not(unix))]
+        let response = response.await;
+        let value = serde_json::to_value(response).expect("serialize response");
+        assert_eq!(value["id"], 19);
+        assert!(value.get("error").is_none(), "{value}");
+        let result = &value["result"];
+        assert_eq!(result["isError"], true);
+        assert_eq!(result["structuredContent"]["code"], "permission_denied");
+        assert_eq!(result["content"][0]["type"], "text");
+        assert!(result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("explicitly denied"));
+    }
 
     #[tokio::test]
     async fn proxy_loop_returns_promptly_on_clean_eof() {

--- a/libs/cua-driver/rust/crates/cua-driver/tests/session_capture_scope_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/session_capture_scope_test.rs
@@ -78,8 +78,15 @@ fn policies_are_isolated_immutable_and_enforced_over_mcp() {
         "get_screen_size",
         json!({"session": "scope-desktop"}),
     );
+    // Every error result now carries a refusal marker, so "no code at all" no
+    // longer distinguishes a permitted call from one that failed for an
+    // unrelated environment reason (a runner with no display, say). Assert
+    // what this test is actually about: the scope policy did not refuse it.
     assert!(
-        code(&desktop_screen_size).is_none(),
+        !matches!(
+            code(&desktop_screen_size),
+            Some("desktop_scope_disabled" | "desktop_escalation_required")
+        ),
         "desktop scope should permit global screen geometry: {desktop_screen_size}"
     );
 


### PR DESCRIPTION
When a daemon or transport failure returns a bare diagnostic such as `{"exit_code": 1}`, strict MCP clients reject `structuredContent` because it matches neither the advertised success schema nor the refusal arm. The caller loses the useful error message.

This change enforces the advertised contract at one shared `tools/call` result boundary used by both direct and daemon-backed dispatch:

- Error diagnostics gain a refusal marker when needed, preserving their existing code, content, and diagnostic fields.
- Successful results with an advertised schema must contain raw structured content accepted by the exact JSON Schema and the existing typed invariants. Missing or malformed output becomes a conforming `tool_output_invalid` error.
- Malformed post-execution output reports unknown execution state and asks the caller to verify state before retrying. The wire boundary retains original content and invalid output as diagnostic evidence.
- Proxy-local authorization refusal uses the same tool-error envelope as direct dispatch and does not forward the denied call to the daemon.
- Tools without an advertised output schema retain their successful result unchanged.

The raw-schema check closes a reproduced gap: omitting required nullable escalation fields from `get_session_state` passes serde validation but fails the advertised schema. `jsonschema` is now an explicit runtime dependency with default features disabled; compiled schemas are cached per published tool. No advertised schema or tool signature changes.

Refs #2963. The synthetic regression covers the reported malformed-envelope shape; the original reporter's live session has not been reproduced, so this PR does not auto-close the issue. Contributor authorship is preserved, with maintainer coauthor credit for the adaptation.

### Validation at 36de3eea15dee912587d1386674ddc6b1050f323

- 599 core unit tests, 37 contract tests, and nine focused proxy tests passed locally. The nullable-field regression failed before the fix and passes afterward.
- Formatting and diff checks passed. Independent code review found no concrete regressions in the maintainer follow-up.
- Ordinary CI passed, including pinned-client MCP discovery, portable contract parity on Linux/Windows/macOS, generated bindings, release metadata, and contributor attribution.
- Canonical [Linux desktop run](https://github.com/trycua/cua/actions/runs/34070565210) passed at the exact candidate SHA: 129 cases (87 delivered, 42 expected refusals), zero failures/skips, plus installer smoke. Environment records and per-case video/trajectory presence were checked, with representative frames inspected. The complete [Windows desktop run](https://github.com/trycua/cua/actions/runs/34070566530) passed: 136 cases (110 delivered, 26 expected refusals), zero failures/skips, plus installer/update smoke. Its shared (84), native (43), and capture (nine) artifacts confirm the exact candidate SHA and per-case video/trajectory evidence. The previously flaky Tauri background-hotkey cell passed with its expected refusal; a representative frame was inspected.
- macOS canonical certification is blocked: the disposable test VM cannot start because the host reports its active-VM limit. No unrelated running VM was stopped and no host installation was changed.

Remaining gates: macOS canonical certification and re-review of the outstanding requested changes. Linux and Windows are certified at the candidate SHA; no complete cross-platform certification, merge, or release is claimed.
