### PR TITLE
docs: refresh public Fleet image pins

### DIFF
--- a/docs/content/docs/how-to-guides/sandbox/configure-pool-with-terraform.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/configure-pool-with-terraform.mdx
@@ -65,7 +65,7 @@ resource "fleets_pool" "linux" {
   name                 = "linux-pool"
   cpu_cores            = 4
   memory               = "8Gi"
-  container_disk_image = "public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04:main-e5d853a9"
+  container_disk_image = "public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04:main-809e3f81"
   runtime              = "kubevirt"
   firmware             = "bios"
 
@@ -117,7 +117,7 @@ resource "fleets_pool" "windows" {
   name                 = "windows-pool"
   cpu_cores            = 4
   memory               = "4Gi"
-  container_disk_image = "public.ecr.aws/k5j5w0x5/cua-windows-2022:latest"
+  container_disk_image = "public.ecr.aws/k5j5w0x5/cua-windows-2022:main-bac7daa3"
   runtime              = "kubevirt"
   firmware             = "efi"
 

--- a/docs/content/docs/how-to-guides/sandbox/create-pool-with-python.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/create-pool-with-python.mdx
@@ -52,7 +52,7 @@ from cua_sandbox import Image, Pool
 
 IMAGE = (
     "public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04"
-    "@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e9f1a89ce40989d5f4475d"
+    "@sha256:c1e601dbb748fdc467c663136f7592e308a91a3c19c309b75261544432826a57"
 )
 
 POOL_NAME = os.environ.get("CUA_POOL_NAME", "cua-live-main-source-manual")

--- a/docs/content/docs/how-to-guides/sandbox/create-pool-with-typescript.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/create-pool-with-typescript.mdx
@@ -25,7 +25,7 @@ The package provides separate runtime entry points:
 This guide uses the public Linux computer-server image:
 
 ```text
-public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e9f1a89ce40989d5f4475d
+public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04@sha256:c1e601dbb748fdc467c663136f7592e308a91a3c19c309b75261544432826a57
 ```
 
 <Callout type="warn">
@@ -81,7 +81,7 @@ import {
 
 const IMAGE =
   'public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04' +
-  '@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e9f1a89ce40989d5f4475d';
+  '@sha256:c1e601dbb748fdc467c663136f7592e308a91a3c19c309b75261544432826a57';
 const BASE_URL = process.env.CUA_FLEET_BASE_URL ?? 'https://run.cua.ai';
 const TOKEN_URL =
   process.env.CUA_TOKEN_URL ??
@@ -238,7 +238,7 @@ import {
 
 const IMAGE =
   'public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04' +
-  '@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e9f1a89ce40989d5f4475d';
+  '@sha256:c1e601dbb748fdc467c663136f7592e308a91a3c19c309b75261544432826a57';
 const BASE_URL = import.meta.env.VITE_CUA_FLEET_BASE_URL ?? 'https://run.cua.ai';
 const TOKEN_URL =
   import.meta.env.VITE_CUA_TOKEN_URL ??

--- a/docs/content/docs/how-to-guides/sandbox/images.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/images.mdx
@@ -197,7 +197,7 @@ is not one, and fails with
 
 ```python
 Image.from_registry('ghcr.io/trycua/macos-tahoe-cua:latest')
-Image.from_registry('public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04:main-38352d34')
+Image.from_registry('public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04:main-809e3f81')
 # chain builder on top
 img = Image.from_registry('ghcr.io/trycua/macos-tahoe-cua:latest').run('echo hi')
 ```

--- a/docs/content/docs/how-to-guides/sandbox/run-openclaw-on-cloud-fleet.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/run-openclaw-on-cloud-fleet.mdx
@@ -35,7 +35,7 @@ You need:
 The example uses this immutable, public KubeVirt containerDisk:
 
 ```text
-public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e4f1a89ce40989d5f4475d
+public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04@sha256:c1e601dbb748fdc467c663136f7592e308a91a3c19c309b75261544432826a57
 ```
 
 It boots Ubuntu 24.04 with XFCE on X11 and exposes the Cua computer server as
@@ -83,7 +83,7 @@ from cua_sandbox import Image, Pool
 
 IMAGE = (
     "public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04"
-    "@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e9f1a89ce40989d5f4475d"
+    "@sha256:c1e601dbb748fdc467c663136f7592e308a91a3c19c309b75261544432826a57"
 )
 POOL_NAME = os.environ["CUA_POOL_NAME"]
 

--- a/docs/content/docs/tutorials/your-first-cloud-fleet.mdx
+++ b/docs/content/docs/tutorials/your-first-cloud-fleet.mdx
@@ -74,7 +74,7 @@ from cua_sandbox import Image, Pool
 
 IMAGE = (
     "public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04"
-    "@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e9f1a89ce40989d5f4475d"
+    "@sha256:c1e601dbb748fdc467c663136f7592e308a91a3c19c309b75261544432826a57"
 )
 
 


### PR DESCRIPTION
## Summary

- refresh public Linux Fleet docs to `cua-ubuntu-24.04:main-809e3f81`
- update immutable Linux digest examples to the matching OCI index digest
- pin the Windows Terraform guide to `cua-windows-2022:main-bac7daa3` instead of `latest`

## Context

Follow-up to trycua/cloud#7310. That PR's merged workflows publish `desktop-workspace` and `cua-windows` to private ECR only; those artifacts are not interchangeable with the anonymously pullable public images used by these docs. This PR therefore refreshes authored docs to the newest verified immutable tags in the existing public repositories rather than exposing private registry references.

`libs/fleet` is intentionally excluded because it is a read-only Copybara mirror.

## Validation

- `git diff --check`
- verified the public Linux tag resolves to OCI index digest `sha256:c1e601dbb748fdc467c663136f7592e308a91a3c19c309b75261544432826a57`
- verified the public Windows tag resolves to OCI index digest `sha256:6d341afc26a37c4072d22ba403a89ecdad9a29aebab79570b5a38da6b8e16370`
- Prettier 3.6.2 passes for all changed files