### PR TITLE
fix(cua-sandbox): reject unauthorized readiness responses

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -441,6 +441,13 @@ class _FleetClient:
                     timeout_secs=_READINESS_PROBE_TIMEOUT_SECS,
                 ),
             )
+            if response.status in (401, 403):
+                # A reachable endpoint is not usable when it rejects this
+                # credential. Do not leak guest/proxy response bodies here.
+                raise PermissionError(
+                    f"Fleet service {service!r} rejected the readiness request "
+                    f"(HTTP {response.status}). Check the credential and service access."
+                )
             if 200 <= response.status < 500:
                 return
             if asyncio.get_running_loop().time() >= deadline:

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
@@ -1,5 +1,6 @@
 import logging
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from cua_sandbox.transport.fleet_cloud import (
@@ -145,6 +146,49 @@ async def test_wait_service_ready_sets_a_native_request_timeout():
 
     _, _, _, request = calls[0]
     assert request.timeout_secs == 30
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [401, 403])
+async def test_readiness_rejects_auth_failure_without_retrying(status):
+    client = _FleetClient.__new__(_FleetClient)
+    client.service_request = AsyncMock(
+        return_value=HttpResponse(status=status, headers=[], body=b"private-response-body")
+    )
+
+    with pytest.raises(PermissionError, match=f"HTTP {status}") as caught:
+        await client.wait_service_ready("sandbox", "server")
+    client.service_request.assert_awaited_once()
+    assert "private-response-body" not in str(caught.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [200, 204, 404])
+async def test_readiness_preserves_reachable_service_compatibility(status):
+    client = _FleetClient.__new__(_FleetClient)
+    client.service_request = AsyncMock(
+        return_value=HttpResponse(status=status, headers=[], body=b"")
+    )
+    await client.wait_service_ready("sandbox", "server")
+    client.service_request.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_readiness_still_retries_unready_service(monkeypatch):
+    from cua_sandbox.transport import fleet_cloud
+
+    client = _FleetClient.__new__(_FleetClient)
+    client.service_request = AsyncMock(
+        side_effect=[
+            HttpResponse(status=503, headers=[], body=b""),
+            HttpResponse(status=200, headers=[], body=b""),
+        ]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr(fleet_cloud.asyncio, "sleep", sleep)
+    await client.wait_service_ready("sandbox", "server")
+    assert client.service_request.await_count == 2
+    sleep.assert_awaited_once_with(2)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Reject HTTP 401/403 during the Fleet guest-service readiness probe instead of reporting the service ready. Previously the `200 <= status < 500` condition accepted those authorization failures.

- Raise an actionable `PermissionError` after an unauthorized/forbidden readiness response.
- Do not print guest/proxy response bodies or retry a terminal access denial in this layer.
- Preserve existing reachable-service behavior for other statuses, including 404 compatibility, and the existing 5xx readiness retry.

## Validation

- Both 401/403 regressions failed against unchanged production code (`DID NOT RAISE`) and pass with this correction.
- 85 Fleet client, transport and configuration tests passed on Python 3.13.15, including resource cleanup on provisioning failure.
- New tests cover 200/204/404 compatibility, 503-to-200 retry, terminal-denial call count and response-body redaction.
- Ruff, Black, isort and whitespace checks passed.

## Limits and related work

This is a reproduced unit-level readiness defect, not a diagnosis or fix for historical 502s, tenant permissions or billing. No live workload or pool was created. Existing cleanup-convergence work remains in #3367 and is not duplicated. This PR and #3582 touch the same client/test files in separate scopes; rebase and rerun the targeted suites after either lands.

## Review and rollback

Draft for SDK maintainer review; no merge or release authorized. Verify the selected hosted path with an authorized test account before release. Revert this commit to restore prior status handling; no migration or production state change.
