### PR TITLE
docs(cua-driver): keep permission seeding guidance self-contained

### DIFF
--- a/libs/cua-driver/tests/runners/macos-lume/seed-tcc-guest.sh
+++ b/libs/cua-driver/tests/runners/macos-lume/seed-tcc-guest.sh
@@ -191,8 +191,6 @@ if ! /usr/bin/grep -q '|auth_value|' <<< "${ACCESS_COLUMNS}"; then
   fail "unsupported TCC access schema; expected modern auth_value column"
 fi
 
-# Keep this row shape in sync with trycua/uvisor's TCCGrant.swift system grant
-# path. Both helpers seed the same modern macOS TCC schema from a signed csreq.
 SQL="
 BEGIN;
 INSERT OR REPLACE INTO access(

--- a/libs/cua-driver/tests/runners/macos-lume/seed-tcc.sh
+++ b/libs/cua-driver/tests/runners/macos-lume/seed-tcc.sh
@@ -33,10 +33,8 @@ usage() {
 Usage: seed-tcc.sh [options] <vm-name> [<vm-name> ...]
 
 Seed macOS Accessibility and Screen Recording TCC rows for CuaDriverLocal.app
-inside running, SSH-reachable, SIP-disabled Lume macOS VMs. This uses the
-same SIP-off system-TCC seed model as the later uvisor `gui grant --gui`
-path; it does not install the app. Run install-local first, then run this
-from the host.
+inside running, SSH-reachable, SIP-disabled Lume macOS VMs. This does not
+install the app. Run install-local first, then run this from the host.
 
 Options:
   --app PATH                 App bundle to grant inside the guest


### PR DESCRIPTION
## Summary

Keep the macOS permission-seeding help focused on what these scripts do and
remove an unrelated cross-project comment. Commands and grant behavior are
unchanged.

## Definition of Done

- [x] Help describes the app prerequisite and guest workflow without an
  unrelated project comparison.
- [x] Remove the cross-project maintenance comment.
- [x] Preserve executable behavior; only help text and a comment change.

## Validation

Reviewed the two-file diff and checked shell syntax. No runtime test is needed
for this wording-only change.
