### PR TITLE
fix(fleet): normalize proxied service path prefix

### DIFF
--- a/.github/workflows/ci-ts-fleet.yml
+++ b/.github/workflows/ci-ts-fleet.yml
@@ -9,6 +9,9 @@ on:
       - ".github/workflows/ci-ts-fleet.yml"
       - ".github/workflows/ts-reusable-build.yml"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/ts-reusable-build.yml

--- a/libs/fleet/backend/handlers/signedsvc.go
+++ b/libs/fleet/backend/handlers/signedsvc.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"strings"
 	"time"
 
 	"cyclops-cs-backend/signedurls"
@@ -51,12 +50,7 @@ func (h Handlers) HandleSignedSvc(w http.ResponseWriter, r *http.Request) {
 	}
 	slog.Info("signed service capability resolved", "url_id", record.ID)
 
-	upstreamPath := r.PathValue("path")
-	if upstreamPath == "" {
-		upstreamPath = "/"
-	} else if !strings.HasPrefix(upstreamPath, "/") {
-		upstreamPath = "/" + upstreamPath
-	}
+	upstreamPath := normalizeProxyUpstreamPath(r.PathValue("path"))
 
 	h.proxyService(
 		w,

--- a/libs/fleet/backend/handlers/svc.go
+++ b/libs/fleet/backend/handlers/svc.go
@@ -50,6 +50,14 @@ func stripOAuth2ProxySvcCookie(header http.Header) {
 	header.Set("Cookie", strings.Join(cookies, "; "))
 }
 
+func normalizeProxyUpstreamPath(pathValue string) string {
+	trimmed := strings.TrimLeft(pathValue, "/\\")
+	if trimmed == "" {
+		return "/"
+	}
+	return "/" + trimmed
+}
+
 func svcProxyErrorStatus(err error) int {
 	if errors.Is(err, context.Canceled) {
 		return statusClientClosedRequest
@@ -256,12 +264,7 @@ func (h Handlers) Svc(w http.ResponseWriter, r *http.Request) {
 	// of SvcRoutePolicy, which has already run by the time this handler is
 	// reached — see auth/authz_ownership.rego.
 
-	upstreamPath := r.PathValue("path")
-	if upstreamPath == "" {
-		upstreamPath = "/"
-	} else if !strings.HasPrefix(upstreamPath, "/") {
-		upstreamPath = "/" + upstreamPath
-	}
+	upstreamPath := normalizeProxyUpstreamPath(r.PathValue("path"))
 
 	h.proxyService(
 		w,

--- a/libs/fleet/backend/handlers/svc_test.go
+++ b/libs/fleet/backend/handlers/svc_test.go
@@ -45,6 +45,29 @@ func TestRewriteLocation(t *testing.T) {
 	}
 }
 
+func TestNormalizeProxyUpstreamPath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: "/"},
+		{name: "root slash", in: "/", want: "/"},
+		{name: "relative", in: "tools", want: "/tools"},
+		{name: "absolute", in: "/tools", want: "/tools"},
+		{name: "double slash", in: "//tools", want: "/tools"},
+		{name: "slash backslash", in: "/\\tools", want: "/tools"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeProxyUpstreamPath(tc.in); got != tc.want {
+				t.Fatalf("normalizeProxyUpstreamPath(%q)=%q want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSvc_Unauthenticated(t *testing.T) {
 	h := Handlers{
 		GatewayCfg: config.GatewayConfiguration{


### PR DESCRIPTION
## Summary

Split out of #3348, where these two Copilot-authored commits had been appended to the cua-driver Valgrind fix branch but touch only the fleet backend and its TypeScript workflow. They are cherry-picked with `-x` so authorship and source commits are preserved.

## Commits

### fix(fleet): normalize proxied service path prefix

Co-authored-by: r33drichards <57335981+r33drichards@users.noreply.github.com>
(cherry picked from commit 842ce8f54bc8d74efc2f52801f1dcb8bd811be7c)

### ci: set explicit token permissions for ts fleet workflow

Co-authored-by: r33drichards <57335981+r33drichards@users.noreply.github.com>
(cherry picked from commit 6464c0a96df2a18bec5fe02860991e3b0ca13578)


## Validation

- [ ] `go test ./libs/fleet/backend/handlers/...` via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwPYqr5ukyx6JQGRLiATWq
