### PR TITLE
docs: remove NixOS Fleet candidate listings

### DIFF
--- a/docs/content/docs/how-to-guides/sandbox/choose-an-image.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/choose-an-image.mdx
@@ -28,8 +28,8 @@ for the published-artifact model.
 
 1. Open the [hosted Fleet image catalog](/reference/sandbox-sdk/os-image-catalog#hosted-fleet-images) and
    choose a Fleet VM artifact that matches your guest OS and workload. Check its
-   architecture and evidence limits. Published candidates and local Docker/Lume
-   images have separate sections; they are not default Fleet selections.
+   architecture and evidence limits. Local Docker/Lume images have a separate
+   section and are not hosted Fleet VM selections.
 2. Check the artifact's guest services against your client. For direct Driver
    access through MCP, choose an image that starts a Driver MCP service. The
    Sandbox SDK's desktop methods instead expect computer-server on port `8000`.

--- a/docs/content/docs/reference/sandbox-sdk/os-image-catalog.mdx
+++ b/docs/content/docs/reference/sandbox-sdk/os-image-catalog.mdx
@@ -1,10 +1,9 @@
 ---
 title: OS and image catalog
-description: Hosted Fleet VM images, published candidates, and local Docker and Lume images, with selection and validation limits.
+description: Hosted Fleet VM images and local Docker and Lume images, with selection and validation limits.
 ---
 
 For a hosted pool, start with [Hosted Fleet images](#hosted-fleet-images).
-[Published candidates](#published-candidates) have a separate validation status.
 [Local images](#local-images) target Docker or Lume on your own hardware, not the
 hosted Fleet VM path.
 
@@ -115,41 +114,6 @@ Windows images do not include a Windows license. Bring your own valid licenses
 covering your intended use, including the applicable hosting and virtualization
 rights. An image being available or booting successfully does not establish
 licensing eligibility. Bundled applications have their own license terms.
-
-## Published candidates
-
-These NixOS artifacts are published candidates, not built-in SDK mappings or
-default Fleet selections. Anonymous registry checks resolved both tags on
-September 7, 2026. Publication does not establish a successful Fleet claim,
-guest-service readiness, or validated desktop operations.
-
-| Candidate | Desktop / window manager | Validation recorded here |
-| --- | --- | --- |
-| NixOS StumpWM | StumpWM | Published; original build and Fleet-operation evidence not established here |
-| NixOS XFCE | Xfce / Xfwm4 | Published; original build and Fleet-operation evidence not established here |
-
-The published tags are:
-
-```text
-public.ecr.aws/k5j5w0x5/cua-nixos-stumpwm:git-ee87f38043c043831a8761016015d6ef5ae783d9
-public.ecr.aws/k5j5w0x5/cua-nixos-xfce:git-ee87f38043c043831a8761016015d6ef5ae783d9
-```
-
-Their resolved digests are:
-
-```text
-public.ecr.aws/k5j5w0x5/cua-nixos-stumpwm@sha256:3c5e87fae2486e8c7a1bc6546338c4183ff0bddbd40dd540981ab4d30e03e374
-public.ecr.aws/k5j5w0x5/cua-nixos-xfce@sha256:cd8075aff31f234bcd0573c424ab3f7d2aaf625798dee2352a76b1f58cff64dd
-```
-
-The public OCI configuration identifies Linux/amd64 artifact packaging, but
-does not identify the guest NixOS release, exact Driver/server versions, or
-service ports. Original public build and Fleet-operation results are not
-available in this catalog. Before adopting either candidate, verify its build
-provenance, Fleet admission, boot, services, and the operations your workload
-needs. A commit-named tag is not itself a build or test result. See [Prepare and
-reference a Fleet image](/how-to-guides/sandbox/prepare-and-reference-a-fleet-image)
-for the artifact and readiness requirements.
 
 ## Local images
 


### PR DESCRIPTION
## Scope

Refs #3639. Follow-up to #3641.

Remove the NixOS Xfce and StumpWM candidate image listings from the public
Fleet catalog. Remove the candidate-section link, description metadata, and
the corresponding selection-guide wording.

The documented hosted images remain Ubuntu 24.04, Omarchy, and Windows Server
2022. Local Docker/Lume guidance and existing image evidence limits remain
unchanged. This is a catalog-scope change, not an image deprecation or a claim
that other images cannot run.

No registry artifacts, pools, SDK mappings, Driver behavior, or runtime
configuration change. No new image availability claims are introduced.

## Validation

- `git diff --check`: passed.
- Public content and asset search: no remaining references to either candidate
  image or the removed `published-candidates` section.
- Independent read-only audit: no other public candidate-image references or
  inbound links to the removed anchor.
- `pnpm --dir docs docs:check-hygiene`: passed.
- `pnpm --dir docs docs:check-links`: passed, zero errors.
- `pnpm --dir docs build`: passed, all 147 static pages generated.
- Production preview: both edited pages return HTTP 200; generated HTML and
  description metadata contain no removed candidate references.
- Cua Driver browser inspection: both pages render correctly at 1200px and
  500px viewport widths; local-image and selection-guide anchors still work.
- All applicable GitHub checks passed, including internal/external links,
  contributor attribution, release metadata, and Fleet mirror guard.

Validated commit: `f587b48a8cd3d7e1a0704b33c04cb39c52fd0958`.

## Delivery

Merged as `ddc7a632a9bc02af400ac052503bd9f6c8503b9f`. The merged docs tree
matches the validated candidate exactly.

Production rollout verified on September 8, 2026 (UTC): both public pages
return HTTP 200, contain the revised copy and metadata, and contain no removed
candidate references. Cua Driver browser inspection confirms the rendered
catalog and selection guide, including the selection-guide anchor.

- https://cua.ai/docs/reference/sandbox-sdk/os-image-catalog
- https://cua.ai/docs/how-to-guides/sandbox/choose-an-image#choose-a-published-fleet-image

No runtime certification is required for this two-file prose-only removal.
