### PR TITLE
docs: use a portable Omarchy catalog anchor

### DIFF
--- a/docs/content/docs/reference/sandbox-sdk/os-image-catalog.mdx
+++ b/docs/content/docs/reference/sandbox-sdk/os-image-catalog.mdx
@@ -23,7 +23,7 @@ select the guest OS, declare services, and claim a pool.
 | Image | Selection | Evidence and limits |
 | --- | --- | --- |
 | [Ubuntu 24.04](#ubuntu-2404) | Built-in `Image.linux()` in SDK 0.4.3; dashboard default differs | Published artifact and SDK mapping checked; no app-level certification established here |
-| [Omarchy / Hyprland](#omarchy-hyprland) | Explicit digest; amd64 guest | Fleet boot and bounded Driver background-selection evidence in the linked recipe |
+| [Omarchy / Hyprland](#omarchy-and-hyprland) | Explicit digest; amd64 guest | Fleet boot and bounded Driver background-selection evidence in the linked recipe |
 | [Windows Server 2022](#windows-server-2022) | Built-in `Image.windows()` in SDK 0.4.3 | Published artifact and EFI selection checked; no app-level certification established here |
 
 Use the exact references in the image details. Publication, boot, and operation
@@ -63,7 +63,7 @@ those guest details. The Sandbox SDK expects a compatible `server` on port
 `8000`; an MCP endpoint must be verified separately. Do not substitute the
 `docker-latest` application-container image for this VM image.
 
-### Omarchy / Hyprland [#omarchy-hyprland]
+### Omarchy and Hyprland
 
 Use the published amd64 Omarchy image from the [Fleet
 recipe](/how-to-guides/sandbox/run-omarchy-on-cloud-fleet):


### PR DESCRIPTION
## Scope

Refs #3639. Follow-up to #3641.

Use the plain heading `Omarchy and Hyprland` and its generated
`#omarchy-and-hyprland` fragment for the Fleet catalog section.

The local docs renderer supports the explicit `[#omarchy-hyprland]` anchor
syntax, but the public site renders it as heading text and produces a
different heading ID. The catalog table link therefore does not reach the
Omarchy section on the public site. A plain heading keeps both renderers
consistent.

Only the heading and its table link change. No image references, runtime
behavior, SDK defaults, pools, or deployment configuration change.

## Validation

- Production docs build: passed (147 static pages).
- Internal docs link check: passed (0 errors).
- Public docs hygiene check: passed.
- Generated HTML contains matching `href="#omarchy-and-hyprland"` and
  `id="omarchy-and-hyprland"`.
- Local production preview: the section fragment lands on the visible heading.
- `git diff --check`: passed.

## Post-merge verification

- Merged as `e686ee9ad32996bdfba9891852cf50a1269693ae`; its tree matches the
  tested candidate.
- The automatic docs rollout completed on September 8, 2026 (UTC).
- The public catalog HTML contains matching link and heading fragments.
- Cua Driver browser verification: clicking the Omarchy table row changes the
  URL to `#omarchy-and-hyprland` and brings the correct heading into view.
- Verified page: https://cua.ai/docs/reference/sandbox-sdk/os-image-catalog#omarchy-and-hyprland
