### PR TITLE
fix(cua-driver): accept every Enter-key spelling in the Linux terminal gate

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
@@ -2683,7 +2683,11 @@ fn char_to_keycode_shift(mapping: &GetKeyboardMappingReply, keysym: u32) -> Opti
 /// Map a human key name (e.g. "Return", "F5", "a") to its X11 keysym. Pure name
 /// resolution — no server interaction — split out from keycode lookup so the
 /// keysym can be remapped onto a spare keycode when the keymap lacks it.
-fn key_name_to_keysym(key: &str) -> Result<u32> {
+/// Resolve a key name in the shared X keysym vocabulary, or error on an
+/// unknown name. Exposed crate-wide so input-adjacent paths (e.g. the
+/// press_key terminal short-circuit gate) can test key identity against
+/// this canonical mapping instead of a local string comparison.
+pub(crate) fn key_name_to_keysym(key: &str) -> Result<u32> {
     // Common X11 keysym names.
     let keysym: u32 = match key.to_lowercase().as_str() {
         "return" | "enter" => 0xFF0D,

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -3224,6 +3224,15 @@ fn terminal_tty_for_window(pid: u32, xid: u64) -> Option<PathBuf> {
     ttys.get(window_index).cloned()
 }
 
+/// True when `key` names the Enter key in the shared X keysym vocabulary
+/// (`key_name_to_keysym`). The terminal pty short-circuit below applies to
+/// every spelling of that physical key — `enter`, `return`, any case — so an
+/// agent following the documented key names cannot silently lose the keypress
+/// on a terminal window (terminals discard synthetic XSendEvent keys).
+fn is_enter_key(key: &str) -> bool {
+    crate::input::key_name_to_keysym(key).ok() == Some(0xFF0D)
+}
+
 /// Type into a terminal window without touching X focus. Resolves the window's
 /// pty, then borrows the emulator's master fd and writes to it (see
 /// `crate::tty`). Returns `Ok(false)` when the target isn't a terminal we can
@@ -4624,11 +4633,38 @@ fn press_key_chord(mods: &[String], key: &str) -> Option<Vec<String>> {
 
 #[cfg(test)]
 mod press_key_tests {
+    use super::is_enter_key;
     use super::press_key_chord;
 
     #[test]
     fn unmodified_press_stays_on_the_single_key_route() {
         assert_eq!(press_key_chord(&[], "return"), None);
+    }
+
+    #[test]
+    fn enter_key_gate_accepts_the_documented_enter_spelling() {
+        assert!(is_enter_key("enter"));
+        assert!(is_enter_key("Enter"));
+        assert!(is_enter_key("ENTER"));
+    }
+
+    #[test]
+    fn enter_key_gate_accepts_the_documented_return_spelling() {
+        // `key_name_to_keysym` resolves "return" and "enter" to the same
+        // physical key (XK_Return, 0xFF0D); the pty short-circuit must not
+        // drop a documented spelling on terminals (they discard synthetic
+        // XSendEvent keys, so a dropped short-circuit loses the keypress).
+        assert!(is_enter_key("return"));
+        assert!(is_enter_key("Return"));
+        assert!(is_enter_key("RETURN"));
+    }
+
+    #[test]
+    fn enter_key_gate_rejects_non_enter_keys() {
+        assert!(!is_enter_key("tab"));
+        assert!(!is_enter_key("escape"));
+        assert!(!is_enter_key("space"));
+        assert!(!is_enter_key(""));
     }
 
     #[test]
@@ -4663,7 +4699,7 @@ impl Tool for PressKeyTool {
                     "session": cua_driver_core::tool_schema::session_schema(),
                     "pid":{"type":"integer"},
                     "window_id":{"type":"integer"},
-                    "key":{"type":"string"},
+                    "key":{"type":"string","description":"Key name: enter/return, tab, escape, space, backspace, delete, insert, home, end, pageup, pagedown, up, down, left, right, f1-f12, or any single ASCII character."},
                     "modifiers":{"type":"array","items":{"type":"string"}},
                     "element_index": cua_driver_core::tool_schema::element_index_schema(),
                     "element_token": cua_driver_core::tool_schema::element_token_schema(),
@@ -4954,7 +4990,7 @@ impl Tool for PressKeyTool {
         let result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
             if resolved_element_index.is_none()
                 && mods.is_empty()
-                && key_for_task.eq_ignore_ascii_case("enter")
+                && is_enter_key(&key_for_task)
             {
                 if inject_terminal_input(pid, xid, "\n")? {
                     return Ok(());


### PR DESCRIPTION
# Fix: accept every Enter-key spelling in the Linux press_key terminal gate

Closes #3657

## What

On Linux X11, `press_key` reports success but silently does nothing when `key: "return"` targets a terminal emulator. The terminal pty short-circuit in `PressKeyTool::invoke` (`platform-linux/src/tools/impl_.rs`) gated on a case-insensitive string comparison with `"enter"` only:

```rust
key_for_task.eq_ignore_ascii_case("enter")
```

Terminals silently discard synthetic XSendEvent keys — that is why the pty short-circuit exists. Every other spelling of the same physical key failed the gate, fell through to XSendEvent, and was dropped by the terminal, with a success response.

`"return"` is a documented spelling: the general Linux resolver `key_name_to_keysym` maps `"return" | "enter"` to `0xFF0D`, the Wayland evdev map accepts both, macOS `key_name_to_code` accepts both (36), Windows `key_name_to_vk` accepts both (`VK_RETURN`), and the cua skill docs teach `keys="return"` as the canonical example. An agent following the documented vocabulary works on macOS and Windows and silently loses the keypress on Linux terminals — this gate was the only inconsistent spelling check in the driver.

## How

- Route the gate through `key_name_to_keysym` (`input/mod.rs`, now `pub(crate)` with a doc comment) via a small `is_enter_key` helper, so the pty short-circuit applies to every spelling of the Enter key (`enter`, `return`, any case).
- Document the accepted key names in the `press_key` schema's `key` parameter so callers are not left guessing (the parameter was previously a bare `{"type": "string"}`).
- Add unit tests in the existing `press_key_tests` module: Enter/Return spellings accepted (case-insensitive), non-Enter keys rejected (`tab`, `escape`, `space`, empty string).

The schema description is a live-platform annotation only — the portable contract manifest pins `press_key.key` as a bare `{"type": "string"}` and is unchanged, and `structural()` schema comparison strips descriptions before comparing.

## Evidence

Reproduced end-to-end on a live Xvfb/openbox/xterm desktop driven through the MCP bridge (Ubuntu 24.04, cua-driver 0.23.2 and 0.24.0): `type_text` + `press_key` with `enter` executes the typed command (proof file created in the VM), while the same flow with `return` leaves the text unexecuted on the input line with `ok=true`. The same input path with the patched binary executes both spellings.

Verified:

- New gate test fails on the pre-fix gate (`eq_ignore_ascii_case("enter")`) and passes with the fix — red first.
- `cargo test -p platform-linux`: 451 passed, 0 failed (includes the crate's schema-consistency tests).
- `cargo fmt --check -p platform-linux`: clean.

## Notes

- Only the unmodified-key (`mods.is_empty()`), no-element, X11-windowed path takes the pty short-circuit — unchanged semantics for hotkeys, Wayland, desktop-scope, and pixel-focus forms, which already accept both spellings.
- Keypad Enter (`XK_KP_Enter`, `0xFF8D`) is not in the Linux/macOS/Windows key maps at all, so it is unchanged by this fix.

## Maintainer exact-head validation

- Upstream pull-request CI is fully green on candidate `c2ca6f1c2326c89f6af91952042e965c8494dae4`: 35 successful checks, with no failures or pending checks.
- [Canonical Linux native lane](https://github.com/trycua/cua/actions/runs/34748238923) passed on that exact candidate SHA.
- The downloaded result records the same source SHA and reports 32 delivered, 7 expected refusals, 0 failed, and 0 skipped across the native GTK3/GTK4 matrix.

