### PR TITLE
release(fleet): publish npm 0.1.1

### DIFF
--- a/libs/typescript/fleet/.bumpversion.cfg
+++ b/libs/typescript/fleet/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 commit = True
 tag = True
 tag_name = npm-fleet-v{new_version}

--- a/libs/typescript/fleet/package.json
+++ b/libs/typescript/fleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycua/fleet",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "packageManager": "pnpm@10.12.3",
   "description": "Browser and WebAssembly SDK for Cua Fleet sandbox lifecycle management",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump `@trycua/fleet` from `0.1.0` to `0.1.1`
- publish the mirrored signed-service URL TypeScript bindings
- unblock the TypeScript signed URL guide and end-to-end testing

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run build` (full Rust → WASM package build)
- `npm pack --dry-run --json`
- installed the packed tarball in a clean temporary npm project
- verified exports: `CreateSignedServiceUrlRequest`, `CreateSignedServiceUrlRequestBuilder`, `SignedServiceUrl`
- verified `CyclopsClient` methods: `createSignedServiceUrl`, `listSignedServiceUrls`, `revokeSignedServiceUrl`

Related: #3508