### PR TITLE
fix(cua-driver): scope trajectory recording to its session

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/recording.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/recording.rs
@@ -477,7 +477,17 @@ impl RecordingSession {
     /// Reserve a turn and capture its target immediately before tool dispatch.
     /// No-op when recording is disabled.
     pub fn begin_turn(&self, tool_name: &str, args: &Value, start_ms: u64) -> Option<PendingTurn> {
-        self.begin_turn_with_capture(tool_name, args, start_ms, true)
+        self.begin_turn_for_session(tool_name, args, start_ms, None)
+    }
+
+    pub fn begin_turn_for_session(
+        &self,
+        tool_name: &str,
+        args: &Value,
+        start_ms: u64,
+        session_id: Option<&str>,
+    ) -> Option<PendingTurn> {
+        self.begin_turn_with_capture(tool_name, args, start_ms, true, session_id)
     }
 
     /// Reserve a turn while deliberately suppressing visual and accessibility
@@ -490,7 +500,17 @@ impl RecordingSession {
         args: &Value,
         start_ms: u64,
     ) -> Option<PendingTurn> {
-        self.begin_turn_with_capture(tool_name, args, start_ms, false)
+        self.begin_private_turn_for_session(tool_name, args, start_ms, None)
+    }
+
+    pub fn begin_private_turn_for_session(
+        &self,
+        tool_name: &str,
+        args: &Value,
+        start_ms: u64,
+        session_id: Option<&str>,
+    ) -> Option<PendingTurn> {
+        self.begin_turn_with_capture(tool_name, args, start_ms, false, session_id)
     }
 
     fn begin_turn_with_capture(
@@ -499,10 +519,11 @@ impl RecordingSession {
         args: &Value,
         start_ms: u64,
         capture_visual_state: bool,
+        session_id: Option<&str>,
     ) -> Option<PendingTurn> {
         let (turn_dir, session_start_ms, generation) = {
             let mut inner = self.inner.lock().unwrap();
-            if !inner.enabled {
+            if !inner.enabled || inner.owner.as_deref() != session_id {
                 return None;
             }
             let out = inner.output_dir.clone()?;
@@ -1144,6 +1165,22 @@ mod tests {
             std::fs::remove_dir(directory).expect("remove refused turn fixture directory");
         }
         std::fs::remove_dir(&output_dir).expect("remove recording fixture directory");
+    }
+
+    #[test]
+    fn turn_admission_is_limited_to_the_recording_owner() {
+        let session = RecordingSession::new();
+        {
+            let mut inner = session.inner.lock().expect("recording lock");
+            inner.enabled = true;
+            inner.owner = Some("owner".into());
+            inner.output_dir = Some(std::env::temp_dir());
+            inner.session_start_ms = now_ms();
+        }
+
+        assert!(session
+            .begin_turn_for_session("click", &serde_json::json!({}), now_ms(), Some("other"))
+            .is_none());
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -1490,11 +1490,7 @@ impl ToolRegistry {
 
         // Reserve and capture the turn before dispatch so recorded evidence
         // shows the application immediately before the action changed it.
-        let should_record = !tool.def().read_only
-            && !matches!(
-                resolved_name,
-                "start_recording" | "stop_recording" | "get_recording_state" | "replay_trajectory"
-            );
+        let should_record = crate::action_record::is_action_tool(resolved_name);
         let private_consent_turn = is_existing_profile_prepare(resolved_name, &args);
         let _desktop_action = if is_physical_desktop_action(resolved_name) {
             let coordinator = desktop_action_coordinator();
@@ -1513,11 +1509,19 @@ impl ToolRegistry {
         let pending_turn = should_record
             .then(|| {
                 if private_consent_turn {
-                    self.recording
-                        .begin_private_turn(resolved_name, &recording_args, start_ms)
+                    self.recording.begin_private_turn_for_session(
+                        resolved_name,
+                        &recording_args,
+                        start_ms,
+                        runtime_session.as_deref(),
+                    )
                 } else {
-                    self.recording
-                        .begin_turn(resolved_name, &recording_args, start_ms)
+                    self.recording.begin_turn_for_session(
+                        resolved_name,
+                        &recording_args,
+                        start_ms,
+                        runtime_session.as_deref(),
+                    )
                 }
             })
             .flatten();


### PR DESCRIPTION
## Summary

- Problem this solves: Trajectory recording admits calls from sessions other than the session that started the recording.
- What changed: Recording admission now requires the owning session and only records action tools.

## Related work

Fixes #3445

RFC (required for a public SDK, CLI, MCP, protocol, compatibility, permission,
or cross-component contract change):
Not required; this is an internal Cua Driver behavior correction.

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: User-visible recording behavior is restricted to the owning session; no public API or protocol change.
- Risk and rollback: Limited to the shared Cua Driver recording admission path; revert the commit if needed.

## Validation

- Focused tests and checks: Focused recording tests pass (19 tests); Rust formatting and diff checks pass.
- Manual or platform evidence: No desktop platform harness was run locally.
- Known gaps or CI still required: Cross-platform Cua Driver CI and clippy remain required; clippy was unavailable in the local toolchain.

## Contributor and release checks

- [ ] The PR is focused and the description matches the final diff.
- [ ] This change does not require an RFC, or the accepted RFC is linked above.
- [ ] Tests, documentation, and platform evidence are included or the gap is explained.
- [ ] The PR title is a Conventional Commit describing the production change.
- [ ] External contributor authorship is preserved, or no external contribution is included.
- [ ] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.