### PR TITLE
fix(cua-cli): preflight credential storage before device login

### DIFF
--- a/.github/workflows/ci-py-cli-unit.yml
+++ b/.github/workflows/ci-py-cli-unit.yml
@@ -1,0 +1,28 @@
+name: "CI: cua-cli unit tests"
+
+on:
+  pull_request:
+    paths:
+      - "libs/python/cua-cli/**"
+      - "libs/python/cua-sandbox/**"
+      - ".github/workflows/ci-py-cli-unit.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.12", "3.13"]
+    env:
+      CUA_TELEMETRY_ENABLED: "false"
+      PYTHON_KEYRING_BACKEND: keyring.backends.fail.Keyring
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Run CLI tests with synthetic credentials
+        run: uv run --project libs/python/cua-cli --extra dev pytest -q libs/python/cua-cli/tests

--- a/libs/python/cua-cli/cua_cli/auth/store.py
+++ b/libs/python/cua-cli/cua_cli/auth/store.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import keyring
+from keyring.backends.null import Keyring as NullKeyring
 from keyring.errors import KeyringError, PasswordDeleteError
 
 KEYRING_SERVICE = "run.cua.ai"
@@ -90,7 +91,22 @@ class OAuthCredentials:
 def _read() -> str | None:
     try:
         return keyring.get_password(KEYRING_SERVICE, KEYRING_ACCOUNT)
-    except KeyringError as error:
+    except (KeyringError, OSError) as error:
+        raise CredentialStorageError(_NO_STORE_MESSAGE) from error
+
+
+def check_credential_store() -> None:
+    """Check read access without writing or requiring valid existing credentials.
+
+    A successful read cannot guarantee that a later write will succeed. Reject
+    the explicitly disabled backend too: its writes silently discard tokens.
+    """
+    try:
+        if isinstance(keyring.get_keyring(), NullKeyring):
+            raise CredentialStorageError(_NO_STORE_MESSAGE)
+        _read()
+    except (KeyringError, OSError) as error:
+        # Backend errors can contain credential material or private paths.
         raise CredentialStorageError(_NO_STORE_MESSAGE) from error
 
 
@@ -112,7 +128,7 @@ def save_credentials(credentials: OAuthCredentials) -> None:
     """Store OIDC credentials in the operating system credential vault."""
     try:
         keyring.set_password(KEYRING_SERVICE, KEYRING_ACCOUNT, json.dumps(credentials.to_dict()))
-    except KeyringError as error:
+    except (KeyringError, OSError) as error:
         raise CredentialStorageError(_NO_STORE_MESSAGE) from error
 
 

--- a/libs/python/cua-cli/cua_cli/commands/auth.py
+++ b/libs/python/cua-cli/cua_cli/commands/auth.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from cua_cli.auth.oidc import OidcClient, OidcError
 from cua_cli.auth.store import (
     CredentialStorageError,
+    check_credential_store,
     clear_credentials,
     load_credentials,
     save_credentials,
@@ -52,6 +53,12 @@ def execute(args: argparse.Namespace) -> int:
 
 def cmd_login(args: argparse.Namespace) -> int:
     """Start OAuth device authorization and store the resulting tokens."""
+    try:
+        check_credential_store()
+    except CredentialStorageError as error:
+        print_error(str(error))
+        return 1
+
     client = OidcClient()
     try:
         discovery = run_async(client.discover())

--- a/libs/python/cua-cli/tests/auth/test_store.py
+++ b/libs/python/cua-cli/tests/auth/test_store.py
@@ -8,10 +8,13 @@ import pytest
 from cua_cli.auth.store import (
     CredentialStorageError,
     OAuthCredentials,
+    check_credential_store,
     clear_credentials,
     load_credentials,
     save_credentials,
 )
+from keyring.backends.fail import Keyring as FailKeyring
+from keyring.backends.null import Keyring as NullKeyring
 from keyring.errors import NoKeyringError
 
 
@@ -22,6 +25,43 @@ def credentials() -> OAuthCredentials:
         expires_at=datetime(2030, 1, 1, tzinfo=UTC),
         scope="openid profile offline_access",
     )
+
+
+@pytest.mark.parametrize("raw", [None, "malformed old credentials", "{}"])
+def test_preflight_reads_without_parsing_or_writing(raw) -> None:
+    with (
+        patch("cua_cli.auth.store.keyring.get_keyring", return_value=object()),
+        patch("cua_cli.auth.store.keyring.get_password", return_value=raw) as read,
+        patch("cua_cli.auth.store.keyring.set_password") as write,
+        patch("cua_cli.auth.store.keyring.delete_password") as delete,
+    ):
+        check_credential_store()
+    read.assert_called_once_with("run.cua.ai", "cua-cli")
+    write.assert_not_called()
+    delete.assert_not_called()
+
+
+@pytest.mark.parametrize("backend", [FailKeyring(), NullKeyring()])
+def test_preflight_rejects_unavailable_or_disabled_backend(backend) -> None:
+    with (
+        patch("cua_cli.auth.store.keyring.get_keyring", return_value=backend),
+        patch("cua_cli.auth.store.keyring.get_password", side_effect=backend.get_password),
+        patch("cua_cli.auth.store.keyring.set_password") as write,
+    ):
+        with pytest.raises(CredentialStorageError, match="secure credential store"):
+            check_credential_store()
+    write.assert_not_called()
+
+
+@pytest.mark.parametrize("error", [NoKeyringError("secret-value"), OSError("secret-value")])
+def test_preflight_sanitizes_backend_errors(error) -> None:
+    with (
+        patch("cua_cli.auth.store.keyring.get_keyring", return_value=object()),
+        patch("cua_cli.auth.store.keyring.get_password", side_effect=error),
+    ):
+        with pytest.raises(CredentialStorageError) as caught:
+            check_credential_store()
+    assert "secret-value" not in str(caught.value)
 
 
 def test_save_credentials_uses_keyring() -> None:

--- a/libs/python/cua-cli/tests/commands/test_auth.py
+++ b/libs/python/cua-cli/tests/commands/test_auth.py
@@ -5,8 +5,24 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
+import keyring
+import pytest
 from cua_cli.auth.store import OAuthCredentials
 from cua_cli.commands import auth
+from keyring.backends.null import Keyring as NullKeyring
+from keyring.errors import NoKeyringError
+
+
+@pytest.fixture(autouse=True)
+def isolated_credential_store():
+    """Never read or write a developer's host credential store in command tests."""
+    with (
+        patch.object(keyring, "get_keyring", return_value=object()),
+        patch.object(keyring, "get_password", return_value=None),
+        patch.object(keyring, "set_password"),
+        patch.object(keyring, "delete_password"),
+    ):
+        yield
 
 
 class FakeOidcClient:
@@ -51,6 +67,48 @@ def test_login_uses_device_flow_without_opening_browser(monkeypatch) -> None:
     assert result == 0
     assert saved[0].access_token == "access-token"
     browser_open.assert_not_called()
+
+
+def test_login_refuses_unavailable_store_before_starting_device_flow(capsys) -> None:
+    with (
+        patch.object(keyring, "get_password", side_effect=NoKeyringError("secret-value")),
+        patch.object(auth, "OidcClient", return_value=FakeOidcClient()) as client,
+        patch.object(auth.webbrowser, "open") as browser_open,
+    ):
+        result = auth.cmd_login(argparse.Namespace(no_browser=False))
+
+    assert result == 1
+    client.assert_not_called()
+    browser_open.assert_not_called()
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+    assert "credential store" in output
+    assert "FLEETS_TOKEN" in output
+    assert "secret-value" not in output
+
+
+def test_login_refuses_disabled_store_before_device_flow() -> None:
+    with (
+        patch.object(keyring, "get_keyring", return_value=NullKeyring()),
+        patch.object(auth, "OidcClient") as client,
+    ):
+        assert auth.cmd_login(argparse.Namespace(no_browser=True)) == 1
+    client.assert_not_called()
+
+
+def test_login_reports_later_write_failure_without_exposing_credentials(capsys) -> None:
+    with (
+        patch.object(auth, "OidcClient", return_value=FakeOidcClient()),
+        patch.object(keyring, "set_password", side_effect=NoKeyringError("secret-value")),
+    ):
+        assert auth.cmd_login(argparse.Namespace(no_browser=True)) == 1
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+    assert "Login failed" in output
+    assert "credential store" in output
+    assert "Logged in" not in output
+    for secret in ("access-token", "refresh-token", "secret-value"):
+        assert secret not in output
 
 
 def test_logout_clears_local_credentials_when_remote_revocation_fails(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Detect unavailable or explicitly disabled credential storage before starting device authorization. This is a narrow login correction: it does not change identity providers, token scopes, credential precedence, or CLI-to-SDK handoff.

- Perform a read-only check of the configured store before discovery or browser launch. Do not write a probe credential, parse stale data, or select a fallback backend.
- Reject the null backend, whose writes silently discard tokens.
- Keep later save failures actionable and sanitize keyring/OS errors.
- Isolate command tests from the host keychain and add CLI unit CI for Python 3.12/3.13.

## Validation

- CLI suite: 201 passed on Python 3.13.15; five coroutine warnings from unrelated image-command tests.
- Focused Ruff, Black, isort, and whitespace checks.
- Synthetic tests cover unavailable/disabled storage, empty/corrupt old contents, pre-network refusal, later write failure, and credential redaction.

A read check does not prove later writability. No real login is required for these tests. Native platform keyring integration remains a separate manual smoke.

## Review and rollback

Requested implementation scope is the pre-login storage diagnostic. Draft for maintainer review; do not merge automatically. Revert this commit to restore the previous login sequence. No migration, plaintext fallback, package upgrade, or deployment is included.
