### PR TITLE
fix(sandbox): bound typed Driver lifecycle and request deadlines

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/interfaces/driver.py
+++ b/libs/python/cua-sandbox/cua_sandbox/interfaces/driver.py
@@ -7,6 +7,7 @@ import importlib
 import json
 import logging
 import re
+import time
 import uuid
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, AsyncIterator
@@ -23,15 +24,16 @@ _CLEANUP_TIMEOUT = 2.0
 logger = logging.getLogger(__name__)
 
 
+def _consume_result(done: asyncio.Future) -> None:
+    if not done.cancelled():
+        done.exception()
+
+
 async def _bounded_cleanup(awaitable: Any) -> bool:
     """Bound best-effort cleanup, including callbacks that ignore cancellation."""
     task = asyncio.ensure_future(awaitable)
 
-    def consume_result(done: asyncio.Future) -> None:
-        if not done.cancelled():
-            done.exception()
-
-    task.add_done_callback(consume_result)
+    task.add_done_callback(_consume_result)
     done, _ = await asyncio.wait({task}, timeout=_CLEANUP_TIMEOUT)
     if task not in done:
         task.cancel()
@@ -75,6 +77,8 @@ class Driver:
         self._principal = uuid.uuid4().hex
         self._lock = asyncio.Lock()
         self._connections: dict[Any, Any] = {}
+        self._opening: dict[Any, asyncio.Task] = {}
+        self._closing: dict[Any, asyncio.Task] = {}
         self._closed = False
         self._loop: asyncio.AbstractEventLoop | None = None
 
@@ -114,14 +118,26 @@ class Driver:
                 )
             sdk = _sdk()
             channel = _channel(sdk, self._transport, service, self._principal)
-            try:
-                await channel.open()
-                driver = sdk.connect_remote_channel(channel)
-            except BaseException:
-                await channel.close()
-                raise
-            self._connections[channel] = driver
+
+            async def open_channel():
+                try:
+                    await channel.open()
+                finally:
+                    # A cancelled carrier may still return an allocated session.
+                    if channel.closed:
+                        await channel.close()
+
+            opening = asyncio.create_task(open_channel())
+            opening.add_done_callback(_consume_result)
+            self._opening[channel] = opening
+            self._connections[channel] = None
         try:
+            await asyncio.shield(opening)
+            async with self._lock:
+                if self._closed or channel.closed:
+                    raise DriverConnectionError("Sandbox Driver accessor is disconnected")
+                driver = sdk.connect_remote_channel(channel)
+                self._connections[channel] = driver
             yield driver
         finally:
             await self._close_connection(channel)
@@ -129,11 +145,25 @@ class Driver:
     async def _close_connection(self, channel: Any) -> None:
         self._check_loop()
         async with self._lock:
-            driver = self._connections.pop(channel, None)
-            if driver is not None:
+            task = self._closing.get(channel)
+            if task is None and channel in self._connections:
+                driver = self._connections.pop(channel)
+                opening = self._opening.pop(channel)
                 channel.closed = True
-                await _bounded_cleanup(channel.close())
-                await _bounded_cleanup(driver.shutdown())
+
+                async def cleanup():
+                    if not opening.done():
+                        await _bounded_cleanup(opening)
+                    await channel.close()
+                    if driver is not None:
+                        await _bounded_cleanup(driver.shutdown())
+
+                task = asyncio.create_task(cleanup())
+                self._closing[channel] = task
+                task.add_done_callback(_consume_result)
+                task.add_done_callback(lambda done: self._closing.pop(channel, None))
+        if task is not None:
+            await asyncio.shield(task)
 
     async def close(self) -> None:
         """Invalidate all connections before the owning transport is closed."""
@@ -142,11 +172,16 @@ class Driver:
             self._closed = True
             for channel in self._connections:
                 channel.closed = True
-        for channel in list(self._connections):
+
+        async def close_channel(channel):
             try:
                 await self._close_connection(channel)
             except Exception:
                 logger.warning("Driver cleanup failed; remote session cleanup is unconfirmed")
+
+        await asyncio.gather(
+            *(close_channel(channel) for channel in set(self._connections) | set(self._closing))
+        )
 
 
 def _channel(sdk: Any, transport: FleetTransport, service: str, principal: str) -> Any:
@@ -164,7 +199,7 @@ def _channel(sdk: Any, transport: FleetTransport, service: str, principal: str) 
         def fail(self, reason: str):
             return sdk.ForeignDriverChannelError.Failed(reason)
 
-        async def request(self, method: str, suffix: str = "", body: Any = None):
+        async def request(self, method: str, suffix: str = "", body: Any = None, *, timeout=None):
             path = "/v1/connections"
             headers = None
             if self.connection_id is not None:
@@ -172,7 +207,12 @@ def _channel(sdk: Any, transport: FleetTransport, service: str, principal: str) 
                 headers = {"X-Cua-Driver-Generation": self.generation}
             try:
                 response = await transport.request_service(
-                    service, method=method, path=path, json_body=body, headers=headers
+                    service,
+                    method=method,
+                    path=path,
+                    json_body=body,
+                    headers=headers,
+                    **({"timeout": timeout} if timeout is not None else {}),
                 )
             except Exception as error:
                 if getattr(error, "status", None) in (401, 403):
@@ -250,6 +290,9 @@ def _channel(sdk: Any, transport: FleetTransport, service: str, principal: str) 
             if self.closed or request.request_id in self.cancelled:
                 raise self.fail("Driver connection is closed or request was cancelled")
             try:
+                deadline = request.deadline_unix_ms
+                if type(deadline) is not int or deadline < 0:
+                    raise ValueError
                 body = {
                     "envelope_version": request.envelope_version,
                     "request_id": request.request_id,
@@ -266,11 +309,19 @@ def _channel(sdk: Any, transport: FleetTransport, service: str, principal: str) 
                     raise ValueError
             except (ValueError, TypeError):
                 raise self.fail("Driver request is malformed or exceeds the size limit") from None
+            timeout = min(deadline - int(time.time() * 1000), 120000) / 1000
+            if timeout <= 0:
+                raise self.fail("Driver request deadline has expired")
+            exchange = asyncio.create_task(self.request("POST", "/exchange", body, timeout=timeout))
+            exchange.add_done_callback(_consume_result)
             try:
-                response = await self.request("POST", "/exchange", body)
-                return await self.decode_response(request, response)
+                done, _ = await asyncio.wait({exchange}, timeout=timeout)
+                if exchange not in done:
+                    raise TimeoutError("Driver request deadline has expired; completion is unknown")
+                return await self.decode_response(request, exchange.result())
             except BaseException:
-                self.closed = True
+                exchange.cancel()
+                await self.cancel(request.request_id)
                 await self.close()
                 raise
 
@@ -329,6 +380,9 @@ def _channel(sdk: Any, transport: FleetTransport, service: str, principal: str) 
 
         async def close(self):
             self.closed = True
+            # Do not memoize a no-op before an in-flight open reveals its ID.
+            if self.connection_id is None:
+                return
             if self._close_task is None:
 
                 async def cleanup():

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
@@ -91,11 +91,17 @@ class FleetTransport(Transport):
         path: str,
         json_body: Any = None,
         headers: dict[str, str] | None = None,
+        timeout: float | None = None,
     ) -> httpx.Response:
         if name not in self._bound.services:
             raise ValueError(f"Fleet sandbox does not expose service {name!r}")
         return await self._request(
-            method, path, json_body=json_body, service_name=name, extra_headers=headers
+            method,
+            path,
+            json_body=json_body,
+            service_name=name,
+            extra_headers=headers,
+            timeout=timeout,
         )
 
     async def create_signed_service_url(
@@ -129,6 +135,7 @@ class FleetTransport(Transport):
         json_body: Any = None,
         service_name: str | None = None,
         extra_headers: dict[str, str] | None = None,
+        timeout: float | None = None,
     ) -> httpx.Response:
         assert self._connected, "Transport not connected"
         body = None if json_body is None else json.dumps(json_body).encode()
@@ -146,7 +153,7 @@ class FleetTransport(Transport):
                 url=f"https://service.invalid{path}",
                 headers=headers,
                 body=body,
-                timeout_secs=_whole_seconds(self._timeout),
+                timeout_secs=_whole_seconds(self._timeout if timeout is None else timeout),
             ),
         )
         request = httpx.Request(method, f"https://service.invalid{path}")

--- a/libs/python/cua-sandbox/docs/typed-driver-development.md
+++ b/libs/python/cua-sandbox/docs/typed-driver-development.md
@@ -62,12 +62,28 @@ waits; an unconfirmed cleanup logs a warning and does not block claim release.
 The carrier's independent session expiry remains the fallback for unreachable
 cleanup. A successful local close is not proof that a remote guest was deleted.
 
+Opening handshakes do not hold the accessor's lifecycle lock. Closing the
+accessor invalidates pending opens and bounds the wait for them, so a stalled
+handshake cannot indefinitely delay claim release. If a cancelled open later
+returns a connection ID, the accessor attempts to delete it without yielding a
+Driver. Deletion can remain unconfirmed if the owning transport has already
+disconnected or the handshake never returns its connection ID.
+
+Each Driver exchange uses the envelope's remaining deadline, capped at 120
+seconds, for its per-request Fleet timeout and local wait. This does not change
+the transport's default timeout for computer-server or other callers. Expired
+requests fail before dispatch. A locally timed-out or cancelled exchange
+invalidates the connection and attempts bounded cancellation and deletion; it
+does not replay the desktop action.
+
 ## Verification and remaining proof
 
 The focused tests cover named-service routing, canonical method dispatch,
 response validation, cancellation, and lifecycle ordering. CI requires the
 native bridge integration test through `CUA_SANDBOX_REQUIRE_NATIVE_DRIVER=1`;
 it fails instead of skipping when the matching native package is absent.
+Regression tests also cover pending-open cleanup, late-open invalidation,
+per-request deadlines, and preservation of ordinary transport timeouts.
 
 These synthetic tests do not prove a real guest desktop effect. Before a
 released tutorial or supported-image claim, qualify the exact candidate on a

--- a/libs/python/cua-sandbox/tests/test_fleet_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_transport.py
@@ -91,3 +91,18 @@ async def test_requests_are_bounded_by_the_transport_timeout():
 
     assert sdk.calls[0][3].timeout_secs == 30
     assert sdk.calls[1][3].timeout_secs == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("default_timeout", [30, 90])
+async def test_service_timeout_override_does_not_change_existing_callers(default_timeout):
+    sdk = FakeSDK([response(), response(), response(body=b'data: {"success":true}\n\n')])
+    transport = FleetTransport(sdk=sdk, bound=sandbox(), timeout=default_timeout)
+    await transport.connect()
+
+    await transport.request_service("api", method="POST", path="/exchange", timeout=119.25)
+    await transport.request_service("api", method="GET", path="/status")
+    await transport.send("shell.run", timeout=15)
+
+    assert [call[3].timeout_secs for call in sdk.calls] == [120, default_timeout, default_timeout]
+    assert transport._timeout == default_timeout

--- a/libs/python/cua-sandbox/tests/test_typed_driver.py
+++ b/libs/python/cua-sandbox/tests/test_typed_driver.py
@@ -87,7 +87,9 @@ class Transport(FleetTransport):
         )
         self.status = 200
 
-    async def request_service(self, name, *, method, path, json_body=None, headers=None):
+    async def request_service(
+        self, name, *, method, path, json_body=None, headers=None, timeout=None
+    ):
         assert self._connected
         self.events.append((name, method, path, json_body, headers))
         data = self.open_data if path == "/v1/connections" else self.response_data
@@ -235,7 +237,7 @@ async def test_exchange_errors_are_sanitized_and_never_replayed(sandbox, status,
         with pytest.raises(ChannelError, match=reason) as error:
             await driver.channel.exchange(envelope())
         assert "secret" not in str(error.value)
-        assert len(sandbox._transport.events) == 3
+        assert len(sandbox._transport.events) == (3 if status in (404, 409) else 4)
         assert sandbox._transport.events[-1][1] == "DELETE"
         assert driver.channel.closed
         before = len(sandbox._transport.events)
@@ -481,3 +483,154 @@ async def test_cancelled_exchange_invalidates_and_deletes(sandbox, monkeypatch):
         assert driver.channel.closed
         assert driver.channel.cleanup_confirmed
         assert sandbox._transport.events[-1][1] == "DELETE"
+
+
+@pytest.mark.parametrize("close_claim", [False, True])
+async def test_pending_open_does_not_block_disconnect(sandbox, monkeypatch, close_claim):
+    monkeypatch.setattr("cua_sandbox.interfaces.driver._CLEANUP_TIMEOUT", 0.01)
+    started = asyncio.Event()
+    original = sandbox._transport.request_service
+
+    async def pending(*args, **kwargs):
+        if kwargs["path"] == "/v1/connections":
+            started.set()
+            await asyncio.Event().wait()
+        return await original(*args, **kwargs)
+
+    monkeypatch.setattr(sandbox._transport, "request_service", pending)
+    if close_claim:
+
+        async def release():
+            sandbox._transport.events.append("release")
+
+        sandbox._claim_handle = SimpleNamespace(release=release, name=None)
+    opening = asyncio.create_task(sandbox.driver.connect().__aenter__())
+    await started.wait()
+    await asyncio.wait_for(sandbox.close() if close_claim else sandbox.disconnect(), 0.5)
+    with pytest.raises(asyncio.CancelledError):
+        await opening
+    assert not sandbox.driver._connections
+    assert sandbox._transport.events[-1] == "disconnect"
+    if close_claim:
+        assert sandbox._transport.events[-2] == "release"
+
+
+@pytest.mark.parametrize("cancel_context", [False, True])
+async def test_late_open_is_cleaned_without_resurrecting(sandbox, monkeypatch, cancel_context):
+    monkeypatch.setattr("cua_sandbox.interfaces.driver._CLEANUP_TIMEOUT", 0.01)
+    started, cancelled, finish, deleted = (asyncio.Event() for _ in range(4))
+    original = sandbox._transport.request_service
+
+    async def resistant(*args, **kwargs):
+        if kwargs["path"] == "/v1/connections":
+            started.set()
+            try:
+                await finish.wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                await finish.wait()
+        response = await original(*args, **kwargs)
+        if kwargs["method"] == "DELETE":
+            deleted.set()
+        return response
+
+    monkeypatch.setattr(sandbox._transport, "request_service", resistant)
+    opening = asyncio.create_task(sandbox.driver.connect().__aenter__())
+    await started.wait()
+    if cancel_context:
+        opening.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(opening, 0.5)
+    else:
+        await asyncio.wait_for(sandbox.driver.close(), 0.5)
+    await cancelled.wait()
+    assert not sandbox.driver._connections
+    finish.set()
+    await asyncio.wait_for(deleted.wait(), 0.5)
+    if not cancel_context:
+        with pytest.raises(DriverConnectionError, match="disconnected"):
+            await opening
+    assert [e[1] for e in sandbox._transport.events] == ["POST", "DELETE"]
+
+
+@pytest.mark.parametrize("deadline", [1120000, 10**1000])
+async def test_driver_deadline_overrides_short_transport_timeout(sandbox, monkeypatch, deadline):
+    monkeypatch.setattr("cua_sandbox.interfaces.driver.time.time", lambda: 1000)
+    original = sandbox._transport.request_service
+    timeouts = []
+
+    async def record(*args, **kwargs):
+        timeouts.append(kwargs.get("timeout"))
+        return await original(*args, **kwargs)
+
+    monkeypatch.setattr(sandbox._transport, "request_service", record)
+    async with sandbox.driver.connect() as driver:
+        await driver.channel.exchange(envelope(deadline_unix_ms=deadline))
+    assert timeouts == [None, 120, None]
+    assert sandbox._transport._timeout == 30
+
+
+@pytest.mark.parametrize("deadline", [0, 999999, 1000000, -1])
+async def test_expired_or_invalid_deadline_never_dispatches(sandbox, monkeypatch, deadline):
+    monkeypatch.setattr("cua_sandbox.interfaces.driver.time.time", lambda: 1000)
+    async with sandbox.driver.connect() as driver:
+        with pytest.raises(ChannelError, match="expired|malformed"):
+            await driver.channel.exchange(envelope(deadline_unix_ms=deadline))
+        assert len(sandbox._transport.events) == 1
+
+
+async def test_local_deadline_cancels_then_deletes_without_replay(sandbox, monkeypatch):
+    monkeypatch.setattr("cua_sandbox.interfaces.driver.time.time", lambda: 1000)
+    original = sandbox._transport.request_service
+    dispatched = []
+
+    async def pending(*args, **kwargs):
+        dispatched.append((kwargs["method"], kwargs["path"]))
+        if kwargs["path"].endswith("/exchange"):
+            await asyncio.Event().wait()
+        return await original(*args, **kwargs)
+
+    monkeypatch.setattr(sandbox._transport, "request_service", pending)
+    async with sandbox.driver.connect() as driver:
+        with pytest.raises(TimeoutError):
+            await driver.channel.exchange(envelope(deadline_unix_ms=1000010))
+        assert driver.channel.closed
+        assert driver.channel.cleanup_confirmed
+    assert dispatched == [
+        ("POST", "/v1/connections"),
+        ("POST", "/v1/connections/connection-1/exchange"),
+        ("POST", "/v1/connections/connection-1/cancel"),
+        ("DELETE", "/v1/connections/connection-1"),
+    ]
+    assert not sandbox.driver._closing
+
+
+async def test_deadline_bounds_cancellation_resistant_exchange(sandbox, monkeypatch):
+    monkeypatch.setattr("cua_sandbox.interfaces.driver.time.time", lambda: 1000)
+    cancelled, finish, returned = (asyncio.Event() for _ in range(3))
+    original = sandbox._transport.request_service
+
+    async def resistant(*args, **kwargs):
+        if kwargs["path"].endswith("/exchange"):
+            try:
+                await finish.wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                await finish.wait()
+            result = await original(*args, **kwargs)
+            returned.set()
+            return result
+        return await original(*args, **kwargs)
+
+    monkeypatch.setattr(sandbox._transport, "request_service", resistant)
+    async with sandbox.driver.connect() as driver:
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(driver.channel.exchange(envelope(deadline_unix_ms=1000010)), 0.5)
+        await cancelled.wait()
+        assert driver.channel.closed
+        assert driver.channel.cleanup_confirmed
+        finish.set()
+        await asyncio.wait_for(returned.wait(), 0.5)
+        with pytest.raises(ChannelError, match="closed"):
+            await driver.channel.exchange(envelope(request_id="next"))
+    assert [event[1] for event in sandbox._transport.events] == ["POST", "POST", "DELETE", "POST"]

--- a/libs/python/cua-sandbox/tests/test_typed_driver_native.py
+++ b/libs/python/cua-sandbox/tests/test_typed_driver_native.py
@@ -41,9 +41,11 @@ class NativeTransport(Transport):
             }
         )
 
-    async def request_service(self, name, *, method, path, json_body=None, headers=None):
+    async def request_service(
+        self, name, *, method, path, json_body=None, headers=None, timeout=None
+    ):
         response = await super().request_service(
-            name, method=method, path=path, json_body=json_body, headers=headers
+            name, method=method, path=path, json_body=json_body, headers=headers, timeout=timeout
         )
         if path.endswith("/exchange"):
             return httpx.Response(


### PR DESCRIPTION
## Landing order

Merge this correction into the accessor branch for #3654 before #3654 lands on main. The accessor and its bounded lifecycle/deadline behavior form one main-branch landing unit. This branch merge is not a release or image rollout.

## Scope

Refs #2512. Stacked on #3654; review this diff against `feat/sandbox-typed-driver-20260907`.

This separate correction addresses two lifecycle/deadline findings in the accessor PR. It follows the [scoped maintainer decision](https://github.com/trycua/cua/issues/2512#issuecomment-5579029576), not a competing implementation or the broader RFC migration. Keep draft and unmerged.

## Changes

- Move opening handshakes outside the lifecycle lock. Track and invalidate pending opens; close connections concurrently and idempotently with bounded waits.
- Attempt deletion if a cancelled open later reveals a session, without yielding an active Driver.
- Give each Driver exchange a per-request Fleet timeout from its remaining envelope deadline, capped at 120 seconds. Preserve the normal 30-second and custom computer-server transport defaults.
- Bound local exchange waits even when a transport ignores cancellation. Cancel then delete on timeout, reject late results, and never replay uncertain desktop actions.
- Add regression tests and clarify the developer-only lifecycle/deadline contract. Preserve the generated typed API, lazy optional dependency, existing Sandbox methods, and guest-only targeting.

## Validation

Candidate: `421610ff8`.

- 232 focused tests pass, including all four native-backed typed Driver cases and Pool/Fleet/lifecycle regression suites.
- isort, Black, Ruff, and `git diff --check` pass for all changed Python files.
- Parent reproduction: a stalled open still prevents disconnect after ten cleanup bounds on unchanged #3654; the new tests prove bounded disconnect and claim release.
- The two timeout-override regressions fail against the parent implementation and pass here.
- Independent code review found no blocking issue.
- The six timing-sensitive lifecycle/deadline cases passed 20 consecutive runs.
- Expanded local transport regression run: 243 passed; 12 HTTP integration cases skipped because no test HTTP endpoint was configured.
- All applicable hosted CI passes at this candidate, including Python/computer-server tests, lint, Linux/macOS/Windows portable compatibility, generated bindings, and native-backed Sandbox tests: https://github.com/trycua/cua/actions/runs/34190925731 . The out-of-scope installer matrix is skipped by its scope check.

## Limits and approval gate

No live Fleet resources, credentials, installed-tool changes, image publication, package release, or deployment were used. Synthetic/native bridge tests do not qualify a real guest desktop.

If a cancellation-resistant open reveals its session only after the owning transport disconnects, deletion is attempted but cannot be confirmed. Independent session expiry remains the fallback. Control cancellation is best effort, not proof that an already-started desktop effect was reversed.

Real-guest routing, desktop effect, computer-server compatibility, stale-connection rejection, and resource cleanup still require separately authorized candidate testing. A sub-second local deadline and whole-second Fleet timeout rounding have separate coverage, not a combined real transport test.

Rollback before merge: close this draft and retain the parent stack. After an approved merge, revert this commit; it changes no schema or infrastructure. Merging the parent without this correction restores the two known defects. No merge or release is authorized by this draft.

