### PR TITLE
fix(docs): authenticate cloud pin dispatch via OIDC

### DIFF
--- a/.github/workflows/cd-docs-pin-dispatch.yml
+++ b/.github/workflows/cd-docs-pin-dispatch.yml
@@ -6,9 +6,9 @@ name: "CD: Docs Pin Dispatch"
 # best-effort: repository_dispatch events can be dropped, so the cloud cron
 # still converges the pin if a notification is lost.
 #
-# The App token mirrors the identity cd-cua-driver-docs.yml already uses for
-# release-time repo writes; the same App installation covers trycua/cloud, and
-# the dispatch endpoint needs contents write on that repository.
+# The cross-repository App credential lives in AWS Secrets Manager. This
+# workflow assumes a main-only OIDC role, then downscopes the App token to
+# contents write on trycua/cloud for the dispatch request.
 
 on:
   push:
@@ -19,7 +19,13 @@ on:
       - "docs/public/**"
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: us-west-2
+  GITHUB_APP_SECRET: copybara/github-app
 
 # Collapse bursts of docs merges into the newest dispatch; the cloud updater
 # always resolves the latest docs commit itself, so older events are redundant.
@@ -31,16 +37,66 @@ jobs:
   dispatch:
     name: Notify trycua/cloud
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          role-to-assume: arn:aws:iam::296062593712:role/github-actions-docs-pin-cua
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Load GitHub App credentials
+        id: github-app
+        shell: bash
+        run: |
+          set -euo pipefail
+          secret_json=$(aws secretsmanager get-secret-value \
+            --secret-id "${GITHUB_APP_SECRET}" \
+            --query SecretString \
+            --output text)
+          app_id=$(jq -er '.app_id | tostring' <<<"${secret_json}")
+          private_key=$(jq -er '.private_key' <<<"${secret_json}")
+          installation_id=$(jq -r '.installation_id // empty | tostring' <<<"${secret_json}")
+
+          mask() {
+            local value=${1//'%'/'%25'}
+            value=${value//$'\r'/'%0D'}
+            value=${value//$'\n'/'%0A'}
+            printf '::add-mask::%s\n' "${value}"
+          }
+          mask "${app_id}"
+          mask "${private_key}"
+          [[ -z "${installation_id}" ]] || mask "${installation_id}"
+
+          delimiter="DOCS_PIN_KEY_$(openssl rand -hex 16)"
+          {
+            printf 'app_id=%s\n' "${app_id}"
+            printf 'private_key<<%s\n%s\n%s\n' "${delimiter}" "${private_key}" "${delimiter}"
+            printf 'installation_id=%s\n' "${installation_id}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ steps.github-app.outputs.app_id }}
+          private-key: ${{ steps.github-app.outputs.private_key }}
+          owner: trycua
           repositories: cloud
           permission-contents: write
+
+      - name: Verify GitHub App installation
+        if: steps.github-app.outputs.installation_id != ''
+        env:
+          ACTUAL_INSTALLATION_ID: ${{ steps.app-token.outputs.installation-id }}
+          EXPECTED_INSTALLATION_ID: ${{ steps.github-app.outputs.installation_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "${ACTUAL_INSTALLATION_ID}" == "${EXPECTED_INSTALLATION_ID}" ]] || {
+            echo "GitHub App installation ID does not match copybara/github-app" >&2
+            exit 1
+          }
 
       - name: Send repository_dispatch to cloud
         env:


### PR DESCRIPTION
## What changed

- replace the repository-local release App credential with the existing cross-repository GitHub App credential from AWS Secrets Manager
- assume a dedicated OIDC role trusted only by `trycua/cua` workflows on `main`
- downscope the minted token to `contents: write` on `trycua/cloud` only
- verify the optional expected installation ID before sending the existing repository dispatch

This restores the immediate docs-pin path while retaining the hourly cloud updater as a convergence fallback.

Fixes #3527

## Root cause

The previous workflow minted from the release App configured in `trycua/cua`. That selected-repository installation cannot resolve `trycua/cloud`, so token creation failed before the dispatch request.

## Security

- no long-lived credential is added to this repository
- GitHub OIDC trust is limited to `repo:trycua/cua:ref:refs/heads/main`
- AWS access is limited to reading `copybara/github-app`
- the GitHub App token is scoped to the `cloud` repository and `contents: write`
- loaded credential fields are masked before being written to action outputs

## Dependency

- [x] trycua/cloud#7365 adds the least-privilege OIDC role
- [x] merged and verified the cloud `main` Terraform apply

## Validation

- Ruby YAML parse
- `git diff --check`
- repository CI
- after merge: manual `workflow_dispatch`, downstream pin update, and publication verification

