### PR TITLE
fix(cua-driver): resolve off-Space main and focused AX windows

### DIFF
--- a/docs/content/docs/reference/cua-driver/limits.mdx
+++ b/docs/content/docs/reference/cua-driver/limits.mdx
@@ -118,19 +118,20 @@ does not imply arbitrary raw background PX delivery on Wayland.
 
 ---
 
-## Off-Space SwiftUI windows strip their AX tree
+## Off-Space windows can disappear from AX enumeration
 
-**Symptom:** `get_window_state({pid, window_id})` on a window on a different Space (e.g. System Settings parked on Space 2 while on Space 1) returns a minimal tree that contains only the menu bar, or just the `AXApplication` root.
+**Symptom:** `get_window_state({pid, window_id})` can return an empty, degraded tree for a live window on another Space. This can affect AppKit as well as SwiftUI, including when all of an application's windows are off the active Space.
 
-**Cause:** macOS 14+ strips AX detail from non-current-Space SwiftUI windows as a privacy/performance tradeoff. AppKit apps are not affected. There is no workaround that keeps the window off-Space.
+**Recovery:** An empty application `AXWindows` array does not necessarily mean the window's accessibility tree is gone. Cua Driver also queries fresh `AXMainWindow` and `AXFocusedWindow` references, validates their process and window role, and joins them to the requested CGWindowID. When an exact candidate is available, reads and semantic actions can work without switching Spaces. A main/focused reference is never substituted for a different requested window.
 
-**Response shape:** Every `get_window_state` response on an off-current-Space window carries `off_space: true`, so callers can decide to switch Space, pick a different window, or skip the turn.
+**Remaining limit:** These references do not enumerate every off-Space sibling, and some applications may still expose no usable exact candidate or controls. An unresolved target returns an empty tree with `degraded_reason` beginning with `ax_window_unresolved`; background input, including pixel input, refuses with `off_space_or_ax_unresolved`. Older builds can omit `off_space` entirely: its absence is not proof that a window is on the current Space.
 
-**Workarounds:**
+**Agent guidance:**
 
-1. Switch the user to the target's Space first. This breaks the no-Space-bounce promise.
-2. Target an AppKit equivalent of the app if one exists.
-3. Limit off-Space automation to AppKit apps where the tree stays populated.
+1. Read the exact window and prefer a fresh `element_token` for a supported semantic action; verify the target's resulting state.
+2. Inspect `background_input` for route-specific refusal reasons. A window recovered only through main/focused references does not prove process-wide keyboard scope: PID-routed keys refuse with `keyboard_scope_unresolved`; use a semantic action instead. Pixel input also requires a valid target capture/coordinate frame; `px_capture_unavailable` is a separate failure, not an AX discovery failure.
+3. Do not retry an unresolved AX action as a pixel click to bypass the refusal, or assume that starting a capture stream restores AX enumeration.
+4. If the exact surface remains unresolved, ask before switching Space or foregrounding. There is no general recovery guarantee for arbitrary off-Space windows.
 
 ---
 

--- a/docs/content/docs/reference/cua-driver/platform-roadmap.mdx
+++ b/docs/content/docs/reference/cua-driver/platform-roadmap.mdx
@@ -54,7 +54,7 @@ is to detect and prove that refusal, not bypass the operating-system boundary.
 | Installed-app confidence checks          | Proven           | Keep the typed Calculator and TextEdit rows as supporting evidence; repo-local fixtures remain the primary behavioral contract. |
 
 Accessibility and Screen Recording consent remain platform prerequisites.
-Off-Space SwiftUI tree stripping, minimized keyboard commits, and applications
+Unresolved off-Space AX surfaces, minimized keyboard commits, and applications
 that accept only HID-tap input are platform or target boundaries; their safe
 alternatives remain documented in [Known Limits](/reference/cua-driver/limits).
 

--- a/libs/cua-driver/docs/macos-off-space-ax-recovery.md
+++ b/libs/cua-driver/docs/macos-off-space-ax-recovery.md
@@ -1,0 +1,47 @@
+# Exact off-Space AX recovery
+
+## Problem and scope
+
+Issue #3501 reports empty exact-window trees and refused input when macOS
+omits the target from `AXWindows`. This work investigates recovery within the
+existing exact `(pid, window_id)` contract; it does not add application-wide
+actions or replace an unresolved target with a sibling.
+
+Independent AppKit and SwiftUI fixtures on macOS 26.6.2 reproduced an empty
+`AXWindows` array while all target windows were off the active Space. Fresh
+`AXMainWindow` and `AXFocusedWindow` attributes still exposed the actual target:
+`_AXUIElementGetWindow` returned its requested CGWindowID, the controls were
+readable, and `AXPress` changed fixture state. The target remained off-Space,
+and before/after foreground process, active Space, and window geometry were
+unchanged. These are prototype observations, not production-driver or continuous
+native-focus certification.
+
+A different live CGWindowID was refused before dispatch. A plain persistent
+ScreenCaptureKit stream did not restore the missing `AXWindows` enumeration.
+Capture and semantic discovery must therefore remain separate concerns.
+
+## Implementation boundary
+
+- Merge fresh window-list, main-window, and focused-window candidates and
+  deduplicate their AX identities.
+- Validate candidate roles and owning processes; preserve exact CGWindowID,
+  WindowServer ownership, and addressed-element ancestry checks.
+- Share acquisition between snapshots and input preflight so recovery does
+  not produce readable-but-unactionable snapshots.
+- Keep unresolved siblings fail-closed. Main/focused attributes are candidates,
+  not proof that every window of an application can be enumerated off-Space.
+- Verify semantic, keyboard, and pixel routes separately; AX discovery alone
+  does not establish raw event delivery or foreground safety.
+
+## Acceptance evidence
+
+Production integration and tests are pending in the initial draft. Required
+evidence includes candidate/identity regression tests, production-driver AppKit
+and SwiftUI off-Space observation and semantic actions, exact wrong-window
+refusal, and separately documented keyboard/pixel behavior and platform limits.
+The complete desktop matrix runs on the stable candidate before ready or merge,
+not against these intermediate prototypes.
+
+This recovery work is separate from PR #3459's diagnostics, PR #2894's
+unattributed AX surfaces, and PR #3530's synthetic-focus changes. It does not
+transplant code from the reference plugin used during investigation.

--- a/libs/cua-driver/docs/macos-off-space-ax-recovery.md
+++ b/libs/cua-driver/docs/macos-off-space-ax-recovery.md
@@ -3,7 +3,7 @@
 ## Problem and scope
 
 Issue #3501 reports empty exact-window trees and refused input when macOS
-omits the target from `AXWindows`. This work investigates recovery within the
+omits the target from `AXWindows`. This change implements recovery within the
 existing exact `(pid, window_id)` contract; it does not add application-wide
 actions or replace an unresolved target with a sibling.
 
@@ -33,14 +33,110 @@ Capture and semantic discovery must therefore remain separate concerns.
 - Verify semantic, keyboard, and pixel routes separately; AX discovery alone
   does not establish raw event delivery or foreground safety.
 
-## Acceptance evidence
+## Production implementation
 
-Production integration and tests are pending in the initial draft. Required
-evidence includes candidate/identity regression tests, production-driver AppKit
-and SwiftUI off-Space observation and semantic actions, exact wrong-window
-refusal, and separately documented keyboard/pixel behavior and platform limits.
-The complete desktop matrix runs on the stable candidate before ready or merge,
-not against these intermediate prototypes.
+`platform-macos/src/ax/bindings.rs::copy_ax_windows` retains the window-list
+candidates and adds fresh same-process `AXWindow` references from the main and
+focused attributes, deduplicated using `CFEqual`. The existing tree scoper and
+mutation preflight both use this helper. Their exact CGWindowID, WindowServer
+owner, and element-ancestry decisions remain in place. Candidate acquisition
+retains the raw-list prefix length so preflight knows whether the exact target
+was enumerated or recovered only through the additional attributes.
+
+The shared planner represents unresolved process-wide keyboard enumeration as
+`None`, not zero competing destinations. For a recovered-only target, PID
+keyboard routes refuse with `keyboard_scope_unresolved` even if its semantic
+tree is usable. Otherwise a missing off-Space sibling could be mistaken for
+proof that the target is the only keyboard destination. Semantic actions and
+exact window-pointer policy remain separate. The public tool schema and the
+Windows/Linux platform adapters are unchanged.
+
+The agent-facing loop remains: choose an exact `(pid, window_id)`, snapshot it,
+act with a fresh element token, and verify that same target. There is no new
+capture-session command, implicit activation, or application-wide fallback.
+
+## Validation checkpoint: September 5, 2026
+
+These are development results on macOS 26.6.2 (25G83), not release certification.
+The source-built production daemon ran on an isolated socket in supported
+embedded mode, inheriting its host's already-granted TCC permissions. It was
+not the installed, signed Lume maintainer daemon.
+
+- Platform unit tests: 362 passed, 2 ignored. This includes new same-process
+  role validation and native AX identity deduplication, plus existing exact
+  window, ownership, ancestry, and background-route tests.
+- Shared background-input tests: 14 passed, including the unresolved-keyboard-
+  enumeration guard and route-specific capability reporting.
+- Testkit unit tests: 55 passed, including the structured refusal classifier.
+- Native AppKit snapshot regression: all six modes passed: main-only,
+  focused-only, both references to one window, a listed sibling plus an omitted
+  main window, no candidates, and an invalid application-role candidate. The
+  exact main window's marker is never replaced with sibling content.
+- Independent production-driver checks against genuine off-Space AppKit and
+  SwiftUI `WindowGroup` windows: raw `AXWindows` remained successfully empty;
+  snapshots recovered controls, `set_value` changed the field, and token-based
+  `click(action: "press")` changed it to `reached`. An independent native AX
+  reader, not just the driver response, verified the effects.
+- Early experiments delivered an addressed `press_key("a")` in both single-
+  window fixtures. This is not sufficient proof of process-wide keyboard scope:
+  the final guard deliberately refuses PID keyboard input on recovered-only
+  windows. Final AppKit and SwiftUI smokes verified `keyboard_scope_unresolved`
+  and an unchanged field. Do not treat the earlier delivery as a capability or a
+  guarantee about generic shortcuts, commit keys, or multi-window applications.
+- A different live CGWindowID belonging to the same process returned an empty,
+  degraded tree and refused background input with `off_space_or_ax_unresolved`.
+  No main/focused substitution occurred.
+- Pixel attempts separately refused with `px_capture_unavailable`: both
+  ScreenCaptureKit capture and the shell capture fallback failed on these
+  off-Space fixtures. The native field stayed unchanged. Recovery of AX is not
+  a demonstrated recovery of capture or pixel input.
+
+The final sequential AppKit and SwiftUI diagnostic runs both retained the same
+foreground sentinel, active Space, target membership/bounds, and sampled cursor
+position; the native sentinel reported no input or key-window resignation.
+Earlier runs observed cursor motion or failed foreground invariance. The final
+runs did not overlap other commands, but this does not establish the cause of
+the earlier failures. These are supporting diagnostics, not complete desktop
+certification or proof against every transient side effect.
+
+The final focused native test invocation passed the six-mode snapshot test but
+failed its two background action/refusal tests. The semantic test stopped at
+Electron sentinel setup, before the target action:
+`foreground sentinel did not become focused by setup click`. The refusal test
+failed the real-cursor-invariance oracle. An earlier run of both stopped at
+sentinel setup. The tests retain their strict focus, z-order, cursor, and
+leaked-input oracles; this checkpoint does not weaken them or claim a pass from
+the independent smoke checks.
+
+### Reproduction and remaining gates
+
+Build the AppKit fixture with
+`libs/cua-driver/tests/fixtures/build/macos.sh --only appkit` and the Electron
+sentinel with the same script's `--only electron` option. With the candidate
+daemon available, run from `libs/cua-driver/rust`:
+
+```sh
+cargo test -p platform-macos --lib --locked
+cargo test -p cua-driver-core background_input --lib --locked
+cargo test -p cua-driver --test harness_appkit_test window_discovery --locked -- --ignored --nocapture --test-threads=1
+```
+
+`CUA_E2E_MACOS_DAEMON_SOCKET` selects an explicit daemon endpoint for the native
+tests. Their fixture uses opt-in `CUA_HARNESS_AX_WINDOW_DISCOVERY` overrides;
+normal launches are unchanged. For a real Space reproduction, put a disposable
+AppKit or SwiftUI fixture in fullscreen, return to the original desktop, and
+use its exact window ID for the snapshot, semantic action, and independent
+state readback. The opt-in enumeration test is deterministic coverage, not a
+substitute for that operating-system behavior.
+
+Before ready/merge, resolve the sentinel setup and cursor-invariance failures and obtain canonical
+native mutation/refusal evidence plus the complete desktop matrix at the exact
+stable candidate SHA, following `test-harnesses-guide.md`. The draft also needs
+ordinary inactive-desktop, Safari/Electron, differing main/focused-window, and
+unexposed sibling coverage before making broader application claims. Keep
+canonical desktop stability and off-Space capture/pixel delivery as explicit
+gaps, not inferred capabilities. No full desktop matrix or release verification
+has run for this change.
 
 This recovery work is separate from PR #3459's diagnostics, PR #2894's
 unattributed AX surfaces, and PR #3530's synthetic-focus changes. It does not

--- a/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
@@ -668,7 +668,20 @@ pixel addressing path, not a different capture.
 | backgrounded / visible     | ✅                                                                                             | ✅                           | ✅                                                    | ✅                             |
 | **minimized**              | ✅                                                                                             | ✅ (actions fire in place)   | ❌ silent no-op — use `set_value` or click equivalent | ❌ no on-screen bounds         |
 | hidden                     | ✅                                                                                             | ✅                           | depends                                               | ❌                             |
-| on another desktop / Space | ⚠️ tree may be stripped on some apps — response carries `off_space: true` so you can detect it | ✅                           | ✅                                                    | ❌ not in current-desktop list |
+| on another desktop / Space | ⚠️ macOS tries exact main/focused-window recovery; the tree may still be unresolved | only with an exact exposed control | route-specific; not guaranteed | macOS requires exact AX resolution and a valid capture frame |
+
+**Off-Space macOS windows.** An empty application window list can affect both
+AppKit and SwiftUI. The driver also checks fresh main/focused AX windows, but
+never substitutes one for a different requested `window_id`. Prefer semantic
+actions on fresh tokens when recovery succeeds and verify the resulting state.
+If `degraded_reason` begins with `ax_window_unresolved` or a route refuses with
+`off_space_or_ax_unresolved`, do not retry as a pixel click: unresolved targets
+remain observation-only. Missing `off_space` is not proof of current-Space
+membership. A recovered main/focused window does not establish process-wide
+keyboard scope: respect `keyboard_scope_unresolved` and use `set_value` or an
+exact semantic action rather than retrying raw keys. Screenshot availability
+is separate from AX recovery; respect `px_capture_unavailable` and route refusals.
+Ask before switching the user's Space or foregrounding an unresolved window.
 
 **Critical cell — minimized + keyboard commit.** The keystroke
 reaches the app but accessibility focus doesn't propagate to renderer

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/background_input.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/background_input.rs
@@ -57,8 +57,8 @@ pub enum ElementAncestry {
 pub struct BackgroundTargetFacts {
     pub window_server: WindowServerOwnership,
     /// The requested CGWindowID is claimed by one of the application's fresh
-    /// `AXWindows` (mapped through `_AXUIElementGetWindow`). Absent means
-    /// off-Space or AX-unresolved: observation-only.
+    /// AX window candidates (mapped through `_AXUIElementGetWindow`). Absent
+    /// means its AX surface remains unresolved: observation-only.
     pub ax_window_present: bool,
     /// `AXMinimized` on the exact target window. `None` means the attribute
     /// could not be read — an unproven fact, which fails closed for pointer
@@ -67,11 +67,11 @@ pub struct BackgroundTargetFacts {
     /// `AXHidden` on the owning application. `None` fails closed like
     /// `target_minimized`.
     pub app_hidden: Option<bool>,
-    /// Same-pid top-level windows, other than the target, that could receive
-    /// process-scoped keyboard input (enumerated from WindowServer so an
-    /// off-Space sibling that AX cannot see still counts; proven-minimized
-    /// siblings are excluded because they cannot be the key window).
-    pub competing_keyboard_destinations: usize,
+    /// Same-pid top-level keyboard destinations other than the target, joined
+    /// between WindowServer and fresh AX enumeration. Proven-minimized siblings
+    /// are excluded. `None` means enumeration is unresolved: alternate exact
+    /// window references do not establish process-wide keyboard scope.
+    pub competing_keyboard_destinations: Option<usize>,
     /// Ancestry proof for an explicitly addressed element, when one exists.
     pub element: ElementAncestry,
 }
@@ -109,6 +109,7 @@ pub mod refusal_codes {
     pub const OFF_SPACE_OR_AX_UNRESOLVED: &str = "off_space_or_ax_unresolved";
     pub const MINIMIZED_OR_HIDDEN: &str = "minimized_or_hidden_window";
     pub const SAME_PID_KEYBOARD_AMBIGUITY: &str = "same_pid_keyboard_ambiguity";
+    pub const KEYBOARD_SCOPE_UNRESOLVED: &str = "keyboard_scope_unresolved";
     pub const ELEMENT_OUTSIDE_TARGET_WINDOW: &str = "element_outside_target_window";
 }
 
@@ -230,7 +231,7 @@ pub fn decide_background_input(
         return refuse(
             refusal_codes::OFF_SPACE_OR_AX_UNRESOLVED,
             format!(
-                "window {} is not among the process's current AXWindows (another Space, \
+                "window {} is not among the process's freshly resolved AX windows (another Space, \
                  or its AX surface is unresolved); background input is refused so a \
                  sibling window cannot receive it. Observation (capture/list_windows) \
                  remains available",
@@ -286,7 +287,20 @@ pub fn decide_background_input(
                 );
             }
             debug_assert!(action.is_pid_keyboard());
-            if facts.competing_keyboard_destinations > 0 {
+            let Some(competing_destinations) = facts.competing_keyboard_destinations else {
+                return refuse(
+                    refusal_codes::KEYBOARD_SCOPE_UNRESOLVED,
+                    format!(
+                        "window {} is resolved, but process-wide keyboard destination \
+                         enumeration is unresolved; an alternate window reference does not \
+                         prove that PID-routed keys cannot reach a sibling. Use an exact \
+                         semantic element action instead",
+                        target.window_id
+                    ),
+                    Some("accessibility"),
+                );
+            };
+            if competing_destinations > 0 {
                 return refuse(
                     refusal_codes::SAME_PID_KEYBOARD_AMBIGUITY,
                     format!(
@@ -294,7 +308,7 @@ pub fn decide_background_input(
                          key events cannot be proven to reach window {} and could mutate a \
                          sibling window. Use an exact element action, the page tool for \
                          browser content, or delivery_mode:\"foreground\"",
-                        target.pid, facts.competing_keyboard_destinations, target.window_id
+                        target.pid, competing_destinations, target.window_id
                     ),
                     Some("accessibility"),
                 );
@@ -378,7 +392,7 @@ mod tests {
             ax_window_present: true,
             target_minimized: Some(false),
             app_hidden: Some(false),
-            competing_keyboard_destinations: 0,
+            competing_keyboard_destinations: Some(0),
             element: ElementAncestry::NotAddressed,
         }
     }
@@ -404,7 +418,7 @@ mod tests {
     #[test]
     fn two_window_process_refuses_background_keyboard_for_both_text_and_keys() {
         let facts = BackgroundTargetFacts {
-            competing_keyboard_destinations: 1,
+            competing_keyboard_destinations: Some(1),
             ..matched_facts()
         };
         for action in [BackgroundAction::InsertText, BackgroundAction::GenericKey] {
@@ -605,7 +619,7 @@ mod tests {
             ax_window_present: false,
             target_minimized: Some(true),
             app_hidden: Some(true),
-            competing_keyboard_destinations: 3,
+            competing_keyboard_destinations: Some(3),
             element: ElementAncestry::OutsideTargetWindow,
         };
         assert_eq!(
@@ -669,6 +683,34 @@ mod tests {
     }
 
     #[test]
+    fn recovered_window_does_not_prove_process_keyboard_scope() {
+        let facts = BackgroundTargetFacts {
+            competing_keyboard_destinations: None,
+            ..matched_facts()
+        };
+        for action in [BackgroundAction::InsertText, BackgroundAction::GenericKey] {
+            assert_eq!(
+                code_of(decide_background_input(TARGET, &facts, action)),
+                refusal_codes::KEYBOARD_SCOPE_UNRESOLVED
+            );
+        }
+        for action in [
+            BackgroundAction::AxSemantic,
+            BackgroundAction::WindowPointer,
+        ] {
+            assert!(decide_background_input(TARGET, &facts, action).is_execute());
+        }
+        let report = background_input_capability_report(TARGET, &facts, None);
+        assert_eq!(report["exact_window"]["status"], "matched");
+        assert_eq!(report["routes"][0]["status"], "available");
+        assert_eq!(report["routes"][2]["status"], "refused");
+        assert_eq!(
+            report["routes"][2]["reason"],
+            refusal_codes::KEYBOARD_SCOPE_UNRESOLVED
+        );
+    }
+
+    #[test]
     fn capability_report_refusals_carry_stable_reason_codes() {
         let facts = BackgroundTargetFacts {
             ax_window_present: false,
@@ -683,7 +725,7 @@ mod tests {
         assert_eq!(report["observation"]["one_shot_capture"], "unavailable");
 
         let two_windows = BackgroundTargetFacts {
-            competing_keyboard_destinations: 1,
+            competing_keyboard_destinations: Some(1),
             ..matched_facts()
         };
         let report = background_input_capability_report(TARGET, &two_windows, None);

--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/e2e.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/e2e.rs
@@ -316,6 +316,7 @@ pub enum RefusalCode {
     BrowserInputIncomplete,
     BrowserActionUnavailable,
     WindowMinimized,
+    OffSpaceOrAxUnresolved,
 }
 
 impl RefusalCode {
@@ -338,6 +339,7 @@ impl RefusalCode {
             "browser_input_incomplete" => Some(Self::BrowserInputIncomplete),
             "browser_action_unavailable" => Some(Self::BrowserActionUnavailable),
             "window_minimized" => Some(Self::WindowMinimized),
+            "off_space_or_ax_unresolved" => Some(Self::OffSpaceOrAxUnresolved),
             _ => None,
         }
     }
@@ -1847,6 +1849,10 @@ mod tests {
             Some(RefusalCode::BackgroundUnavailable)
         );
         assert_eq!(RefusalCode::from_driver_code("background_timeout"), None);
+        assert_eq!(
+            RefusalCode::from_driver_code("off_space_or_ax_unresolved"),
+            Some(RefusalCode::OffSpaceOrAxUnresolved)
+        );
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
@@ -66,6 +66,10 @@ impl Harness {
     }
 
     fn launch_with_command_oracle(command_oracle: Option<&Path>) -> Self {
+        Self::launch_with_options(command_oracle, None)
+    }
+
+    fn launch_with_options(command_oracle: Option<&Path>, discovery_mode: Option<&str>) -> Self {
         let exe = harness_exe();
         assert!(
             exe.exists(),
@@ -78,6 +82,9 @@ impl Harness {
         command.stdout(Stdio::null()).stderr(Stdio::null());
         if let Some(path) = command_oracle {
             command.env("CUA_APPKIT_COMMAND_ORACLE", path);
+        }
+        if let Some(mode) = discovery_mode {
+            command.env("CUA_HARNESS_AX_WINDOW_DISCOVERY", mode);
         }
         let app = command
             .spawn()
@@ -159,16 +166,38 @@ fn run_case(
     case: cua_driver_testkit::e2e::CaseSpec,
     test: impl FnOnce(u32, u64, &mut McpDriver) -> Observation,
 ) {
+    run_case_with_discovery_mode(case, None, test);
+}
+
+fn run_case_with_discovery_mode(
+    case: cua_driver_testkit::e2e::CaseSpec,
+    discovery_mode: Option<&str>,
+    test: impl FnOnce(u32, u64, &mut McpDriver) -> Observation,
+) {
     let cell_id = case.cell_id.clone();
     let delivery = case.delivery;
     execute_case(case, |evidence| {
         let mut driver = McpDriver::spawn_macos_daemon_proxy_named(&cell_id)
             .expect("start installed macOS daemon proxy");
         *evidence = recording_evidence(driver.recording_dir());
-        let harness = Harness::launch();
-        let (wid, _) = driver
+        let harness = Harness::launch_with_options(None, discovery_mode);
+        let (wid, title) = driver
             .find_window(harness.pid as i64, "CuaTestHarness AppKit")
             .expect("AppKit main window not found");
+        let wid = if title == "CuaTestHarness AppKit" {
+            wid
+        } else {
+            let windows = driver.call("list_windows", serde_json::json!({ "pid": harness.pid }));
+            windows.structured()["windows"]
+                .as_array()
+                .and_then(|windows| {
+                    windows
+                        .iter()
+                        .find(|window| window["title"] == "CuaTestHarness AppKit")
+                })
+                .and_then(|window| window["window_id"].as_u64())
+                .expect("exact AppKit main window not found")
+        };
         if delivery != cua_driver_testkit::e2e::Delivery::Background {
             driver.start_behavior_recording();
         }
@@ -208,6 +237,215 @@ fn run_background_case_targeting(
 }
 
 // ── tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[ignore]
+fn harness_appkit_window_discovery_snapshot() {
+    for mode in [
+        "main",
+        "focused",
+        "both",
+        "listed-sibling",
+        "none",
+        "invalid",
+    ] {
+        let case = native_readonly_case(
+            "appkit",
+            &format!("ax_window_discovery_snapshot_{mode}"),
+            Targeting::Ax,
+            DriverRoute::AxRead,
+            vec![OracleKind::AxState],
+        );
+        run_case_with_discovery_mode(case, Some(mode), |pid, window_id, driver| {
+            let snapshot = snapshot_elements(driver, pid, window_id);
+            assert!(!snapshot.is_error(), "{mode}: {}", snapshot.text());
+            if matches!(mode, "none" | "invalid") {
+                assert_eq!(snapshot.structured()["degraded"], true, "{mode}");
+                assert_eq!(snapshot.structured()["element_count"], 0, "{mode}");
+                assert!(
+                    snapshot.tree_text().is_empty(),
+                    "{mode}: {}",
+                    snapshot.text()
+                );
+            } else {
+                assert!(
+                    snapshot.tree_text().contains("HARNESS_TEXT_MARKER_v1"),
+                    "{mode}: {}",
+                    snapshot.text()
+                );
+                assert!(
+                    snapshot.tree_text().contains("counter=0"),
+                    "{mode}: {}",
+                    snapshot.text()
+                );
+                assert!(
+                    !snapshot
+                        .tree_text()
+                        .contains("bring_to_front secondary ordinary window"),
+                    "{mode}: {}",
+                    snapshot.text()
+                );
+                assert_eq!(
+                    snapshot.structured()["background_input"]["routes"][2]["reason"],
+                    "keyboard_scope_unresolved",
+                    "{mode}: {}",
+                    snapshot.text()
+                );
+            }
+            Observation::delivered(vec![OracleKind::AxState], Evidence::default())
+        });
+    }
+}
+
+#[test]
+#[ignore]
+fn harness_appkit_main_focused_window_discovery() {
+    for mode in ["main", "focused", "both", "listed-sibling"] {
+        let case = native_background_case(
+            "appkit",
+            &format!("ax_window_discovery_{mode}"),
+            Targeting::Ax,
+            DriverRoute::MacosAxAction,
+        );
+        run_case_with_discovery_mode(case, Some(mode), |pid, window_id, driver| {
+            let (_, passed) = run_with_background_oracles(
+                driver,
+                TargetWindow {
+                    pid,
+                    native_id: window_id,
+                },
+                |driver| {
+                    let before = snapshot_elements(driver, pid, window_id);
+                    assert!(!before.is_error(), "{mode}: {}", before.text());
+                    assert!(
+                        before.tree_text().contains("counter=0"),
+                        "{mode}: {}",
+                        before.text()
+                    );
+                    let token = element_token_by_id(&before, "btn-increment");
+                    let clicked = driver.call(
+                        "click",
+                        serde_json::json!({
+                            "pid": pid as i64,
+                            "window_id": window_id,
+                            "element_token": token,
+                            "action": "press",
+                            "delivery_mode": "background"
+                        }),
+                    );
+                    assert!(!clicked.is_error(), "{mode}: {}", clicked.text());
+                    let after = snapshot_elements(driver, pid, window_id);
+                    assert!(
+                        after.tree_text().contains("counter=1"),
+                        "{mode}: {}",
+                        after.text()
+                    );
+                    let field = element_token_by_id(&after, "txt-input");
+                    let changed = driver.call(
+                        "set_value",
+                        serde_json::json!({
+                            "pid": pid as i64,
+                            "window_id": window_id,
+                            "element_token": field,
+                            "value": "exact-window-recovery"
+                        }),
+                    );
+                    assert!(!changed.is_error(), "{mode}: {}", changed.text());
+                    let final_state = snapshot_elements(driver, pid, window_id);
+                    assert!(
+                        final_state.tree_text().contains("exact-window-recovery"),
+                        "{mode}: {}",
+                        final_state.text()
+                    );
+                    let refused = driver.call(
+                        "press_key",
+                        serde_json::json!({
+                            "pid": pid as i64,
+                            "window_id": window_id,
+                            "element_token": element_token_by_id(&final_state, "txt-input"),
+                            "key": "a",
+                            "delivery_mode": "background"
+                        }),
+                    );
+                    assert!(refused.is_error(), "{mode}: {}", refused.text());
+                    assert_eq!(refused.structured()["code"], "keyboard_scope_unresolved");
+                    assert!(snapshot_elements(driver, pid, window_id)
+                        .tree_text()
+                        .contains("exact-window-recovery"));
+                },
+            )
+            .unwrap_or_else(|error| panic!("{mode}: background desktop contract failed: {error}"));
+            Observation::delivered_with_fixture_state(passed)
+        });
+    }
+}
+
+#[test]
+#[ignore]
+fn harness_appkit_unresolved_window_discovery_refuses() {
+    for mode in ["none", "invalid"] {
+        let mut case = native_background_case(
+            "appkit",
+            &format!("ax_window_discovery_{mode}"),
+            Targeting::Ax,
+            DriverRoute::MacosCgEventPid,
+        )
+        .expecting_refusal(vec![RefusalCode::OffSpaceOrAxUnresolved]);
+        case.oracles
+            .retain(|oracle| *oracle != OracleKind::FixtureState);
+        case.oracles.push(OracleKind::AxState);
+        run_case_with_discovery_mode(case, Some(mode), |pid, window_id, driver| {
+            let snapshot = snapshot_elements(driver, pid, window_id);
+            assert!(!snapshot.is_error(), "{mode}: {}", snapshot.text());
+            assert_eq!(
+                snapshot.structured()["degraded"],
+                true,
+                "{mode}: {}",
+                snapshot.text()
+            );
+            assert_eq!(
+                snapshot.structured()["element_count"],
+                0,
+                "{mode}: {}",
+                snapshot.text()
+            );
+            assert!(!snapshot.tree_text().contains("HARNESS_TEXT_MARKER_v1"));
+            let (refused, mut passed) = run_with_background_oracles(
+                driver,
+                TargetWindow {
+                    pid,
+                    native_id: window_id,
+                },
+                |driver| {
+                    driver.call(
+                        "press_key",
+                        serde_json::json!({
+                            "pid": pid as i64,
+                            "window_id": window_id,
+                            "key": "a",
+                            "delivery_mode": "background"
+                        }),
+                    )
+                },
+            )
+            .unwrap_or_else(|error| panic!("{mode}: background desktop contract failed: {error}"));
+            assert!(refused.is_error(), "{mode}: {}", refused.text());
+            assert_eq!(
+                refused.structured()["code"],
+                "off_space_or_ax_unresolved",
+                "{mode}: {}",
+                refused.text()
+            );
+            passed.push(OracleKind::AxState);
+            Observation::refused(
+                RefusalCode::OffSpaceOrAxUnresolved,
+                passed,
+                refused.text(),
+                Evidence::default(),
+            )
+        });
+    }
+}
 
 #[test]
 #[ignore]

--- a/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
@@ -12,7 +12,7 @@
 
 use core_foundation::{
     array::CFArrayRef,
-    base::{CFRelease, CFRetain, CFTypeID, CFTypeRef},
+    base::{CFEqual, CFRelease, CFRetain, CFTypeID, CFTypeRef},
     string::CFStringRef,
 };
 use std::os::raw::{c_int, c_void};
@@ -82,6 +82,7 @@ extern "C" {
         timeout_in_seconds: f32,
     ) -> AXError;
     pub fn AXUIElementGetTypeID() -> CFTypeID;
+    pub fn AXUIElementGetPid(element: AXUIElementRef, pid: *mut i32) -> AXError;
     pub fn AXIsProcessTrusted() -> bool;
     /// `AXIsProcessTrustedWithOptions(options)` — when called with
     /// `{kAXTrustedCheckOptionPrompt: true}` raises the system Accessibility
@@ -685,14 +686,70 @@ pub unsafe fn ax_get_window_id(element: AXUIElementRef) -> Option<u32> {
     }
 }
 
-/// Read the `AXWindows` attribute of an application element.
-/// Unlike `AXChildren`, this returns the window list regardless of whether
-/// the app is frontmost. Returns a Vec of retained AXUIElementRefs.
+/// Copy fresh application windows from `AXWindows`, `AXMainWindow`, and
+/// `AXFocusedWindow`. macOS can omit off-Space windows from the array while
+/// retaining their main/focused references. Additional candidates must be
+/// same-process AXWindows; callers still match their exact CGWindowIDs.
+/// Returns a Vec of retained AXUIElementRefs without duplicate added identities.
 ///
 /// # Safety
 ///
 /// `element` must be valid, and the caller must release every returned element.
 pub unsafe fn copy_ax_windows(element: AXUIElementRef) -> Vec<AXUIElementRef> {
+    copy_ax_windows_with_list_count(element).0
+}
+
+pub(crate) unsafe fn copy_ax_windows_with_list_count(
+    element: AXUIElementRef,
+) -> (Vec<AXUIElementRef>, usize) {
+    let mut windows = copy_ax_window_list(element);
+    let listed_count = windows.len();
+    let mut application_pid = 0;
+    if AXUIElementGetPid(element, &mut application_pid) != kAXErrorSuccess || application_pid <= 0 {
+        return (windows, listed_count);
+    }
+
+    for attribute in ["AXMainWindow", "AXFocusedWindow"] {
+        let Some(candidate) = copy_element_attr(element, attribute) else {
+            continue;
+        };
+        let mut candidate_pid = 0;
+        let candidate_pid = (AXUIElementGetPid(candidate, &mut candidate_pid) == kAXErrorSuccess)
+            .then_some(candidate_pid);
+        let role = if candidate_pid == Some(application_pid) {
+            copy_string_attr(candidate, "AXRole")
+        } else {
+            None
+        };
+        if is_same_application_window(application_pid, candidate_pid, role.as_deref()) {
+            push_unique_ax_element(&mut windows, candidate);
+        } else {
+            CFRelease(candidate as CFTypeRef);
+        }
+    }
+    (windows, listed_count)
+}
+
+fn is_same_application_window(
+    application_pid: i32,
+    candidate_pid: Option<i32>,
+    role: Option<&str>,
+) -> bool {
+    application_pid > 0 && candidate_pid == Some(application_pid) && role == Some("AXWindow")
+}
+
+unsafe fn push_unique_ax_element(elements: &mut Vec<AXUIElementRef>, candidate: AXUIElementRef) {
+    if elements
+        .iter()
+        .any(|&element| CFEqual(element as CFTypeRef, candidate as CFTypeRef) != 0)
+    {
+        CFRelease(candidate as CFTypeRef);
+    } else {
+        elements.push(candidate);
+    }
+}
+
+unsafe fn copy_ax_window_list(element: AXUIElementRef) -> Vec<AXUIElementRef> {
     let attr = CFStr::new("AXWindows");
     let mut value: CFTypeRef = std::ptr::null();
     let err = AXUIElementCopyAttributeValue(element, attr.as_concrete_TypeRef(), &mut value);
@@ -723,6 +780,47 @@ pub unsafe fn copy_ax_windows(element: AXUIElementRef) -> Vec<AXUIElementRef> {
 mod tests {
     use super::*;
     use core_foundation::{boolean::CFBoolean, number::CFNumber};
+
+    #[test]
+    fn additional_window_candidates_require_same_process_window_role() {
+        assert!(is_same_application_window(42, Some(42), Some("AXWindow")));
+        for (application_pid, candidate_pid, role) in [
+            (42, Some(7), Some("AXWindow")),
+            (42, None, Some("AXWindow")),
+            (42, Some(42), None),
+            (42, Some(42), Some("AXApplication")),
+            (42, Some(42), Some("AXSheet")),
+            (0, Some(0), Some("AXWindow")),
+            (-1, Some(-1), Some("AXWindow")),
+        ] {
+            assert!(!is_same_application_window(
+                application_pid,
+                candidate_pid,
+                role
+            ));
+        }
+    }
+
+    #[test]
+    fn additional_ax_candidates_deduplicate_by_native_identity() {
+        unsafe {
+            let first = AXUIElementCreateApplication(42);
+            let same_identity = AXUIElementCreateApplication(42);
+            let other_identity = AXUIElementCreateApplication(7);
+            assert!(!first.is_null());
+            assert!(!same_identity.is_null());
+            assert!(!other_identity.is_null());
+
+            let mut elements = vec![first];
+            push_unique_ax_element(&mut elements, same_identity);
+            assert_eq!(elements.len(), 1);
+            push_unique_ax_element(&mut elements, other_identity);
+            assert_eq!(elements.len(), 2);
+            for element in elements {
+                CFRelease(element as CFTypeRef);
+            }
+        }
+    }
 
     #[test]
     fn stringish_value_coerces_cfstring_cfnumber_and_cfboolean() {

--- a/libs/cua-driver/rust/crates/platform-macos/src/ax/exact_target.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/ax/exact_target.rs
@@ -2,7 +2,7 @@
 //!
 //! Gathers the facts [`cua_driver_core::background_input`] needs about one
 //! requested `(pid, CGWindowID)` immediately before a background mutation:
-//! WindowServer ownership, fresh `AXWindows` membership (mapped through
+//! WindowServer ownership, fresh AX window candidates (mapped through
 //! `_AXUIElementGetWindow`), minimized/hidden state, competing same-pid AX
 //! top-level keyboard destinations, and addressed-element ancestry. All reads are
 //! bounded and fail closed — an unreadable fact never unlocks a route.
@@ -13,8 +13,8 @@ use cua_driver_core::background_input::{
 };
 
 use super::bindings::{
-    ax_get_window_id, copy_ax_windows, copy_bool_attr, copy_element_attr, copy_string_attr,
-    focused_element_of_pid, AXUIElementCreateApplication, AXUIElementRef,
+    ax_get_window_id, copy_ax_windows_with_list_count, copy_bool_attr, copy_element_attr,
+    copy_string_attr, focused_element_of_pid, AXUIElementCreateApplication, AXUIElementRef,
 };
 use crate::windows::{all_windows, resolve_window_owner, WindowOwner};
 
@@ -89,24 +89,29 @@ pub unsafe fn focused_element_in_window(pid: i32, window_id: u32) -> Option<AXUI
     }
 }
 
-/// One fresh `AXWindows` row: the mapped CGWindowID plus its minimized state.
+/// One fresh AX window candidate: the mapped CGWindowID plus its minimized state.
 /// `minimized: None` means the attribute could not be read — unknown, not
 /// "not minimized".
 struct AxWindowRecord {
     window_id: u32,
     minimized: Option<bool>,
+    listed: bool,
 }
 
-/// Map the application's fresh `AXWindows` through `_AXUIElementGetWindow`.
+/// Map the application's fresh window-list and main/focused candidates through
+/// `_AXUIElementGetWindow`.
 /// Windows whose id the SPI cannot resolve are omitted: an unmappable window
 /// can never satisfy an exact-target requirement.
 unsafe fn ax_window_records(app: AXUIElementRef) -> Vec<AxWindowRecord> {
-    copy_ax_windows(app)
+    let (windows, listed_count) = copy_ax_windows_with_list_count(app);
+    windows
         .into_iter()
-        .filter_map(|window| {
+        .enumerate()
+        .filter_map(|(index, window)| {
             let record = ax_get_window_id(window).map(|window_id| AxWindowRecord {
                 window_id,
                 minimized: copy_bool_attr(window, "AXMinimized"),
+                listed: index < listed_count,
             });
             CFRelease(window as CFTypeRef);
             record
@@ -119,7 +124,7 @@ unsafe fn ax_window_records(app: AXUIElementRef) -> Vec<AxWindowRecord> {
 /// WindowServer may expose several layer-0 compositor surfaces for one native
 /// Electron, Tauri, or WebKit window. A raw same-pid CGWindow row is therefore
 /// not enough to prove another process-scoped keyboard destination. Requiring a
-/// fresh `AXWindows` mapping preserves the fail-closed two-window guard while
+/// fresh exact AX window mapping preserves the fail-closed two-window guard while
 /// ignoring render surfaces that cannot independently become the AX key window.
 fn count_competing_keyboard_destinations(
     pid: i32,
@@ -200,7 +205,9 @@ pub fn gather_background_facts(
         ax_window_present: target.is_some(),
         target_minimized: target.and_then(|record| record.minimized),
         app_hidden,
-        competing_keyboard_destinations,
+        competing_keyboard_destinations: target
+            .filter(|target| target.listed)
+            .map(|_| competing_keyboard_destinations),
         element: element.unwrap_or(ElementAncestry::NotAddressed),
     }
 }
@@ -213,6 +220,7 @@ mod tests {
         AxWindowRecord {
             window_id,
             minimized,
+            listed: true,
         }
     }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/ax/tree.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/ax/tree.rs
@@ -154,11 +154,10 @@ pub struct TreeWalkResult {
 /// walked (plus non-window children like the menu bar). When None, all
 /// top-level children are walked.
 ///
-/// Key background-app fix: at the application root we union `AXChildren`
-/// and `AXWindows`. macOS only puts windows in `AXChildren` when the app
-/// is frontmost; `AXWindows` returns the window list regardless of focus
-/// state. Without this union, Safari / any backgrounded app returns an
-/// empty tree.
+/// At the application root we union `AXChildren` with freshly discoverable
+/// application windows. Background windows can be absent from `AXChildren`,
+/// and off-Space windows can be absent from `AXWindows` while their exact
+/// `AXMainWindow` or `AXFocusedWindow` references remain available.
 ///
 /// # Safety
 /// Calls macOS AX API. Must be called on a thread that has a CF run loop.
@@ -222,9 +221,8 @@ pub fn walk_tree_bounded(
         // the now-materialized (potentially large) tree bounded.
         super::enablement::ensure_chromium_ax_enabled(pid, app_elem);
 
-        // Union AXChildren + AXWindows — the only way to see background windows.
-        // AXChildren omits windows when the app isn't frontmost (AppKit limitation).
-        // AXWindows returns the window list regardless of activation state.
+        // Union root children with fresh window-list and main/focused candidates.
+        // Neither AXChildren nor AXWindows alone enumerates every off-Space target.
         let from_children = copy_children(app_elem);
         let from_windows = copy_ax_windows(app_elem);
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/scroll.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/scroll.rs
@@ -791,7 +791,7 @@ mod tests {
             ax_window_present: true,
             target_minimized: Some(false),
             app_hidden: Some(false),
-            competing_keyboard_destinations: 0,
+            competing_keyboard_destinations: Some(0),
             element: ElementAncestry::OutsideTargetWindow,
         };
         let refusal = match decide_background_input(target, &facts, BackgroundAction::AxSemantic) {

--- a/libs/cua-driver/tests/fixtures/apps/macos/appkit/main.swift
+++ b/libs/cua-driver/tests/fixtures/apps/macos/appkit/main.swift
@@ -55,6 +55,40 @@ let kSecondaryWindowTitle = "CuaTestHarness AppKit Secondary"
 let kSheetWindowTitle = "CuaTestHarness AppKit Sheet"
 let kFloatingWindowTitle = "CuaTestHarness AppKit Floating"
 
+final class WindowDiscoveryApplication: NSApplication {
+    private var discoveryMode: String? {
+        ProcessInfo.processInfo.environment["CUA_HARNESS_AX_WINDOW_DISCOVERY"]
+    }
+
+    override func accessibilityWindows() -> [Any]? {
+        guard let mode = discoveryMode else { return super.accessibilityWindows() }
+        if mode == "listed-sibling" {
+            return super.accessibilityWindows()?.filter { ($0 as? NSWindow) !== mainWindow }
+        }
+        return []
+    }
+
+    override func accessibilityChildren() -> [Any]? {
+        guard discoveryMode != nil else { return super.accessibilityChildren() }
+        return super.accessibilityChildren()?.filter { !($0 is NSWindow) }
+    }
+
+    override func accessibilityMainWindow() -> Any? {
+        switch discoveryMode {
+        case "focused", "none": return nil
+        case "invalid": return self
+        default: return super.accessibilityMainWindow()
+        }
+    }
+
+    override func accessibilityFocusedWindow() -> Any? {
+        switch discoveryMode {
+        case "main", "none", "invalid": return nil
+        default: return super.accessibilityFocusedWindow()
+        }
+    }
+}
+
 // MARK: - Controller
 
 final class HarnessWindowController: NSObject, NSTextFieldDelegate, NSTableViewDataSource, NSTableViewDelegate, NSMenuItemValidation {
@@ -607,7 +641,7 @@ func installMenuBar(target: HarnessWindowController) {
 @main
 struct CuaAppKitHarness {
     static func main() {
-        let app = NSApplication.shared
+        let app = WindowDiscoveryApplication.shared
         app.setActivationPolicy(.regular)
         let controller = HarnessWindowController()
         installMenuBar(target: controller)
@@ -615,6 +649,8 @@ struct CuaAppKitHarness {
         var matrixWindows: BringToFrontMatrixWindows?
         if let mode = ProcessInfo.processInfo.environment["CUA_HARNESS_BRING_TO_FRONT_MODE"] {
             matrixWindows = BringToFrontMatrixWindows(parent: controller.window, mode: mode)
+        } else if ProcessInfo.processInfo.environment["CUA_HARNESS_AX_WINDOW_DISCOVERY"] == "listed-sibling" {
+            matrixWindows = BringToFrontMatrixWindows(parent: controller.window, mode: "normal")
         }
         app.activate(ignoringOtherApps: true)
         writeBringToFrontWindowReport(main: controller.window, matrix: matrixWindows)

--- a/scripts/ci/macos/run-rust-e2e.sh
+++ b/scripts/ci/macos/run-rust-e2e.sh
@@ -343,6 +343,9 @@ if [[ "${SUITE}" == native || "${SUITE}" == all ]]; then
       --ignored --nocapture --test-threads=1
     for appkit_test in \
     harness_appkit_smoke \
+    harness_appkit_main_focused_window_discovery \
+    harness_appkit_window_discovery_snapshot \
+    harness_appkit_unresolved_window_discovery_refuses \
     harness_appkit_query_projects_structured_elements \
     harness_appkit_stale_element_token_fails_closed \
     harness_appkit_invoke_menu_live_path \


### PR DESCRIPTION
## Summary

Recover exact off-Space AX windows that macOS omits from `AXWindows` but still exposes through fresh `AXMainWindow` or `AXFocusedWindow` references.

Refs #3501
Refs #3458

Implementation: `d39f4ccf29d6fd1580426ab57478d15ffc19cecd`. Evidence was collected from the working-tree contents recorded in this commit; no production or fixture code changed after the final checks. This is not complete desktop certification.

## Scope and safety

- Share fresh window-list/main/focused acquisition between snapshots and mutation preflight. Validate additional candidates' process/role and deduplicate native AX identity.
- Preserve exact CGWindowID, WindowServer ownership, and addressed-element ancestry. Never substitute a main/focused window for a different requested target.
- Retain raw-list provenance. A recovered-only window is not proof of complete process-wide keyboard enumeration: the common planner represents that scope as unknown and refuses PID keyboard routes with `keyboard_scope_unresolved`. Exact semantic actions remain available.
- No new capture-session requirement, app-root/title/frame fallback, implicit foreground activation, or public tool-schema change. Windows/Linux adapters are unchanged.
- Keep unexposed siblings, screenshot availability, raw event delivery, and desktop stability as distinct questions. Correct the Known Limits and agent skill's previous blanket AppKit exemption/no-workaround/off_space-flag claims.
- Distinct from #3459 (diagnostics), #2894 (unattributed AX surfaces), and #3530 (synthetic focus). No reference-plugin source is transplanted.

## Validation

macOS 26.6.2 (25G83), source-built production daemon on an isolated embedded-mode socket with the host's existing TCC grants; **not** the signed Lume maintainer daemon.

- **362 platform unit tests passed**, 2 ignored.
- **14 shared background-input tests passed**, including unknown keyboard enumeration and route-specific capability reporting.
- **55 testkit unit tests passed**.
- **Native snapshot regression passed all six scenarios**: main-only, focused-only, duplicate references, listed sibling plus omitted main, no candidates, invalid application-role candidate. Correct target content and keyboard-scope refusals are checked.
- **Final isolated AppKit and genuine SwiftUI WindowGroup off-Space smokes passed**: raw AXWindows remained empty; production snapshots, `set_value`, and token-based AXPress worked; an independent native reader verified effects. A different live same-process CGWindowID stayed empty and refused input.
- Final recovered-only targets refused `press_key` with `keyboard_scope_unresolved`, leaving fields unchanged. Early single-window keyboard delivery experiments are **not** claimed as a supported capability.
- Pixel attempts separately refused with `px_capture_unavailable`, with unchanged fixture state. Starting a stream alone did not restore AX enumeration in the earlier independent probe.
- Final sequential smokes retained foreground sentinel, active Space, target bounds/membership, and sampled cursor position, with no native sentinel input/key resignation. Earlier runs had foreground/cursor failures; their cause is not established. These smokes do not replace canonical desktop evidence.
- Rustfmt and `git diff --check` passed. Swift fixture and native test target compile.

## Remaining gates — keep draft

- The final strict `harness_appkit_test window_discovery` invocation is **1 passed, 2 failed**. Semantic test: `foreground sentinel did not become focused by setup click` before its target action. Refusal test: real-cursor-invariance failure. Do not treat either as a pass or weaken the oracles.
- Resolve those failures in the canonical logged-in/TCC-authorized macOS lane and obtain mutation/refusal recordings.
- Broader normal inactive-desktop, Safari/Electron, differing main/focused candidates, and non-main sibling coverage remain unverified. Capture/pixel recovery is not delivered by this patch.
- Run the complete desktop E2E matrix at the stable exact candidate immediately before ready/merge, per repository policy. It has **not** run here. No release/shipping claim.
- Recheck final files/title and require `CI: Release metadata` before ready/merge. The `fix(cua-driver)` title reflects the user-visible production correction.

Reproduction commands, architecture boundary, and detailed evidence: `libs/cua-driver/docs/macos-off-space-ax-recovery.md`.
