### PR TITLE
test(cua-driver): verify live Windows executable grants

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/browser_platform.rs
@@ -1966,6 +1966,43 @@ mod tests {
         assert_eq!(executable.as_deref(), Some(expected.as_str()));
     }
 
+    #[tokio::test]
+    async fn live_executable_grant_matches_without_installed_app_identity() {
+        use cua_driver_core::session_manifest::load_manifest;
+        use std::io::Write;
+
+        let pid = i64::from(std::process::id());
+        let fingerprint = WindowsBrowserPlatform::default()
+            .process_fingerprint(pid)
+            .await
+            .expect("live Windows process identity");
+        let directory = tempfile::tempdir().unwrap();
+        for (executable, allowed) in [
+            (std::env::current_exe().unwrap(), true),
+            (directory.path().join("ungranted-application.exe"), false),
+        ] {
+            let mut file = tempfile::NamedTempFile::new().unwrap();
+            write!(file, "version: 3\nallow:\n  tools: [get_window_state, click]\nresources:\n  apps:\n    - executable: {}\n      windows: all\n",
+                serde_json::to_string(&executable).unwrap()).unwrap();
+            let manifest = load_manifest(file.path()).unwrap();
+            for (adapter, kind) in [
+                ("private_observation", "window"),
+                ("desktop_input", "window_input"),
+            ] {
+                let resource = serde_json::json!({
+                    "kind": kind,
+                    "pid": pid,
+                    "window_id": 7,
+                    "fingerprint": fingerprint,
+                    "bundle_id": null,
+                    "launch_path": null,
+                });
+                assert_eq!(manifest.authorize_protected_resource(adapter, &resource).is_ok(), allowed,
+                    "{adapter} must use the live executable fingerprint even without an installed-app match");
+            }
+        }
+    }
+
     #[test]
     fn isolated_browser_candidates_are_vendor_attested_protected_installs() {
         let candidates = isolated_browser_candidates_from_roots(


### PR DESCRIPTION
Issue #3330 reports that Windows bounded application grants cannot match processes without installed-app identity fields. Main already canonicalizes live Windows executable fingerprints (#3299), and shared authorization enriches resources with those fingerprints before grant matching.

Add a Windows-native regression across that boundary: collect the live test process fingerprint, load a v3 executable manifest, and verify both observation and input grants with null `bundle_id` and `launch_path`. The exact executable is allowed and a different executable is denied. This is test coverage; no authorization behavior changes.

Refs #3330.

Validation:
- `cargo fmt --all -- --check` and `git diff --check` pass.
- [Windows run 34056147716](https://github.com/trycua/cua/actions/runs/34056147716) passed the complete job and explicitly executed `live_executable_grant_matches_without_installed_app_identity`. Its PR-merge checkout tree exactly matches candidate `d301ae0287986474c2823ded6217da55a371c473`.
- Tested candidate `5996b0667d14a441506909453126885f725d1cfa` is rebased onto main after #3596 with an identical patch. [Windows run 34065623076](https://github.com/trycua/cua/actions/runs/34065623076) passed, including all 586 core tests and the live executable-grant regression. All ordinary PR checks passed or were skipped by workflow conditions.
- Final head `b9077d6cf68fede6e6c5905fbf7487b4f257b8f0` rebases over intervening Fleet documentation merges. Compared with the passing candidate, only Fleet documentation and its dedicated tutorial test/workflow differ. The grant patch, complete Driver source/tests, and every Driver CI workflow are identical. Existing Windows behavioral evidence remains applicable; fresh required merge checks are revalidated.
- The window ID in this test is synthetic. This proves native identity collection plus grant matching, not actual window ownership, capture, input, or bounded enumeration. Server 2025 end-to-end replay remains required before resolving the issue.

`no-release` accounts for the test-only edit in a release-tracked source file. Release publication is excluded.
