### PR TITLE
fix(docs): restore Cua CLI navigation group

### DIFF
--- a/docs/content/docs/reference/cua-cli/index.mdx
+++ b/docs/content/docs/reference/cua-cli/index.mdx
@@ -1,0 +1,10 @@
+---
+title: Cua CLI reference
+description: Commands, authentication, and MCP server reference for the cua CLI.
+---
+
+Use this reference for the `cua` command-line interface:
+
+- [CLI reference](/reference/cua-cli/cli-reference) documents commands and options.
+- [Authentication](/reference/cua-cli/authentication) covers stored credentials and Fleet access.
+- [MCP server](/reference/cua-cli/mcp-server) documents `cua serve-mcp`, permissions, and exposed tools.

--- a/docs/content/docs/reference/cua-cli/meta.json
+++ b/docs/content/docs/reference/cua-cli/meta.json
@@ -1,1 +1,1 @@
-{ "title": "Cua CLI", "pages": ["cli-reference", "authentication", "mcp-server"] }
+{ "title": "Cua CLI", "pages": ["index", "cli-reference", "authentication", "mcp-server"] }


### PR DESCRIPTION
## What changed

- add a landing page for the Cua CLI reference section
- register the landing page first in the Cua CLI navigation metadata
- preserve the existing CLI reference, authentication, and MCP server URLs

## Root cause

The website product navigation flattens the Fumadocs source tree. A reference folder only survives that flattening as a labeled navigation item when it has a landing page (`href`). `reference/cua-cli` had metadata and child pages but no `index.mdx`, so the `Cua CLI` folder node had no link and was dropped; its children, including `MCP server`, appeared directly in the Cloud Fleets reference list.

## Validation

- `corepack pnpm exec prettier --check content/docs/reference/cua-cli/meta.json content/docs/reference/cua-cli/index.mdx`
- `corepack pnpm run docs:check-links`
- `corepack pnpm run docs:check-hygiene`
- `corepack pnpm run build`
- rendered `/docs/reference/cua-cli/mcp-server` locally and confirmed the sidebar includes the `/docs/reference/cua-cli` landing link and the MCP server child link