### PR TITLE
fix(cua-sandbox): explain supported Fleet credential routes

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -223,9 +223,22 @@ class _FleetClient:
             client_id = get_client_id()
             client_secret = get_client_secret()
             if not client_id or not client_secret:
+                missing = ", ".join(
+                    name
+                    for name, value in (
+                        ("CUA_CLIENT_ID", client_id),
+                        ("CUA_CLIENT_SECRET", client_secret),
+                    )
+                    if not value
+                )
                 raise ValueError(
                     "Fleet cloud sandboxes require CUA_CLIENT_ID and CUA_CLIENT_SECRET, "
-                    "or cua.configure(client_id=..., client_secret=...)."
+                    "or cua.configure(client_id=..., client_secret=...). "
+                    f"Missing client credential fields: {missing}. "
+                    "Alternatively supply a Fleet token with FLEETS_TOKEN or "
+                    "cua.configure(fleet_token=...). "
+                    "This SDK path does not read the CLI credential store populated by "
+                    "'cua auth login'. CUA_API_KEY is not a Fleet credential."
                 )
         self._base_url = get_fleet_base_url().rstrip("/")
         self._http_client = CyclopsHttpClient()

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
@@ -389,3 +389,37 @@ def test_fleet_client_requires_credentials_when_no_workload_token_exists(monkeyp
         match="Fleet cloud sandboxes require CUA_CLIENT_ID and CUA_CLIENT_SECRET",
     ):
         _FleetClient()
+
+
+@pytest.mark.parametrize(
+    "client_id,client_secret,missing",
+    [
+        (None, None, "CUA_CLIENT_ID, CUA_CLIENT_SECRET"),
+        ("synthetic-client-id", None, "CUA_CLIENT_SECRET"),
+        (None, "synthetic-client-secret", "CUA_CLIENT_ID"),
+    ],
+)
+def test_missing_fleet_auth_explains_supported_routes_without_network(
+    monkeypatch, client_id, client_secret, missing
+):
+    from cua_sandbox.transport import fleet_cloud
+
+    monkeypatch.setattr(fleet_cloud, "get_fleet_token", lambda: None)
+    monkeypatch.setattr(fleet_cloud, "get_client_id", lambda: client_id)
+    monkeypatch.setattr(fleet_cloud, "get_client_secret", lambda: client_secret)
+    monkeypatch.setattr(
+        fleet_cloud,
+        "CyclopsHttpClient",
+        lambda: pytest.fail("missing credentials must fail before network construction"),
+    )
+    with pytest.raises(ValueError) as caught:
+        _FleetClient()
+    message = str(caught.value)
+    assert "Missing client credential fields: " + missing in message
+    assert "FLEETS_TOKEN" in message
+    assert "cua.configure(fleet_token=...)" in message
+    assert "cua auth login" in message
+    assert "does not read the CLI credential store" in message
+    assert "CUA_API_KEY is not a Fleet credential" in message
+    assert "synthetic-client-id" not in message
+    assert "synthetic-client-secret" not in message


### PR DESCRIPTION
## Summary

Explain the actual credential routes when the Fleet SDK has no usable token or complete client-credential pair. This changes the early error only; it does not implement a new CLI-to-SDK handoff.

- Name `FLEETS_TOKEN` and `cua.configure(fleet_token=...)` alongside client credentials.
- Identify missing client-credential field names without printing values.
- Explain that this SDK path does not read the separate session stored by `cua auth login`, and that `CUA_API_KEY` is not a Fleet credential.
- Continue failing before HTTP client construction.

## Validation

- Three missing/partial-credential regressions failed against the original diagnostic and pass with the correction.
- 82 Fleet client, transport and configuration tests passed on Python 3.13.15, including token precedence, configured endpoints and generated-SDK refresh behavior.
- Ruff, Black, isort and whitespace checks passed.
- Only synthetic credentials used; no network or credential-store access in the new tests.

## Boundaries

No token audience, refresh policy, environment precedence, legacy/custom endpoint routing or permissions change. A static token still has its existing lifetime; this does not resolve #3127. Existing credential-acquisition documentation remains in #3556 rather than being duplicated here. A unified session handoff would require a separate accepted auth contract.

## Review and rollback

Draft for review, no merge or release authorized. Revert the diagnostic/tests to roll back; no migration or persistent state change.
