### PR TITLE
fix(cua-driver): isolate screenshot transforms between clients

### DIFF
--- a/libs/cua-driver/docs/screenshot-transform-isolation.md
+++ b/libs/cua-driver/docs/screenshot-transform-isolation.md
@@ -38,10 +38,13 @@ Metadata clarification remains tracked in
   clients and windows, explicit native transforms, missing-context refusal,
   ambiguous windowless lookup, concurrent capture, session cleanup, and late
   publication after cleanup.
-- The canonical AppKit `harness_appkit_counter_px_background` row captures a
-  small screenshot, obtains a differently sized capture through another MCP
-  connection, then requires the first client's pixel click to increment the
-  fixture counter. Its existing background desktop oracles remain in force.
+- The canonical AppKit `harness_appkit_counter_px_background`, WPF
+  `harness_wpf_left_click_px_background`, and supported GTK3 left-click pixel
+  rows capture a small screenshot, obtain a differently sized capture through
+  another MCP connection to the same daemon, then require the first client's
+  pixel click to change the expected fixture state. Their existing desktop
+  oracles remain in force. The second connection does not allocate an unrelated
+  behavior recording.
 - Ordinary Linux and Windows CI compile the adapter changes on their native
   targets. Host-only checks of those crates on macOS are not native coverage.
 
@@ -59,6 +62,11 @@ session still replaces its earlier transform. The caller must use its latest
 image. Window movement, resize, display transitions, zoom-context ownership,
 and recording rendered against a different image size require their own
 acceptance evidence; this change does not claim to solve them all.
+
+On a compositor that cannot produce a window image, the common missing-context
+precondition can precede the adapter's background-delivery refusal. The existing
+Wayland refusal rows require explicit reconciliation and native verification
+before readiness; supported X11 coverage is not a substitute for those rows.
 
 Before readiness, run the canonical desktop gates at the stable candidate SHA
 and retain the tested artifact identity. Do not replace those gates with the

--- a/libs/cua-driver/docs/screenshot-transform-isolation.md
+++ b/libs/cua-driver/docs/screenshot-transform-isolation.md
@@ -1,0 +1,65 @@
+# Screenshot transform ownership
+
+Window screenshot coordinates belong to the lifecycle session that obtained the
+image. The shared resize registry keys each transform by private session
+identity, PID, and window ID. A native-size capture records an explicit identity
+transform; it does not remove another session's downscale information.
+
+The macOS, Windows, and Linux adapters publish and consume the same registry.
+Session cleanup drops that session's entries, and a completed capture cannot
+recreate entries after its session has ended. Linux recording-point conversion
+and delegated pixel-focus operations use the originating session's transform.
+
+Before a public window-pixel action is dispatched, the common tool registry
+requires a known transform for that session and target. Missing or ambiguous
+context returns `screenshot_context_missing` rather than borrowing another
+client's transform or treating resized coordinates as native pixels. Desktop,
+semantic element, and explicit zoom routes keep their existing coordinate
+contracts. Internally delegated element-focus clicks are not public screenshot
+requests and retain their native geometry conversion.
+
+## Client usage
+
+Keep capture and pixel action on the same persistent MCP connection. For
+multi-call CLI work, repeat the same explicit `session` label on capture and
+action. Unnamed one-shot CLI calls have disposable lifecycle identities; a
+later process cannot adopt the earlier process's screenshot context. It must
+capture within a retained session instead of silently clicking with a missing
+resize ratio.
+
+This does not change `screenshot_scale`: on macOS that remains the proven
+native capture backing scale, not the resize ratio of the delivered PNG.
+Metadata clarification remains tracked in
+[#1882](https://github.com/trycua/cua/issues/1882).
+
+## Regression coverage
+
+- `cargo test -p cua-driver-core image_resize --lib --locked` covers independent
+  clients and windows, explicit native transforms, missing-context refusal,
+  ambiguous windowless lookup, concurrent capture, session cleanup, and late
+  publication after cleanup.
+- The canonical AppKit `harness_appkit_counter_px_background` row captures a
+  small screenshot, obtains a differently sized capture through another MCP
+  connection, then requires the first client's pixel click to increment the
+  fixture counter. Its existing background desktop oracles remain in force.
+- Ordinary Linux and Windows CI compile the adapter changes on their native
+  targets. Host-only checks of those crates on macOS are not native coverage.
+
+The installed macOS 0.23.2 baseline delivered a target click, a wrong-region
+click after another client's native capture, and a target click after refresh.
+That diagnostic used a disposable native receiver and independent mouse-event
+logs; it is not exact-candidate certification.
+
+## Remaining boundaries
+
+This is a session-isolation correction, not a new image-token protocol or a
+replacement for the snapshot lifecycle work in
+[#3616](https://github.com/trycua/cua/pull/3616). A later capture within the same
+session still replaces its earlier transform. The caller must use its latest
+image. Window movement, resize, display transitions, zoom-context ownership,
+and recording rendered against a different image size require their own
+acceptance evidence; this change does not claim to solve them all.
+
+Before readiness, run the canonical desktop gates at the stable candidate SHA
+and retain the tested artifact identity. Do not replace those gates with the
+installed-version baseline or arithmetic-only tests.

--- a/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
@@ -948,6 +948,13 @@ Passing `window_id` alongside `x, y` is optional but recommended —
 it pins the coordinate conversion to the window whose screenshot
 produced the pixel.
 
+Keep the screenshot and pixel action in the same lifecycle session. Another
+client's capture must not change your coordinate transform. If the current
+session has no matching screenshot context, the driver returns
+`screenshot_context_missing` instead of guessing. For multi-call CLI work,
+repeat the same explicit `session` label on capture and action; unnamed
+one-shot CLI calls cannot carry screenshot context into the next process.
+
 PNGs returned by `get_window_state` are capped at **1568 px long-side
 by default** (`max_image_dimension` config), matching Anthropic's
 multimodal-vision downsampling limit. The image the model reasons

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/image_resize.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/image_resize.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+type WindowRatios = HashMap<(u32, Option<u64>), f64>;
+
 #[derive(Default)]
 pub struct ResizeRegistry {
-    owners: Mutex<HashMap<Option<String>, HashMap<(u32, Option<u64>), f64>>>,
+    owners: Mutex<HashMap<Option<String>, WindowRatios>>,
 }
 
 impl ResizeRegistry {
@@ -51,6 +53,58 @@ impl ResizeRegistry {
             }
         }
         agreed
+    }
+
+    pub fn pixel_refusal(
+        &self,
+        tool: &str,
+        args: &serde_json::Value,
+    ) -> Option<crate::protocol::ToolResult> {
+        if !matches!(
+            tool,
+            "click"
+                | "double_click"
+                | "right_click"
+                | "drag"
+                | "scroll"
+                | "type_text"
+                | "type_text_chars"
+                | "press_key"
+                | "hotkey"
+                | "mouse_button_down"
+                | "mouse_drag"
+                | "mouse_button_up"
+        ) || args.get("scope").and_then(serde_json::Value::as_str) == Some("desktop")
+            || args.get("from_zoom").and_then(serde_json::Value::as_bool) == Some(true)
+            || args
+                .get("element_token")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|token| !token.is_empty())
+            || args
+                .get("element_index")
+                .and_then(serde_json::Value::as_u64)
+                .is_some()
+            || !["x", "y", "from_x", "from_y", "to_x", "to_y"]
+                .iter()
+                .any(|key| args.get(*key).is_some())
+        {
+            return None;
+        }
+        let session = args
+            .get("_session_id")
+            .and_then(serde_json::Value::as_str)?;
+        let pid = u32::try_from(args.get("pid")?.as_u64()?).ok()?;
+        let window_id = args.get("window_id").and_then(serde_json::Value::as_u64);
+        if self.ratio(Some(session), pid, window_id).is_some() {
+            return None;
+        }
+        Some(crate::protocol::ToolResult::error(
+            "No screenshot coordinate frame is available for this session and window. Call get_window_state with a screenshot on the same connection before using pixels. For multi-call CLI work, repeat the same explicit session label on capture and action."
+        ).with_structured(serde_json::json!({
+            "code": "screenshot_context_missing",
+            "pid": pid,
+            "window_id": window_id
+        })))
     }
 
     pub fn clear_session(&self, session: &str) {
@@ -123,6 +177,85 @@ mod tests {
         assert_eq!(registry.ratio(Some("resize-one"), 10, None), Some(2.0));
         registry.set_ratio(Some("resize-one"), 10, Some(21), 3.0);
         assert_eq!(registry.ratio(Some("resize-one"), 10, None), None);
+    }
+
+    #[test]
+    fn new_session_refuses_pixels_instead_of_borrowing_or_guessing_a_transform() {
+        let registry = ResizeRegistry::new();
+        registry.set_ratio(Some("resize-owner-context"), 10, Some(20), 7.35);
+        let args = serde_json::json!({"_session_id": "resize-new-context", "pid": 10, "window_id": 20, "x": 99.5, "y": 62.5});
+        let refusal = registry
+            .pixel_refusal("click", &args)
+            .expect("missing owner frame must refuse");
+        assert_eq!(
+            refusal.structured_content.unwrap()["code"],
+            "screenshot_context_missing"
+        );
+        let mut null_target = args.clone();
+        null_target["element_token"] = serde_json::Value::Null;
+        null_target["element_index"] = serde_json::Value::Null;
+        assert!(registry.pixel_refusal("click", &null_target).is_some());
+        registry.set_ratio(Some("resize-new-context"), 10, Some(20), 1.0);
+        assert!(registry.pixel_refusal("click", &args).is_none());
+    }
+
+    #[test]
+    fn desktop_zoom_and_semantic_actions_do_not_require_a_window_image_transform() {
+        let registry = ResizeRegistry::new();
+        for extra in [
+            serde_json::json!({"scope":"desktop"}),
+            serde_json::json!({"from_zoom":true}),
+            serde_json::json!({"element_token":"s00000001:0"}),
+        ] {
+            let mut args = serde_json::json!({"_session_id":"resize-exempt", "pid":10, "window_id":20, "x":1, "y":2});
+            args.as_object_mut()
+                .unwrap()
+                .extend(extra.as_object().unwrap().clone());
+            assert!(registry.pixel_refusal("click", &args).is_none());
+        }
+        assert!(registry
+            .pixel_refusal(
+                "get_window_state",
+                &serde_json::json!({"_session_id":"resize-exempt", "pid":10, "window_id":20})
+            )
+            .is_none());
+    }
+
+    #[test]
+    fn session_end_hook_removes_state_and_rejects_late_capture_publication() {
+        let registry = std::sync::Arc::new(ResizeRegistry::new());
+        let ending = format!("resize-end-{}", uuid::Uuid::new_v4());
+        let cleanup = registry.clone();
+        let _hook = crate::session::register_scoped_session_end_hook(move |session| {
+            cleanup.clear_session(session);
+        });
+        registry.set_ratio(Some(&ending), 10, Some(20), 7.35);
+        assert!(crate::session::fire_session_end(&ending));
+        assert_eq!(registry.ratio(Some(&ending), 10, Some(20)), None);
+        registry.set_ratio(Some(&ending), 10, Some(20), 2.0);
+        assert_eq!(registry.ratio(Some(&ending), 10, Some(20)), None);
+        assert!(registry.owners.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn concurrent_capture_does_not_change_another_clients_pixel_transform() {
+        let registry = std::sync::Arc::new(ResizeRegistry::new());
+        registry.set_ratio(Some("resize-concurrent-a"), 10, Some(20), 7.35);
+        let writer = registry.clone();
+        let thread = std::thread::spawn(move || {
+            for _ in 0..1000 {
+                writer.set_ratio(Some("resize-concurrent-b"), 10, Some(20), 2.0);
+                writer.clear_ratio(Some("resize-concurrent-b"), 10, Some(20));
+            }
+        });
+        for _ in 0..1000 {
+            let ratio = registry
+                .ratio(Some("resize-concurrent-a"), 10, Some(20))
+                .unwrap();
+            assert!((99.5 * ratio - 731.325).abs() < 1e-9);
+            assert!((62.5 * ratio - 459.375).abs() < 1e-9);
+        }
+        thread.join().unwrap();
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/image_resize.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/image_resize.rs
@@ -1,0 +1,141 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+#[derive(Default)]
+pub struct ResizeRegistry {
+    owners: Mutex<HashMap<Option<String>, HashMap<(u32, Option<u64>), f64>>>,
+}
+
+impl ResizeRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set_ratio(&self, session: Option<&str>, pid: u32, window_id: Option<u64>, ratio: f64) {
+        let mut owners = self.owners.lock().unwrap();
+        if session.is_some_and(crate::session::is_session_ended) {
+            return;
+        }
+        owners
+            .entry(session.map(str::to_owned))
+            .or_default()
+            .insert((pid, window_id), ratio);
+    }
+
+    pub fn clear_ratio(&self, session: Option<&str>, pid: u32, window_id: Option<u64>) {
+        let mut owners = self.owners.lock().unwrap();
+        let owner = session.map(str::to_owned);
+        if let Some(ratios) = owners.get_mut(&owner) {
+            ratios.remove(&(pid, window_id));
+            if ratios.is_empty() {
+                owners.remove(&owner);
+            }
+        }
+    }
+
+    pub fn ratio(&self, session: Option<&str>, pid: u32, window_id: Option<u64>) -> Option<f64> {
+        let owners = self.owners.lock().unwrap();
+        let ratios = owners.get(&session.map(str::to_owned))?;
+        if let Some(window_id) = window_id {
+            return ratios.get(&(pid, Some(window_id))).copied();
+        }
+        let mut agreed = None;
+        for (_, &ratio) in ratios
+            .iter()
+            .filter(|((owner_pid, _), _)| *owner_pid == pid)
+        {
+            match agreed {
+                None => agreed = Some(ratio),
+                Some(previous) if (previous - ratio).abs() < 1e-9 => {}
+                Some(_) => return None,
+            }
+        }
+        agreed
+    }
+
+    pub fn clear_session(&self, session: &str) {
+        self.owners
+            .lock()
+            .unwrap()
+            .remove(&Some(session.to_owned()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_capture_by_another_client_does_not_clear_the_resize_ratio() {
+        let registry = ResizeRegistry::new();
+        registry.set_ratio(Some("resize-client-a"), 10, Some(20), 7.35);
+        registry.clear_ratio(Some("resize-client-b"), 10, Some(20));
+        assert_eq!(
+            registry.ratio(Some("resize-client-a"), 10, Some(20)),
+            Some(7.35)
+        );
+        assert_eq!(registry.ratio(Some("resize-client-b"), 10, Some(20)), None);
+    }
+
+    #[test]
+    fn differently_resized_captures_are_isolated_by_client_and_window() {
+        let registry = ResizeRegistry::new();
+        registry.set_ratio(Some("resize-a"), 10, Some(20), 7.35);
+        registry.set_ratio(Some("resize-b"), 10, Some(20), 2.0);
+        registry.set_ratio(Some("resize-a"), 10, Some(21), 3.0);
+        assert_eq!(registry.ratio(Some("resize-a"), 10, Some(20)), Some(7.35));
+        assert_eq!(registry.ratio(Some("resize-b"), 10, Some(20)), Some(2.0));
+        assert_eq!(registry.ratio(Some("resize-a"), 10, Some(21)), Some(3.0));
+    }
+
+    #[test]
+    fn same_client_native_capture_clears_only_its_exact_window() {
+        let registry = ResizeRegistry::new();
+        registry.set_ratio(Some("resize-owner"), 10, Some(20), 7.35);
+        registry.set_ratio(Some("resize-owner"), 10, Some(21), 2.0);
+        registry.clear_ratio(Some("resize-owner"), 10, Some(20));
+        assert_eq!(registry.ratio(Some("resize-owner"), 10, Some(20)), None);
+        assert_eq!(
+            registry.ratio(Some("resize-owner"), 10, Some(21)),
+            Some(2.0)
+        );
+    }
+
+    #[test]
+    fn anonymous_calls_do_not_borrow_a_named_clients_ratio() {
+        let registry = ResizeRegistry::new();
+        registry.set_ratio(Some("resize-named"), 10, Some(20), 7.35);
+        registry.set_ratio(None, 10, Some(20), 2.0);
+        assert_eq!(registry.ratio(None, 10, Some(20)), Some(2.0));
+        assert_eq!(
+            registry.ratio(Some("resize-named"), 10, Some(20)),
+            Some(7.35)
+        );
+        assert_eq!(registry.ratio(Some("resize-new"), 10, Some(20)), None);
+    }
+
+    #[test]
+    fn windowless_lookup_never_crosses_owner_or_ambiguous_windows() {
+        let registry = ResizeRegistry::new();
+        registry.set_ratio(Some("resize-one"), 10, Some(20), 2.0);
+        registry.set_ratio(Some("resize-one"), 10, Some(21), 2.0);
+        registry.set_ratio(Some("resize-two"), 10, Some(20), 7.35);
+        assert_eq!(registry.ratio(Some("resize-one"), 10, None), Some(2.0));
+        registry.set_ratio(Some("resize-one"), 10, Some(21), 3.0);
+        assert_eq!(registry.ratio(Some("resize-one"), 10, None), None);
+    }
+
+    #[test]
+    fn disconnect_clears_only_the_ending_client() {
+        let registry = ResizeRegistry::new();
+        registry.set_ratio(Some("resize-ending"), 10, Some(20), 7.35);
+        registry.set_ratio(Some("resize-survivor"), 10, Some(20), 2.0);
+        registry.clear_session("resize-ending");
+        assert_eq!(registry.ratio(Some("resize-ending"), 10, Some(20)), None);
+        assert_eq!(
+            registry.ratio(Some("resize-survivor"), 10, Some(20)),
+            Some(2.0)
+        );
+        assert_eq!(registry.owners.lock().unwrap().len(), 1);
+    }
+}

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/image_resize.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/image_resize.rs
@@ -120,15 +120,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn native_capture_by_another_client_does_not_clear_the_resize_ratio() {
+    fn native_capture_by_another_client_preserves_both_transforms() {
         let registry = ResizeRegistry::new();
         registry.set_ratio(Some("resize-client-a"), 10, Some(20), 7.35);
-        registry.clear_ratio(Some("resize-client-b"), 10, Some(20));
+        registry.set_ratio(Some("resize-client-b"), 10, Some(20), 1.0);
         assert_eq!(
             registry.ratio(Some("resize-client-a"), 10, Some(20)),
             Some(7.35)
         );
-        assert_eq!(registry.ratio(Some("resize-client-b"), 10, Some(20)), None);
+        assert_eq!(
+            registry.ratio(Some("resize-client-b"), 10, Some(20)),
+            Some(1.0)
+        );
     }
 
     #[test]
@@ -143,7 +146,7 @@ mod tests {
     }
 
     #[test]
-    fn same_client_native_capture_clears_only_its_exact_window() {
+    fn capture_invalidation_clears_only_its_exact_window() {
         let registry = ResizeRegistry::new();
         registry.set_ratio(Some("resize-owner"), 10, Some(20), 7.35);
         registry.set_ratio(Some("resize-owner"), 10, Some(21), 2.0);

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/lib.rs
@@ -65,6 +65,7 @@ pub mod expectation;
 pub mod ffmpeg_install;
 pub mod health_report;
 pub mod history;
+pub mod image_resize;
 pub mod image_utils;
 pub mod page;
 pub mod pip_hook;

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -633,6 +633,7 @@ pub struct ToolRegistry {
     order: Vec<String>,
     /// Shared recording session — auto-records each non-read-only tool call.
     pub recording: Arc<RecordingSession>,
+    pub image_resize: Option<Arc<crate::image_resize::ResizeRegistry>>,
     /// Optional encrypted Computer History runtime. It is installed only by a
     /// trusted host that admitted the experimental preview.
     history: Option<Arc<crate::history::HistoryManager>>,
@@ -702,6 +703,7 @@ impl ToolRegistry {
             tools: HashMap::new(),
             order: Vec::new(),
             recording,
+            image_resize: None,
             history: None,
             replay_registry: Arc::new(std::sync::Mutex::new(std::sync::Weak::new())),
             session_end_hooks: vec![session_end_hook],
@@ -1484,6 +1486,14 @@ impl ToolRegistry {
             } else {
                 None
             };
+
+        if let Some(refusal) = self
+            .image_resize
+            .as_ref()
+            .and_then(|registry| registry.pixel_refusal(resolved_name, &args))
+        {
+            return refusal;
+        }
 
         // Capture start time for recording timestamps only after validation.
         let launch_snapshot = if resolved_name == "launch_app" {
@@ -4366,6 +4376,41 @@ resources:
             serde_json::Value::Bool(true)
         );
         assert!(received.get("_protected_process_fingerprint").is_none());
+    }
+
+    #[tokio::test]
+    async fn pixel_dispatch_requires_the_trusted_sessions_screenshot_context() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let mut registry = argument_registry("click", None, hits.clone());
+        let resize = Arc::new(crate::image_resize::ResizeRegistry::new());
+        Arc::get_mut(&mut registry).unwrap().image_resize = Some(resize.clone());
+        let context = unrestricted_context();
+        let mut adapter_args = serde_json::json!({"_session_id":"pixel-owner-a", "_transport_session_id":"pixel-transport-a"});
+        let evidence = TrustedInvocationEvidence::extract_from_adapter_args(&mut adapter_args);
+        let mut namespaced = serde_json::json!({"_session_id":"pixel-owner-a"});
+        namespace_runtime_args(&mut namespaced, context.as_ref(), &evidence);
+        let owner = namespaced["_session_id"].as_str().unwrap();
+        let args = serde_json::json!({"pid":123, "window_id":456, "x":99.5, "y":62.5, "_session_id":"pixel-forged-owner"});
+        resize.set_ratio(Some("pixel-forged-owner"), 123, Some(456), 7.35);
+        let refused = registry
+            .invoke_with_context_and_evidence(
+                "click",
+                args.clone(),
+                context.clone(),
+                evidence.clone(),
+            )
+            .await;
+        assert_eq!(
+            refused.structured_content.unwrap()["code"],
+            "screenshot_context_missing"
+        );
+        assert_eq!(hits.load(Ordering::SeqCst), 0);
+        resize.set_ratio(Some(owner), 123, Some(456), 7.35);
+        let allowed = registry
+            .invoke_with_context_and_evidence("click", args, context, evidence)
+            .await;
+        assert_ne!(allowed.is_error, Some(true), "{allowed:?}");
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/mcp.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/mcp.rs
@@ -25,6 +25,7 @@ use crate::CALL_TIMEOUT;
 pub struct McpDriver {
     reaper: ChildReaper,
     _daemon: Option<TestDaemon>,
+    socket: String,
     stdin: ChildStdin,
     rx: Receiver<String>,
     next_id: u32,
@@ -95,6 +96,10 @@ impl McpDriver {
             return None;
         }
         Self::spawn_internal(&[], &["mcp", "--socket", socket], None, false, false)
+    }
+
+    pub fn spawn_peer_unrecorded(&self) -> Option<Self> {
+        Self::spawn_daemon_proxy_unrecorded(&self.socket)
     }
 
     /// Spawn the driver with extra environment variables set on the child.
@@ -188,9 +193,18 @@ impl McpDriver {
             }
         });
 
+        let socket = daemon
+            .as_ref()
+            .map(|daemon| daemon.socket.clone())
+            .or_else(|| {
+                args.windows(2)
+                    .find(|pair| pair[0] == "--socket")
+                    .map(|pair| pair[1].to_owned())
+            })?;
         let mut d = McpDriver {
             reaper,
             _daemon: daemon,
+            socket,
             stdin,
             rx,
             next_id: 2,

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
@@ -958,8 +958,9 @@ fn harness_appkit_counter_px_background() {
                 .as_u64()
                 .expect("small screenshot width");
             assert!(small_width <= 200);
-            let mut observer = McpDriver::spawn_macos_daemon_proxy_named("appkit-resize-observer")
-                .expect("start independent capture client");
+            let mut observer = driver
+                .spawn_peer_unrecorded()
+                .expect("start independent capture client on the same daemon");
             let config = observer.call("set_config", serde_json::json!({"max_image_dimension": 0}));
             assert!(
                 !config.is_error(),

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
@@ -943,8 +943,37 @@ fn harness_appkit_counter_px_background() {
         Targeting::Px,
         DriverRoute::MacosAxAction,
         |pid, wid, driver| {
+            let config = driver.call(
+                "set_config",
+                serde_json::json!({"max_image_dimension": 200}),
+            );
+            assert!(
+                !config.is_error(),
+                "small capture config: {}",
+                config.text()
+            );
             let pre = snapshot_elements(driver, pid, wid);
             let (x, y, width, height) = element_pixel_frame(&pre, "btn-increment");
+            let small_width = pre.structured()["screenshot_width"]
+                .as_u64()
+                .expect("small screenshot width");
+            assert!(small_width <= 200);
+            let mut observer = McpDriver::spawn_macos_daemon_proxy_named("appkit-resize-observer")
+                .expect("start independent capture client");
+            let config = observer.call("set_config", serde_json::json!({"max_image_dimension": 0}));
+            assert!(
+                !config.is_error(),
+                "native capture config: {}",
+                config.text()
+            );
+            let other = snapshot_elements(&mut observer, pid, wid);
+            assert!(!other.is_error(), "other client capture: {}", other.text());
+            assert!(
+                other.structured()["screenshot_width"]
+                    .as_u64()
+                    .expect("native screenshot width")
+                    > small_width
+            );
             let response = driver.call(
                 "click",
                 serde_json::json!({

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_gtk3_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_gtk3_test.rs
@@ -650,7 +650,51 @@ fn invoke_operation(
         Delivery::Foreground => "foreground",
         Delivery::NotApplicable => unreachable!("catalog operations require delivery"),
     };
+    let resize_probe = !expect_refusal
+        && matches!(
+            row.operation,
+            Operation::PxClick {
+                button: "left",
+                count: 1,
+                ..
+            }
+        );
+    if resize_probe {
+        let config = driver.call(
+            "set_config",
+            serde_json::json!({"max_image_dimension": 200}),
+        );
+        assert!(
+            !config.is_error(),
+            "small capture config: {}",
+            config.text()
+        );
+    }
     let pre = snapshot(driver, pid, window_id);
+    let _observer = resize_probe.then(|| {
+        let small_width = pre.structured()["screenshot_width"]
+            .as_u64()
+            .expect("small screenshot width");
+        assert!(small_width <= 200);
+        let mut observer = driver
+            .spawn_peer_unrecorded()
+            .expect("start independent capture client on the same daemon");
+        let config = observer.call("set_config", serde_json::json!({"max_image_dimension": 0}));
+        assert!(
+            !config.is_error(),
+            "native capture config: {}",
+            config.text()
+        );
+        let other = snapshot(&mut observer, pid, window_id);
+        assert!(!other.is_error(), "other client capture: {}", other.text());
+        assert!(
+            other.structured()["screenshot_width"]
+                .as_u64()
+                .expect("native screenshot width")
+                > small_width
+        );
+        observer
+    });
     assert!(
         !ax::looks_empty(pre.tree_text()),
         "required GTK3 AT-SPI tree is empty"

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
@@ -657,9 +657,39 @@ fn harness_wpf_left_click_px_background() {
             .expect("main window");
         wait_for_fixture_file_text(&state_path, "lbl-click-count", "clicks=0");
 
+        let config = driver.call(
+            "set_config",
+            serde_json::json!({"max_image_dimension": 200}),
+        );
+        assert!(
+            !config.is_error(),
+            "small capture config: {}",
+            config.text()
+        );
         let bounds = window_bounds(&mut driver, pid, wid);
         let ready_state = snapshot(&mut driver, pid, wid);
         let (x, y) = pixel_center(&ready_state, "border-click-target", bounds);
+        let small_width = ready_state.structured()["screenshot_width"]
+            .as_u64()
+            .expect("small screenshot width");
+        assert!(small_width <= 200);
+        let mut observer = driver
+            .spawn_peer_unrecorded()
+            .expect("start independent capture client on the same daemon");
+        let config = observer.call("set_config", serde_json::json!({"max_image_dimension": 0}));
+        assert!(
+            !config.is_error(),
+            "native capture config: {}",
+            config.text()
+        );
+        let other = snapshot(&mut observer, pid, wid);
+        assert!(!other.is_error(), "other client capture: {}", other.text());
+        assert!(
+            other.structured()["screenshot_width"]
+                .as_u64()
+                .expect("native screenshot width")
+                > small_width
+        );
         let geometry_probe = driver.call(
             "click",
             serde_json::json!({

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -91,26 +91,7 @@ pub fn load_driver_config() -> DriverConfig {
     cfg
 }
 
-pub struct ResizeRegistry {
-    ratios: std::sync::Mutex<std::collections::HashMap<u32, f64>>,
-}
-
-impl ResizeRegistry {
-    pub fn new() -> Self {
-        Self {
-            ratios: std::sync::Mutex::new(Default::default()),
-        }
-    }
-    pub fn set_ratio(&self, pid: u32, ratio: f64) {
-        self.ratios.lock().unwrap().insert(pid, ratio);
-    }
-    pub fn clear_ratio(&self, pid: u32) {
-        self.ratios.lock().unwrap().remove(&pid);
-    }
-    pub fn ratio(&self, pid: u32) -> Option<f64> {
-        self.ratios.lock().unwrap().get(&pid).copied()
-    }
-}
+pub use cua_driver_core::image_resize::ResizeRegistry;
 
 /// Per-process zoom context — stores padded crop origin and resize scale from
 /// the most recent `zoom` call so `click(from_zoom=true)` can translate
@@ -805,6 +786,7 @@ impl Tool for GetWindowStateTool {
             .and_then(|value| value.as_bool())
             == Some(true);
         let state = self.state.clone();
+        let session_id = args.opt_str("_session_id");
         let query_for_walk = query.clone();
 
         let result = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
@@ -1005,10 +987,20 @@ impl Tool for GetWindowStateTool {
                     if !observation_only {
                         if let Some(ow) = orig_w {
                             if w > 0 {
-                                state.resize_registry.set_ratio(pid, ow as f64 / w as f64);
+                                state.resize_registry.set_ratio(
+                                    session_id.as_deref(),
+                                    pid,
+                                    Some(xid),
+                                    ow as f64 / w as f64,
+                                );
                             }
                         } else {
-                            state.resize_registry.clear_ratio(pid);
+                            state.resize_registry.set_ratio(
+                                session_id.as_deref(),
+                                pid,
+                                Some(xid),
+                                1.0,
+                            );
                         }
                     }
                     // ax mode + screenshot_out_file writes the PNG to disk and
@@ -3660,7 +3652,11 @@ impl Tool for ClickTool {
                     ))
                 }
             }
-        } else if let Some(ratio) = self.state.resize_registry.ratio(pid) {
+        } else if let Some(ratio) =
+            self.state
+                .resize_registry
+                .ratio(args.opt_str("_session_id").as_deref(), pid, Some(xid))
+        {
             x *= ratio;
             y *= ratio;
         }
@@ -5722,7 +5718,11 @@ impl Tool for ScrollTool {
                 // Pixel targets use the latest screenshot's coordinate frame.
                 // Apply the same buffer-to-window ratio as click/drag before
                 // positioning either the agent cursor or the input device.
-                let ratio = self.state.resize_registry.ratio(pid).unwrap_or(1.0);
+                let ratio = self
+                    .state
+                    .resize_registry
+                    .ratio(args.opt_str("_session_id").as_deref(), pid, Some(xid))
+                    .unwrap_or(1.0);
                 Some((x * ratio, y * ratio))
             }
             (None, None) => None,
@@ -6249,7 +6249,11 @@ impl Tool for DoubleClickTool {
                     ))
                 }
             }
-        } else if let Some(ratio) = self.state.resize_registry.ratio(pid) {
+        } else if let Some(ratio) =
+            self.state
+                .resize_registry
+                .ratio(args.opt_str("_session_id").as_deref(), pid, Some(xid))
+        {
             x *= ratio;
             y *= ratio;
         }
@@ -6488,7 +6492,11 @@ impl Tool for RightClickTool {
                     ))
                 }
             }
-        } else if let Some(ratio) = self.state.resize_registry.ratio(pid) {
+        } else if let Some(ratio) =
+            self.state
+                .resize_registry
+                .ratio(args.opt_str("_session_id").as_deref(), pid, Some(xid))
+        {
             x *= ratio;
             y *= ratio;
         }
@@ -6737,7 +6745,11 @@ impl Tool for DragTool {
                     ))
                 }
             }
-        } else if let Some(ratio) = self.state.resize_registry.ratio(pid) {
+        } else if let Some(ratio) =
+            self.state
+                .resize_registry
+                .ratio(args.opt_str("_session_id").as_deref(), pid, Some(xid))
+        {
             from_x *= ratio;
             from_y *= ratio;
             to_x *= ratio;
@@ -7200,7 +7212,11 @@ impl Tool for MouseButtonDownTool {
                     ))
                 }
             }
-        } else if let Some(ratio) = self.state.resize_registry.ratio(pid) {
+        } else if let Some(ratio) =
+            self.state
+                .resize_registry
+                .ratio(args.opt_str("_session_id").as_deref(), pid, Some(xid))
+        {
             x *= ratio;
             y *= ratio;
         }
@@ -7346,7 +7362,11 @@ impl Tool for MouseDragTool {
                     .with_structured(mouse_hold_json(&cursor_id, Some(&hold)))
                 }
             }
-        } else if let Some(ratio) = self.state.resize_registry.ratio(hold.pid) {
+        } else if let Some(ratio) = self.state.resize_registry.ratio(
+            args.opt_str("_session_id").as_deref(),
+            hold.pid,
+            Some(hold.xid),
+        ) {
             to_x *= ratio;
             to_y *= ratio;
         }
@@ -7552,7 +7572,11 @@ impl Tool for MouseButtonUpTool {
                     .with_structured(mouse_hold_json(&cursor_id, Some(&hold)))
                 }
             }
-        } else if let Some(ratio) = self.state.resize_registry.ratio(hold.pid) {
+        } else if let Some(ratio) = self.state.resize_registry.ratio(
+            args.opt_str("_session_id").as_deref(),
+            hold.pid,
+            Some(hold.xid),
+        ) {
             x *= ratio;
             y *= ratio;
         }
@@ -9604,6 +9628,7 @@ pub fn build_registry_with_provider(
 ) -> ToolRegistry {
     let state = ToolState::new();
     let mut r = ToolRegistry::new_with_protected_consent_provider(provider);
+    r.image_resize = Some(state.resize_registry.clone());
     if crate::wayland::is_wayland() && crate::wayland::hyprland::is_session() {
         let recording_state = Arc::downgrade(&state);
         r.recording
@@ -9615,7 +9640,11 @@ pub fn build_registry_with_provider(
                     // translating to the recording's full-output image.
                     if args.bool_or("from_zoom", false) {
                         (x, y) = state.zoom_registry.get(pid)?.zoom_to_window(x, y);
-                    } else if let Some(ratio) = state.resize_registry.ratio(pid) {
+                    } else if let Some(ratio) = state.resize_registry.ratio(
+                        args.opt_str("_session_id").as_deref(),
+                        pid,
+                        window_id,
+                    ) {
                         x *= ratio;
                         y *= ratio;
                     }
@@ -9662,6 +9691,9 @@ pub fn build_registry_with_provider(
         let cursor_registry = state.cursor_registry.clone();
         let state_for_session_end = state.clone();
         cua_driver_core::session::register_scoped_session_end_hook(move |session_id| {
+            state_for_session_end
+                .resize_registry
+                .clear_session(session_id);
             cursor_registry.remove(session_id);
             crate::overlay::remove_cursor(session_id.to_owned());
             state_for_session_end

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/click.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/click.rs
@@ -811,7 +811,11 @@ impl Tool for ClickTool {
                         ))
                     }
                 }
-            } else if let Some(ratio) = self.state.resize_registry.ratio(pid, window_id) {
+            } else if let Some(ratio) = self.state.resize_registry.ratio(
+                args.opt_str("_session_id").as_deref(),
+                pid as u32,
+                window_id.map(u64::from),
+            ) {
                 // Coordinates are in the downscaled image space; scale back to native pixels.
                 cx *= ratio;
                 cy *= ratio;

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/double_click.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/double_click.rs
@@ -184,7 +184,11 @@ impl Tool for DoubleClickTool {
         };
 
         // Scale back from downscaled-image space to native pixels when needed.
-        if let Some(ratio) = self.state.resize_registry.ratio(pid, window_id) {
+        if let Some(ratio) = self.state.resize_registry.ratio(
+            args.opt_str("_session_id").as_deref(),
+            pid as u32,
+            window_id.map(u64::from),
+        ) {
             cx *= ratio;
             cy *= ratio;
         }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/drag.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/drag.rs
@@ -253,7 +253,11 @@ impl Tool for DragTool {
                     ))
                 }
             }
-        } else if let Some(ratio) = self.state.resize_registry.ratio(pid, window_id) {
+        } else if let Some(ratio) = self.state.resize_registry.ratio(
+            args.opt_str("_session_id").as_deref(),
+            pid as u32,
+            window_id.map(u64::from),
+        ) {
             from_x *= ratio;
             from_y *= ratio;
             to_x *= ratio;

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
@@ -450,13 +450,19 @@ impl Tool for GetWindowStateTool {
                         if let Some(ow) = orig_w {
                             if w > 0 {
                                 self.state.resize_registry.set_ratio(
-                                    pid,
-                                    window_id,
+                                    session_id.as_deref(),
+                                    pid as u32,
+                                    Some(u64::from(window_id)),
                                     ow as f64 / w as f64,
                                 );
                             }
                         } else {
-                            self.state.resize_registry.clear_ratio(pid, window_id);
+                            self.state.resize_registry.set_ratio(
+                                session_id.as_deref(),
+                                pid as u32,
+                                Some(u64::from(window_id)),
+                                1.0,
+                            );
                         }
                     }
                     Some((b64, file_path, w, h, bounds, scale))
@@ -466,7 +472,11 @@ impl Tool for GetWindowStateTool {
                         "Screenshot frame could not be verified for window {window_id}: {e:?}"
                     );
                     if !observation_only {
-                        self.state.resize_registry.clear_ratio(pid, window_id);
+                        self.state.resize_registry.clear_ratio(
+                            session_id.as_deref(),
+                            pid as u32,
+                            Some(u64::from(window_id)),
+                        );
                     }
                     screenshot_frame_error = Some(e);
                     None

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
@@ -493,69 +493,7 @@ impl ZoomRegistry {
     }
 }
 
-/// Tracks the per-(pid, window_id) ratio applied by `max_image_dimension`
-/// downscaling.
-///
-/// `ratio = original_dim / resized_dim` — multiply resized image coordinates
-/// by this to recover original (native) window-local pixel coordinates.
-/// Mirrors Swift's `ImageResizeRegistry`.
-///
-/// Keyed per window, matching the element cache and the element-token
-/// registry. A pid-only key leaked the ratio recorded while snapshotting
-/// window A into pixel clicks aimed at window B of the same pid, sending them
-/// off-target (issue #2237).
-pub struct ResizeRegistry {
-    inner: std::sync::Mutex<HashMap<(i32, u32), f64>>,
-}
-
-impl Default for ResizeRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ResizeRegistry {
-    pub fn new() -> Self {
-        Self {
-            inner: std::sync::Mutex::new(HashMap::new()),
-        }
-    }
-
-    /// Record that (pid, window_id)'s screenshot was downscaled by `ratio`.
-    pub fn set_ratio(&self, pid: i32, window_id: u32, ratio: f64) {
-        self.inner.lock().unwrap().insert((pid, window_id), ratio);
-    }
-
-    /// Remove the ratio entry for one window (no active downscale).
-    pub fn clear_ratio(&self, pid: i32, window_id: u32) {
-        self.inner.lock().unwrap().remove(&(pid, window_id));
-    }
-
-    /// The ratio for a window, or `None` if no downscale happened.
-    ///
-    /// `window_id: None` is the screen-scope (legacy) path: it returns a ratio
-    /// only when every window recorded for `pid` agrees on one, so a
-    /// window-less caller can never inherit some other window's scale. That
-    /// preserves today's behaviour for the single-window case without guessing
-    /// across windows.
-    pub fn ratio(&self, pid: i32, window_id: Option<u32>) -> Option<f64> {
-        let inner = self.inner.lock().unwrap();
-        match window_id {
-            Some(wid) => inner.get(&(pid, wid)).copied(),
-            None => {
-                let mut agreed: Option<f64> = None;
-                for (_, ratio) in inner.iter().filter(|((p, _), _)| *p == pid) {
-                    match agreed {
-                        None => agreed = Some(*ratio),
-                        Some(seen) if (seen - *ratio).abs() < 1e-9 => {}
-                        Some(_) => return None,
-                    }
-                }
-                agreed
-            }
-        }
-    }
-}
+pub use cua_driver_core::image_resize::ResizeRegistry;
 
 /// Runtime-mutable driver configuration persisted across calls within a session.
 pub struct DriverConfig {
@@ -806,6 +744,7 @@ pub fn register_all(
         host_owns_permission_ux,
         host_bundle_id,
     ));
+    registry.image_resize = Some(state.resize_registry.clone());
     let cursor_outcome_reader = {
         let cursor_registry = state.cursor_registry.clone();
         cua_driver_core::session::register_scoped_cursor_outcome_reader(std::sync::Arc::new(
@@ -865,10 +804,12 @@ pub fn register_all(
     // recording ownership is handled separately on the core RecordingSession.
     {
         let session_config = state.session_config.clone();
+        let resize_registry = state.resize_registry.clone();
         let cursor_registry = state.cursor_registry.clone();
         let registration =
             cua_driver_core::session::register_scoped_session_end_hook(move |session_id| {
                 session_config.clear(session_id);
+                resize_registry.clear_session(session_id);
                 // Per-session agent cursor: the session_id is the cursor key when
                 // the caller gave no explicit cursor_id, so dropping it here both
                 // prunes the metadata registry and stops the overlay painting that
@@ -1072,18 +1013,18 @@ mod resize_registry_tests {
     #[test]
     fn resize_ratio_is_keyed_per_window() {
         let reg = ResizeRegistry::new();
-        reg.set_ratio(800, 11, 2.0);
-        reg.set_ratio(800, 22, 1.25);
-        assert_eq!(reg.ratio(800, Some(11)), Some(2.0));
-        assert_eq!(reg.ratio(800, Some(22)), Some(1.25));
+        reg.set_ratio(None, 800, Some(11), 2.0);
+        reg.set_ratio(None, 800, Some(22), 1.25);
+        assert_eq!(reg.ratio(None, 800, Some(11)), Some(2.0));
+        assert_eq!(reg.ratio(None, 800, Some(22)), Some(1.25));
     }
 
     #[test]
     fn undownscaled_window_reports_no_ratio() {
         let reg = ResizeRegistry::new();
-        reg.set_ratio(800, 11, 2.0);
+        reg.set_ratio(None, 800, Some(11), 2.0);
         assert_eq!(
-            reg.ratio(800, Some(22)),
+            reg.ratio(None, 800, Some(22)),
             None,
             "window 22 was never downscaled; it must not inherit window 11's ratio"
         );
@@ -1092,20 +1033,20 @@ mod resize_registry_tests {
     #[test]
     fn clearing_one_window_keeps_the_other() {
         let reg = ResizeRegistry::new();
-        reg.set_ratio(800, 11, 2.0);
-        reg.set_ratio(800, 22, 1.25);
-        reg.clear_ratio(800, 11);
-        assert_eq!(reg.ratio(800, Some(11)), None);
-        assert_eq!(reg.ratio(800, Some(22)), Some(1.25));
+        reg.set_ratio(None, 800, Some(11), 2.0);
+        reg.set_ratio(None, 800, Some(22), 1.25);
+        reg.clear_ratio(None, 800, Some(11));
+        assert_eq!(reg.ratio(None, 800, Some(11)), None);
+        assert_eq!(reg.ratio(None, 800, Some(22)), Some(1.25));
     }
 
     #[test]
     fn distinct_pids_with_the_same_window_id_do_not_collide() {
         let reg = ResizeRegistry::new();
-        reg.set_ratio(800, 11, 2.0);
-        reg.set_ratio(900, 11, 3.0);
-        assert_eq!(reg.ratio(800, Some(11)), Some(2.0));
-        assert_eq!(reg.ratio(900, Some(11)), Some(3.0));
+        reg.set_ratio(None, 800, Some(11), 2.0);
+        reg.set_ratio(None, 900, Some(11), 3.0);
+        assert_eq!(reg.ratio(None, 800, Some(11)), Some(2.0));
+        assert_eq!(reg.ratio(None, 900, Some(11)), Some(3.0));
     }
 
     /// Screen-scope callers pass no window_id. One window (the common case)
@@ -1113,18 +1054,22 @@ mod resize_registry_tests {
     #[test]
     fn screen_scope_lookup_only_answers_when_windows_agree() {
         let reg = ResizeRegistry::new();
-        assert_eq!(reg.ratio(800, None), None, "nothing recorded yet");
-        reg.set_ratio(800, 11, 2.0);
+        assert_eq!(reg.ratio(None, 800, None), None, "nothing recorded yet");
+        reg.set_ratio(None, 800, Some(11), 2.0);
         assert_eq!(
-            reg.ratio(800, None),
+            reg.ratio(None, 800, None),
             Some(2.0),
             "single window is unambiguous"
         );
-        reg.set_ratio(800, 22, 2.0);
-        assert_eq!(reg.ratio(800, None), Some(2.0), "agreeing windows answer");
-        reg.set_ratio(800, 33, 1.25);
+        reg.set_ratio(None, 800, Some(22), 2.0);
         assert_eq!(
-            reg.ratio(800, None),
+            reg.ratio(None, 800, None),
+            Some(2.0),
+            "agreeing windows answer"
+        );
+        reg.set_ratio(None, 800, Some(33), 1.25);
+        assert_eq!(
+            reg.ratio(None, 800, None),
             None,
             "disagreeing windows must not pick one arbitrarily"
         );

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/right_click.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/right_click.rs
@@ -178,7 +178,11 @@ impl Tool for RightClickTool {
         // ── Pixel path ───────────────────────────────────────────────────────
         let (mut cx, mut cy) = (x.unwrap(), y.unwrap());
         // Scale back from downscaled-image space to native pixels when needed.
-        if let Some(ratio) = self.state.resize_registry.ratio(pid, window_id) {
+        if let Some(ratio) = self.state.resize_registry.ratio(
+            args.opt_str("_session_id").as_deref(),
+            pid as u32,
+            window_id.map(u64::from),
+        ) {
             cx *= ratio;
             cy *= ratio;
         }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/scroll.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/scroll.rs
@@ -451,7 +451,11 @@ impl Tool for ScrollTool {
             // click pixel path — undo any session downscale, then translate
             // through the shared window frame (which refuses a window with no
             // live frame rather than scrolling at screen-absolute coords).
-            if let Some(ratio) = self.state.resize_registry.ratio(pid, window_id) {
+            if let Some(ratio) = self.state.resize_registry.ratio(
+                args.opt_str("_session_id").as_deref(),
+                pid as u32,
+                window_id.map(u64::from),
+            ) {
                 cx *= ratio;
                 cy *= ratio;
             }

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -8690,7 +8690,11 @@ impl Tool for ZoomTool {
         let ratio = self
             .state
             .resize_registry
-            .ratio(raw_pid as u32)
+            .ratio(
+                args.opt_str("_session_id").as_deref(),
+                raw_pid as u32,
+                Some(hwnd),
+            )
             .unwrap_or(1.0);
         let (nx1, ny1, nx2, ny2) = (x1 * ratio, y1 * ratio, x2 * ratio, y2 * ratio);
 

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -548,26 +548,7 @@ pub fn load_driver_config() -> DriverConfig {
     cfg
 }
 
-pub struct ResizeRegistry {
-    ratios: std::sync::Mutex<std::collections::HashMap<u32, f64>>,
-}
-
-impl ResizeRegistry {
-    pub fn new() -> Self {
-        Self {
-            ratios: std::sync::Mutex::new(Default::default()),
-        }
-    }
-    pub fn set_ratio(&self, pid: u32, ratio: f64) {
-        self.ratios.lock().unwrap().insert(pid, ratio);
-    }
-    pub fn clear_ratio(&self, pid: u32) {
-        self.ratios.lock().unwrap().remove(&pid);
-    }
-    pub fn ratio(&self, pid: u32) -> Option<f64> {
-        self.ratios.lock().unwrap().get(&pid).copied()
-    }
-}
+pub use cua_driver_core::image_resize::ResizeRegistry;
 
 /// Per-process zoom context — stores padded crop origin and resize scale from
 /// the most recent `zoom` call so `click(from_zoom=true)` can translate
@@ -1381,6 +1362,7 @@ impl Tool for GetWindowStateTool {
         }
 
         let state = self.state.clone();
+        let session_id = args.opt_str("_session_id");
         let q = query.clone();
         let out_file = screenshot_out_file.clone();
         let blocking = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
@@ -1570,10 +1552,20 @@ impl Tool for GetWindowStateTool {
                     if !observation_only {
                         if let Some(ow) = orig_w {
                             if w > 0 {
-                                state.resize_registry.set_ratio(pid, ow as f64 / w as f64);
+                                state.resize_registry.set_ratio(
+                                    session_id.as_deref(),
+                                    pid,
+                                    Some(hwnd),
+                                    ow as f64 / w as f64,
+                                );
                             }
                         } else {
-                            state.resize_registry.clear_ratio(pid);
+                            state.resize_registry.set_ratio(
+                                session_id.as_deref(),
+                                pid,
+                                Some(hwnd),
+                                1.0,
+                            );
                         }
                     }
                     // base64 is embedded only when no out_file was given (vision
@@ -3824,7 +3816,11 @@ impl Tool for ClickTool {
                         ))
                     }
                 }
-            } else if let Some(ratio) = self.state.resize_registry.ratio(pid) {
+            } else if let Some(ratio) = self.state.resize_registry.ratio(
+                args.opt_str("_session_id").as_deref(),
+                pid,
+                Some(hwnd),
+            ) {
                 px *= ratio;
                 py *= ratio;
             }
@@ -5283,7 +5279,11 @@ impl Tool for PressKeyTool {
                 Err(result) => return result,
             };
             let (mut px, mut py) = screen_to_bitmap(hwnd, cx, cy);
-            if let Some(ratio) = self.state.resize_registry.ratio(pid) {
+            if let Some(ratio) = self.state.resize_registry.ratio(
+                args.opt_str("_session_id").as_deref(),
+                pid,
+                Some(hwnd),
+            ) {
                 px = (px as f64 / ratio).round() as i32;
                 py = (py as f64 / ratio).round() as i32;
             }
@@ -6795,7 +6795,11 @@ impl Tool for DoubleClickTool {
                         ))
                     }
                 }
-            } else if let Some(ratio) = self.state.resize_registry.ratio(pid) {
+            } else if let Some(ratio) = self.state.resize_registry.ratio(
+                args.opt_str("_session_id").as_deref(),
+                pid,
+                Some(hwnd),
+            ) {
                 px *= ratio;
                 py *= ratio;
             }
@@ -7139,7 +7143,11 @@ impl Tool for RightClickTool {
                         ))
                     }
                 }
-            } else if let Some(ratio) = self.state.resize_registry.ratio(pid) {
+            } else if let Some(ratio) = self.state.resize_registry.ratio(
+                args.opt_str("_session_id").as_deref(),
+                pid,
+                Some(hwnd),
+            ) {
                 px *= ratio;
                 py *= ratio;
             }
@@ -7378,7 +7386,11 @@ impl Tool for DragTool {
                     ))
                 }
             }
-        } else if let Some(ratio) = self.state.resize_registry.ratio(pid) {
+        } else if let Some(ratio) =
+            self.state
+                .resize_registry
+                .ratio(args.opt_str("_session_id").as_deref(), pid, hwnd_opt)
+        {
             from_x *= ratio;
             from_y *= ratio;
             to_x *= ratio;
@@ -9872,8 +9884,10 @@ pub fn build_registry_with_provider(
     // deregisters when that runtime's registry is dropped. Mirrors the macOS
     // `register_all` session_end hook (platform-macos/src/tools/mod.rs).
     let cursor_registry = state.cursor_registry.clone();
+    let resize_registry = state.resize_registry.clone();
     let session_end_hook =
         cua_driver_core::session::register_scoped_session_end_hook(move |session_id| {
+            resize_registry.clear_session(session_id);
             cursor_registry.remove(session_id);
             crate::overlay::remove_cursor(session_id.to_owned());
         });
@@ -9883,6 +9897,7 @@ pub fn build_registry_with_provider(
         });
 
     let mut r = ToolRegistry::new_with_protected_consent_provider(provider);
+    r.image_resize = Some(state.resize_registry.clone());
     r.retain_cursor_outcome_reader(cursor_outcome_reader);
     r.retain_session_end_hook(session_end_hook);
     r.retain_session_revive_hook(session_revive_hook);


### PR DESCRIPTION
## Superseded by issue #3630

At maintainer request, this work has moved to #3630 as a defect/evidence record for architectural review alongside RFC #3473 and active PR #3616. This prototype is closed without merging. Its branch and commits are retained for regression-test reuse and provenance; do not treat the session-registry design or its refusal changes as approved. The validation below is the historical prototype record, not a current readiness claim.

## Scope

Refs #1882. This draft fixes cross-client screenshot transform interference, rather than claiming that the metadata/documentation issue is fully resolved. It does not introduce image-token machinery or supersede RFC #3473 / PR #3616.

Current head: `21fad867081f6b69d91418c39572aededdbace22`.

### Confirmed defect

Two persistent MCP clients captured the same unchanged 1470×932-point disposable AppKit window using installed macOS cua-driver 0.23.2. Client A requested a 200×127 image; client B requested native resolution. A clicked the same image coordinate `(99.5, 62.5)` throughout:

| Sequence | Native receiver landing, window-top coordinates | Outcome |
| --- | --- | --- |
| A capture → A click | `(731.325, 459.375)` | Target |
| A capture → B native capture → A click | `(99.5, 62.5)` | Wrong region |
| A refresh → A click | `(731.325, 459.375)` | Target |

The receiver's mouse events, not the driver's unverifiable action response, are the oracle. Window geometry and backing scale remained unchanged. The baseline binary SHA-256 was `67ccfc99e69ebb5881fdfc3787d85abcd8cc2beb7423f255549557623cab6907`; its reported source SHA was null. This is installed-version diagnostic evidence, not exact-main or candidate certification. No existing user browser tabs were targeted.

## Implementation

- [x] Shared core resize registry keyed by trusted private lifecycle identity, PID, and window ID.
- [x] macOS, Windows, and Linux captures and resize consumers use that registry, including delegated pixel-focus paths, Linux held-pointer/recording conversion, and Windows zoom crop conversion.
- [x] Native-size captures publish identity transforms instead of clearing another client's scale.
- [x] Session cleanup removes only the owner's transforms; late capture completion cannot resurrect an ended session.
- [x] Common dispatch refuses missing or ambiguous window-pixel context with `screenshot_context_missing`, rather than borrowing another client's transform or guessing native pixels.
- [x] Documented persistent MCP / explicit CLI `session` usage. Unnamed one-shot CLI calls cannot retain screenshot context across processes.
- [x] Shared unit and trusted-dispatch regressions, plus same-daemon two-client interference in existing AppKit, WPF, and supported GTK3 pixel rows. Their fixture-state and desktop oracles remain required; the observer connection does not create an unrelated recording.

## Validation so far

- `cargo test -p cua-driver-core --locked`: **620 passed** (615 library, 5 integration); one documentation test ignored. Rerun against the final local source before the latest commit.
- `cargo test -p platform-macos --lib --locked`: **365 passed, 2 ignored**, at `dfd15de01f00b85d3685aba9039e5529ffcd5acc`. The subsequent product diff is a Windows-only zoom call-site correction; remaining changes are tests/testkit/docs.
- `cargo test -p cua-driver-testkit --lib --locked`: passed after adding the peer-connection helper.
- AppKit native regression target compiles after the peer-connection update; this is **not** a native execution result.
- Source driver build, formatting, and diff checks passed.
- Previous-head Linux native unit/compile, Linux/macOS portable contract parity, generated contract/SDK checks, and release metadata passed.
- Previous-head Windows CI caught one missed zoom resize lookup; this head supplies session/window identity there. Windows compilation and dependent checks are rerunning, not yet claimed green.

## Readiness blockers / boundaries

- [ ] Native candidate replay and the canonical stable-SHA desktop matrix. The source-built private daemon's read-only permission check reported Accessibility=false and Screen Recording=false; the separately installed signed application is authorized. No TCC reset, installed-app replacement, or permission prompt was performed. The private probe daemon has been stopped.
- [ ] Reconcile and verify Wayland refusal precedence: when a compositor cannot supply a window screenshot, the new common missing-context precondition can precede the adapter's background-unavailable refusal. Existing refusal rows must explicitly cover that ordering before readiness; X11 success is not Wayland certification.
- [ ] Latest-head Windows/Linux CI, native harness compilation, and documentation/contract checks.

A later capture in the **same** session still replaces that session's previous transform. This draft does not claim image-ID freshness, window/display-change invalidation, zoom-context ownership, or every recording-rendering alignment case. `screenshot_scale` retains its existing native-backing-scale meaning.

The PR remains draft and must not be treated as merge-ready or exact-candidate desktop-certified.
