### PR TITLE
feat(agent): add optional Qwen XML tool-call parser for generic VLM loop

### DIFF
--- a/libs/python/agent/cua_agent/loops/generic_vlm.py
+++ b/libs/python/agent/cua_agent/loops/generic_vlm.py
@@ -23,6 +23,12 @@ from ..responses import (
     make_reasoning_item,
 )
 from ..types import AgentCapability
+from .qwen_xml import (
+    ToolCallParser,
+    convert_qwen_tool_args_to_computer_action,
+    parse_tool_calls_from_text,
+    strip_parsed_tool_calls_from_text,
+)
 
 # ComputerUse tool schema (OpenAI function tool format)
 QWEN3_COMPUTER_TOOL: Dict[str, Any] = {
@@ -153,87 +159,6 @@ async def _unnormalize_coordinate(args: Dict[str, Any], dims: Tuple[int, int]) -
     return args
 
 
-def convert_qwen_tool_args_to_computer_action(args: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """
-    Convert Qwen computer tool arguments to the Computer Calls action schema.
-
-    Qwen (example):
-        {"action": "left_click", "coordinate": [114, 68]}
-
-    Target (example):
-        {"action": "left_click", "x": 114, "y": 68}
-
-    Other mappings:
-    - right_click, middle_click, double_click (triple_click -> double_click)
-    - mouse_move -> { action: "move", x, y }
-    - key -> { action: "keypress", keys: [...] }
-    - type -> { action: "type", text }
-    - scroll/hscroll -> { action: "scroll", scroll_x, scroll_y, x, y }
-    - wait -> { action: "wait" }
-    - terminate/answer are not direct UI actions; return None for now
-    """
-    if not isinstance(args, dict):
-        return None
-
-    action = args.get("action")
-    if not isinstance(action, str):
-        return None
-
-    # Coordinates helper
-    coord = args.get("coordinate")
-    x = y = None
-    if isinstance(coord, (list, tuple)) and len(coord) >= 2:
-        try:
-            x = int(round(float(coord[0])))
-            y = int(round(float(coord[1])))
-        except Exception:
-            x = y = None
-
-    # Map actions
-    a = action.lower()
-    if a in {"left_click", "right_click", "middle_click", "double_click"}:
-        if x is None or y is None:
-            return None
-        return {"action": a, "x": x, "y": y}
-    if a == "triple_click":
-        # Approximate as double_click
-        if x is None or y is None:
-            return None
-        return {"action": "double_click", "x": x, "y": y}
-    if a == "mouse_move":
-        if x is None or y is None:
-            return None
-        return {"action": "move", "x": x, "y": y}
-    if a == "key":
-        keys = args.get("keys")
-        if isinstance(keys, list) and all(isinstance(k, str) for k in keys):
-            return {"action": "keypress", "keys": keys}
-        return None
-    if a == "type":
-        text = args.get("text")
-        if isinstance(text, str):
-            return {"action": "type", "text": text}
-        return None
-    if a in {"scroll", "hscroll"}:
-        pixels = args.get("pixels") or 0
-        try:
-            pixels_val = int(round(float(pixels)))
-        except Exception:
-            pixels_val = 0
-        scroll_x = pixels_val if a == "hscroll" else 0
-        scroll_y = pixels_val if a == "scroll" else 0
-        # Include cursor position if available (optional)
-        out: Dict[str, Any] = {"action": "scroll", "scroll_x": scroll_x, "scroll_y": scroll_y}
-        if x is not None and y is not None:
-            out.update({"x": x, "y": y})
-        return out
-    if a == "wait":
-        return {"action": "wait"}
-
-    # Non-UI or terminal actions: terminate/answer -> not mapped here
-    return None
-
-
 @register_agent(models=r"(?i).*", priority=-100)
 class GenericVlmConfig(AsyncAgentConfig):
     async def predict_step(
@@ -245,12 +170,16 @@ class GenericVlmConfig(AsyncAgentConfig):
         stream: bool = False,
         computer_handler=None,
         use_prompt_caching: Optional[bool] = False,
+        tool_call_parser: Optional[ToolCallParser] = None,
         _on_api_start=None,
         _on_api_end=None,
         _on_usage=None,
         _on_screenshot=None,
         **kwargs,
     ) -> Dict[str, Any]:
+        if tool_call_parser not in (None, "qwen_xml"):
+            raise ValueError(f"Unsupported tool_call_parser: {tool_call_parser!r}")
+
         # Build messages using NousFnCallPrompt system with tool schema in text
         # Start with converted conversation (images/text preserved)
         converted_msgs = convert_responses_items_to_completion_messages(
@@ -427,9 +356,67 @@ class GenericVlmConfig(AsyncAgentConfig):
             output_items.append(make_reasoning_item(reasoning_text))
 
         # Priority 1: Try to parse tool call from content text (OpenRouter format)
-        tool_call = _parse_tool_call_from_text(content_text)
+        tool_call = (
+            None if tool_call_parser == "qwen_xml" else _parse_tool_call_from_text(content_text)
+        )
+        parsed_tool_calls = (
+            parse_tool_calls_from_text(content_text, tool_call_parser="qwen_xml")
+            if tool_call_parser == "qwen_xml"
+            else []
+        )
 
-        if tool_call and isinstance(tool_call, dict):
+        if parsed_tool_calls:
+            processed_tool_calls = []
+            accepted_tool_calls = []
+            for i, parsed_tool_call in enumerate(parsed_tool_calls):
+                fn_name = parsed_tool_call.get("name") or "computer"
+                raw_args = parsed_tool_call.get("arguments") or {}
+                if not isinstance(raw_args, dict):
+                    raw_args = {}
+                args = raw_args
+
+                if "coordinate" in args and last_rw is not None and last_rh is not None:
+                    args = await _unnormalize_coordinate(args, (last_rw, last_rh))
+
+                if fn_name == "computer":
+                    converted_action = convert_qwen_tool_args_to_computer_action(args)
+                    if not converted_action:
+                        continue
+                    args = converted_action
+
+                processed_tool_calls.append(
+                    {
+                        "type": "function",
+                        "id": f"call_{i}",
+                        "function": {
+                            "name": fn_name,
+                            "arguments": json.dumps(args),
+                        },
+                    }
+                )
+                accepted_tool_calls.append(parsed_tool_call)
+
+            if processed_tool_calls:
+                assistant_text = strip_parsed_tool_calls_from_text(
+                    content_text, accepted_tool_calls
+                )
+                if assistant_text:
+                    output_items.extend(
+                        convert_completion_messages_to_responses_items(
+                            [{"role": "assistant", "content": assistant_text}]
+                        )
+                    )
+
+                fake_cm = {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": processed_tool_calls,
+                }
+                output_items.extend(convert_completion_messages_to_responses_items([fake_cm]))
+            else:
+                fake_cm = {"role": "assistant", "content": content_text}
+                output_items.extend(convert_completion_messages_to_responses_items([fake_cm]))
+        elif tool_call and isinstance(tool_call, dict):
             fn_name = tool_call.get("name") or "computer"
             raw_args = tool_call.get("arguments") or {}
             # Unnormalize coordinates to actual screen size using last resized dims

--- a/libs/python/agent/cua_agent/loops/qwen35.py
+++ b/libs/python/agent/cua_agent/loops/qwen35.py
@@ -7,7 +7,6 @@ Qwen3-VL agent loop implementation using litellm with function/tool calling.
 from __future__ import annotations
 
 import json
-import re
 from typing import Any, Dict, List, Optional, Tuple
 
 import litellm
@@ -23,6 +22,10 @@ from ..responses import (
     make_reasoning_item,
 )
 from ..types import AgentCapability
+from .qwen_xml import (
+    convert_qwen_tool_args_to_computer_action,
+    parse_tool_call_from_text as parse_qwen_tool_call_from_text,
+)
 
 # ComputerUse tool schema (OpenAI function tool format)
 QWEN3_5_COMPUTER_TOOL: Dict[str, Any] = {
@@ -143,39 +146,7 @@ def _parse_tool_call_from_text(text: str) -> Optional[Dict[str, Any]]:
     1. JSON: ``<tool_call>{"name": "computer", "arguments": {...}}</tool_call>``
     2. XML-style (qwen35-4b): ``<tool_call><function=computer><parameter=action>left_click</parameter>...</tool_call>``
     """
-    # --- Format 1: JSON ---
-    m = re.search(r"<tool_call>\s*(\{[\s\S]*?\})\s*</tool_call>", text)
-    if m:
-        try:
-            return json.loads(m.group(1))
-        except Exception:
-            pass
-
-    # --- Format 2: XML-style <function=name><parameter=key>value</parameter> ---
-    fn_match = re.search(
-        r"<tool_call>\s*<function=(\w+)>([\s\S]*?)</function>\s*</tool_call>", text
-    )
-    if fn_match:
-        fn_name = fn_match.group(1)
-        params_block = fn_match.group(2)
-        # Extract all <parameter=key>value</parameter> pairs
-        params: Dict[str, Any] = {}
-        for pm in re.finditer(r"<parameter=(\w+)>\s*([\s\S]*?)\s*</parameter>", params_block):
-            key = pm.group(1)
-            val = pm.group(2).strip()
-            # Try to parse as JSON (for arrays/numbers), fall back to string
-            try:
-                params[key] = json.loads(val)
-            except (json.JSONDecodeError, ValueError):
-                params[key] = val
-        # The XML format uses <parameter=type> for the action field name,
-        # but the Qwen tool schema calls it "action".  Remap if we got
-        # "type" that looks like an action name rather than a literal type.
-        if "type" in params and "action" not in params:
-            params["action"] = params.pop("type")
-        return {"name": fn_name, "arguments": params}
-
-    return None
+    return parse_qwen_tool_call_from_text(text, tool_call_parser="qwen_xml")
 
 
 async def _unnormalize_coordinate(args: Dict[str, Any], dims: Tuple[int, int]) -> Dict[str, Any]:
@@ -189,87 +160,6 @@ async def _unnormalize_coordinate(args: Dict[str, Any], dims: Tuple[int, int]) -
     y_abs = max(0.0, min(height, (y / 1000.0) * height))
     args = {**args, "coordinate": [round(x_abs), round(y_abs)]}
     return args
-
-
-def convert_qwen_tool_args_to_computer_action(args: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """
-    Convert Qwen computer tool arguments to the Computer Calls action schema.
-
-    Qwen (example):
-        {"action": "left_click", "coordinate": [114, 68]}
-
-    Target (example):
-        {"action": "left_click", "x": 114, "y": 68}
-
-    Other mappings:
-    - right_click, middle_click, double_click (triple_click -> double_click)
-    - mouse_move -> { action: "move", x, y }
-    - key -> { action: "keypress", keys: [...] }
-    - type -> { action: "type", text }
-    - scroll/hscroll -> { action: "scroll", scroll_x, scroll_y, x, y }
-    - wait -> { action: "wait" }
-    - terminate/answer are not direct UI actions; return None for now
-    """
-    if not isinstance(args, dict):
-        return None
-
-    action = args.get("action")
-    if not isinstance(action, str):
-        return None
-
-    # Coordinates helper
-    coord = args.get("coordinate")
-    x = y = None
-    if isinstance(coord, (list, tuple)) and len(coord) >= 2:
-        try:
-            x = int(round(float(coord[0])))
-            y = int(round(float(coord[1])))
-        except Exception:
-            x = y = None
-
-    # Map actions
-    a = action.lower()
-    if a in {"left_click", "right_click", "middle_click", "double_click"}:
-        if x is None or y is None:
-            return None
-        return {"action": a, "x": x, "y": y}
-    if a == "triple_click":
-        # Approximate as double_click
-        if x is None or y is None:
-            return None
-        return {"action": "double_click", "x": x, "y": y}
-    if a == "mouse_move":
-        if x is None or y is None:
-            return None
-        return {"action": "move", "x": x, "y": y}
-    if a == "key":
-        keys = args.get("keys")
-        if isinstance(keys, list) and all(isinstance(k, str) for k in keys):
-            return {"action": "keypress", "keys": keys}
-        return None
-    if a == "type":
-        text = args.get("text")
-        if isinstance(text, str):
-            return {"action": "type", "text": text}
-        return None
-    if a in {"scroll", "hscroll"}:
-        pixels = args.get("pixels") or 0
-        try:
-            pixels_val = int(round(float(pixels)))
-        except Exception:
-            pixels_val = 0
-        scroll_x = pixels_val if a == "hscroll" else 0
-        scroll_y = pixels_val if a == "scroll" else 0
-        # Include cursor position if available (optional)
-        out: Dict[str, Any] = {"action": "scroll", "scroll_x": scroll_x, "scroll_y": scroll_y}
-        if x is not None and y is not None:
-            out.update({"x": x, "y": y})
-        return out
-    if a == "wait":
-        return {"action": "wait"}
-
-    # Non-UI or terminal actions: terminate/answer -> not mapped here
-    return None
 
 
 @register_agent(models=r"(?i).*qwen35.*", priority=1)
@@ -534,7 +424,6 @@ class Qwen35Config(AsyncAgentConfig):
             output_items.extend(convert_completion_messages_to_responses_items([fake_cm]))
 
         elif tool_calls_array:
-
             output_items.append(
                 {
                     "type": "message",

--- a/libs/python/agent/cua_agent/loops/qwen_xml.py
+++ b/libs/python/agent/cua_agent/loops/qwen_xml.py
@@ -1,0 +1,309 @@
+"""Utilities for parsing Qwen-style tool calls from assistant text."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List, Literal, Optional
+
+ToolCallParser = Literal["qwen_xml"]
+
+_TOOL_CALL_RE = re.compile(r"<tool_call>\s*([\s\S]*?)\s*</tool_call>")
+_FUNCTION_RE = re.compile(r"<function=([A-Za-z_][\w.-]*)>\s*([\s\S]*?)\s*</function>")
+_PARAMETER_OPEN_RE = re.compile(r"<parameter=([A-Za-z_][\w.-]*)>")
+
+_DIRECT_COMPUTER_ACTIONS = {
+    "click",
+    "double_click",
+    "drag",
+    "hscroll",
+    "key",
+    "keypress",
+    "left_click",
+    "left_click_drag",
+    "middle_click",
+    "mouse_move",
+    "move",
+    "right_click",
+    "screenshot",
+    "scroll",
+    "text",
+    "triple_click",
+    "type",
+    "wait",
+}
+
+
+def _parse_json_value(value: str) -> Any:
+    stripped = value.strip()
+    try:
+        return json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        return stripped
+
+
+def _parse_json_tool_call(inner_text: str) -> Optional[Dict[str, Any]]:
+    json_start = inner_text.find("{")
+    if json_start == -1:
+        return None
+
+    brace_count = 0
+    json_end = json_start
+    for i in range(json_start, len(inner_text)):
+        if inner_text[i] == "{":
+            brace_count += 1
+        elif inner_text[i] == "}":
+            brace_count -= 1
+            if brace_count == 0:
+                json_end = i + 1
+                break
+
+    if brace_count != 0:
+        return None
+
+    try:
+        tool_call = json.loads(inner_text[json_start:json_end])
+    except Exception:
+        return None
+
+    if not isinstance(tool_call, dict):
+        return None
+    return tool_call
+
+
+def _parse_qwen_xml_parameters(params_block: str) -> Dict[str, Any]:
+    params: Dict[str, Any] = {}
+    param_openings = list(_PARAMETER_OPEN_RE.finditer(params_block))
+
+    for i, param_match in enumerate(param_openings):
+        param_name = param_match.group(1)
+        value_start = param_match.end()
+        close_match = re.search(r"</parameter>", params_block[value_start:])
+        next_open = param_openings[i + 1] if i + 1 < len(param_openings) else None
+
+        if close_match is None:
+            if param_name in _DIRECT_COMPUTER_ACTIONS and "action" not in params:
+                params["action"] = param_name
+            continue
+
+        value_end = value_start + close_match.start()
+
+        if (
+            param_name in _DIRECT_COMPUTER_ACTIONS
+            and next_open is not None
+            and next_open.start() < value_end
+            and "action" not in params
+        ):
+            params["action"] = param_name
+            continue
+
+        value = params_block[value_start:value_end]
+        if param_name in _DIRECT_COMPUTER_ACTIONS and not value.strip():
+            if "action" not in params:
+                params["action"] = param_name
+            continue
+        params[param_name] = _parse_json_value(value)
+
+    return params
+
+
+def _parse_qwen_xml_tool_calls(inner_text: str) -> List[Dict[str, Any]]:
+    tool_calls: List[Dict[str, Any]] = []
+    for fn_match in _FUNCTION_RE.finditer(inner_text):
+        fn_name = fn_match.group(1)
+        params_block = fn_match.group(2)
+
+        params = _parse_qwen_xml_parameters(params_block)
+
+        if fn_name in _DIRECT_COMPUTER_ACTIONS:
+            if "action" not in params and "type" not in params:
+                params["action"] = fn_name
+            tool_name = "computer"
+        else:
+            tool_name = fn_name
+
+        if tool_name in {"computer", "computer_use"} and "type" in params:
+            if "action" not in params:
+                params["action"] = params["type"]
+            del params["type"]
+
+        tool_calls.append({"name": tool_name, "arguments": params})
+    return tool_calls
+
+
+def parse_tool_calls_from_text(
+    text: str,
+    tool_call_parser: Optional[ToolCallParser] = None,
+) -> List[Dict[str, Any]]:
+    """Extract tool calls from assistant text.
+
+    With no parser selected, only JSON inside ``<tool_call>`` is parsed. The
+    optional ``qwen_xml`` parser additionally accepts Qwen's XML-style function
+    and parameter tags.
+    """
+    if tool_call_parser not in (None, "qwen_xml"):
+        raise ValueError(f"Unsupported tool_call_parser: {tool_call_parser!r}")
+
+    tool_calls: List[Dict[str, Any]] = []
+    for match in _TOOL_CALL_RE.finditer(text):
+        inner_text = match.group(1)
+        json_tool_call = _parse_json_tool_call(inner_text)
+        if json_tool_call:
+            tool_calls.append(
+                {
+                    **json_tool_call,
+                    "_raw_text": match.group(0),
+                    "_raw_index": match.start(),
+                    "_raw_end": match.end(),
+                }
+            )
+            continue
+
+        if tool_call_parser == "qwen_xml":
+            for tool_call in _parse_qwen_xml_tool_calls(inner_text):
+                tool_calls.append(
+                    {
+                        **tool_call,
+                        "_raw_text": match.group(0),
+                        "_raw_index": match.start(),
+                        "_raw_end": match.end(),
+                    }
+                )
+
+    return tool_calls
+
+
+def parse_tool_call_from_text(
+    text: str,
+    tool_call_parser: Optional[ToolCallParser] = None,
+) -> Optional[Dict[str, Any]]:
+    """Extract the first tool call from assistant text."""
+    tool_calls = parse_tool_calls_from_text(text, tool_call_parser=tool_call_parser)
+    if not tool_calls:
+        return None
+
+    tool_call = dict(tool_calls[0])
+    tool_call.pop("_raw_text", None)
+    tool_call.pop("_raw_index", None)
+    tool_call.pop("_raw_end", None)
+    return tool_call
+
+
+def strip_parsed_tool_calls_from_text(text: str, tool_calls: List[Dict[str, Any]]) -> str:
+    """Remove parsed tool-call blocks from assistant text, preserving surrounding text."""
+    stripped = text
+    spans = set()
+    for tool_call in tool_calls:
+        raw_text = tool_call.get("_raw_text")
+        raw_index = tool_call.get("_raw_index")
+        raw_end = tool_call.get("_raw_end")
+        if not isinstance(raw_text, str):
+            continue
+
+        if (
+            isinstance(raw_index, int)
+            and isinstance(raw_end, int)
+            and raw_index >= 0
+            and raw_end >= raw_index
+            and text[raw_index:raw_end] == raw_text
+        ):
+            spans.add((raw_index, raw_end))
+            continue
+
+        start = text.find(raw_text)
+        if start != -1:
+            spans.add((start, start + len(raw_text)))
+
+    for start, end in sorted(spans, reverse=True):
+        stripped = stripped[:start] + stripped[end:]
+    return stripped.strip()
+
+
+def convert_qwen_tool_args_to_computer_action(args: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """
+    Convert Qwen computer tool arguments to the Computer Calls action schema.
+
+    Qwen (example):
+        {"action": "left_click", "coordinate": [114, 68]}
+
+    Target (example):
+        {"action": "left_click", "x": 114, "y": 68}
+
+    Other mappings:
+    - right_click, middle_click, double_click (triple_click -> double_click)
+    - mouse_move -> { action: "move", x, y }
+    - key -> { action: "keypress", keys: [...] }
+    - type -> { action: "type", text }
+    - scroll/hscroll -> { action: "scroll", scroll_x, scroll_y, x, y }
+    - wait -> { action: "wait" }
+    - terminate/answer are not direct UI actions; return None for now
+    """
+    if not isinstance(args, dict):
+        return None
+
+    action = args.get("action")
+    if not isinstance(action, str):
+        return None
+
+    coord = args.get("coordinate")
+    if coord is None and args.get("x") is not None and args.get("y") is not None:
+        coord = [args.get("x"), args.get("y")]
+
+    x = y = None
+    if isinstance(coord, (list, tuple)) and len(coord) >= 2:
+        try:
+            x = int(round(float(coord[0])))
+            y = int(round(float(coord[1])))
+        except Exception:
+            x = y = None
+
+    a = action.lower()
+    if a == "click":
+        if x is None or y is None:
+            return None
+        button = args.get("button", "left")
+        if button == "right":
+            return {"action": "right_click", "x": x, "y": y}
+        if button in {"middle", "wheel"}:
+            return {"action": "middle_click", "x": x, "y": y}
+        return {"action": "left_click", "x": x, "y": y}
+    if a in {"left_click", "right_click", "middle_click", "double_click"}:
+        if x is None or y is None:
+            return None
+        return {"action": a, "x": x, "y": y}
+    if a == "triple_click":
+        if x is None or y is None:
+            return None
+        return {"action": "double_click", "x": x, "y": y}
+    if a in {"mouse_move", "move"}:
+        if x is None or y is None:
+            return None
+        return {"action": "move", "x": x, "y": y}
+    if a in {"key", "keypress"}:
+        keys = args.get("keys")
+        if isinstance(keys, list) and all(isinstance(k, str) for k in keys):
+            return {"action": "keypress", "keys": keys}
+        return None
+    if a in {"type", "text"}:
+        text = args.get("text")
+        if isinstance(text, str):
+            return {"action": "type", "text": text}
+        return None
+    if a in {"scroll", "hscroll"}:
+        pixels = args.get("pixels") or 0
+        try:
+            pixels_val = int(round(float(pixels)))
+        except Exception:
+            pixels_val = 0
+        scroll_x = pixels_val if a == "hscroll" else 0
+        scroll_y = pixels_val if a == "scroll" else 0
+        out: Dict[str, Any] = {"action": "scroll", "scroll_x": scroll_x, "scroll_y": scroll_y}
+        if x is not None and y is not None:
+            out.update({"x": x, "y": y})
+        return out
+    if a == "wait":
+        return {"action": "wait"}
+    if a == "screenshot":
+        return {"action": "screenshot"}
+
+    return None

--- a/libs/python/agent/tests/test_generic_vlm_tool_call_parser.py
+++ b/libs/python/agent/tests/test_generic_vlm_tool_call_parser.py
@@ -1,0 +1,145 @@
+import sys
+import types
+
+import pytest
+
+from cua_agent.loops import generic_vlm
+
+PNG_1X1 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+
+
+class MockUsage:
+    def model_dump(self):
+        return {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+
+
+class MockResponse:
+    def __init__(self, content: str):
+        self.usage = {}
+        self._hidden_params = {}
+        self._content = content
+
+    def model_dump(self):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": self._content,
+                    }
+                }
+            ]
+        }
+
+
+@pytest.fixture
+def generic_vlm_test_env(monkeypatch):
+    qwen_vl_utils = types.ModuleType("qwen_vl_utils")
+    qwen_vl_utils.smart_resize = lambda h, w, **kwargs: (h, w)
+    monkeypatch.setitem(sys.modules, "qwen_vl_utils", qwen_vl_utils)
+    monkeypatch.setattr(generic_vlm, "_build_nous_system", lambda functions: None)
+    monkeypatch.setattr(
+        generic_vlm.LiteLLMCompletionResponsesConfig,
+        "_transform_chat_completion_usage_to_responses_usage",
+        lambda usage: MockUsage(),
+    )
+
+
+def input_messages():
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Use the computer."},
+                {"type": "input_image", "image_url": f"data:image/png;base64,{PNG_1X1}"},
+            ],
+        }
+    ]
+
+
+async def run_predict(monkeypatch, content: str, **kwargs):
+    async def fake_acompletion(**api_kwargs):
+        return MockResponse(content)
+
+    monkeypatch.setattr(generic_vlm.litellm, "acompletion", fake_acompletion)
+    return await generic_vlm.GenericVlmConfig().predict_step(
+        messages=input_messages(),
+        model="openai/test-model",
+        tools=[],
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_xml_remains_text_without_tool_call_parser(monkeypatch, generic_vlm_test_env):
+    xml = """
+    <tool_call>
+    <function=computer>
+    <parameter=type>type</parameter>
+    <parameter=text>https://example.com</parameter>
+    </function>
+    </tool_call>
+    """
+
+    result = await run_predict(monkeypatch, xml)
+
+    assert not any(item.get("type") == "computer_call" for item in result["output"])
+    [message] = [item for item in result["output"] if item.get("type") == "message"]
+    assert message["content"][0]["text"] == xml
+
+
+@pytest.mark.asyncio
+async def test_qwen_xml_parser_converts_xml_to_computer_call(monkeypatch, generic_vlm_test_env):
+    xml = """
+    I will type the URL.
+    <tool_call>
+    <function=computer>
+    <parameter=type>type</parameter>
+    <parameter=text>https://example.com</parameter>
+    </function>
+    </tool_call>
+    """
+
+    result = await run_predict(monkeypatch, xml, tool_call_parser="qwen_xml")
+
+    messages = [item for item in result["output"] if item.get("type") == "message"]
+    computer_calls = [item for item in result["output"] if item.get("type") == "computer_call"]
+    assert messages[0]["content"][0]["text"] == "I will type the URL."
+    assert computer_calls == [
+        {
+            "type": "computer_call",
+            "call_id": "call_0",
+            "action": {"text": "https://example.com", "type": "type"},
+            "status": "completed",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_qwen_xml_parser_ignores_incomplete_text_action(monkeypatch, generic_vlm_test_env):
+    xml = """
+    <tool_call>
+    <function=computer>
+    <parameter=type>text</parameter>
+    </function>
+    </tool_call>
+    """
+
+    result = await run_predict(monkeypatch, xml, tool_call_parser="qwen_xml")
+
+    assert not any(item.get("type") == "computer_call" for item in result["output"])
+    [message] = [item for item in result["output"] if item.get("type") == "message"]
+    assert message["content"][0]["text"] == xml
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_call_parser_raises_clear_error():
+    with pytest.raises(ValueError, match="Unsupported tool_call_parser"):
+        await generic_vlm.GenericVlmConfig().predict_step(
+            messages=[],
+            model="openai/test-model",
+            tools=[],
+            tool_call_parser="json",  # type: ignore[arg-type]
+        )

--- a/libs/python/agent/tests/test_qwen_xml.py
+++ b/libs/python/agent/tests/test_qwen_xml.py
@@ -1,0 +1,203 @@
+from cua_agent.loops.qwen_xml import (
+    convert_qwen_tool_args_to_computer_action,
+    parse_tool_call_from_text,
+    parse_tool_calls_from_text,
+)
+
+
+def test_xml_computer_click_with_type_parameter():
+    tool_call = parse_tool_call_from_text(
+        """
+        <tool_call>
+        <function=computer>
+        <parameter=type>left_click</parameter>
+        <parameter=coordinate>[10, 20]</parameter>
+        </function>
+        </tool_call>
+        """,
+        tool_call_parser="qwen_xml",
+    )
+
+    assert tool_call == {
+        "name": "computer",
+        "arguments": {"action": "left_click", "coordinate": [10, 20]},
+    }
+    assert convert_qwen_tool_args_to_computer_action(tool_call["arguments"]) == {
+        "action": "left_click",
+        "x": 10,
+        "y": 20,
+    }
+
+
+def test_xml_computer_click_with_action_parameter():
+    tool_call = parse_tool_call_from_text(
+        """
+        <tool_call>
+        <function=computer>
+        <parameter=action>left_click</parameter>
+        <parameter=coordinate>[30, 40]</parameter>
+        </function>
+        </tool_call>
+        """,
+        tool_call_parser="qwen_xml",
+    )
+
+    assert tool_call == {
+        "name": "computer",
+        "arguments": {"action": "left_click", "coordinate": [30, 40]},
+    }
+
+
+def test_xml_computer_click_alias_with_xy_and_button():
+    tool_call = parse_tool_call_from_text(
+        """
+        <tool_call>
+        <function=computer>
+        <parameter=x>884</parameter>
+        <parameter=y>22</parameter>
+        <parameter=type>click</parameter>
+        <parameter=button>left</parameter>
+        </function>
+        </tool_call>
+        """,
+        tool_call_parser="qwen_xml",
+    )
+
+    assert tool_call == {
+        "name": "computer",
+        "arguments": {"x": 884, "y": 22, "action": "click", "button": "left"},
+    }
+    assert convert_qwen_tool_args_to_computer_action(tool_call["arguments"]) == {
+        "action": "left_click",
+        "x": 884,
+        "y": 22,
+    }
+
+
+def test_xml_type_action_with_text_payload():
+    tool_call = parse_tool_call_from_text(
+        """
+        <tool_call>
+        <function=computer>
+        <parameter=type>type</parameter>
+        <parameter=text>https://example.com</parameter>
+        </function>
+        </tool_call>
+        """,
+        tool_call_parser="qwen_xml",
+    )
+
+    assert tool_call == {
+        "name": "computer",
+        "arguments": {"action": "type", "text": "https://example.com"},
+    }
+    assert convert_qwen_tool_args_to_computer_action(tool_call["arguments"]) == {
+        "action": "type",
+        "text": "https://example.com",
+    }
+
+
+def test_xml_text_action_without_text_payload_has_no_executable_action():
+    tool_call = parse_tool_call_from_text(
+        """
+        <tool_call>
+        <function=computer>
+        <parameter=type>text</parameter>
+        </function>
+        </tool_call>
+        """,
+        tool_call_parser="qwen_xml",
+    )
+
+    assert tool_call == {"name": "computer", "arguments": {"action": "text"}}
+    assert convert_qwen_tool_args_to_computer_action(tool_call["arguments"]) is None
+
+
+def test_xml_key_action_with_keys_list():
+    tool_call = parse_tool_call_from_text(
+        """
+        <tool_call>
+        <function=computer>
+        <parameter=action>key</parameter>
+        <parameter=keys>["ctrl", "a"]</parameter>
+        </function>
+        </tool_call>
+        """,
+        tool_call_parser="qwen_xml",
+    )
+
+    assert convert_qwen_tool_args_to_computer_action(tool_call["arguments"]) == {
+        "action": "keypress",
+        "keys": ["ctrl", "a"],
+    }
+
+
+def test_direct_action_function_is_parsed_as_computer_action():
+    tool_call = parse_tool_call_from_text(
+        """
+        <tool_call>
+        <function=left_click>
+        <parameter=coordinate>[50, 60]</parameter>
+        </function>
+        </tool_call>
+        """,
+        tool_call_parser="qwen_xml",
+    )
+
+    assert tool_call == {
+        "name": "computer",
+        "arguments": {"coordinate": [50, 60], "action": "left_click"},
+    }
+
+
+def test_xml_action_flag_parameter_is_parsed_when_payload_exists():
+    tool_call = parse_tool_call_from_text(
+        """
+        <tool_call>
+        <function=computer>
+        <parameter=left_click>
+        <parameter=coordinate>[70, 80]</parameter>
+        </function>
+        </tool_call>
+        """,
+        tool_call_parser="qwen_xml",
+    )
+
+    assert tool_call == {
+        "name": "computer",
+        "arguments": {"coordinate": [70, 80], "action": "left_click"},
+    }
+    assert convert_qwen_tool_args_to_computer_action(tool_call["arguments"]) == {
+        "action": "left_click",
+        "x": 70,
+        "y": 80,
+    }
+
+
+def test_multiple_xml_tool_calls_are_parsed_in_order():
+    tool_calls = parse_tool_calls_from_text(
+        """
+        <tool_call>
+        <function=computer><parameter=type>wait</parameter></function>
+        </tool_call>
+        <tool_call>
+        <function=computer>
+        <parameter=type>type</parameter>
+        <parameter=text>done</parameter>
+        </function>
+        </tool_call>
+        """,
+        tool_call_parser="qwen_xml",
+    )
+
+    assert [tool_call["arguments"]["action"] for tool_call in tool_calls] == ["wait", "type"]
+
+
+def test_malformed_xml_does_not_crash_or_parse():
+    assert (
+        parse_tool_calls_from_text(
+            "<tool_call><function=computer><parameter=type>left_click",
+            tool_call_parser="qwen_xml",
+        )
+        == []
+    )


### PR DESCRIPTION
Superseded.

The parser scope was clarified to require two separate profiles, so this pull request was closed and the work is being redone on a correctly named branch.
