### PR TITLE
docs: fix Fleet README attribution placement field

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
   <p align="center">Scale computer-use 2.0 with open-source drivers, cross-OS fleets, and benchmarks for training, evaluation, and data generation.</p>
 
-  <p align="center"><strong><a href="https://run.cua.ai/?utm_source=github&utm_medium=referral&utm_campaign=fleet_activation&utm_content=repo_readme" target="_blank" rel="noopener noreferrer">Try Cua Fleets now at run.cua.ai</a></strong></p>
+  <p align="center"><strong><a href="https://run.cua.ai/?utm_source=github&utm_medium=referral&utm_campaign=fleet_activation&content_id=repo_readme" target="_blank" rel="noopener noreferrer">Try Cua Fleets now at run.cua.ai</a></strong></p>
 
   <p align="center">
     <a href="https://cua.ai" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/cua.ai-0ea5e9" alt="cua.ai"></a>


### PR DESCRIPTION
## Summary

Change the Fleet README CTA placement parameter from `utm_content=repo_readme` to `content_id=repo_readme`, matching Fleet's attribution capture contract.

Only the query-field name changes. The destination, link label, source, medium, campaign, and placement are unchanged. The capture allowlist is not expanded.

## Validation

- Extracted the actual README href and verified all four attribution values survive capture.
- Verified the exact URL against capture/bind regression coverage, including a simulated authentication return and removal after binding.
- `git diff --check` passes; the diff contains only the README query-field substitution.

No live sign-in or workload was generated. This change does not recover placement data from earlier visits. Rollback is the reverse one-line change.
