### PR TITLE
fix(cua-driver): end MCP proxy when daemon control closes

### DIFF
--- a/.github/workflows/ci-rust-windows.yml
+++ b/.github/workflows/ci-rust-windows.yml
@@ -33,6 +33,11 @@ on:
       - "libs/cua-driver/tests/fixtures/**"
       - ".github/workflows/ci-rust-windows.yml"
   workflow_dispatch:
+    inputs:
+      proxy_idle_seconds:
+        description: "Idle duration for MCP recovery diagnostic (1-3600 seconds)"
+        type: number
+        default: 1
 
 permissions:
   contents: read
@@ -45,7 +50,7 @@ jobs:
   unit:
     name: Rust Windows unit and compile
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && inputs.proxy_idle_seconds > 1 && 90 || 30 }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@stable
@@ -77,6 +82,11 @@ jobs:
       - name: Run MCP proxy lifecycle regressions
         working-directory: libs/cua-driver/rust
         run: "cargo test -p cua-driver --bin cua-driver proxy::tests:: --locked"
+      - name: Run real MCP proxy recovery regression
+        working-directory: libs/cua-driver/rust
+        env:
+          CUA_PROXY_RECOVERY_IDLE_SECONDS: ${{ inputs.proxy_idle_seconds || 1 }}
+        run: cargo test -p cua-driver --test protocol_proxy_recovery_test --locked -- --nocapture
       - name: Run named-pipe readiness regression
         working-directory: libs/cua-driver/rust
         run: cargo test -p cua-driver-testkit stalled_pipe_attempt_is_bounded_and_does_not_block_the_next_probe --lib --locked

--- a/.github/workflows/ci-rust-windows.yml
+++ b/.github/workflows/ci-rust-windows.yml
@@ -76,7 +76,7 @@ jobs:
         run: cargo test -p platform-windows post_message_pixel_click_reports_synthetic_transport --lib --locked
       - name: Run MCP proxy lifecycle regressions
         working-directory: libs/cua-driver/rust
-        run: cargo test -p cua-driver --bin cua-driver proxy::tests:: --locked
+        run: "cargo test -p cua-driver --bin cua-driver proxy::tests:: --locked"
       - name: Run named-pipe readiness regression
         working-directory: libs/cua-driver/rust
         run: cargo test -p cua-driver-testkit stalled_pipe_attempt_is_bounded_and_does_not_block_the_next_probe --lib --locked

--- a/.github/workflows/ci-rust-windows.yml
+++ b/.github/workflows/ci-rust-windows.yml
@@ -87,6 +87,8 @@ jobs:
         env:
           CUA_PROXY_RECOVERY_IDLE_SECONDS: ${{ inputs.proxy_idle_seconds || 1 }}
         run: cargo test -p cua-driver --test protocol_proxy_recovery_test --locked -- --nocapture
+      - name: Test sentinel setup barrier
+        run: node --test libs/cua-driver/tests/fixtures/apps/cross-platform/electron/preload.test.js
       - name: Run named-pipe readiness regression
         working-directory: libs/cua-driver/rust
         run: cargo test -p cua-driver-testkit stalled_pipe_attempt_is_bounded_and_does_not_block_the_next_probe --lib --locked

--- a/.github/workflows/ci-rust-windows.yml
+++ b/.github/workflows/ci-rust-windows.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Run pixel click transport regression
         working-directory: libs/cua-driver/rust
         run: cargo test -p platform-windows post_message_pixel_click_reports_synthetic_transport --lib --locked
+      - name: Run MCP proxy lifecycle regressions
+        working-directory: libs/cua-driver/rust
+        run: cargo test -p cua-driver --bin cua-driver proxy::tests:: --locked
       - name: Run named-pipe readiness regression
         working-directory: libs/cua-driver/rust
         run: cargo test -p cua-driver-testkit stalled_pipe_attempt_is_bounded_and_does_not_block_the_next_probe --lib --locked

--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/sentinel.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/sentinel.rs
@@ -70,6 +70,10 @@ impl ForegroundSentinel {
             .args(&electron.args)
             .env("CUA_E2E_SENTINEL", "1")
             .env("CUA_E2E_SENTINEL_JOURNAL", &journal_path)
+            .env(
+                "CUA_E2E_SENTINEL_CONTROL",
+                journal_path.with_extension("control.json"),
+            )
             .env("CUA_E2E_USER_DATA_DIR", user_data.path())
             .env("CUA_ELECTRON_CDP_PORT", cdp_port.to_string())
             .stdout(Stdio::null())
@@ -113,13 +117,13 @@ impl ForegroundSentinel {
         let focus_deadline = Instant::now() + Duration::from_secs(10);
         if is_wayland_session() {
             wait_for_journal(&journal_path, focus_deadline, r#""kind":"ready""#, "ready");
-            try_activate_native_foreground(driver, target)?;
+            activate_and_drain_setup_click(driver, target, &journal_path)?;
             // Electron may already be focused before its preload listener is ready.
             // The compositor observation is the authoritative Wayland focus gate.
             wait_for_native_focus_stable(target);
         } else {
             wait_for_journal(&journal_path, focus_deadline, r#""kind":"ready""#, "ready");
-            try_activate_native_foreground(driver, target)?;
+            activate_and_drain_setup_click(driver, target, &journal_path)?;
             wait_for_native_focus_stable(target);
             // On macOS the Electron renderer can report `document.hasFocus()`
             // as false at DOMContentLoaded, then become natively focused
@@ -282,7 +286,7 @@ impl ForegroundSentinel {
             }
         }
 
-        activate_native_foreground(driver, self.target);
+        activate_and_drain_setup_click(driver, self.target, &self.journal_path)?;
         #[cfg(target_os = "linux")]
         set_sway_fullscreen(driver, self.target, true)?;
         wait_for_native_focus_stable(self.target);
@@ -328,15 +332,12 @@ impl ForegroundSentinel {
         driver: &mut impl Driver,
         target: TargetWindow,
     ) -> Result<(), String> {
-        activate_native_foreground(driver, self.target);
+        activate_and_drain_setup_click(driver, self.target, &self.journal_path)?;
         wait_for_native_focus_stable(self.target);
         std::thread::sleep(Duration::from_millis(100));
         reset_journal(&self.journal_path)?;
-        // Windows establishes focus with a physical click. Its DOM `click`
-        // can arrive after the native focus transition and the first journal
-        // reset, falsely attributing setup input to the background action.
-        // A later heartbeat is an event-loop barrier: once observed, clear the
-        // journal again so the action boundary starts from a quiet sentinel.
+        // This heartbeat checks liveness only. Windows setup input has already
+        // crossed its explicit renderer/main journal barrier before the reset.
         wait_for_event(&self.journal_path, "heartbeat", Duration::from_secs(2))?;
         reset_journal(&self.journal_path)?;
         self.assert_background_posture(target)
@@ -470,9 +471,52 @@ fn is_wayland_session() -> bool {
             .is_ok_and(|session| session.eq_ignore_ascii_case("wayland"))
 }
 
-fn activate_native_foreground(driver: &mut impl Driver, target: TargetWindow) {
-    try_activate_native_foreground(driver, target)
-        .unwrap_or_else(|error| panic!("could not activate foreground sentinel: {error}"));
+fn activate_and_drain_setup_click(
+    driver: &mut impl Driver,
+    target: TargetWindow,
+    _journal_path: &std::path::Path,
+) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    let token = {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT_TOKEN: AtomicU64 = AtomicU64::new(1);
+        let token = NEXT_TOKEN.fetch_add(1, Ordering::Relaxed).to_string();
+        fs::write(
+            _journal_path.with_extension("control.json"),
+            serde_json::json!({ "token": token }).to_string(),
+        )
+        .map_err(|error| format!("arm sentinel setup click: {error}"))?;
+        wait_for_setup_click_marker(_journal_path, "setup-click-armed", &token)?;
+        token
+    };
+    try_activate_native_foreground(driver, target)?;
+    #[cfg(target_os = "windows")]
+    wait_for_setup_click_marker(_journal_path, "setup-click-drained", &token)?;
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn wait_for_setup_click_marker(
+    path: &std::path::Path,
+    kind: &str,
+    token: &str,
+) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let events = read_journal_events(path)?;
+        if events
+            .iter()
+            .any(|event| event_kind(event) == Some(kind) && event["token"].as_str() == Some(token))
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "sentinel setup barrier {kind:?} token {token:?} timed out: {events:?}"
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
 }
 
 fn raise_for_focus_canary(driver: &mut impl Driver, target: TargetWindow) -> Result<(), String> {

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -1726,11 +1726,15 @@ where
         on_startup(daemon, true);
     }
 
+    run_mcp_runtime(crate::proxy::run_proxy(socket_path))
+}
+
+pub(crate) fn run_mcp_runtime<T>(future: impl std::future::Future<Output = T>) -> T {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .expect("tokio runtime");
-    let result = rt.block_on(crate::proxy::run_proxy(socket_path));
+    let result = rt.block_on(future);
     // Tokio stdin uses an uncancellable blocking read. After control loss the
     // MCP client can still hold stdin open; waiting for that read during Drop
     // would keep the failed proxy process alive and prevent client recovery.

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -1730,7 +1730,13 @@ where
         .enable_all()
         .build()
         .expect("tokio runtime");
-    rt.block_on(crate::proxy::run_proxy(socket_path))
+    let result = rt.block_on(crate::proxy::run_proxy(socket_path));
+    // Tokio stdin uses an uncancellable blocking read. After control loss the
+    // MCP client can still hold stdin open; waiting for that read during Drop
+    // would keep the failed proxy process alive and prevent client recovery.
+    // run_proxy has already dropped its scoped daemon control connection.
+    rt.shutdown_background();
+    result
 }
 
 /// Emit a stable, machine-readable JSON description of the cua-driver CLI

--- a/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
@@ -835,6 +835,60 @@ mod tests {
     use super::*;
     use crate::serve::DaemonResponse;
 
+    #[test]
+    fn control_disconnect_exits_with_stdin_open() {
+        const CHILD_ENV: &str = "CUA_TEST_MCP_CONTROL_STDIN_CHILD";
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let result = crate::cli::run_mcp_runtime(async {
+                let cached_tools = Arc::new(serde_json::json!({"tools": []}));
+                supervise_control_connection(
+                    // Let run_proxy_io park in the real blocking stdin read.
+                    tokio::time::sleep(std::time::Duration::from_millis(100)),
+                    run_proxy_io(
+                        BufReader::new(tokio::io::stdin()),
+                        tokio::io::sink(),
+                        "unused.sock",
+                        &cached_tools,
+                        "disconnect",
+                        false,
+                    ),
+                )
+                .await
+            });
+            assert!(result.is_err());
+            return;
+        }
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "proxy::tests::control_disconnect_exits_with_stdin_open",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, "1")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if let Some(status) = child.try_wait().unwrap() {
+                assert!(
+                    status.success(),
+                    "MCP runtime subprocess failed: {:?}",
+                    child.wait_with_output().unwrap()
+                );
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                child.kill().unwrap();
+                child.wait().unwrap();
+                panic!("control disconnect left the MCP process waiting for client stdin EOF");
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
     #[tokio::test]
     async fn control_disconnect_ends_idle_proxy() {
         let (control, daemon) = tokio::io::duplex(64);

--- a/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
@@ -207,17 +207,15 @@ pub async fn run_proxy(socket_path: String) -> anyhow::Result<()> {
     // calls. Besides lifecycle cleanup, that registered control channel is the
     // trust boundary used by destructive `browser_prepare` calls.
     let (control_ready_tx, control_ready_rx) = tokio::sync::oneshot::channel();
-    {
-        let socket = socket_path.clone();
-        let sid = session_id.clone();
-        tokio::spawn(async move {
-            run_control_connection(socket, sid, control_ready_tx).await;
-        });
-    }
-    tokio::time::timeout(std::time::Duration::from_secs(4), control_ready_rx)
-        .await
-        .map_err(|_| anyhow::anyhow!("daemon did not acknowledge the MCP control session"))?
-        .map_err(|_| anyhow::anyhow!("daemon control session closed before acknowledgement"))?;
+    let control = run_control_connection(socket_path.clone(), session_id.clone(), control_ready_tx);
+    tokio::pin!(control);
+    supervise_control_connection(&mut control, async {
+        tokio::time::timeout(std::time::Duration::from_secs(4), control_ready_rx)
+            .await
+            .map_err(|_| anyhow::anyhow!("daemon did not acknowledge the MCP control session"))?
+            .map_err(|_| anyhow::anyhow!("daemon control session closed before acknowledgement"))
+    })
+    .await?;
 
     // Cache the tool list once at startup. The daemon's registry is
     // static for the lifetime of the daemon, so polling on every
@@ -229,15 +227,32 @@ pub async fn run_proxy(socket_path: String) -> anyhow::Result<()> {
 
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
-    run_proxy_io(
-        BufReader::new(stdin),
-        tokio::io::BufWriter::new(stdout),
-        &socket_path,
-        &cached_tools_list,
-        &session_id,
-        daemon_observes_tool_calls,
+    supervise_control_connection(
+        &mut control,
+        run_proxy_io(
+            BufReader::new(stdin),
+            tokio::io::BufWriter::new(stdout),
+            &socket_path,
+            &cached_tools_list,
+            &session_id,
+            daemon_observes_tool_calls,
+        ),
     )
     .await
+}
+
+/// Keep the MCP transport alive only while its daemon-owned identity is live.
+/// Dropping the scoped control future also closes its socket on stdin EOF,
+/// startup failure, or cancellation; no detached task can retain the session.
+async fn supervise_control_connection<T>(
+    control: impl std::future::Future<Output = ()>,
+    work: impl std::future::Future<Output = anyhow::Result<T>>,
+) -> anyhow::Result<T> {
+    tokio::select! {
+        biased;
+        _ = control => anyhow::bail!("daemon control session closed; reconnect the MCP client"),
+        result = work => result,
+    }
 }
 
 /// Run the service-owned stdio loop over caller-provided I/O.
@@ -378,10 +393,9 @@ fn proxy_knows_tool(cached_tools_list: &serde_json::Value, name: &str) -> bool {
 /// `session_begin` and fires `session_end` when this connection EOFs — which
 /// the kernel triggers on proxy exit AND on kill -9.
 ///
-/// On any read result/error (daemon-side close, broken pipe), the loop exits
-/// and the task ends; the proxy keeps running on its per-call connections. A
-/// connect failure (racing daemon startup) is logged and swallowed — it must
-/// not bail the proxy.
+/// On EOF/error (daemon-side close, broken pipe), this future completes and
+/// its supervisor closes the MCP proxy. Per-call connections must never keep
+/// serving the ended identity. Startup connection failures follow the same path.
 async fn run_control_connection(
     socket_path: String,
     session_id: String,
@@ -820,6 +834,80 @@ async fn forward_tool_call(
 mod tests {
     use super::*;
     use crate::serve::DaemonResponse;
+
+    #[tokio::test]
+    async fn control_disconnect_ends_idle_proxy() {
+        let (control, daemon) = tokio::io::duplex(64);
+        let control = async move {
+            let mut reader = BufReader::new(control);
+            let mut line = String::new();
+            let _ = reader.read_line(&mut line).await;
+        };
+        let proxy =
+            supervise_control_connection(control, std::future::pending::<anyhow::Result<()>>());
+        tokio::pin!(proxy);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), &mut proxy)
+                .await
+                .is_err(),
+            "an idle live control connection must remain usable"
+        );
+        drop(daemon);
+        let error = tokio::time::timeout(std::time::Duration::from_millis(250), proxy)
+            .await
+            .expect("control EOF must end the proxy promptly")
+            .unwrap_err();
+        assert!(error.to_string().contains("reconnect the MCP client"));
+    }
+
+    #[tokio::test]
+    async fn proxy_eof_drops_its_control_connection() {
+        let (control, daemon) = tokio::io::duplex(64);
+        let control = async move {
+            let mut reader = BufReader::new(control);
+            let mut line = String::new();
+            let _ = reader.read_line(&mut line).await;
+        };
+        let cached_tools = Arc::new(serde_json::json!({"tools": []}));
+        let mut writer = Vec::new();
+        supervise_control_connection(
+            control,
+            run_proxy_io(
+                BufReader::new(&b""[..]),
+                &mut writer,
+                "unused.sock",
+                &cached_tools,
+                "eof",
+                false,
+            ),
+        )
+        .await
+        .unwrap();
+        let mut daemon = BufReader::new(daemon);
+        let mut line = String::new();
+        assert_eq!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(250),
+                daemon.read_line(&mut line)
+            )
+            .await
+            .expect("proxy EOF must release daemon session ownership")
+            .unwrap(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn closed_control_prevents_ready_request_dispatch() {
+        let dispatched = std::sync::atomic::AtomicBool::new(false);
+        let result = supervise_control_connection(async {}, async {
+            dispatched.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        })
+        .await;
+        assert!(result.is_err());
+        assert!(!dispatched.load(std::sync::atomic::Ordering::SeqCst));
+    }
 
     #[tokio::test]
     async fn proxy_loop_returns_promptly_on_clean_eof() {

--- a/libs/cua-driver/rust/crates/cua-driver/tests/protocol_proxy_recovery_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/protocol_proxy_recovery_test.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Cua AI, Inc.
+
 //! Real stdio proxies and a real daemon, with selective control-channel loss.
 //! Set CUA_PROXY_RECOVERY_IDLE_SECONDS=1200 for a long-idle diagnostic replay.
 //! This injects a known transport failure; it does not reproduce an unknown trigger.

--- a/libs/cua-driver/rust/crates/cua-driver/tests/protocol_proxy_recovery_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/protocol_proxy_recovery_test.rs
@@ -118,6 +118,7 @@ struct Process(Child, #[allow(dead_code)] tempfile::TempDir);
 impl Process {
     fn spawn(args: &[&str]) -> Self {
         let driver_home = tempfile::tempdir().expect("isolated driver state");
+        let idle_seconds = recovery_idle_seconds();
         let mut command = Command::new(env!("CARGO_BIN_EXE_cua-driver"));
         command
             .args(args)
@@ -125,6 +126,11 @@ impl Process {
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .env("CUA_DRIVER_RS_TELEMETRY_ENABLED", "false")
+            // This test isolates transport lifetime from intentional session expiry.
+            .env(
+                "CUA_DRIVER_RS_SESSION_IDLE_TTL_SECS",
+                (idle_seconds + 60).max(300).to_string(),
+            )
             .env("HOME", driver_home.path())
             .env("USERPROFILE", driver_home.path())
             .env("LOCALAPPDATA", driver_home.path())
@@ -151,6 +157,21 @@ impl Process {
             std::thread::sleep(Duration::from_millis(20));
         }
     }
+}
+
+fn recovery_idle_seconds() -> u64 {
+    let seconds = std::env::var("CUA_PROXY_RECOVERY_IDLE_SECONDS")
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .expect("idle seconds must be an integer")
+        })
+        .unwrap_or(1);
+    assert!(
+        (1..=3600).contains(&seconds),
+        "idle seconds must be 1..=3600"
+    );
+    seconds
 }
 
 impl Drop for Process {
@@ -346,17 +367,7 @@ async fn real_proxies_recover_from_control_loss_without_waiting_for_stdin() {
     session_active(&daemon_endpoint, "peer-client").await;
     session_active(&daemon_endpoint, "idle-client").await;
 
-    let idle_seconds = std::env::var("CUA_PROXY_RECOVERY_IDLE_SECONDS")
-        .map(|value| {
-            value
-                .parse::<u64>()
-                .expect("idle seconds must be an integer")
-        })
-        .unwrap_or(1);
-    assert!(
-        (1..=3600).contains(&idle_seconds),
-        "idle seconds must be 1..=3600"
-    );
+    let idle_seconds = recovery_idle_seconds();
     tokio::time::sleep(Duration::from_secs(idle_seconds)).await;
     drop(peer.stdin.take());
     assert!(

--- a/libs/cua-driver/rust/crates/cua-driver/tests/protocol_proxy_recovery_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/protocol_proxy_recovery_test.rs
@@ -22,6 +22,17 @@ trait Stream: AsyncRead + AsyncWrite + Unpin + Send {}
 impl<T: AsyncRead + AsyncWrite + Unpin + Send> Stream for T {}
 type Connection = Box<dyn Stream>;
 
+async fn copy_until_disconnect<A: Stream, B: Stream>(incoming: &mut A, upstream: &mut B) {
+    let (mut client_read, mut client_write) = tokio::io::split(incoming);
+    let (mut daemon_read, mut daemon_write) = tokio::io::split(upstream);
+    // Named pipes cannot half-close: AsyncWrite::shutdown only flushes. Drop
+    // both handles on either EOF so the relay preserves peer-disconnect semantics.
+    tokio::select! {
+        _ = tokio::io::copy(&mut client_read, &mut daemon_write) => {},
+        _ = tokio::io::copy(&mut daemon_read, &mut client_write) => {},
+    }
+}
+
 async fn connect(endpoint: &str) -> std::io::Result<Connection> {
     #[cfg(unix)]
     return Ok(Box::new(tokio::net::UnixStream::connect(endpoint).await?));
@@ -61,10 +72,10 @@ async fn forward(
         controls.send(cut).unwrap();
         tokio::select! {
             _ = cut_rx => {},
-            _ = tokio::io::copy_bidirectional(&mut incoming, &mut upstream) => {},
+            _ = copy_until_disconnect(&mut incoming, &mut upstream) => {},
         }
     } else {
-        let _ = tokio::io::copy_bidirectional(&mut incoming, &mut upstream).await;
+        copy_until_disconnect(&mut incoming, &mut upstream).await;
     }
 }
 

--- a/libs/cua-driver/rust/crates/cua-driver/tests/protocol_proxy_recovery_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/protocol_proxy_recovery_test.rs
@@ -1,0 +1,388 @@
+//! Real stdio proxies and a real daemon, with selective control-channel loss.
+//! Set CUA_PROXY_RECOVERY_IDLE_SECONDS=1200 for a long-idle diagnostic replay.
+//! This injects a known transport failure; it does not reproduce an unknown trigger.
+
+#![cfg(any(unix, target_os = "windows"))]
+
+use cua_driver_testkit::spawn_in_job;
+use serde_json::{json, Value};
+use std::io::{BufRead, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::sync::{mpsc as async_mpsc, oneshot};
+
+const BOUND: Duration = Duration::from_secs(10);
+
+trait Stream: AsyncRead + AsyncWrite + Unpin + Send {}
+impl<T: AsyncRead + AsyncWrite + Unpin + Send> Stream for T {}
+type Connection = Box<dyn Stream>;
+
+async fn connect(endpoint: &str) -> std::io::Result<Connection> {
+    #[cfg(unix)]
+    return Ok(Box::new(tokio::net::UnixStream::connect(endpoint).await?));
+    #[cfg(target_os = "windows")]
+    {
+        let deadline = Instant::now() + BOUND;
+        loop {
+            match tokio::net::windows::named_pipe::ClientOptions::new().open(endpoint) {
+                Ok(pipe) => return Ok(Box::new(pipe)),
+                Err(error) if Instant::now() >= deadline => return Err(error),
+                Err(_) => tokio::time::sleep(Duration::from_millis(20)).await,
+            }
+        }
+    }
+}
+
+// Forward the handshake and all responses unchanged. Only a session_begin
+// connection can be cut; per-call connections and the daemon stay alive.
+async fn forward(
+    incoming: Connection,
+    daemon: String,
+    controls: async_mpsc::UnboundedSender<oneshot::Sender<()>>,
+) {
+    let mut incoming = BufReader::new(incoming);
+    let mut first = String::new();
+    if !matches!(tokio::time::timeout(BOUND, incoming.read_line(&mut first)).await, Ok(Ok(n)) if n > 0)
+    {
+        return;
+    }
+    let request: Value = serde_json::from_str(&first).expect("relay request JSON");
+    let mut upstream = connect(&daemon)
+        .await
+        .expect("connect relay to real daemon");
+    upstream.write_all(first.as_bytes()).await.unwrap();
+    if request["method"] == "session_begin" {
+        let (cut, cut_rx) = oneshot::channel();
+        controls.send(cut).unwrap();
+        tokio::select! {
+            _ = cut_rx => {},
+            _ = tokio::io::copy_bidirectional(&mut incoming, &mut upstream) => {},
+        }
+    } else {
+        let _ = tokio::io::copy_bidirectional(&mut incoming, &mut upstream).await;
+    }
+}
+
+async fn relay(
+    endpoint: &str,
+    daemon: String,
+    controls: async_mpsc::UnboundedSender<oneshot::Sender<()>>,
+) -> tokio::task::JoinHandle<()> {
+    #[cfg(unix)]
+    {
+        let listener = tokio::net::UnixListener::bind(endpoint).unwrap();
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                tokio::spawn(forward(Box::new(stream), daemon.clone(), controls.clone()));
+            }
+        })
+    }
+    #[cfg(target_os = "windows")]
+    {
+        use tokio::net::windows::named_pipe::ServerOptions;
+        let mut listener = ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(endpoint)
+            .unwrap();
+        let endpoint = endpoint.to_owned();
+        tokio::spawn(async move {
+            loop {
+                listener.connect().await.unwrap();
+                let next = ServerOptions::new().create(&endpoint).unwrap();
+                let stream = std::mem::replace(&mut listener, next);
+                tokio::spawn(forward(Box::new(stream), daemon.clone(), controls.clone()));
+            }
+        })
+    }
+}
+
+struct Process(Child, #[allow(dead_code)] tempfile::TempDir);
+
+impl Process {
+    fn spawn(args: &[&str]) -> Self {
+        let driver_home = tempfile::tempdir().expect("isolated driver state");
+        let mut command = Command::new(env!("CARGO_BIN_EXE_cua-driver"));
+        command
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .env("CUA_DRIVER_RS_TELEMETRY_ENABLED", "false")
+            .env("HOME", driver_home.path())
+            .env("USERPROFILE", driver_home.path())
+            .env("LOCALAPPDATA", driver_home.path())
+            .env("XDG_STATE_HOME", driver_home.path())
+            .env("CUA_DRIVER_HOME", driver_home.path())
+            .env("CUA_DRIVER_LOCAL_HOME", driver_home.path())
+            .env("CUA_DRIVER_RS_HOME", driver_home.path());
+        Self(
+            spawn_in_job(&mut command).expect("spawn source-built driver"),
+            driver_home,
+        )
+    }
+
+    fn exit(&mut self) -> std::process::ExitStatus {
+        let deadline = Instant::now() + BOUND;
+        loop {
+            if let Some(status) = self.0.try_wait().unwrap() {
+                return status;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "driver process did not exit within {BOUND:?}"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+impl Drop for Process {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+struct Client {
+    process: Process,
+    stdin: Option<ChildStdin>,
+    responses: Receiver<Value>,
+    id: u64,
+}
+
+impl Client {
+    fn spawn(endpoint: &str) -> Self {
+        let mut process = Process::spawn(&["mcp", "--socket", endpoint]);
+        let stdin = process.0.stdin.take();
+        let stdout = process.0.stdout.take().unwrap();
+        let (tx, responses) = mpsc::channel();
+        std::thread::spawn(move || {
+            for line in std::io::BufReader::new(stdout).lines() {
+                let response =
+                    serde_json::from_str(&line.expect("read MCP stdout")).expect("MCP JSON");
+                if tx.send(response).is_err() {
+                    break;
+                }
+            }
+        });
+        let mut client = Self {
+            process,
+            stdin,
+            responses,
+            id: 0,
+        };
+        let response = client.request(
+            "initialize",
+            json!({
+                "protocolVersion":"2024-11-05", "capabilities":{},
+                "clientInfo":{"name":"proxy-recovery-test","version":"1"}
+            }),
+        );
+        assert!(response["result"]["serverInfo"].is_object(), "{response}");
+        writeln!(
+            client.stdin.as_mut().unwrap(),
+            "{}",
+            json!({"jsonrpc":"2.0","method":"notifications/initialized"})
+        )
+        .unwrap();
+        client
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> Value {
+        self.id += 1;
+        writeln!(
+            self.stdin.as_mut().unwrap(),
+            "{}",
+            json!({
+                "jsonrpc":"2.0", "id":self.id, "method":method, "params":params
+            })
+        )
+        .unwrap();
+        let deadline = Instant::now() + BOUND;
+        loop {
+            let response = self
+                .responses
+                .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                .expect("bounded MCP response");
+            if response["id"] == self.id {
+                assert!(response.get("error").is_none(), "{response}");
+                return response;
+            }
+        }
+    }
+
+    fn call(&mut self, name: &str, arguments: Value) {
+        let response = self.request("tools/call", json!({"name":name,"arguments":arguments}));
+        assert_ne!(response["result"]["isError"], true, "{response}");
+        assert!(response["result"]["content"].is_array(), "{response}");
+    }
+
+    fn eof(&self) {
+        assert!(
+            matches!(
+                self.responses.recv_timeout(BOUND),
+                Err(mpsc::RecvTimeoutError::Disconnected)
+            ),
+            "MCP stdout must close promptly without additional responses"
+        );
+    }
+}
+
+async fn daemon_request(endpoint: &str, request: Value) -> Value {
+    tokio::time::timeout(BOUND, async {
+        let mut stream = connect(endpoint).await.unwrap();
+        stream
+            .write_all(format!("{request}\n").as_bytes())
+            .await
+            .unwrap();
+        let mut line = String::new();
+        BufReader::new(stream).read_line(&mut line).await.unwrap();
+        let response: Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(response["ok"], true, "{response}");
+        response["result"].clone()
+    })
+    .await
+    .expect("bounded daemon request")
+}
+
+async fn session_absent(endpoint: &str, label: &str) {
+    let deadline = Instant::now() + BOUND;
+    loop {
+        let result = daemon_request(endpoint, json!({"method":"sessions_list"})).await;
+        let sessions = result["sessions"]
+            .as_array()
+            .expect("operator sessions array");
+        if !sessions.iter().any(|session| session["session"] == label) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "session {label} was not cleaned up: {result}"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn session_active(endpoint: &str, label: &str) {
+    let result = daemon_request(endpoint, json!({"method":"sessions_list"})).await;
+    assert!(
+        result["sessions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|session| session["session"] == label && session["state"] == "active"),
+        "expected active session {label}: {result}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn real_proxies_recover_from_control_loss_without_waiting_for_stdin() {
+    #[cfg(unix)]
+    let directory = tempfile::Builder::new()
+        .prefix("cua-recovery-")
+        .tempdir_in("/tmp")
+        .unwrap();
+    #[cfg(unix)]
+    let (daemon_endpoint, proxy_endpoint) = (
+        directory.path().join("d.sock").display().to_string(),
+        directory.path().join("p.sock").display().to_string(),
+    );
+    #[cfg(target_os = "windows")]
+    let (daemon_endpoint, proxy_endpoint) = (
+        format!(r"\\.\pipe\cua-recovery-{}-daemon", std::process::id()),
+        format!(r"\\.\pipe\cua-recovery-{}-proxy", std::process::id()),
+    );
+    let mut daemon = Process::spawn(&[
+        "serve",
+        "--socket",
+        &daemon_endpoint,
+        "--no-overlay",
+        "--no-permissions-gate",
+        "--dangerously-bypass-approvals",
+    ]);
+    let deadline = Instant::now() + BOUND;
+    loop {
+        assert!(
+            daemon.0.try_wait().unwrap().is_none(),
+            "daemon exited during startup"
+        );
+        if connect(&daemon_endpoint).await.is_ok() {
+            break;
+        }
+        assert!(Instant::now() < deadline, "daemon readiness timeout");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let (control_tx, mut controls) = async_mpsc::unbounded_channel();
+    let relay_task = relay(&proxy_endpoint, daemon_endpoint.clone(), control_tx).await;
+    let mut idle = Client::spawn(&proxy_endpoint);
+    let idle_control = tokio::time::timeout(BOUND, controls.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    idle.call("start_session", json!({"session":"idle-client"}));
+    let mut peer = Client::spawn(&proxy_endpoint);
+    let _peer_control = tokio::time::timeout(BOUND, controls.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    peer.call("start_session", json!({"session":"peer-client"}));
+    session_active(&daemon_endpoint, "peer-client").await;
+    session_active(&daemon_endpoint, "idle-client").await;
+
+    let idle_seconds = std::env::var("CUA_PROXY_RECOVERY_IDLE_SECONDS")
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .expect("idle seconds must be an integer")
+        })
+        .unwrap_or(1);
+    assert!(
+        (1..=3600).contains(&idle_seconds),
+        "idle seconds must be 1..=3600"
+    );
+    tokio::time::sleep(Duration::from_secs(idle_seconds)).await;
+    drop(peer.stdin.take());
+    assert!(
+        peer.process.exit().success(),
+        "peer stdin EOF should exit successfully"
+    );
+    peer.eof();
+    session_absent(&daemon_endpoint, "peer-client").await;
+    session_active(&daemon_endpoint, "idle-client").await;
+    idle.call("get_config", json!({"session":"idle-client"}));
+
+    let mut survivor = Client::spawn(&proxy_endpoint);
+    let _survivor_control = tokio::time::timeout(BOUND, controls.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    survivor.call("start_session", json!({"session":"survivor"}));
+    idle_control
+        .send(())
+        .expect("idle control must still be connected");
+    assert!(idle.stdin.is_some(), "retain stdin during control loss");
+    assert!(
+        !idle.process.exit().success(),
+        "lost control must fail the proxy"
+    );
+    idle.eof();
+    session_absent(&daemon_endpoint, "idle-client").await;
+    session_active(&daemon_endpoint, "survivor").await;
+    survivor.call("get_config", json!({"session":"survivor"}));
+    assert!(
+        daemon.0.try_wait().unwrap().is_none(),
+        "daemon must survive selective loss"
+    );
+
+    let mut fresh = Client::spawn(&proxy_endpoint);
+    let _fresh_control = tokio::time::timeout(BOUND, controls.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    fresh.call("get_config", json!({}));
+    survivor.call("get_config", json!({"session":"survivor"}));
+    relay_task.abort();
+}

--- a/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/main.js
+++ b/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/main.js
@@ -12,6 +12,7 @@ const nativeWayland = process.platform === 'linux' && Boolean(process.env.WAYLAN
 const customCuaCompositor = process.env.CUA_E2E_WAYLAND_SESSION === 'cua-compositor';
 const fixtureJournalUrl = process.env.CUA_E2E_FIXTURE_JOURNAL_URL || '';
 const sentinelJournalPath = process.env.CUA_E2E_SENTINEL_JOURNAL || '';
+const sentinelControlPath = process.env.CUA_E2E_SENTINEL_CONTROL || '';
 if (process.env.CUA_E2E_USER_DATA_DIR) {
   app.setPath('userData', process.env.CUA_E2E_USER_DATA_DIR);
 }
@@ -59,6 +60,7 @@ ipcMain.on('cua-e2e-sentinel-event', (_event, entry) => {
 
 let mainWindow;
 let sentinelHeartbeatTimer;
+let sentinelSetupToken;
 
 function createWindow() {
   const fixedTitle = sentinelMode
@@ -144,6 +146,17 @@ function createWindow() {
           if (!sentinelHeartbeatTimer) {
             sentinelHeartbeatTimer = setInterval(() => {
               if (mainWindow && !mainWindow.isDestroyed()) {
+                if (process.platform === 'win32' && sentinelControlPath) {
+                  // A partially written request is retried on the next tick.
+                  let request;
+                  try {
+                    request = JSON.parse(fs.readFileSync(sentinelControlPath, 'utf8'));
+                  } catch {}
+                  if (typeof request?.token === 'string' && request.token !== sentinelSetupToken) {
+                    sentinelSetupToken = request.token;
+                    mainWindow.webContents.send('cua-e2e-sentinel-arm-setup-click', request.token);
+                  }
+                }
                 mainWindow.webContents.send('cua-e2e-sentinel-heartbeat-probe');
               }
             }, 100);

--- a/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/preload.js
+++ b/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/preload.js
@@ -11,6 +11,7 @@ contextBridge.exposeInMainWorld('cuaE2E', {
 });
 
 const sentinelMode = fixtureConfig.sentinelMode;
+let setupClick;
 
 function record(kind, details = {}) {
   if (!sentinelMode) return;
@@ -19,9 +20,24 @@ function record(kind, details = {}) {
     at_ms: Date.now(),
     ...details,
   });
+  if (setupClick) {
+    const expected = ['pointerdown', 'pointerup', 'click'];
+    if (kind === expected[setupClick.step]) setupClick.step += 1;
+    if (setupClick.step === expected.length) {
+      const token = setupClick.token;
+      setupClick = undefined;
+      // Same renderer/channel as the pointer events: main journals this only
+      // after it has synchronously appended the complete setup click.
+      record('setup-click-drained', { token });
+    }
+  }
 }
 
 if (sentinelMode) {
+  ipcRenderer.on('cua-e2e-sentinel-arm-setup-click', (_event, token) => {
+    setupClick = { token, step: 0 };
+    record('setup-click-armed', { token });
+  });
   window.addEventListener('DOMContentLoaded', () => {
     document.body.innerHTML = `
       <main style="min-height:100vh;background:#146c43;color:white;display:grid;place-content:center;text-align:center;font:24px system-ui">

--- a/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/preload.test.js
+++ b/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/preload.test.js
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Cua AI, Inc.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function sentinelRenderer() {
+  const listeners = new Map();
+  const ipcListeners = new Map();
+  const pending = [];
+  vm.runInNewContext(fs.readFileSync(path.join(__dirname, 'preload.js'), 'utf8'), {
+    require: () => ({
+      contextBridge: { exposeInMainWorld() {} },
+      ipcRenderer: {
+        sendSync: () => ({ sentinelMode: true }),
+        send: (channel, entry) => pending.push({ channel, entry }),
+        on: (channel, handler) => ipcListeners.set(channel, handler),
+      },
+    }),
+    window: { addEventListener: (kind, handler) => listeners.set(kind, handler) },
+  });
+  return {
+    arm: token => ipcListeners.get('cua-e2e-sentinel-arm-setup-click')(null, token),
+    heartbeat: () => ipcListeners.get('cua-e2e-sentinel-heartbeat-probe')(),
+    input: kind => listeners.get(kind)({ button: 0, clientX: 10, clientY: 20 }),
+    pending,
+  };
+}
+
+test('setup barrier follows the full click on the same journal IPC channel', () => {
+  const renderer = sentinelRenderer();
+  renderer.arm('first');
+  renderer.heartbeat();
+  renderer.input('pointerdown');
+  renderer.input('pointerup');
+  assert.equal(renderer.pending.some(({ entry }) => entry.kind === 'setup-click-drained'), false);
+  renderer.input('click');
+  assert.deepEqual(renderer.pending.map(({ entry }) => entry.kind), [
+    'setup-click-armed', 'heartbeat', 'pointerdown', 'pointerup', 'click', 'setup-click-drained',
+  ]);
+  assert.ok(renderer.pending.every(({ channel }) => channel === 'cua-e2e-sentinel-event'));
+  assert.equal(renderer.pending.at(-1).entry.token, 'first');
+  // An action's later pointer input remains observable after setup completes.
+  renderer.input('pointerdown');
+  assert.equal(renderer.pending.at(-1).entry.kind, 'pointerdown');
+});
+
+test('heartbeats, stale clicks, and partial clicks cannot complete a new setup token', () => {
+  const renderer = sentinelRenderer();
+  renderer.input('pointerdown');
+  renderer.input('pointerup');
+  renderer.input('click');
+  renderer.arm('first');
+  renderer.input('pointerdown');
+  renderer.arm('second');
+  renderer.input('pointerup');
+  renderer.input('click');
+  renderer.heartbeat();
+  assert.equal(renderer.pending.some(({ entry }) => entry.kind === 'setup-click-drained'), false);
+  renderer.input('pointerdown');
+  renderer.input('pointerup');
+  renderer.input('click');
+  assert.equal(renderer.pending.at(-1).entry.kind, 'setup-click-drained');
+  assert.equal(renderer.pending.at(-1).entry.token, 'second');
+});


### PR DESCRIPTION
When the daemon closes an MCP proxy's control connection, the proxy currently keeps accepting tool calls with an ended identity. This change ends the stdio proxy promptly so the client can reconnect with a fresh identity. It also scopes the control socket to the proxy lifetime and avoids waiting indefinitely for Tokio's blocking stdin reader during runtime shutdown.

Refs #3329. This addresses known control-channel loss; the originally reported Windows idle/peer-exit trigger is not established and may have an additional cause.

### Recovery proof

A real-process integration test launches an isolated source-built daemon and independent stdio MCP clients. A transparent Unix/named-pipe relay drops only one session's control connection. The test verifies peer EOF cleanup, idle-client survival, bounded process exit and stdout EOF with stdin retained, an unaffected peer, and replacement-client initialization plus successful tool calls. Child preferences/state are isolated.

The default idle interval is one second. For longer runs, the isolated daemon session TTL is set to at least idle + 60 seconds (minimum 300), separating control transport lifetime from intentional idle expiry; this is not a default-configuration idle reproduction. Manual Windows CI accepts `proxy_idle_seconds=1200` for a 20-minute diagnostic; the test also supports `CUA_PROXY_RECOVERY_IDLE_SECONDS`. This proves recovery after injected loss, not reproduction of the unknown original trigger.

### Sentinel certification fix

An earlier Windows shared case returned the expected `background_unavailable` refusal but recorded pointerdown/pointerup/click in the foreground sentinel. Artifact review places the setup cursor at the sentinel center for 34 ms and its restoration 87 ms before action dispatch. Delayed setup delivery is the leading explanation; the old artifacts do not prove the exact event ordering.

The harness now arms a unique renderer token before the native setup click and waits for its full pointerdown/pointerup/click sequence to be journaled before reset. The completion marker uses the same renderer IPC channel and synchronous main-process journal append as the input events. Heartbeats remain liveness checks. `NoLeakedInput` is unchanged; there is no coordinate or timestamp forgiveness.

### Validation and remaining gates

Current candidate: `9a5b9080481443729b10b1348933ce9fb3cf895b`. Ordinary PR CI is green (24 successful checks, one expected skip), including release metadata and contributor attribution.

- Existing focused proxy suite: ten tests passed, including the real-stdin shutdown regression. Restoring the old shutdown behavior fails its five-second bound.
- Current real-process recovery test passed locally on macOS: one test, zero failures, 3.65 seconds. The corrected short recovery test and sentinel barrier tests also passed on Windows in [ordinary CI](https://github.com/trycua/cua/actions/runs/34071340456). The original long-idle run was canceled after the short Windows test exposed a relay bug: Tokio named-pipe shutdown only flushes, so `copy_bidirectional` retained the upstream handle after peer EOF. The test-only relay now drops both handles when either direction ends. The corrected test passes locally (3.65 seconds); the [replacement 20-minute Windows diagnostic](https://github.com/trycua/cua/actions/runs/34071348678) passed the complete workflow at the current candidate, including the 20-minute recovery test. The test covers peer cleanup, retained-stdin control-loss exit and stdout EOF, unaffected peer, and fresh-client initialization/tool use.
- Current sentinel changes: 73 local testkit unit tests and two JavaScript barrier regressions passed; formatting and diff checks passed. The [Windows shared replay](https://github.com/trycua/cua/actions/runs/34070627248) passed all 84 cases (62 delivered, 22 expected refusals), zero failures/skips, at `3d5967912b17f5255c53bb7ac6885f70fdfd5a86`. Source and all per-case video/trajectory references were verified. The previously failing Tauri background-hotkey cell passed all declared oracles, including `NoLeakedInput`. Subsequent commits change only the recovery test, not the product or sentinel harness.
- At product-equivalent `ba27fba202b2f8bf51ee39f02b6f67c0fcec63dd`, [Windows unit CI](https://github.com/trycua/cua/actions/runs/34056056966) passed. The [canonical Linux run](https://github.com/trycua/cua/actions/runs/34056689065) passed 129 desktop cases: 87 delivered and 42 expected refusals, zero failures/skips, plus installer smoke. These results are historical evidence, not recertification of the modified sentinel harness.
- The [earlier canonical Windows run](https://github.com/trycua/cua/actions/runs/34056687954) passed installer, capture (nine cases), and native (43 cases). The shared lane failed one of 84 cases (`windows-tauri-hotkey-ax-background`), motivating the barrier change.

The complete final-candidate [Linux canonical run](https://github.com/trycua/cua/actions/runs/34072032522) passed: 129 cases (87 delivered, 42 expected refusals), zero failures/skips, plus installer smoke. All lanes report the current SHA, per-case video/trajectory presence was verified, and a representative shared-lane frame was inspected. The complete final-candidate [Windows canonical run](https://github.com/trycua/cua/actions/runs/34072030720) passed: 136 cases (110 delivered, 26 expected refusals), zero failures/skips, plus installer/update smoke. All lanes report the current SHA; every case has retained video/trajectory evidence, and a representative frame was inspected. The formerly failing Tauri background-hotkey cell passed all declared oracles including `NoLeakedInput`.

Scope caveat from current source: runtime-owned sessions normally expire after 300 idle seconds. An explicit named session must be repeated on later calls; starting that name does not revive a distinct unnamed implicit session. Current code supports same-owner explicit named revival after cleanup, but this transport test does not exercise ordinary expiry/revival or the historical v0.21.0 sequence. #3329 remains open for that reproduction.

Draft retained. Linux and Windows canonical certification, ordinary CI, and the 20-minute controlled Windows recovery diagnostic are complete at the current candidate. Remaining gates: macOS canonical execution is blocked by the host active-VM limit, and maintainer review remains required. No unrelated VM was stopped. The originally proposed Server 2025 Fleet replay and historical/default-TTL reproduction remain pending. No original-root-cause resolution, complete cross-platform certification, merge, or release is claimed.
