### PR TITLE
fix(agent): execute computer tool calls that arrive as function calls

### DIFF
--- a/libs/python/agent/cua_agent/agent.py
+++ b/libs/python/agent/cua_agent/agent.py
@@ -64,6 +64,79 @@ def assert_callable_with(f, *args, **kwargs):
         raise IllegalArgumentError(f"Expected {sig}, got args={args} kwargs={kwargs}") from e
 
 
+# Name of the computer tool as advertised to models without native
+# computer-use support. Those models are given a plain function tool (see
+# `loops/openai.py::_map_computer_tool_to_openai`) and answer with
+# `function_call` items rather than `computer_call` items.
+COMPUTER_FUNCTION_TOOL_NAME = "computer"
+
+
+def parse_computer_function_call(arguments: Any) -> Tuple[str, Dict[str, Any]]:
+    """Map a `computer` function-call payload onto a computer action.
+
+    Two shapes arrive here:
+
+    - the flat schema the function tool advertises, e.g.
+      ``{"action": "click", "x": 12, "y": 34}``;
+    - the native action dict, e.g. ``{"type": "click", "x": 12, "y": 34}``,
+      which `replace_failed_computer_calls_with_function_calls` re-emits when a
+      computer_call is retried as a function_call.
+
+    Returns the action name and its keyword arguments.
+    """
+    if arguments is None:
+        parsed: Any = {}
+    elif isinstance(arguments, str):
+        try:
+            parsed = json.loads(arguments or "{}")
+        except json.JSONDecodeError as e:
+            raise ToolError(f"computer call arguments are not valid JSON: {e}") from e
+    elif isinstance(arguments, dict):
+        parsed = dict(arguments)
+    else:
+        raise ToolError(
+            f"computer call arguments must be a JSON object, got {type(arguments).__name__}"
+        )
+    if not isinstance(parsed, dict):
+        raise ToolError("computer call arguments must be a JSON object")
+
+    # Omitted optional fields are commonly sent as null by function-calling
+    # models; they are absent arguments, not values.
+    action_args = {k: v for k, v in parsed.items() if v is not None}
+    action_type = action_args.pop("action", None) or action_args.pop("type", None)
+    action_args.pop("type", None)
+    if not isinstance(action_type, str) or not action_type:
+        raise ToolError("computer call is missing its `action`")
+
+    # The flat schema spells a drag as start/end coordinates; the computer
+    # handler protocol takes a path.
+    if action_type == "drag" and "path" not in action_args:
+        corners = ["start_x", "start_y", "end_x", "end_y"]
+        if all(corner in action_args for corner in corners):
+            start_x, start_y, end_x, end_y = (action_args.pop(c) for c in corners)
+            action_args["path"] = [{"x": start_x, "y": start_y}, {"x": end_x, "y": end_y}]
+
+    return action_type, action_args
+
+
+def accepted_action_args(method: Callable, action_args: Dict[str, Any]) -> Dict[str, Any]:
+    """Drop arguments the action does not take.
+
+    The function tool advertises one flat parameter object shared by every
+    action, so fields belonging to other actions are noise by construction —
+    models routinely echo them back (a `keypress` carrying `status`, say).
+    Native `computer_call` items are unaffected: their action dict is already
+    per-action.
+    """
+    try:
+        parameters = inspect.signature(method).parameters
+    except (TypeError, ValueError):
+        return action_args
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values()):
+        return action_args
+    return {name: value for name, value in action_args.items() if name in parameters}
+
+
 def get_json(obj: Any, max_depth: int = 10) -> Any:
     def custom_serializer(o: Any, depth: int = 0, seen: Optional[Set[int]] = None) -> Any:
         if seen is None:
@@ -767,42 +840,11 @@ class ComputerAgent:
                 # Extract action arguments (all fields except 'type')
                 action_args = {k: v for k, v in action.items() if k != "type"}
 
-                # Execute the computer action
-                computer_method = getattr(computer, action_type, None)
-                action_result = None
-                if computer_method:
-                    assert_callable_with(computer_method, **action_args)
-                    action_result = await computer_method(**action_args)
-                else:
-                    raise ToolError(f"Unknown computer action: {action_type}")
-
-                # Track computer action execution
-                if self.telemetry_enabled and is_telemetry_enabled():
-                    record_event(
-                        "computer_action_executed",
-                        {
-                            "action_type": action_type,
-                        },
-                    )
-                    record_event(
-                        "agent_tool_executed",
-                        {
-                            "tool_type": "computer",
-                            "tool_name": action_type,
-                        },
-                    )
-
-                # Check if this was a terminate action
-                is_terminate = action_type == "terminate" or (
-                    isinstance(action_result, dict) and action_result.get("terminated")
-                )
-
-                # Take screenshot after action (skip for terminate)
-                if not is_terminate:
-                    if self.screenshot_delay and self.screenshot_delay > 0:
-                        await asyncio.sleep(self.screenshot_delay)
-                    screenshot_base64 = await computer.screenshot()
-                    await self._on_screenshot(screenshot_base64, "screenshot_after")
+                (
+                    action_result,
+                    screenshot_base64,
+                    is_terminate,
+                ) = await self._execute_computer_action(computer, action_type, action_args)
 
                 # Handle safety checks
                 pending_checks = item.get("pending_safety_checks", [])
@@ -850,9 +892,19 @@ class ComputerAgent:
             if item_type == "function_call":
                 await self._on_function_call_start(item)
                 # Perform function call
-                function = self._get_tool(item.get("name"))
+                name = item.get("name")
+                function = self._get_tool(name)
+                if function is None and name == COMPUTER_FUNCTION_TOOL_NAME:
+                    # Models without native computer-use support are given the
+                    # computer tool as a plain function, so they answer with a
+                    # `function_call` instead of a `computer_call`. The action
+                    # semantics are the same; only the item shape differs. A
+                    # caller-registered tool named "computer" still wins above.
+                    result = await self._execute_computer_function_call(item, computer)
+                    await self._on_function_call_end(item, result)
+                    return result
                 if not function:
-                    raise ToolError(f"Function {item.get('name')} not found")
+                    raise ToolError(f"Function {name} not found")
 
                 args = json.loads(item.get("arguments"))
 
@@ -894,6 +946,106 @@ class ComputerAgent:
             return [make_tool_error_item(repr(e), call_id)]
 
         return []
+
+    async def _execute_computer_action(
+        self, computer: Any, action_type: str, action_args: Dict[str, Any]
+    ) -> Tuple[Any, Optional[str], bool]:
+        """Run one computer action and capture the screen it left behind.
+
+        Shared by the native `computer_call` path and the function-calling
+        `computer` path so both execute identical semantics. Returns the
+        action's own result, the post-action screenshot (absent for a
+        terminating action), and whether the action terminated the task.
+        """
+        computer_method = getattr(computer, action_type, None)
+        if not computer_method:
+            raise ToolError(f"Unknown computer action: {action_type}")
+        assert_callable_with(computer_method, **action_args)
+        action_result = await computer_method(**action_args)
+
+        # Track computer action execution
+        if self.telemetry_enabled and is_telemetry_enabled():
+            record_event(
+                "computer_action_executed",
+                {
+                    "action_type": action_type,
+                },
+            )
+            record_event(
+                "agent_tool_executed",
+                {
+                    "tool_type": "computer",
+                    "tool_name": action_type,
+                },
+            )
+
+        # Check if this was a terminate action
+        is_terminate = bool(
+            action_type == "terminate"
+            or (isinstance(action_result, dict) and action_result.get("terminated"))
+        )
+
+        # Take screenshot after action (skip for terminate)
+        screenshot_base64: Optional[str] = None
+        if not is_terminate:
+            if self.screenshot_delay and self.screenshot_delay > 0:
+                await asyncio.sleep(self.screenshot_delay)
+            screenshot_base64 = await computer.screenshot()
+            await self._on_screenshot(screenshot_base64, "screenshot_after")
+
+        return action_result, screenshot_base64, is_terminate
+
+    async def _execute_computer_function_call(
+        self, item: Dict[str, Any], computer: Any
+    ) -> List[Dict[str, Any]]:
+        """Execute a `computer` action that arrived as a function call."""
+        if not computer:
+            raise ToolError("Computer handler is required for computer calls")
+
+        action_type, action_args = parse_computer_function_call(item.get("arguments"))
+        computer_method = getattr(computer, action_type, None)
+        if not computer_method:
+            raise ToolError(f"Unknown computer action: {action_type}")
+        action_args = accepted_action_args(computer_method, action_args)
+
+        action_result, screenshot_base64, _is_terminate = await self._execute_computer_action(
+            computer, action_type, action_args
+        )
+
+        if action_result is None:
+            output = f"{action_type} executed."
+        elif isinstance(action_result, (dict, list)):
+            output = json.dumps(action_result)
+        else:
+            output = str(action_result)
+        if screenshot_base64:
+            output = f"{output} A screenshot taken after the action follows."
+
+        # The model that emitted this item holds the function tool, not
+        # `computer_use_preview`, so the reply has to be a function_call_output
+        # — and that carries text only. The screenshot therefore rides in its
+        # own user message, which `ImageRetentionCallback` trims like any other
+        # post-action capture.
+        results: List[Dict[str, Any]] = [
+            {
+                "type": "function_call_output",
+                "call_id": item.get("call_id"),
+                "output": output,
+            }
+        ]
+        if screenshot_base64:
+            results.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_image",
+                            "image_url": f"data:image/png;base64,{screenshot_base64}",
+                        }
+                    ],
+                }
+            )
+        return results
 
     # ============================================================================
     # MAIN AGENT LOOP

--- a/libs/python/agent/cua_agent/callbacks/image_retention.py
+++ b/libs/python/agent/cua_agent/callbacks/image_retention.py
@@ -37,11 +37,32 @@ class ImageRetentionCallback(AsyncCallbackHandler):
 
         return self._apply_image_retention(messages)
 
+    @staticmethod
+    def _is_function_call_screenshot(messages: List[Dict[str, Any]], idx: int) -> bool:
+        """Whether messages[idx] is a post-action screenshot from a computer function call.
+
+        A `function_call_output` carries text only, so the function-calling
+        computer path (models without native computer-use support) delivers its
+        post-action screenshot as the user message right after that output.
+        Those images are subject to the same retention policy as
+        `computer_call_output` screenshots.
+        """
+        msg = messages[idx]
+        if msg.get("role") != "user":
+            return False
+        content = msg.get("content")
+        if not isinstance(content, list) or len(content) != 1:
+            return False
+        if not isinstance(content[0], dict) or content[0].get("type") != "input_image":
+            return False
+        return idx > 0 and messages[idx - 1].get("type") == "function_call_output"
+
     def _apply_image_retention(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Apply image retention policy to keep only the N most recent images.
 
         Removes computer_call_output items with image_url and their corresponding computer_call items,
-        keeping only the most recent N image pairs based on only_n_most_recent_images setting.
+        along with post-action screenshots delivered for computer function calls,
+        keeping only the most recent N images based on only_n_most_recent_images setting.
 
         Args:
             messages: List of message dictionaries
@@ -52,13 +73,15 @@ class ImageRetentionCallback(AsyncCallbackHandler):
         if self.only_n_most_recent_images is None:
             return messages
 
-        # Gather indices of all computer_call_output messages that contain an image_url
+        # Gather indices of all messages carrying a post-action screenshot
         output_indices: List[int] = []
         for idx, msg in enumerate(messages):
             if msg.get("type") == "computer_call_output":
                 out = msg.get("output")
                 if isinstance(out, dict) and ("image_url" in out):
                     output_indices.append(idx)
+            elif self._is_function_call_screenshot(messages, idx):
+                output_indices.append(idx)
 
         # Nothing to trim
         if len(output_indices) <= self.only_n_most_recent_images:
@@ -74,7 +97,13 @@ class ImageRetentionCallback(AsyncCallbackHandler):
             if idx in keep_output_indices:
                 continue  # keep this screenshot and its context
 
-            to_remove.add(idx)  # remove the computer_call_output itself
+            to_remove.add(idx)  # remove the image-bearing message itself
+
+            if messages[idx].get("type") != "computer_call_output":
+                # A function-call screenshot stands alone. Its `function_call` /
+                # `function_call_output` pair is text and must stay paired, so
+                # dropping the image is the whole trim.
+                continue
 
             # Remove the immediately preceding computer_call with matching call_id (if present)
             call_id = messages[idx].get("call_id")

--- a/libs/python/agent/tests/test_computer_function_call.py
+++ b/libs/python/agent/tests/test_computer_function_call.py
@@ -1,0 +1,382 @@
+"""Tests for executing the computer tool when it arrives as a function call.
+
+Models without native computer-use support are given the computer tool as a
+plain function (`loops/openai.py::_map_computer_tool_to_openai` with
+`use_native_tool=False`), so they answer with `function_call` items named
+"computer" instead of `computer_call` items. This file covers that dispatch
+path: argument mapping, execution against the computer handler, and the shape
+of the items fed back to the model.
+
+Following SRP: this file tests ONE behavior (the computer function-call path).
+"""
+
+import json
+from typing import Any, Dict, List, Optional, Union
+from unittest.mock import patch
+
+import pytest
+
+
+class FakeComputerHandler:
+    """Minimal computer handler that records the calls it receives."""
+
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    async def get_environment(self) -> str:
+        return "linux"
+
+    async def get_dimensions(self):
+        return (1024, 768)
+
+    async def screenshot(self, text: Optional[str] = None) -> str:
+        self.calls.append({"action": "screenshot"})
+        return "c2NyZWVuc2hvdA=="
+
+    async def click(self, x: int, y: int, button: str = "left") -> None:
+        self.calls.append({"action": "click", "x": x, "y": y, "button": button})
+
+    async def keypress(self, keys: Union[List[str], str]) -> None:
+        self.calls.append({"action": "keypress", "keys": keys})
+
+    async def type(self, text: str) -> None:
+        self.calls.append({"action": "type", "text": text})
+
+    async def drag(self, path: List[Dict[str, int]]) -> None:
+        self.calls.append({"action": "drag", "path": path})
+
+    async def terminate(self, status: str = "success") -> Dict[str, Any]:
+        self.calls.append({"action": "terminate", "status": status})
+        return {"success": True, "status": status, "terminated": True}
+
+
+def make_agent(**kwargs):
+    from cua_agent import ComputerAgent
+
+    return ComputerAgent(model="openai/gpt-5.4", **kwargs)
+
+
+def computer_function_call(arguments: Any, call_id: str = "call_1") -> Dict[str, Any]:
+    return {
+        "type": "function_call",
+        "id": "fc_1",
+        "call_id": call_id,
+        "name": "computer",
+        "arguments": arguments,
+    }
+
+
+def error_of(items: List[Dict[str, Any]]) -> Optional[str]:
+    """The error message of a tool-error item, or None if there isn't one."""
+    if len(items) != 1 or items[0].get("type") != "function_call_output":
+        return None
+    try:
+        payload = json.loads(items[0]["output"])
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return payload.get("error") if isinstance(payload, dict) else None
+
+
+@patch("cua_agent.agent.litellm")
+class TestComputerFunctionCallDispatch:
+    """A function_call named "computer" runs the requested computer action."""
+
+    @pytest.mark.asyncio
+    async def test_flat_arguments_reach_the_computer_handler(self, _litellm, disable_telemetry):
+        """The advertised flat schema (`{"action": ..., "x": ...}`) executes.
+
+        Regression for the dispatch gap: this used to fall through to the
+        custom-tool lookup and fail with "Function computer not found", so the
+        function-calling harness could never actually drive a computer.
+        """
+        computer = FakeComputerHandler()
+        agent = make_agent()
+
+        items = await agent._handle_item(
+            computer_function_call(json.dumps({"action": "click", "x": 12, "y": 34})),
+            computer,
+        )
+
+        assert error_of(items) is None, error_of(items)
+        assert computer.calls[0] == {"action": "click", "x": 12, "y": 34, "button": "left"}
+
+        # The model holds the function tool, not computer_use_preview, so the
+        # reply must be a function_call_output; the screenshot rides along as
+        # its own user message because that output carries text only.
+        assert items[0]["type"] == "function_call_output"
+        assert items[0]["call_id"] == "call_1"
+        assert "screenshot" in items[0]["output"]
+        assert items[1] == {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,c2NyZWVuc2hvdA==",
+                }
+            ],
+        }
+
+    @pytest.mark.asyncio
+    async def test_native_action_shape_is_accepted(self, _litellm, disable_telemetry):
+        """`{"type": "click"}` works too — that is what a retried computer_call carries.
+
+        `replace_failed_computer_calls_with_function_calls` rewrites a failed
+        computer_call into a function_call whose arguments are the native
+        action dict, so both spellings reach this path.
+        """
+        computer = FakeComputerHandler()
+        agent = make_agent()
+
+        items = await agent._handle_item(
+            computer_function_call(
+                json.dumps({"type": "click", "x": 5, "y": 6, "button": "right"})
+            ),
+            computer,
+        )
+
+        assert error_of(items) is None, error_of(items)
+        assert computer.calls[0] == {"action": "click", "x": 5, "y": 6, "button": "right"}
+
+    @pytest.mark.asyncio
+    async def test_unrelated_and_null_fields_are_dropped(self, _litellm, disable_telemetry):
+        """The flat schema is one parameter object shared by every action.
+
+        Models routinely echo fields that belong to other actions — the
+        reported trace shows a `keypress` carrying `status: "success"` — and
+        send omitted optionals as null. Neither is an argument to `keypress`.
+        """
+        computer = FakeComputerHandler()
+        agent = make_agent()
+
+        items = await agent._handle_item(
+            computer_function_call(
+                json.dumps(
+                    {
+                        "action": "keypress",
+                        "keys": ["ctrl", "alt", "t"],
+                        "status": "success",
+                        "x": None,
+                    }
+                )
+            ),
+            computer,
+        )
+
+        assert error_of(items) is None, error_of(items)
+        assert computer.calls[0] == {"action": "keypress", "keys": ["ctrl", "alt", "t"]}
+
+    @pytest.mark.asyncio
+    async def test_drag_start_and_end_become_a_path(self, _litellm, disable_telemetry):
+        """The flat schema spells a drag as coordinates; the handler takes a path."""
+        computer = FakeComputerHandler()
+        agent = make_agent()
+
+        items = await agent._handle_item(
+            computer_function_call(
+                json.dumps(
+                    {
+                        "action": "drag",
+                        "start_x": 1,
+                        "start_y": 2,
+                        "end_x": 30,
+                        "end_y": 40,
+                    }
+                )
+            ),
+            computer,
+        )
+
+        assert error_of(items) is None, error_of(items)
+        assert computer.calls[0] == {
+            "action": "drag",
+            "path": [{"x": 1, "y": 2}, {"x": 30, "y": 40}],
+        }
+
+    @pytest.mark.asyncio
+    async def test_terminate_reports_its_result_without_a_screenshot(
+        self, _litellm, disable_telemetry
+    ):
+        computer = FakeComputerHandler()
+        agent = make_agent()
+
+        items = await agent._handle_item(
+            computer_function_call(json.dumps({"action": "terminate", "status": "success"})),
+            computer,
+        )
+
+        assert computer.calls == [{"action": "terminate", "status": "success"}]
+        assert len(items) == 1
+        assert json.loads(items[0]["output"]) == {
+            "success": True,
+            "status": "success",
+            "terminated": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_screenshot_action_returns_the_capture(self, _litellm, disable_telemetry):
+        computer = FakeComputerHandler()
+        agent = make_agent()
+
+        items = await agent._handle_item(
+            computer_function_call(json.dumps({"action": "screenshot"})),
+            computer,
+        )
+
+        assert error_of(items) is None, error_of(items)
+        assert items[1]["content"][0]["type"] == "input_image"
+
+    @pytest.mark.asyncio
+    async def test_a_registered_tool_named_computer_still_wins(self, _litellm, disable_telemetry):
+        """Built-in computer semantics are the fallback, not an override."""
+        seen: List[Dict[str, Any]] = []
+
+        def computer(**kwargs):
+            """A caller-registered tool that takes the "computer" name."""
+            seen.append(kwargs)
+            return "custom tool ran"
+
+        handler = FakeComputerHandler()
+        agent = make_agent(tools=[computer])
+
+        items = await agent._handle_item(
+            computer_function_call(json.dumps({"action": "click", "x": 1, "y": 2})),
+            handler,
+        )
+
+        assert seen == [{"action": "click", "x": 1, "y": 2}]
+        assert handler.calls == []
+        assert items == [
+            {"type": "function_call_output", "call_id": "call_1", "output": "custom tool ran"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_is_reported_to_the_model(self, _litellm, disable_telemetry):
+        computer = FakeComputerHandler()
+        agent = make_agent()
+
+        items = await agent._handle_item(
+            computer_function_call(json.dumps({"action": "teleport", "x": 1})),
+            computer,
+        )
+
+        assert "teleport" in (error_of(items) or "")
+        assert computer.calls == []
+
+    @pytest.mark.asyncio
+    async def test_missing_action_is_reported_to_the_model(self, _litellm, disable_telemetry):
+        computer = FakeComputerHandler()
+        agent = make_agent()
+
+        items = await agent._handle_item(computer_function_call(json.dumps({"x": 1})), computer)
+
+        assert "action" in (error_of(items) or "")
+        assert computer.calls == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_arguments_are_reported_to_the_model(self, _litellm, disable_telemetry):
+        computer = FakeComputerHandler()
+        agent = make_agent()
+
+        items = await agent._handle_item(computer_function_call("{not json"), computer)
+
+        assert "JSON" in (error_of(items) or "")
+        assert computer.calls == []
+
+    @pytest.mark.asyncio
+    async def test_native_computer_call_path_is_unchanged(self, _litellm, disable_telemetry):
+        """The native item type still answers with a computer_call_output."""
+        computer = FakeComputerHandler()
+        agent = make_agent()
+
+        items = await agent._handle_item(
+            {
+                "type": "computer_call",
+                "call_id": "call_native",
+                "action": {"type": "click", "x": 7, "y": 8, "button": "left"},
+            },
+            computer,
+        )
+
+        assert computer.calls[0] == {"action": "click", "x": 7, "y": 8, "button": "left"}
+        assert items == [
+            {
+                "type": "computer_call_output",
+                "call_id": "call_native",
+                "acknowledged_safety_checks": [],
+                "output": {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,c2NyZWVuc2hvdA==",
+                },
+            }
+        ]
+
+
+class TestFunctionCallScreenshotRetention:
+    """Post-action screenshots from this path obey the image retention policy."""
+
+    @staticmethod
+    def trajectory(count: int) -> List[Dict[str, Any]]:
+        messages: List[Dict[str, Any]] = []
+        for i in range(count):
+            messages.extend(
+                [
+                    {
+                        "type": "function_call",
+                        "call_id": f"call_{i}",
+                        "name": "computer",
+                        "arguments": json.dumps({"action": "click", "x": i, "y": i}),
+                    },
+                    {"type": "function_call_output", "call_id": f"call_{i}", "output": "click"},
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_image", "image_url": f"data:image/png;base64,{i}"}
+                        ],
+                    },
+                ]
+            )
+        return messages
+
+    @pytest.mark.asyncio
+    async def test_only_the_most_recent_screenshots_are_kept(self):
+        from cua_agent.callbacks import ImageRetentionCallback
+
+        kept = await ImageRetentionCallback(only_n_most_recent_images=2).on_llm_start(
+            self.trajectory(4)
+        )
+
+        images = [m["content"][0]["image_url"] for m in kept if m.get("role") == "user"]
+        assert images == ["data:image/png;base64,2", "data:image/png;base64,3"]
+
+        # The text pairs stay intact: a function_call without its output (or an
+        # output without its call) is rejected by the Responses API.
+        calls = [m["call_id"] for m in kept if m.get("type") == "function_call"]
+        outputs = [m["call_id"] for m in kept if m.get("type") == "function_call_output"]
+        assert calls == outputs == [f"call_{i}" for i in range(4)]
+
+    @pytest.mark.asyncio
+    async def test_a_user_image_that_is_not_a_post_action_capture_is_left_alone(self):
+        """The task's own attached image is input, not a trimmable capture."""
+        from cua_agent.callbacks import ImageRetentionCallback
+
+        messages: List[Dict[str, Any]] = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "match this"},
+                    {"type": "input_image", "image_url": "data:image/png;base64,task"},
+                ],
+            },
+            *self.trajectory(2),
+        ]
+
+        kept = await ImageRetentionCallback(only_n_most_recent_images=1).on_llm_start(messages)
+
+        images = [
+            content["image_url"]
+            for m in kept
+            if m.get("role") == "user"
+            for content in m["content"]
+            if content.get("type") == "input_image"
+        ]
+        assert images == ["data:image/png;base64,task", "data:image/png;base64,1"]


### PR DESCRIPTION
Fixes #3614.

## Problem

When the configured model does not match `computer-use-preview`, the OpenAI loop hands it the computer tool as a **plain function** (`_map_computer_tool_to_openai(use_native_tool=False)`). The model then answers with a `function_call` named `computer` instead of a `computer_call`.

The dispatch loop had no execution path for that item. `function_call` went straight to `_get_tool()`, which only searches caller-registered tools, so `"computer"` was never found:

```python
if item_type == "function_call":
    await self._on_function_call_start(item)
    function = self._get_tool(item.get("name"))
    if not function:
        raise ToolError(f"Function {item.get('name')} not found")
```

The `ToolError` is caught and fed back to the model, which concludes the tool is unavailable and stops — an accurate report of what happened. As the issue notes, this means the function-calling harness has never actually been able to execute a computer action; only literal `computer-use-preview` models worked, and for models where `computer_use_preview` is rejected by the API this is a hard blocker rather than a degraded path.

## Change

A `computer` function call now runs the same action semantics as a native `computer_call`.

- The shared execution — method lookup, argument validation, telemetry, terminate detection, post-action screenshot — moved into `_execute_computer_action`, which both item types call, so the two paths cannot drift.
- **Both argument spellings are accepted**: the flat schema the function tool advertises (`{"action": "click", "x": 12, "y": 34}`) and the native action dict (`{"type": "click", ...}`), which `replace_failed_computer_calls_with_function_calls` re-emits when a computer_call is retried as a function_call.
- **Flat drag coordinates** (`start_x`/`start_y`/`end_x`/`end_y`) map onto the handler protocol's `path`.
- **Null and non-applicable fields are dropped.** The function tool advertises one flat parameter object shared by every action, so fields belonging to other actions are noise by construction — the trace in the issue shows a `keypress` carrying `status: "success"`. Native `computer_call` items are untouched by this: their action dict is already per-action.
- The reply is a **`function_call_output`**, because the model holds the function tool and not `computer_use_preview`; a `computer_call_output` would not be a valid input item for it. That output carries text only, so the post-action screenshot rides in its own user message.
- `ImageRetentionCallback` now recognizes those captures, so `only_n_most_recent_images` keeps working on this path. It trims only the image message: the `function_call` / `function_call_output` pair is text and has to stay paired.
- A caller-registered tool named `computer` still wins. The built-in semantics are the fallback, not an override.

Malformed arguments, a missing `action`, and an unknown action are reported to the model as tool errors rather than raising.

## Validation

```
CUA_TELEMETRY_ENABLED=false uv run pytest libs/python/agent/tests -q   # 62 passed
uv run ruff check libs/python/agent                                    # All checks passed
uv run ruff format ...                                                 # clean
```

`libs/python/agent/tests/test_computer_function_call.py` is new: 13 tests over flat and native argument shapes, field filtering, drag mapping, terminate, screenshot delivery, custom-tool precedence, the three error paths, and retention. Verified against unmodified `main` (stashing only the two source files): **11 fail, 2 pass** — the two that pass are the deliberate no-change guards, `test_native_computer_call_path_is_unchanged` and `test_a_registered_tool_named_computer_still_wins`.

## Known gaps

- No live API call was made from here; the tests drive `_handle_item` against a fake computer handler. The issue already carries the live evidence that the model emits well-formed `function_call` items against this exact schema.
- Only the dispatch gap is addressed. `OperatorNormalizerCallback` still normalizes hallucinated action spellings for `computer_call` items only; extending it to function-call items is a separate change.
