### PR TITLE
docs: separate hosted Fleet images from local runtimes

### DIFF
--- a/docs/content/docs/how-to-guides/sandbox/choose-an-image.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/choose-an-image.mdx
@@ -13,7 +13,7 @@ before creating the pool. For execution on your own hardware, use
 | Run a Fleet workload using an existing image               | [Choose a published Fleet image](#choose-a-published-fleet-image)    | A registry artifact reference for a pool.                                 |
 | Run a Fleet workload that needs a custom guest             | [Prepare and reference a Fleet image](/how-to-guides/sandbox/prepare-and-reference-a-fleet-image) | A bootable guest disk packaged and published as a containerDisk artifact. |
 
-Before choosing an artifact, check the [OS and image catalog](/reference/sandbox-sdk/os-image-catalog)
+Before choosing an artifact, check the [hosted Fleet image catalog](/reference/sandbox-sdk/os-image-catalog#hosted-fleet-images)
 for architecture, guest services, and verification limits. A registry reference
 does not prove that the guest is accessible, bootable, or ready for your client.
 Declaring a service port does not install the service.
@@ -26,13 +26,14 @@ for the published-artifact model.
 
 ## Choose a published Fleet image
 
-1. Open the [OS and image catalog](/reference/sandbox-sdk/os-image-catalog) and
+1. Open the [hosted Fleet image catalog](/reference/sandbox-sdk/os-image-catalog#hosted-fleet-images) and
    choose a Fleet VM artifact that matches your guest OS and workload. Check its
-   architecture and evidence limits. Local Docker and Lume entries are separate
-   runtime choices, not built-in Fleet mappings.
-2. Check the artifact's guest services against your client. The Sandbox SDK's
-   default connection expects computer-server on port `8000`; an MCP client needs
-   an image that starts an MCP service. Declaring a port does not install either
+   architecture and evidence limits. Published candidates and local Docker/Lume
+   images have separate sections; they are not default Fleet selections.
+2. Check the artifact's guest services against your client. For direct Driver
+   access through MCP, choose an image that starts a Driver MCP service. The
+   Sandbox SDK's desktop methods instead expect computer-server on port `8000`.
+   Declaring a port does not install either
    service. See the [Fleet guest-service contract](/reference/sandbox-sdk/runtime-support#fleet-guest-service-contract).
 3. Use the built-in constructor for a mapped artifact, or copy the exact registry
    reference into `Image.from_registry()`. Set the guest OS and `kind='vm'`
@@ -40,6 +41,11 @@ for the published-artifact model.
 4. Follow [Create a sandbox pool with Python](/how-to-guides/sandbox/create-pool-with-python) to apply
    the image and claim a replica. Confirm registry access, guest readiness, and
    the operation your workload needs before reusing that pool.
+
+The Ubuntu SDK mapping and dashboard default select different tags. Check the
+[Ubuntu image details](/reference/sandbox-sdk/os-image-catalog#ubuntu-2404) and use
+an explicit digest when both paths must select the same artifact. Changing a
+catalog recommendation does not upgrade an existing pool.
 
 For an explicit registry reference, set `FLEET_IMAGE_REF` to the artifact you
 selected, then construct the image specification:

--- a/docs/content/docs/reference/cua-driver/platform-support.mdx
+++ b/docs/content/docs/reference/cua-driver/platform-support.mdx
@@ -79,7 +79,7 @@ For the relationship between distributions, desktops, and compositors, read
 | ------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | X11/Xorg                        | Supported             | Window discovery and capture, AT-SPI trees and actions, foreground pointer and keyboard input, semantic background delivery, desktop scope, and structured refusals | Raw background delivery depends on the target toolkit. X11 accepting an event does not prove the application handled it.                                                                                                  |
 | Sway (wlroots reference lane)   | Supported with limits | The complete typed Electron, Tauri, GTK, capture, and desktop-scope catalog, including foreground/background and AX/PX outcomes                                     | Focus-bound and raw background input shapes without a target-addressed protocol return structured refusals. Other wlroots compositors are expected to share protocol support but are not yet proven.                      |
-| Hyprland / Omarchy              | Experimental          | Separate [driver, discovery-foundation, and input-candidate evidence](#hyprland-and-omarchy); no released general Hyprland support claim                       | Do not inherit Sway coverage. The default plugin build is discovery-only. The opt-in input v3 source candidate requires complete native harness acceptance, bounded qualified-app evidence, and release validation. |
+| Hyprland / Omarchy              | Experimental          | [Qualified isolated input released in 0.24.0](#hyprland-and-omarchy), with separate native-harness and bounded app evidence; not general Hyprland support | Do not inherit Sway coverage. The default plugin build is discovery-only. The separate opt-in input v3 plugin is limited to the qualified applications and exact compositor ABI/toolchain. |
 | GNOME/Mutter                    | Supported with limits | AT-SPI actions, GTK controls, compositor-backed window geometry and capture, verified foreground activation, and portal/libei foreground input                      | The bundled WinRects Shell helper and one Shell-session restart are prerequisites for authoritative geometry and activation. Portal video recording remains incomplete.                                                   |
 | KDE/KWin                        | Experimental          | Plasma 6 session startup, GTK AT-SPI discovery, generic discovery where exposed, and portal interface availability                                                  | The optional KWin helper exposes read-only window identity and state, not activation or input. Raw target-addressed input refuses until a target-bound KWin input path exists; no complete behavioral matrix is accepted. |
 | `cua-compositor` nested session | Experimental          | Native GTK behavior, capture and scope, private route metadata, independent observation, and per-cell video                                                         | The complete shared renderer matrix is not accepted. Unicode text and a canonical parallel-drag row remain unproven; this route does not establish a stock-Wayland capability.                                            |
@@ -90,20 +90,20 @@ For the relationship between distributions, desktops, and compositors, read
 Omarchy uses Hyprland; it is not a separate display protocol. Modern Hyprland
 is not based on wlroots, so its support must be recorded separately from Sway.
 
-The following is a source-work status snapshot as of September 7, 2026, not an
-installer or release-support matrix:
+The following records source-work history and release status as of September 7,
+2026. It is not certification of every installer, image, or host configuration:
 
 | Work                           | Evidence and boundary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Driver capture and observation | [Merged PR #3557](https://github.com/trycua/cua/pull/3557) reports scale-1 GTK3 capture, semantic actions, and independent focus/cursor checks at source `b50a4f78f277d05700200e84c5d0f0ea72f10c47`. That candidate's canonical native suite stopped at the foreground-key preflight; no matrix cells ran. This is historical focused evidence, not desktop certification or released support. |
 | Optional Hyprland plugin       | [Merged PR #3547](https://github.com/trycua/cua/pull/3547) adds discovery and liveness only. Its [validation report](https://github.com/trycua/cua/blob/7c58a4d5b078b81f657d8e7e906712f8e3a96148/libs/cua-driver/hyprland-plugin/tests/validation.md) records native build and live lifecycle evidence on Hyprland `0.56.2`. All six input message types return `background_unavailable`; the foundation creates no synthetic seat and changes no Driver delivery route. |
-| Isolated raw background input  | [PR #3572](https://github.com/trycua/cua/pull/3572) records dated, exact-source validation results for the experimental input v3 candidate, using Driver's shared per-action policy and two independent compositor seats. Complete native harness acceptance and bounded qualified-app proof are separate requirements. Earlier [desktop-transition evidence](https://github.com/trycua/cua/blob/e8542dece6c8195a8db50ba79aba9615a78340b1/libs/cua-driver/hyprland-plugin/tests/desktop-state-validation.md) belongs to the separate signed experiment. The candidate is not released. |
+| Isolated raw background input  | [Merged PR #3572](https://github.com/trycua/cua/pull/3572) records dated, exact-source validation results for the experimental input v3 candidate, using Driver's shared per-action policy and two independent compositor seats. Complete native harness acceptance and bounded qualified-app proof are separate requirements. Earlier [desktop-transition evidence](https://github.com/trycua/cua/blob/e8542dece6c8195a8db50ba79aba9615a78340b1/libs/cua-driver/hyprland-plugin/tests/desktop-state-validation.md) belongs to the separate signed experiment. The qualified feature shipped in [Cua Driver 0.24.0](https://github.com/trycua/cua/releases/tag/cua-driver-rs-v0.24.0); its separate plugin assets retain the stated application and ABI/toolchain limits. |
 
 The plugin is disabled by default and outside the portable driver installation
 path. Switching driver channels alone does not install or enable it. Its
 Hyprland ABI and compiler toolchain must match the compositor that loads it.
 
-The v3 candidate adds no Omarchy-specific approval panel or external signer.
+The v3 input plugin adds no Omarchy-specific approval panel or external signer.
 Driver applies its normal permission, resource, and lifecycle checks on every
 action. Same-user local sockets and application qualification do not sandbox
 native code running as the desktop user. The two seats, `Cua-Agent` and
@@ -113,11 +113,11 @@ plugin requires a desktop restart.
 The initial native application qualification scope is Calc from
 `libreoffice-fresh 26.2.5-3` and Inkscape `1.4.4-6`. Driver checks the running
 executable against the expected package path and exact local package metadata
-before each action. Those checks establish eligibility for the candidate, not
+before each action. Those checks establish eligibility for isolated input, not
 proof that every application operation works. The plugin requires a live native
 surface and the exact compiled default `evdev`/`pc105`/`us` keymap. Variants,
 options, remaps, multiple layout groups, Unicode, IME input, arbitrary held-key
-streams, and modified pointer gestures are outside the candidate. Chromium,
+streams, and modified pointer gestures are outside the qualified contract. Chromium,
 Electron, and XWayland raw background input are also outside this scope.
 Semantic AT-SPI actions retain their separate behavior.
 
@@ -134,7 +134,7 @@ plugin tree and uninstrumented module hash at
 recorded actions and observation intervals. It does not replace acceptance of
 the unchanged complete Linux canonical runner on native Hyprland.
 
-Unsupported targets and desktop states refuse. The candidate does not silently
+Unsupported targets and desktop states refuse. The plugin does not silently
 switch to foreground input, wake a display, or unlock a session. A dispatch
 acknowledgement does not prove an application effect; canceled, partial, or
 unknown actions must not be replayed automatically.

--- a/docs/content/docs/reference/sandbox-sdk/os-image-catalog.mdx
+++ b/docs/content/docs/reference/sandbox-sdk/os-image-catalog.mdx
@@ -1,20 +1,208 @@
 ---
 title: OS and image catalog
-description: Sandbox operating systems, Linux distributions, desktop environments, window managers, and image registries.
+description: Hosted Fleet VM images, published candidates, and local Docker and Lume images, with selection and validation limits.
 ---
+
+For a hosted pool, start with [Hosted Fleet images](#hosted-fleet-images).
+[Published candidates](#published-candidates) have a separate validation status.
+[Local images](#local-images) target Docker or Lume on your own hardware, not the
+hosted Fleet VM path.
+
+This catalog describes specific artifacts and SDK mappings, not every image
+deployed in every Fleet pool. An image update does not upgrade existing pools.
+Registry and documentation checks below are dated September 7, 2026; mutable
+tags can resolve differently later.
+
+## Hosted Fleet images
+
+These VM image references use Fleet's `containerDisk` path, not an ordinary
+application-container runtime. Follow [Choose a Fleet
+image](/how-to-guides/sandbox/choose-an-image#choose-a-published-fleet-image) to
+select the guest OS, declare services, and claim a pool.
+
+| Image | Selection | Evidence and limits |
+| --- | --- | --- |
+| [Ubuntu 24.04](#ubuntu-2404) | Built-in `Image.linux()` in SDK 0.4.3; dashboard default differs | Published artifact and SDK mapping checked; no app-level certification established here |
+| [Omarchy / Hyprland](#omarchy-hyprland) | Explicit digest; amd64 guest | Fleet boot and bounded Driver background-selection evidence in the linked recipe |
+| [Windows Server 2022](#windows-server-2022) | Built-in `Image.windows()` in SDK 0.4.3 | Published artifact and EFI selection checked; no app-level certification established here |
+
+Use the exact references in the image details. Publication, boot, and operation
+checks establish different things; see [Evidence levels](#evidence-levels).
+
+### Ubuntu 24.04
+
+`Image.linux()` in `cua-sandbox` 0.4.3 selects this versioned Fleet VM tag:
+
+```text
+public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04:main-38352d34
+```
+
+The tag resolved to this digest at the dated registry check:
+
+```text
+public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04@sha256:eb68411ed8b4d7c39829cdfe854b9d0485b78ee064c3171fd8e3f7450f7ccee7
+```
+
+The Fleet dashboard's Ubuntu default uses
+`public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04:latest`, which resolved to a different
+digest at that check:
+
+```text
+public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04@sha256:c1e601dbb748fdc467c663136f7592e308a91a3c19c309b75261544432826a57
+```
+
+The SDK pin and dashboard default are different selection paths; neither
+implies that an existing pool has changed. Inspect the image reference selected
+for your pool. Use an explicit digest when the same artifact must be selected
+from both paths. This catalog does not change the versioned SDK mapping.
+
+The [SDK mapping evidence](/reference/sandbox-sdk/runtime-support#evidence-and-limits)
+does not identify the guest desktop, guest architecture, or installed Driver and
+computer-server versions. OCI manifest architecture alone does not establish
+those guest details. The Sandbox SDK expects a compatible `server` on port
+`8000`; an MCP endpoint must be verified separately. Do not substitute the
+`docker-latest` application-container image for this VM image.
+
+### Omarchy / Hyprland [#omarchy-hyprland]
+
+Use the published amd64 Omarchy image from the [Fleet
+recipe](/how-to-guides/sandbox/run-omarchy-on-cloud-fleet):
+
+```text
+public.ecr.aws/k5j5w0x5/cua-omarchy-workspace@sha256:dc448dcc986f443980dfb3586f1b91d8699091ad96a74b369016535f0dbb0342
+```
+
+The guest runs Arch-based Omarchy with Hyprland / Wayland. The recipe documents
+Cua Driver and Hyprland plugin 0.24.0, the `mcp` service on port `3000` at `/mcp`,
+and the compatibility `computer-server` service on port `8000`. The recipe does
+not specify a computer-server package version.
+
+The recipe's recording shows two Driver sessions making background selections
+in LibreOffice Calc and Inkscape while a terminal stays in the foreground. It
+does not establish data edits or continuous foreground-isolation testing. The
+[0.24.0 release](https://github.com/trycua/cua/releases/tag/cua-driver-rs-v0.24.0)
+and its [pinned plugin contract](https://github.com/trycua/cua/blob/4b3396d9fe4bd3cf723b0eb8db83c18a8764b520/libs/cua-driver/hyprland-plugin/packaging/release/USAGE.md)
+define the compositor, application-package, keyboard, and two-lane limits.
+Chromium, Electron, and XWayland raw background input are outside that contract.
+
+This reference replaces the older `d9b7be06...` recommendation. Existing pools
+using the older image are not automatically upgraded. The separate
+[ARM64 Omarchy guide](/how-to-guides/lume/run-omarchy-arm64) is for local Lume,
+not this Fleet artifact.
+
+### Windows Server 2022
+
+`Image.windows()` in `cua-sandbox` 0.4.3 selects this versioned Fleet VM tag:
+
+```text
+public.ecr.aws/k5j5w0x5/cua-windows-2022:main-bac7daa3
+```
+
+At the dated registry check, this tag and `latest` resolved to:
+
+```text
+public.ecr.aws/k5j5w0x5/cua-windows-2022@sha256:6d341afc26a37c4072d22ba403a89ecdad9a29aebab79570b5a38da6b8e16370
+```
+
+The guest uses the native Windows desktop. The
+[SDK contract](/reference/sandbox-sdk/runtime-support#windows-firmware) selects
+EFI for a Windows Fleet template. It does not establish guest architecture,
+installed Driver/server versions, service readiness, or desktop-operation
+certification for this artifact. The Sandbox SDK expects `server: 8000`; an MCP
+endpoint must be verified separately.
 
 Windows images do not include a Windows license. Bring your own valid licenses
 covering your intended use, including the applicable hosting and virtualization
 rights. An image being available or booting successfully does not establish
 licensing eligibility. Bundled applications have their own license terms.
 
-| OS      | Distribution / version / architecture                                   | Desktop / window manager                         | Image kind / runtime                       | Registry image or source                                                                                                | Evidence / limits                                                                                                                                                                                                                                                                                                                     |
-| ------- | ----------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Linux   | Ubuntu 24.04; artifact architecture not established by SDK mapping      | Artifact-dependent; not specified by SDK mapping | Fleet containerDisk; local bare-metal QEMU | `public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04:main-38352d34`                                                                | `Image.linux()` mapping in `cua-sandbox` 0.4.3; versioned tag, not a digest pin. [SDK checks](/reference/sandbox-sdk/runtime-support#evidence-and-limits) establish selection, not a live pull, boot, or guest-service check.                                                                                                         |
-| Linux   | Ubuntu 24.04                                                            | XFCE runtime mapping                             | Local Docker container                     | `public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04:docker-latest`                                                                | Local container selector; mutable tag, not the Fleet VM disk                                                                                                                                                                                                                                                                          |
-| Linux   | Omarchy (Arch Linux-based), amd64                                       | Hyprland / Wayland                               | Fleet containerDisk                        | `public.ecr.aws/k5j5w0x5/cua-omarchy-workspace@sha256:d9b7be06beac425084eaa99eb912589b38b5cc86ae3e3ec45c9c5d59d4b3a7ab` | Digest-pinned explicit registry image. The [Fleet recipe](/how-to-guides/sandbox/run-omarchy-on-cloud-fleet) reports boot verification and defines `server: 8000` (computer-server) and `mcp: 3000` (Cua Driver); it does not certify every operation or Hyprland configuration.                                                      |
-| Linux   | NixOS; release and architecture not recorded in the publication summary | StumpWM                                          | Published candidate image                  | `public.ecr.aws/k5j5w0x5/cua-nixos-stumpwm:git-ee87f38043c043831a8761016015d6ef5ae783d9`                                | [Publication summary](https://github.com/trycua/cua/pull/3585) reports computer-server and Cua Driver included, guest tests and CI anonymous-pull checks passed. Component versions, service ports, and Fleet claim checks are not recorded there. Commit-named candidate tag, not a digest pin or `latest`; no built-in SDK mapping. |
-| Linux   | NixOS; release and architecture not recorded in the publication summary | Xfce / Xfwm4                                     | Published candidate image                  | `public.ecr.aws/k5j5w0x5/cua-nixos-xfce:git-ee87f38043c043831a8761016015d6ef5ae783d9`                                   | [Publication summary](https://github.com/trycua/cua/pull/3585) reports computer-server and Cua Driver included, guest tests and CI anonymous-pull checks passed. Component versions, service ports, and Fleet claim checks are not recorded there. Commit-named candidate tag, not a digest pin or `latest`; no built-in SDK mapping. |
-| Windows | Server 2022; artifact architecture not established by SDK mapping       | Native Windows desktop                           | Fleet containerDisk; local Hyper-V or QEMU | `public.ecr.aws/k5j5w0x5/cua-windows-2022:main-bac7daa3`                                                                | `Image.windows()` mapping in `cua-sandbox` 0.4.3; Fleet selects EFI. Versioned tag, not a digest pin. [SDK checks](/reference/sandbox-sdk/runtime-support#evidence-and-limits) establish selection and firmware, not a live pull, boot, or guest-service check.                                                                       |
-| macOS   | Sequoia 15                                                              | Native macOS desktop                             | Local Lume VM                              | `ghcr.io/trycua/macos-sequoia-cua:latest`                                                                               | Compatible Apple silicon host required; mutable tag; no built-in Fleet mapping                                                                                                                                                                                                                                                        |
-| macOS   | Tahoe 26                                                                | Native macOS desktop                             | Local Lume VM                              | `ghcr.io/trycua/macos-tahoe-cua:latest`                                                                                 | Default `Image.macos()` version; compatible Apple silicon host required; mutable tag; no built-in Fleet mapping                                                                                                                                                                                                                       |
+## Published candidates
+
+These NixOS artifacts are published candidates, not built-in SDK mappings or
+default Fleet selections. Anonymous registry checks resolved both tags on
+September 7, 2026. Publication does not establish a successful Fleet claim,
+guest-service readiness, or validated desktop operations.
+
+| Candidate | Desktop / window manager | Validation recorded here |
+| --- | --- | --- |
+| NixOS StumpWM | StumpWM | Published; original build and Fleet-operation evidence not established here |
+| NixOS XFCE | Xfce / Xfwm4 | Published; original build and Fleet-operation evidence not established here |
+
+The published tags are:
+
+```text
+public.ecr.aws/k5j5w0x5/cua-nixos-stumpwm:git-ee87f38043c043831a8761016015d6ef5ae783d9
+public.ecr.aws/k5j5w0x5/cua-nixos-xfce:git-ee87f38043c043831a8761016015d6ef5ae783d9
+```
+
+Their resolved digests are:
+
+```text
+public.ecr.aws/k5j5w0x5/cua-nixos-stumpwm@sha256:3c5e87fae2486e8c7a1bc6546338c4183ff0bddbd40dd540981ab4d30e03e374
+public.ecr.aws/k5j5w0x5/cua-nixos-xfce@sha256:cd8075aff31f234bcd0573c424ab3f7d2aaf625798dee2352a76b1f58cff64dd
+```
+
+The public OCI configuration identifies Linux/amd64 artifact packaging, but
+does not identify the guest NixOS release, exact Driver/server versions, or
+service ports. Original public build and Fleet-operation results are not
+available in this catalog. Before adopting either candidate, verify its build
+provenance, Fleet admission, boot, services, and the operations your workload
+needs. A commit-named tag is not itself a build or test result. See [Prepare and
+reference a Fleet image](/how-to-guides/sandbox/prepare-and-reference-a-fleet-image)
+for the artifact and readiness requirements.
+
+## Local images
+
+These references target local runtimes. They are not substitutes for Fleet
+`containerDisk` images and are not built-in hosted Fleet mappings in SDK 0.4.3.
+
+| Image | Local runtime | Selector or requirement |
+| --- | --- | --- |
+| Ubuntu 24.04 / XFCE | Docker application container | `Image.linux(kind='container')` |
+| macOS Sequoia 15 | Lume VM | `Image.macos('15')`; compatible Apple silicon host |
+| macOS Tahoe 26 | Lume VM | Default `Image.macos()`; compatible Apple silicon host |
+
+The local registry references are:
+
+```text
+public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04:docker-latest
+ghcr.io/trycua/macos-sequoia-cua:latest
+ghcr.io/trycua/macos-tahoe-cua:latest
+```
+
+These mutable tags resolved at the dated registry check; no new local boot or
+application tests are recorded here. Follow [Build a local sandbox
+image](/how-to-guides/sandbox/images) and the
+[runtime support matrix](/reference/sandbox-sdk/runtime-support#operating-systems-and-image-kinds).
+The Lume distinction concerns these artifacts and SDK mappings, not a claim
+about every macOS hosting service.
+
+## Evidence levels
+
+These labels describe different checks, not interchangeable guarantees:
+
+| Evidence | What it establishes | What it does not establish |
+| --- | --- | --- |
+| Published | A registry manifest resolves for the exact reference | Guest boot, installed service versions, or operation support |
+| Fleet boot observed | Dated evidence records a guest boot for the identified artifact | Every service is ready or every desktop operation works |
+| Operations validated | Linked results identify the tested artifact, environment, and operations | Untested applications, configurations, or later image versions |
+
+An SDK mapping establishes which image specification the client selects; it is
+not boot evidence. OCI platform metadata describes artifact packaging, not
+independent inspection of the guest disk. Missing evidence here is not proof
+that an image cannot boot.
+
+## Driver and compatibility-server connections
+
+Choose an image whose guest starts the service your client needs. Declaring a
+Fleet service port does not install or start that service.
+
+| Client path | Required guest service | Connection |
+| --- | --- | --- |
+| Cua Driver through MCP | A running Driver MCP endpoint | Use the image's documented service name, port, and MCP path through the authenticated Fleet claim |
+| Sandbox SDK desktop methods | A compatible computer-server endpoint | SDK 0.4.3 defaults to `server: 8000` and checks `/status` |
+
+The Omarchy recipe documents both paths. Do not infer another image's MCP port
+or Driver version from its OS name. See the
+[Fleet guest-service contract](/reference/sandbox-sdk/runtime-support#fleet-guest-service-contract)
+for connection and readiness limits.


### PR DESCRIPTION
## Summary

Fixes #3639.

- Separate hosted Fleet VM images, published candidates, and local Docker/Lume images.
- Link the Fleet selection guide directly to hosted images and distinguish direct Driver/MCP connections from Sandbox SDK computer-server connections.
- Align the Omarchy digest with the recipe updated in #3634 and correct the linked Hyprland release status against Cua Driver 0.24.0.
- Record the Ubuntu SDK pin versus dashboard default difference, dated registry checks, and the limits of publication, boot, and operation evidence.
- Remove the NixOS catalog's circular documentation citation without claiming unverified build provenance or Fleet-operation coverage.

## Scope and evidence

Documentation only. No SDK mappings, dashboard defaults, existing pools, release artifacts, or image deployments change. A machine-readable catalog and automated updates are separate follow-up work.

The catalog retains SDK 0.4.3 mappings and deliberate unknowns for guest architecture, component versions, and candidate validation where the cited evidence does not establish them. OCI carrier metadata is not treated as guest inspection. The Omarchy recording is described as bounded background selections, not proof of arbitrary app edits or continuous foreground isolation.

## Validation

- Internal link check: passed, zero errors.
- Docs hygiene: passed on the final commit.
- Production docs build: passed on the final commit, including TypeScript and all 147 static pages.
- Independent read-only review: one stale candidate/release wording contradiction identified and corrected; no other concrete findings in scope.
- Cua Driver / standalone Chrome render checks: passed at 1200 x 859 and 500 x 859 CSS-pixel viewports. Inspected the catalog sections, selection procedure, and changed Hyprland section; verified the hosted-image and Omarchy anchors. Narrow-window proof is not mobile-device certification.
- GitHub CI: all applicable checks passed, including internal/external links, generated-reference sync, release metadata, and contributor attribution. The installer execution matrix is correctly skipped for this docs-only diff.

Verified commit: `3f71e8bc4`.

Maintainer approved merging the reviewed docs-only change. No image, pool, or runtime-default changes are included.
