### PR TITLE
fix(security): refresh MCP compatibility probe dependencies

### DIFF
--- a/.github/scripts/cua-driver-mcp-compat/package-lock.json
+++ b/.github/scripts/cua-driver-mcp-compat/package-lock.json
@@ -845,9 +845,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
-      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/.github/scripts/cua-driver-mcp-compat/package-lock.json
+++ b/.github/scripts/cua-driver-mcp-compat/package-lock.json
@@ -708,9 +708,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -1113,9 +1113,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
## Problem

The release-blocking CUA Driver compatibility probe resolves vulnerable versions of `fast-uri`, `qs`, and Hono. The September 10 review identified nine Dependabot alerts in this graph. This PR updates that graph without changing the probe or its three directly pinned clients.

## What changed

- Resolve `fast-uri` at 3.1.7 and `qs` at 6.16.0, retaining the original fixes.
- Resolve Hono at 4.13.5 to cover the three newer advisories.
- Keep the change lockfile-only; application code, probe code, and public APIs are unchanged.

## Definition of Done

- [x] **Address the four fast-uri alerts.** Version 3.1.7 exceeds the 3.1.6 patched floor for GHSA-5jgf-p345-68v8, GHSA-jqff-g426-hqxp, GHSA-fph4-wmhf-6fwf, and GHSA-f65p-4m7j-42xc.
- [x] **Address both qs alerts.** Version 6.16.0 meets the patched floor for GHSA-4mjr-xmp4-gh2g and GHSA-x5fp-wj9c-mxmx.
- [x] **Address the three newer Hono alerts.** Version 4.13.5 meets the patched floor for alerts 1209–1211.
- [x] **Preserve a reproducible dependency install.** Clean installation with lifecycle scripts disabled succeeds; the lockfile audit reports no known vulnerabilities.
- [x] **Preserve release-workflow wiring.** The focused release-wiring checks pass.
- [ ] **Run the exact packaged-driver compatibility probe in GitHub Actions.** Dependency installation is not a substitute for `npm run verify` with a release-candidate Driver binary.
- [ ] **Confirm alert closure after merge to main.** Alerts 1185, 1187–1191, and 1209–1211 remain subject to GitHub's post-merge evaluation.

## Validation

Current-main integrated candidate: `915f86a50281` (original contributor commits preserved).

From the repository root:

```sh
(cd .github/scripts/cua-driver-mcp-compat && npm ci --ignore-scripts && npm ls fast-uri qs hono --all && npm audit --package-lock-only)
python3 .github/scripts/tests/test_cua_driver_release_wiring.py
```

At the current candidate, clean install resolves `fast-uri 3.1.7`, `qs 6.16.0`, and `hono 4.13.5`; `npm audit --package-lock-only` reports zero known vulnerabilities, and the 48 focused release-wiring tests pass. Fresh exact-head compatibility CI is running. This establishes the dependency result, not production reachability.

