### PR TITLE
fix(cua-driver): map standalone Wayland modifier keys

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
@@ -2197,6 +2197,10 @@ fn partition_modifiers(keys: &[String]) -> anyhow::Result<(Vec<String>, String)>
 /// values pass through (single characters and valid keysym names work as-is).
 fn key_to_keysym(key: &str) -> String {
     match key.to_lowercase().as_str() {
+        "ctrl" | "control" => "Control_L",
+        "alt" => "Alt_L",
+        "shift" => "Shift_L",
+        "super" | "meta" | "cmd" | "command" | "win" | "windows" => "Super_L",
         "enter" | "return" => "Return",
         "tab" => "Tab",
         "esc" | "escape" => "Escape",
@@ -2456,6 +2460,11 @@ fn libei_hotkey(mods: &[String], key: &str) -> anyhow::Result<()> {
 /// known mapping so the caller can fail loudly.
 fn key_to_evdev(key: &str) -> Option<u32> {
     let code = match key.to_lowercase().as_str() {
+        "ctrl" | "control" => 29, // KEY_LEFTCTRL
+        "alt" => 56,              // KEY_LEFTALT
+        "shift" => 42,            // KEY_LEFTSHIFT
+        "super" | "meta" | "cmd" | "command" | "win" | "windows" => 125, // KEY_LEFTMETA
+
         "enter" | "return" => 28,        // KEY_ENTER
         "tab" => 15,                     // KEY_TAB
         "esc" | "escape" => 1,           // KEY_ESC
@@ -3839,6 +3848,37 @@ mod tests {
         );
         assert!(validate_injectable_hotkey(&["7".to_owned()]).is_err());
         assert!(validate_injectable_hotkey(&["hyper".to_owned(), "k".to_owned()]).is_err());
+    }
+
+    #[test]
+    fn standalone_modifiers_map_to_native_keyboard_keys() {
+        for (aliases, keysym, evdev) in [
+            (&["ctrl", "control"][..], "Control_L", 29),
+            (&["alt"][..], "Alt_L", 56),
+            (&["shift"][..], "Shift_L", 42),
+            (
+                &["super", "meta", "cmd", "command", "win", "windows"][..],
+                "Super_L",
+                125,
+            ),
+        ] {
+            for alias in aliases {
+                for key in [alias.to_string(), alias.to_uppercase()] {
+                    assert_eq!(key_to_keysym(&key), keysym, "wtype key {key}");
+                    assert_eq!(key_to_evdev(&key), Some(evdev), "libei key {key}");
+                }
+            }
+        }
+        assert_eq!(key_to_keysym("Super_R"), "Super_R");
+    }
+
+    #[test]
+    #[ignore = "requires a focused native Wayland surface and wtype"]
+    fn standalone_modifiers_reach_wayland_keyboard() {
+        for key in ["meta", "ctrl", "alt", "shift"] {
+            press_key_focused(key).unwrap_or_else(|error| panic!("{key}: {error}"));
+            press_key_focused("escape").expect("input remains usable after a modifier tap");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Standalone modifier taps on native Wayland fail because `press_key("meta")` passes `meta` to `wtype -k`, which rejects it as an unknown keysym. The driver then unnecessarily falls back to libei; on a host without a portal session bus this surfaces as `libei worker channel closed`. Ctrl, Alt, and Shift have the same missing mappings. This was reproduced with cua-driver 0.22.0 and the mappings are still absent on main.

Map the modifier aliases already accepted by `partition_modifiers` to native X keysyms and evdev keycodes. Add case-insensitive regression coverage and an opt-in native keyboard smoke test. A standalone modifier remains a press/release tap; chords retain their existing behavior.

## Related work

No linked issue. This repairs existing key input behavior and does not change a public contract, so no RFC is proposed.

## Compatibility and risk

- Native Wayland key input now accepts the same modifier aliases as chords. Existing X keysym passthrough remains unchanged.
- The patch only adds converter entries and tests. It does not change backend selection or worker lifecycle.
- Nested cua-compositor injection uses its own named-key whitelist and is outside this change.

## Validation

- Added regression test failed before the mapping change (`ctrl` instead of `Control_L`).
- `cargo test -p platform-linux --lib wayland::tests --no-default-features`: 28 passed, 1 ignored.
- Same command with `--features portal-input`: 28 passed, 1 ignored.
- Formatting and `git diff --check` passed.
- Ran the separately compiled, portal-enabled ignored test on an Omarchy/Hyprland desktop with wtype and no session bus. All four modifier taps and subsequent Escape input succeeded. Chromium event capture confirmed keydown/keyup events for Meta, Control, Alt, and Shift and no held modifier flags on subsequent Escape events. The installed driver was not replaced.
- The existing wtype path uses synthetic physical keycodes, and Chromium reported Meta events with `metaKey=false`; this patch does not change that existing native `Super_L` behavior or claim to repair modifier-mask semantics.
- Live libei delivery, nested injection, and the wider platform matrix remain untested. The libei error-reporting/worker-lifecycle behavior is separate from the missing mappings.

Additional downstream packaging validation: the same commit was backported without conflicts to cua-driver 0.22.2 at `6309cc93dea771c7980a23d586608b465293a4de`. Its 27 focused Wayland tests passed. A Debian Bookworm release SDK library was loaded by the unchanged 0.22.2 npm bindings in an isolated container on Omarchy/Hyprland: the original library failed the Meta tap with a 20-second libei readiness timeout; the patched library delivered all four modifier keydown/keyup pairs and subsequent Escape events to a Chromium fixture. This is supporting backport evidence, not certification of the upstream PR candidate or a replacement for the canonical matrix.

## September 21 re-audit and 0.28.2 backport

Re-audited upstream main `9bbfa7dd3e27ca7f1861ede70aaca390174493f9`: the affected Wayland module is byte-identical to this PR’s original base, and the standalone modifier mappings remain absent. No production code change is required in this PR.

The same 40-line patch applies unchanged to published CUA Driver 0.28.2 (tag source `fc188250b4ca8549b8e61f937fdb1fb560770e86`). Downstream backport: [`ebc42f2ce00401adf750bcbdb083cc69e973c83c`](https://github.com/ceckert/cua/commit/ebc42f2ce00401adf750bcbdb083cc69e973c83c), branch `octogee/cua-driver-0.28.2-modifier-keys`.

Validation on that exact backport:

- Source-extracted Rust mapping regression fails against unpatched 0.28.2 (`ctrl` versus `Control_L`) and passes with the fix.
- Debian Bookworm Linux ARM64 (native) and AMD64 (local emulation) Docker builders: `cargo test --locked -p platform-linux --lib wayland::tests --features portal-input` passes 28 tests on each architecture; the live Wayland surface smoke remains ignored.
- Broader `cargo test --locked -p platform-linux --lib --features portal-input`: 453 passed, 6 ignored on each architecture.
- `cargo build --locked --release -p cua-driver-sdk --features portal-input` succeeds on both architectures; ELF machine type and dynamic-library load checks also pass.
- Canonical `cargo fmt --all -- --check` and `git diff --check` pass.
- Six downstream installer regressions pass, enforcing matched 0.28.2 SDK/native/backport versions and exact upstream artifact hashes before replacement.

These are source, unit, and packaging checks for the 0.28.2 backport—not new desktop-delivery evidence, not certification of this upstream PR candidate, and not a substitute for the canonical desktop matrix. No new live Wayland/libei, Windows, or macOS evidence is claimed. The PR remains draft.

## Contributor and release checks

This PR remains draft under the repository's desktop E2E readiness rule. Before marking it ready, the exact final candidate needs the canonical Windows, Linux, and macOS desktop matrix, with fixture-state evidence rather than successful return values alone. The local ignored test and Chromium capture above are supporting diagnostics, not substitutes for that matrix. Current candidate: `584dfe4` (resolve the full head SHA when scheduling certification). No maintainer selection/review has been recorded yet; this is a small, self-contained unselected contribution under CONTRIBUTING.md.

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [ ] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.
