### PR TITLE
docs: link product entry pages to first tutorials

### DIFF
--- a/docs/content/docs/concepts/what-is-cua-bench.mdx
+++ b/docs/content/docs/concepts/what-is-cua-bench.mdx
@@ -7,6 +7,9 @@ Cua-Bench is an MIT-licensed framework for computer-use benchmarks and reinforce
 environments. It packages the task, starting state, agent interface, and evaluator needed to run a
 repeatable experiment across Linux, Windows, Android, browser, or simulated environments.
 
+New to Cua-Bench? Follow [Build your first Cua-Bench task](/tutorials/your-first-cua-bench-task)
+to create and verify a small simulated task.
+
 <VideoDemo
   className="my-8"
   src="https://github.com/user-attachments/assets/35bf5156-d326-4484-ad1a-87a7991c85f6"

--- a/docs/content/docs/how-to-guides/driver/install.mdx
+++ b/docs/content/docs/how-to-guides/driver/install.mdx
@@ -8,6 +8,8 @@ import { Callout } from 'fumadocs-ui/components/callout';
 
 Cua Driver supports macOS, Windows, and Linux. Use the same **one-line installer** on each platform; the script selects the right install path for the host and _does not require administrator access_.
 
+New to Cua Driver? Follow [Drive your first app](/tutorials/drive-your-first-app) for a guided walkthrough from installation to your first app interaction.
+
 <Callout type="info">
   Cua Driver sends content-free product telemetry by default. The installer shows this notice before
   the first event. Run `cua-driver telemetry disable` at any time to stop telemetry; the preference


### PR DESCRIPTION
## Summary

Readers arriving directly at the Cua Driver installation guide or Cua-Bench overview need an easy path to a guided first task. Add a short newcomer link near each introduction to the existing product tutorial.

## Related work

No linked issue. This is a focused documentation navigation improvement.

## Compatibility and risk

Only two introductory paragraphs are added. No code samples, product claims, routes, or APIs change. Rollback is removal of those paragraphs.

## Validation

- Prettier check passed for both edited MDX files.
- Documentation internal-link check passed: 0 errored files, 0 errors.
- Public documentation hygiene check passed.
- `git diff --check` passed.
- Verified both tutorial destinations exist and the entry pages did not already link to them.
- Full application build not run for this link-only change; PR CI remains pending.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This documentation-only change does not require an RFC.
- [x] Focused verification is included and the build gap is explained.
- [x] The PR title is a Conventional Commit.
- [x] No external contribution is included.
- [x] No release-tracked product files changed.
