### PR TITLE
fix(cua-driver): preserve foreground focus during macOS clicks

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/sentinel.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/sentinel.rs
@@ -162,11 +162,7 @@ impl ForegroundSentinel {
             violations.push("foreground sentinel heartbeat stopped".to_owned());
         }
         if !is_wayland_session() {
-            if events.iter().any(|event| {
-                event_kind(event) == Some("blur")
-                    || (event_kind(event) == Some("visibility")
-                        && event["state"].as_str() == Some("hidden"))
-            }) {
+            if events.iter().any(is_focus_loss_event) {
                 violations.push("foreground sentinel lost focus".to_owned());
             } else {
                 passed.push(OracleKind::Focus);
@@ -268,6 +264,13 @@ impl ForegroundSentinel {
         if is_wayland_session() {
             wait_for_native_focus_lost(self.target)?;
         } else {
+            #[cfg(target_os = "macos")]
+            wait_for_event(
+                &self.journal_path,
+                "native-window-blur",
+                Duration::from_secs(3),
+            )?;
+            #[cfg(not(target_os = "macos"))]
             wait_for_event(&self.journal_path, "blur", Duration::from_secs(3))?;
             let (_, focus_violations) = self.observe();
             if !focus_violations
@@ -447,6 +450,12 @@ fn read_journal_events(path: &std::path::Path) -> Result<Vec<serde_json::Value>,
 
 fn event_kind(event: &serde_json::Value) -> Option<&str> {
     event["kind"].as_str()
+}
+
+fn is_focus_loss_event(event: &serde_json::Value) -> bool {
+    event_kind(event) == Some("blur")
+        || event_kind(event) == Some("native-window-blur")
+        || (event_kind(event) == Some("visibility") && event["state"].as_str() == Some("hidden"))
 }
 
 fn wait_for_event(path: &std::path::Path, kind: &str, timeout: Duration) -> Result<(), String> {
@@ -1068,5 +1077,24 @@ fn electron_fixture() -> ElectronFixture {
                 "--force-renderer-accessibility",
             ],
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_focus_loss_event;
+
+    #[test]
+    fn native_window_blur_is_a_focus_loss_even_without_dom_blur() {
+        assert!(is_focus_loss_event(
+            &serde_json::json!({"kind": "native-window-blur"})
+        ));
+        assert!(is_focus_loss_event(&serde_json::json!({"kind": "blur"})));
+        assert!(is_focus_loss_event(
+            &serde_json::json!({"kind": "visibility", "state": "hidden"})
+        ));
+        assert!(!is_focus_loss_event(
+            &serde_json::json!({"kind": "native-window-focus"})
+        ));
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
@@ -1112,6 +1112,12 @@ fn harness_appkit_double_click_px_background() {
                 "AppKit double click failed: {}",
                 response.text()
             );
+            assert_eq!(
+                response.structured()["synthetic_target_focus"],
+                true,
+                "background double click must exercise target-only synthetic focus: {}",
+                response.raw
+            );
             std::thread::sleep(Duration::from_millis(250));
             assert!(
                 snapshot_elements(driver, pid, wid)

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs
@@ -344,30 +344,36 @@ fn click_at_xy_inner(
     })
 }
 
-/// Prepare a raw background pixel click by making the target AppKit-active
-/// without raising or restacking its window.
+/// Prepare a raw background pixel click by making only the target window
+/// synthetically active for event routing. The user's real foreground process
+/// is never sent a defocus or restore record.
 ///
-/// The Swift implementation ran this immediately before the stamped event
-/// stream. The original Rust port retained the SkyLight primitive but omitted
-/// this call while cursor-overlay repinning was incomplete. Callers should
-/// re-pin their overlay after this returns, then post the click sequence.
-///
-/// Returns whether the private focus-without-raise recipe succeeded. Event
-/// posting remains best-effort when the private APIs are unavailable.
-pub fn prepare_background_pixel_click(pid: i32, wid: u32) -> bool {
-    let activated = crate::input::skylight::activate_without_raise(pid as libc::pid_t, wid);
-    // Match Swift's settle interval so AppKit updates its active/key-window
-    // routing before the mouseMoved + primer + target stream arrives.
-    std::thread::sleep(std::time::Duration::from_millis(50));
-    activated
+/// `Ok(None)` means the exact target is already the real front process and no
+/// synthetic session is needed. Otherwise the returned context must travel
+/// with the click and be ended after the target renderer consumes mouse-up.
+/// Missing/private SPI failures are fatal here: a background-only request must
+/// fail closed instead of silently escalating to real activation.
+pub fn prepare_background_pixel_click(
+    pid: i32,
+    wid: u32,
+) -> anyhow::Result<Option<crate::input::skylight::SyntheticTargetFocusContext>> {
+    if crate::input::skylight::front_process_matches(pid as libc::pid_t, wid) == Some(true) {
+        return Ok(None);
+    }
+
+    let context = crate::input::skylight::begin_synthetic_target_focus(pid as libc::pid_t, wid)?;
+    // Preserve the old 50 ms prologue budget. The SkyLight helper already
+    // waits 40 ms after posting the target-focus record.
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    Ok(Some(context))
 }
 
 /// Post the stamped event half of the Chromium-compatible left-click recipe
 /// matching Swift's `clickViaAuthSignedPost`.
 ///
 /// The sequence stays PID/window-routed throughout. The caller must first run
-/// [`prepare_background_pixel_click`] for background delivery, then re-pin any
-/// cursor overlay before entering this event stream.
+/// [`prepare_background_pixel_click`] for background delivery, then pass its
+/// context here so cleanup is paired with the event stream.
 ///  1. Stamped `mouseMoved` at target coords (f0=2, cursor-state primer).
 ///  2. Off-screen primer down/up at (-1, -1) (f0=1/2) — satisfies Chromium's
 ///     user-activation gate without hitting any DOM element.
@@ -396,6 +402,7 @@ pub fn click_at_xy_chromium(
     wid: u32,
     count: usize,
     modifiers: &[&str],
+    focus_context: Option<crate::input::skylight::SyntheticTargetFocusContext>,
 ) -> anyhow::Result<()> {
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -515,6 +522,14 @@ pub fn click_at_xy_chromium(
             // clear of coalescing back into pair N.
             std::thread::sleep(std::time::Duration::from_millis(80));
         }
+    }
+
+    if let Some(context) = focus_context {
+        // SkyLight delivery is asynchronous. Keep only the target's synthetic
+        // active state alive long enough for Chromium's renderer hop to consume
+        // the final mouse-up, then deactivate only that target.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        crate::input::skylight::end_synthetic_target_focus(context)?;
     }
 
     Ok(())

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
@@ -228,9 +228,14 @@ pub fn is_available() -> bool {
     post_to_pid_fn().is_some()
 }
 
-/// `true` when the focus-without-raise SPIs resolved, including either the
-/// modern window-owner PSN lookup or the deprecated pid fallback.
-pub fn is_focus_without_raise_available() -> bool {
+/// `true` when the target-only synthetic-focus SPIs resolved, including either
+/// the modern window-owner PSN lookup or the deprecated pid fallback.
+///
+/// `_SLPSGetFrontProcess` is observation-only here: teardown reads it so a user
+/// who genuinely activates the target during an in-flight click keeps control.
+/// The background action never addresses, defocuses, or later re-focuses the
+/// user's real foreground process.
+pub fn is_synthetic_target_focus_available() -> bool {
     let has_psn_lookup = (connection_id_fn().is_some()
         && get_window_owner_fn().is_some()
         && get_connection_psn_fn().is_some())
@@ -486,66 +491,150 @@ impl SpaceQuery {
     }
 }
 
-// ── Focus-without-raise ───────────────────────────────────────────────────────
+// ── Target-only synthetic focus ───────────────────────────────────────────────
 
-/// Activate `target_pid`'s window `target_wid` without raising any windows
-/// or triggering Space-follow. Ported from yabai's
-/// `window_manager_focus_window_without_raise`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SyntheticFocusCommand {
+    psn: [u8; 8],
+    window_id: u32,
+    focused: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SyntheticTargetFocusPlan {
+    activate_target: SyntheticFocusCommand,
+    deactivate_target: SyntheticFocusCommand,
+}
+
+/// Opaque cleanup token for a target-only synthetic-focus session.
 ///
-/// Recipe:
-/// 1. `_SLPSGetFrontProcess` → capture current front PSN.
-/// 2. `SLSGetWindowOwner + SLSGetConnectionPSN` → target PSN, with
-///    `GetProcessForPID(target_pid)` as an older-system fallback.
-/// 3. Post 248-byte defocus record to front PSN (`bytes[0x8a] = 0x02`).
-/// 4. Post 248-byte focus record to target PSN (`bytes[0x8a] = 0x01`,
-///    `bytes[0x3c..0x3f]` = `target_wid` little-endian).
+/// The token deliberately contains only the target identity. Structurally, the
+/// cleanup path cannot send a focus record to whichever application happens to
+/// be in the real foreground.
+#[derive(Debug)]
+pub struct SyntheticTargetFocusContext {
+    deactivate_target: Option<SyntheticFocusCommand>,
+}
+
+impl Drop for SyntheticTargetFocusContext {
+    fn drop(&mut self) {
+        // Error/cancellation safety: never leave the target believing it is
+        // active merely because event construction or task joining failed.
+        // The explicit end path below remains preferable because it also gives
+        // AppKit one short settle interval after the record is posted.
+        if let Some(command) = self.deactivate_target.take() {
+            let front_psn = current_front_process_psn();
+            if should_deactivate_synthetic_target(front_psn, command.psn) {
+                let _ = post_synthetic_focus_command(&command);
+            }
+        }
+    }
+}
+
+fn synthetic_target_focus_plan(target_psn: [u8; 8], target_wid: u32) -> SyntheticTargetFocusPlan {
+    SyntheticTargetFocusPlan {
+        activate_target: SyntheticFocusCommand {
+            psn: target_psn,
+            window_id: target_wid,
+            focused: true,
+        },
+        deactivate_target: SyntheticFocusCommand {
+            psn: target_psn,
+            window_id: target_wid,
+            focused: false,
+        },
+    }
+}
+
+fn synthetic_focus_record(window_id: u32, focused: bool) -> [u8; 0xF8] {
+    let mut record = [0u8; 0xF8];
+    record[0x04] = 0xF8;
+    record[0x08] = 0x0D;
+    record[0x3C..0x40].copy_from_slice(&window_id.to_le_bytes());
+    record[0x8A] = if focused { 0x01 } else { 0x02 };
+    record
+}
+
+fn current_front_process_psn() -> Option<[u8; 8]> {
+    let get_front = get_front_process_fn()?;
+    let mut psn = [0u8; 8];
+    (unsafe { get_front(psn.as_mut_ptr() as *mut c_void) } == 0).then_some(psn)
+}
+
+fn should_deactivate_synthetic_target(
+    current_front_psn: Option<[u8; 8]>,
+    target_psn: [u8; 8],
+) -> bool {
+    // Unknown is fail-safe for user intervention: leaving a process-local
+    // synthetic belief behind is preferable to deactivating a target the user
+    // may just have made genuinely frontmost.
+    current_front_psn.is_some_and(|front_psn| front_psn != target_psn)
+}
+
+fn post_synthetic_focus_command(command: &SyntheticFocusCommand) -> anyhow::Result<()> {
+    let post = post_event_record_to_fn()
+        .ok_or_else(|| anyhow::anyhow!("target-only synthetic focus is unavailable"))?;
+    let record = synthetic_focus_record(command.window_id, command.focused);
+    let status = unsafe { post(command.psn.as_ptr() as *const c_void, record.as_ptr()) };
+    if status != 0 {
+        anyhow::bail!("target-only synthetic focus event failed with OSStatus {status}");
+    }
+    Ok(())
+}
+
+/// Make only `target_pid`'s exact window synthetically active for event routing.
 ///
-/// Deliberately skips `SLPSSetFrontProcessWithOptions` — see the Swift
-/// reference `FocusWithoutRaise.swift` for why omitting it keeps
-/// Chromium's user-activation gate open.
+/// This is intentionally not the traditional yabai/Cua
+/// "focus-without-raise" sequence. That sequence first posted a defocus record
+/// to the user's real foreground process; even though WindowServer did not
+/// raise the target, AppKit delivered `resignActive`/`resignKey` and could move
+/// the user's first responder. A background action must not mutate that state.
 ///
-/// Returns `true` when all SPIs resolved and both posts succeeded.
-pub fn activate_without_raise(target_pid: pid_t, target_wid: u32) -> bool {
-    let post_fn = match post_event_record_to_fn() {
-        Some(f) => f,
-        None => return false,
-    };
-    let get_front = match get_front_process_fn() {
-        Some(f) => f,
-        None => return false,
-    };
-    // 8-byte PSN buffers (two UInt32s).
-    let mut prev_psn = [0u8; 8];
+/// The returned context must be passed to [`end_synthetic_target_focus`] after
+/// the target renderer has consumed the final input event.
+pub fn begin_synthetic_target_focus(
+    target_pid: pid_t,
+    target_wid: u32,
+) -> anyhow::Result<SyntheticTargetFocusContext> {
+    if !is_synthetic_target_focus_available() {
+        anyhow::bail!("target-only synthetic focus is unavailable");
+    }
+
     let mut target_psn = [0u8; 8];
-
-    let ok_prev = unsafe { get_front(prev_psn.as_mut_ptr() as *mut c_void) } == 0;
-    if !ok_prev {
-        return false;
-    }
-
     if !get_process_psn_for_window(target_wid, target_pid, &mut target_psn) {
-        return false;
+        anyhow::bail!(
+            "could not resolve pid {target_pid} window {target_wid} for target-only synthetic focus"
+        );
     }
 
-    // Build the 248-byte event buffer.
-    let mut buf = [0u8; 0xF8];
-    buf[0x04] = 0xF8;
-    buf[0x08] = 0x0D;
-    // Stamp target window id in little-endian at bytes 0x3c–0x3f.
-    buf[0x3C] = (target_wid & 0xFF) as u8;
-    buf[0x3D] = ((target_wid >> 8) & 0xFF) as u8;
-    buf[0x3E] = ((target_wid >> 16) & 0xFF) as u8;
-    buf[0x3F] = ((target_wid >> 24) & 0xFF) as u8;
+    let plan = synthetic_target_focus_plan(target_psn, target_wid);
+    post_synthetic_focus_command(&plan.activate_target)?;
+    std::thread::sleep(std::time::Duration::from_millis(40));
+    Ok(SyntheticTargetFocusContext {
+        deactivate_target: Some(plan.deactivate_target),
+    })
+}
 
-    // Step 3: defocus previous front.
-    buf[0x8A] = 0x02;
-    let defocus_ok = unsafe { post_fn(prev_psn.as_ptr() as *const c_void, buf.as_ptr()) == 0 };
-
-    // Step 4: focus target.
-    buf[0x8A] = 0x01;
-    let focus_ok = unsafe { post_fn(target_psn.as_ptr() as *const c_void, buf.as_ptr()) == 0 };
-
-    defocus_ok && focus_ok
+/// Remove the synthetic event-routing state installed on the target only.
+pub fn end_synthetic_target_focus(mut context: SyntheticTargetFocusContext) -> anyhow::Result<()> {
+    let command = context
+        .deactivate_target
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("target-only synthetic focus was already ended"))?;
+    let front_psn = current_front_process_psn();
+    if front_psn.is_none() {
+        anyhow::bail!(
+            "could not verify the real foreground during target-only synthetic focus cleanup; target state was left unchanged"
+        );
+    }
+    if !should_deactivate_synthetic_target(front_psn, command.psn) {
+        // Real activation supersedes the synthetic belief. In particular, do
+        // not undo a user takeover that happened while the click was in flight.
+        return Ok(());
+    }
+    post_synthetic_focus_command(&command)?;
+    std::thread::sleep(std::time::Duration::from_millis(40));
+    Ok(())
 }
 
 // ── NSMenu shortcut activation ────────────────────────────────────────────────
@@ -897,7 +986,49 @@ pub fn with_menu_shortcut_activation(
 
 #[cfg(test)]
 mod tests {
-    use super::{make_key_window_record, preserves_exact_existing_focus};
+    use super::{
+        make_key_window_record, preserves_exact_existing_focus, should_deactivate_synthetic_target,
+        synthetic_focus_record, synthetic_target_focus_plan,
+    };
+
+    #[test]
+    fn synthetic_focus_plan_addresses_only_the_target() {
+        let target_psn = [1, 2, 3, 4, 5, 6, 7, 8];
+        let plan = synthetic_target_focus_plan(target_psn, 0x7856_3412);
+
+        assert_eq!(plan.activate_target.psn, target_psn);
+        assert_eq!(plan.deactivate_target.psn, target_psn);
+        assert_eq!(plan.activate_target.window_id, 0x7856_3412);
+        assert_eq!(plan.deactivate_target.window_id, 0x7856_3412);
+        assert!(plan.activate_target.focused);
+        assert!(!plan.deactivate_target.focused);
+    }
+
+    #[test]
+    fn synthetic_focus_records_encode_exact_window_and_transition() {
+        let activate = synthetic_focus_record(0x7856_3412, true);
+        let deactivate = synthetic_focus_record(0x7856_3412, false);
+
+        assert_eq!(activate.len(), 0xF8);
+        assert_eq!(activate[0x04], 0xF8);
+        assert_eq!(activate[0x08], 0x0D);
+        assert_eq!(&activate[0x3C..0x40], &[0x12, 0x34, 0x56, 0x78]);
+        assert_eq!(activate[0x8A], 0x01);
+        assert_eq!(deactivate[0x8A], 0x02);
+    }
+
+    #[test]
+    fn synthetic_focus_cleanup_preserves_a_real_user_takeover() {
+        let target = [1, 2, 3, 4, 5, 6, 7, 8];
+        let other = [8, 7, 6, 5, 4, 3, 2, 1];
+
+        assert!(!should_deactivate_synthetic_target(Some(target), target));
+        assert!(should_deactivate_synthetic_target(Some(other), target));
+        assert!(
+            !should_deactivate_synthetic_target(None, target),
+            "an unknown real foreground must fail safe for user intervention"
+        );
+    }
 
     #[test]
     fn make_key_records_address_only_the_exact_window() {

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/click.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/click.rs
@@ -51,9 +51,9 @@ static DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();
 enum PixelActivationPolicy {
     /// Standard background delivery: suppress activation of the target.
     SuppressTarget,
-    /// Left-click with a concrete window: intentionally make the target
-    /// AppKit-active without raising it, while suppressing every other app.
-    AllowTargetWithoutRaise,
+    /// Left-click with a concrete window: synthesize event-routing focus only
+    /// inside the target. The real foreground application remains active/key.
+    SyntheticTargetFocus,
     /// Explicit foreground rung owns its brief activation and restoration.
     ForegroundAssist,
 }
@@ -92,32 +92,9 @@ fn pixel_activation_policy(
     if effective_foreground {
         PixelActivationPolicy::ForegroundAssist
     } else if button == "left" && has_window {
-        PixelActivationPolicy::AllowTargetWithoutRaise
+        PixelActivationPolicy::SyntheticTargetFocus
     } else {
         PixelActivationPolicy::SuppressTarget
-    }
-}
-
-/// Return the prior foreground pid that should be restored after a raw
-/// background pixel click.
-///
-/// This decision deliberately depends on observed application state rather
-/// than the private focus recipe's return value. The recipe can be unavailable
-/// or partially fail while the raw click still makes the target AppKit-active;
-/// in that case the allow-target suppression lease will not restore it for us.
-fn background_pixel_restore_pid(
-    activation_policy: PixelActivationPolicy,
-    prior_front: Option<i32>,
-    target_pid: i32,
-    observed_front: Option<i32>,
-) -> Option<i32> {
-    if activation_policy == PixelActivationPolicy::AllowTargetWithoutRaise
-        && prior_front != Some(target_pid)
-        && observed_front == Some(target_pid)
-    {
-        prior_front
-    } else {
-        None
     }
 }
 
@@ -981,37 +958,43 @@ impl Tool for ClickTool {
             // shape as the AX path, so we wrap identically.
             let prior_front = apps::frontmost_pid();
             let snapshot = match activation_policy {
-                PixelActivationPolicy::SuppressTarget => {
+                PixelActivationPolicy::SuppressTarget
+                | PixelActivationPolicy::SyntheticTargetFocus => {
                     WindowChangeDetector::snapshot(prior_front)
-                }
-                PixelActivationPolicy::AllowTargetWithoutRaise => {
-                    WindowChangeDetector::snapshot_allowing_activation(prior_front, pid)
                 }
                 PixelActivationPolicy::ForegroundAssist => {
                     WindowChangeDetector::snapshot_without_suppression(prior_front)
                 }
             };
 
-            // Restore the Swift background-click prologue that was left
-            // disconnected in the original Rust port. It makes an opaque
-            // target AppKit-active without raising/restacking its window, which
-            // is required by Chromium gates and remote-HID proxies such as
-            // iPhone Mirroring. Re-pin after the focus record because changing
-            // AppKit active state can disturb overlay ordering.
-            let focus_without_raise =
-                if activation_policy == PixelActivationPolicy::AllowTargetWithoutRaise {
+            // Chromium needs its internal event-routing state to appear active
+            // before it accepts a click for a fully covered window. Install that
+            // state only on the target. The old focus-without-raise prologue also
+            // sent `focused=false` to the real foreground app, which could fire
+            // resignActive/resignKey and steal the user's keyboard destination
+            // despite leaving window z-order unchanged.
+            let synthetic_focus_context =
+                if activation_policy == PixelActivationPolicy::SyntheticTargetFocus {
                     let wid = window_id.expect("activation policy requires window_id");
                     match tokio::task::spawn_blocking(move || {
                         crate::input::mouse::prepare_background_pixel_click(pid, wid)
                     })
                     .await
                     {
-                        Ok(activated) => {
+                        Ok(Ok(context)) => {
                             crate::cursor::overlay::send_command(
                                 cursor_key.clone(),
                                 cursor_overlay::OverlayCommand::PinAbove(wid as u64),
                             );
-                            activated
+                            context
+                        }
+                        Ok(Err(error)) => {
+                            return ToolResult::error(format!(
+                                "Background click target-only focus failed: {error}"
+                            ))
+                            .with_structured(serde_json::json!({
+                                "code": "background_unavailable"
+                            }));
                         }
                         Err(error) => {
                             return ToolResult::error(format!(
@@ -1020,8 +1003,9 @@ impl Tool for ClickTool {
                         }
                     }
                 } else {
-                    false
+                    None
                 };
+            let used_synthetic_target_focus = synthetic_focus_context.is_some();
 
             // Pulse only after the activation settle so it visually coincides
             // with the real target click rather than the private focus prelude.
@@ -1039,7 +1023,11 @@ impl Tool for ClickTool {
             // routed `click_at_xy_with_window_local` for back-compat.
             let button_kind = button_str.clone();
             let result = focus_guard::with_focus_suppressed(
-                if activation_policy == PixelActivationPolicy::SuppressTarget {
+                if matches!(
+                    activation_policy,
+                    PixelActivationPolicy::SuppressTarget
+                        | PixelActivationPolicy::SyntheticTargetFocus
+                ) {
                     Some(pid)
                 } else {
                     None
@@ -1094,7 +1082,7 @@ impl Tool for ClickTool {
                                         return crate::input::mouse::click_at_xy_chromium(
                                             pid, screen_x, screen_y,
                                             win_local_x, win_local_y,
-                                            wid, count, &m,
+                                            wid, count, &m, synthetic_focus_context,
                                         );
                                     }
                                     crate::input::mouse::click_at_xy(pid, screen_x, screen_y, count, &m)
@@ -1128,29 +1116,6 @@ impl Tool for ClickTool {
             )
             .await;
 
-            // The no-raise record can make NSWorkspace report the target as
-            // active even though its window never moved in z-order. Once the
-            // click has been queued, restore the prior app if the target is
-            // still reported frontmost. Base this on observed state, not
-            // `focus_without_raise`: the private recipe can report failure
-            // after partially activating the target, and the raw click can
-            // self-activate even when that recipe is unavailable. Do not
-            // overwrite a different app here; the wildcard suppression lease
-            // handles genuine side effects.
-            if activation_policy == PixelActivationPolicy::AllowTargetWithoutRaise
-                && prior_front != Some(pid)
-            {
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                if let Some(previous_pid) = background_pixel_restore_pid(
-                    activation_policy,
-                    prior_front,
-                    pid,
-                    apps::frontmost_pid(),
-                ) {
-                    let _ = apps::activate_pid(previous_pid);
-                }
-            }
-
             let changes = super::finish_window_observation(snapshot, &args).await;
 
             let button_label = match button_str.as_str() {
@@ -1177,7 +1142,8 @@ impl Tool for ClickTool {
                         "path": path,
                         "verified": false,
                         "effect": "unverifiable",
-                        "focus_without_raise": focus_without_raise
+                        "focus_without_raise": used_synthetic_target_focus,
+                        "synthetic_target_focus": used_synthetic_target_focus
                     }))
                 }
                 Ok(Err(e)) => ToolResult::error(format!("{button_label} failed: {e}")),
@@ -1563,15 +1529,14 @@ mod tests {
         }
     }
 
-    /// Regression for the Swift→Rust port gap: only a raw background left
-    /// click with an exact window may intentionally activate the target
-    /// without raising it. Other background buttons retain strict suppression,
-    /// and the explicit foreground rung owns its separate activation.
+    /// A raw background left click with an exact window may install target-only
+    /// synthetic routing focus. Other background buttons retain strict
+    /// suppression, and the explicit foreground rung owns real activation.
     #[test]
-    fn raw_background_left_click_restores_focus_without_raise_policy() {
+    fn raw_background_left_click_uses_target_only_synthetic_focus() {
         assert_eq!(
             pixel_activation_policy("left", false, true),
-            PixelActivationPolicy::AllowTargetWithoutRaise
+            PixelActivationPolicy::SyntheticTargetFocus
         );
         assert_eq!(
             pixel_activation_policy("left", false, false),
@@ -1588,44 +1553,6 @@ mod tests {
         assert_eq!(
             pixel_activation_policy("left", true, true),
             PixelActivationPolicy::ForegroundAssist
-        );
-    }
-
-    /// The no-foreground contract must not depend on the private activation
-    /// recipe reporting full success. If that recipe is unavailable or only
-    /// partially succeeds but the target is nevertheless observed frontmost,
-    /// restore the user's prior app.
-    #[test]
-    fn failed_private_activation_still_restores_observed_target_focus() {
-        assert_eq!(
-            background_pixel_restore_pid(
-                PixelActivationPolicy::AllowTargetWithoutRaise,
-                Some(7),
-                42,
-                Some(42),
-            ),
-            Some(7)
-        );
-
-        assert_eq!(
-            background_pixel_restore_pid(
-                PixelActivationPolicy::AllowTargetWithoutRaise,
-                Some(7),
-                42,
-                Some(99),
-            ),
-            None,
-            "do not overwrite an unrelated app that became frontmost"
-        );
-        assert_eq!(
-            background_pixel_restore_pid(
-                PixelActivationPolicy::SuppressTarget,
-                Some(7),
-                42,
-                Some(42),
-            ),
-            None,
-            "strict-suppression paths retain their existing ownership"
         );
     }
 }

--- a/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/main.js
+++ b/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/main.js
@@ -52,9 +52,13 @@ ipcMain.on('cua-e2e-fixture-state', (_event, state) => {
   request.end(body);
 });
 
-ipcMain.on('cua-e2e-sentinel-event', (_event, entry) => {
+function appendSentinelEvent(entry) {
   if (!sentinelMode || !sentinelJournalPath) return;
   fs.appendFileSync(sentinelJournalPath, `${JSON.stringify(entry)}\n`, 'utf8');
+}
+
+ipcMain.on('cua-e2e-sentinel-event', (_event, entry) => {
+  appendSentinelEvent(entry);
 });
 
 let mainWindow;
@@ -105,6 +109,20 @@ function createWindow() {
   // 'cua-driver Web Harness' (the page's title).
   mainWindow.on('page-title-updated', e => e.preventDefault());
   mainWindow.setTitle(fixedTitle);
+  if (sentinelMode) {
+    // Renderer `window.blur` is not a complete macOS focus oracle. AppKit can
+    // deliver resignActive/resignKey to Electron's native window without the
+    // WebContents emitting a DOM blur. Journal BrowserWindow focus transitions
+    // independently so the background-action gate catches that exact class.
+    mainWindow.on('focus', () => appendSentinelEvent({
+      kind: 'native-window-focus',
+      at_ms: Date.now(),
+    }));
+    mainWindow.on('blur', () => appendSentinelEvent({
+      kind: 'native-window-blur',
+      at_ms: Date.now(),
+    }));
+  }
   mainWindow.webContents.setWindowOpenHandler(() => ({
     action: 'allow',
     overrideBrowserWindowOptions: {


### PR DESCRIPTION
## Summary
- replace the macOS background pixel-click focus-without-raise sequence with target-only synthetic focus
- never send defocus or restore records to the user foreground process
- skip target deactivation if the user genuinely activates that target while the click is in flight
- fail closed when the private target-only route is unavailable and clean up target state on errors
- keep target activation under the existing strict focus-suppression observer
- extend the foreground sentinel with native BrowserWindow blur so AppKit-level loss cannot hide behind unchanged DOM focus
- require the existing background raw-double-click E2E cell to attest that it used target-only synthetic focus

Refs #3331

Salvaged from iFurySt/open-codex-computer-use#48.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p platform-macos` (362 passed, 2 ignored)
- `cargo test -p cua-driver-testkit` (56 unit tests and 2 integration-schema tests passed)
- `cargo test -p cua-driver --test harness_appkit_test --no-run`
- `node --check libs/cua-driver/tests/fixtures/apps/cross-platform/electron/main.js`
- focused target-only record, plan, user-takeover cleanup, and native-sentinel classification tests pass

## Pending native evidence
The local console session is currently locked (`CGSSessionScreenIsLocked=Yes`). The covered-target focus test cannot establish an active/key foreground sentinel while locked, so no native focus-preservation result is claimed yet. After unlock the sentinel first runs a deliberate focus-loss/input-leak canary, then the background raw double click must prove target effect, target-only route use, unchanged frontmost PID, no native or DOM blur, unchanged real pointer, unchanged z-order, and safe user takeover.

## Known unrelated validation noise
`cargo clippy -p platform-macos --all-targets -- -D warnings` is currently blocked by pre-existing lints in cursor-overlay and other untouched platform-macos files under Rust 1.98.