### PR TITLE
docs: align task entry points and tutorial labels

### DIFF
--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -3,27 +3,37 @@ title: 'Cua documentation'
 description: 'Open-source computer-use automation for real machines and isolated desktops.'
 ---
 
-Cua is an open-source MIT-licensed platform ([github.com/trycua/cua](https://github.com/trycua/cua)) for **computer-use automation**: letting AI agents operate computers by clicking, typing, and reading the screen and accessibility tree. What we refer to as **Computer-Use 2.0** treats the GUI as one tool surface in an agent loop, alongside code, shell, files, and APIs. Use Cua Driver to drive a machine you already have, Cua Sandbox to start an isolated desktop locally or in a Cloud Fleet, or Cua-Bench to evaluate computer-use agents.
+Cua is an open-source MIT-licensed platform ([github.com/trycua/cua](https://github.com/trycua/cua)) for **computer-use automation**: letting AI agents operate computers by clicking, typing, and reading the screen and accessibility tree. What we refer to as **Computer-Use 2.0** treats the GUI as one tool surface in an agent loop, alongside code, shell, files, and APIs. Use Cloud Fleets to provision isolated cloud desktops, Cua Driver to operate a machine you already have, Lume to manage local macOS VMs, or Cua-Bench to evaluate computer-use agents.
 
 For live service availability and incident updates, see [Cua Status](https://status.cua.ai).
 
 import { Card, Cards } from 'fumadocs-ui/components/card';
 
+## Choose your path
+
 <Cards>
+  <Card title="Your first Cloud Fleet" href="/tutorials/your-first-cloud-fleet">
+    Provision a Cloud Fleet, claim an isolated Linux desktop, run a command, save a screenshot, and
+    delete the cloud resources when you finish.
+  </Card>
   <Card title="Drive a real app — Cua Driver" href="/tutorials/drive-your-first-app">
     Run a background driver on macOS, Windows, or Linux so an agent can operate native GUI apps you
     already have without bringing them to the foreground or moving the real mouse. It speaks MCP
     over stdio and is also a plain CLI.
   </Card>
-  <Card title="Start a cloud desktop — Cua Sandbox" href="/tutorials/your-first-cloud-fleet">
-    Provision a Cloud Fleet, claim a fresh isolated Linux desktop, run a useful operation, and
-    delete the cloud resources when you finish.
+  <Card title="Create a local macOS VM with Lume" href="/tutorials/create-your-first-lume-vm">
+    Install Lume on an Apple Silicon Mac, create a vanilla Tahoe guest, and connect over SSH.
   </Card>
-  <Card title="Evaluate agents with Cua-Bench" href="/concepts/what-is-cua-bench">
-    Define verifiable computer-use tasks, run agents across local or hosted environments, and score
-    the resulting trajectories.
+  <Card title="Build your first Cua-Bench task" href="/tutorials/your-first-cua-bench-task">
+    Create and verify a simulated computer-use task before evaluating agents.
   </Card>
 </Cards>
+
+Local sandboxes and Cloud Fleets share the [Sandbox SDK](/reference/sandbox-sdk),
+but their credentials, images, connections, and cleanup behavior differ. Start
+with [How sandboxes work](/concepts/how-sandboxes-work) for the shared model and
+[Runtime support](/reference/sandbox-sdk/runtime-support) for the differences.
+The Lume tutorial uses the Lume CLI directly, not the Sandbox SDK.
 
 Building Cua Driver into your own product? Start with [Choose a Cua Driver
 integration](/concepts/choose-a-cua-driver-integration) to decide whether MCP,
@@ -55,7 +65,7 @@ These recordings show agents operating desktop apps while the user's active wind
 
 ## How these docs are organised
 
-Get Started: learn by doing. Start with [Get Started](/tutorials).
+Tutorials: learn by doing. [Choose a first tutorial](/tutorials).
 
 Concepts: understand how and why Cua works. Start with [Concepts](/concepts).
 
@@ -65,4 +75,10 @@ How-to guides: recipes for a goal. Start with [How-to guides](/how-to-guides).
 
 Reference: precise technical description. Start with [Reference](/reference).
 
-For existing apps and signed-in state, start with **Cua Driver**. For fresh isolated desktops, start with **Cua Sandbox** and choose local or Cloud Fleet execution. Lume is the local Apple Silicon VM substrate behind part of the stack.
+## Find a tool or API
+
+- [Cloud Fleets overview](/cloud-fleets): pools, claims, and cloud capacity.
+- [Sandbox SDK reference](/reference/sandbox-sdk): the shared Python API and its runtime-specific contracts.
+- [Cua CLI reference](/reference/cua-cli/cli-reference): the general command-line interface, with separate [authentication](/reference/cua-cli/authentication) and [CLI MCP server](/reference/cua-cli/mcp-server) references.
+- [Lume reference](/reference/lume/cli-reference): local VM commands.
+- [Connect your agent to Cua docs](/how-to-guides/agent-context/connect-your-agent-to-cua-docs): documentation lookup, distinct from controlling a desktop with Driver.

--- a/docs/content/docs/tutorials/create-your-first-lume-vm.mdx
+++ b/docs/content/docs/tutorials/create-your-first-lume-vm.mdx
@@ -1,11 +1,14 @@
 ---
-title: Local macOS sandboxes with Lume
+title: Create a local macOS VM with Lume
 description: Install Lume and create a vanilla macOS Tahoe VM from an Apple restore image.
 ---
 
 This tutorial walks through one complete local VM setup on an Apple Silicon Mac.
 You will install Lume, download a Tahoe restore image, create a vanilla VM, and
 connect to it over SSH.
+
+This path uses the Lume CLI directly. It does not create a Cloud Fleet or
+connect the Sandbox SDK to the VM.
 
 ## Before you start
 

--- a/docs/content/docs/tutorials/index.mdx
+++ b/docs/content/docs/tutorials/index.mdx
@@ -1,15 +1,23 @@
 ---
-title: 'Get Started'
+title: 'Start here'
 description: 'Learn Cua by following end-to-end builds.'
 ---
 
-Get started with Cua by building something end to end. Each tutorial is *one happy path* you can follow from start to finish.
+Choose the tutorial that matches where you want to work. Each tutorial follows
+one path from setup to a verifiable result.
 
-- [Drive your first app with Cua Driver](/tutorials/drive-your-first-app) - operate a native app in the background.
 - [Your first Cloud Fleet](/tutorials/your-first-cloud-fleet) - provision an isolated Linux desktop in the cloud and clean it up.
-- [Local macOS sandboxes with Lume](/tutorials/create-your-first-lume-vm) - install Lume and boot a vanilla Tahoe guest.
+- [Drive your first app with Cua Driver](/tutorials/drive-your-first-app) - operate a native app on a machine you already have.
+- [Create a local macOS VM with Lume](/tutorials/create-your-first-lume-vm) - install Lume, boot a vanilla Tahoe guest, and connect over SSH.
 - [Build your first Cua-Bench task](/tutorials/your-first-cua-bench-task) - create and verify a simulated computer-use task.
 
-Building a Python or TypeScript application? [Use Cua Driver in process](/how-to-guides/driver/use-sdk-in-process) after completing the first tutorial.
+The Fleet tutorial needs Fleet credentials and account access. The Driver
+tutorial acts on your existing desktop. The Lume tutorial uses its CLI on an
+Apple Silicon Mac; it is not a local Sandbox SDK tutorial. Each page lists its
+own prerequisites.
+
+Building a Python or TypeScript application with Driver? [Use Cua Driver in
+process](/how-to-guides/driver/use-sdk-in-process) after completing the Driver
+tutorial.
 
 Once you are comfortable, [How-to guides](/how-to-guides) cover specific goals and [Reference](/reference) has the exact APIs.

--- a/docs/content/docs/tutorials/meta.json
+++ b/docs/content/docs/tutorials/meta.json
@@ -1,10 +1,10 @@
 {
-  "title": "Get Started",
+  "title": "Start here",
   "icon": "GraduationCap",
   "pages": [
     "index",
-    "drive-your-first-app",
     "your-first-cloud-fleet",
+    "drive-your-first-app",
     "create-your-first-lume-vm",
     "your-first-cua-bench-task"
   ]


### PR DESCRIPTION
Refs #3603.

## Changes
- Feature Cloud Fleet before Driver in landing cards, the tutorial index, and tutorial metadata.
- Label the existing Lume tutorial for its actual outcome: creating a local macOS VM through the Lume CLI.
- Link the shared Sandbox SDK, runtime differences, standalone CLI references, and docs-agent setup without implying local/Fleet parity.
- Preserve all URLs, existing anchors, and executable tutorial examples.

## Validation
- Documentation hygiene: pass.
- Internal links: 0 errored files, 0 errors.
- Prettier on all four modified files: pass.
- Production Fumadocs build: pass, 139 content routes (142 generated pages including framework routes).
- Compared fenced code in all changed MDX against main: unchanged.
- Tutorial metadata assertion confirms Fleet first.
- git diff --check: pass.

## Scope and remaining gate
Four curated docs files only; no generated references, package behavior, runtime qualification, or deployment changes. Combined rendering and CI evidence will be added after the independent navigation and focused-guide work is reviewed. Keep open for human review; do not merge automatically.

## Combined content review evidence (September 6, 2026)

Final-head CI passes. The combined content build generates 142 documentation pages and passes internal-link checks. All 142 HTML pages and their Markdown twins return HTTP 200 in the combined production-renderer local preview. Cua Driver in isolated Chrome verifies desktop/narrow rendering of the changed entry points and guides, with explicit DOM-click checks for onward links and preserved credential anchors. This is documentation/rendering proof, not a new live Fleet provisioning test. Independent content review found no actionable issues. This PR remains draft and unmerged.
