### PR TITLE
fix(cua-driver): keep strict local signing noninteractive

### DIFF
--- a/libs/cua-driver/python/tests/test_install_local_signing.py
+++ b/libs/cua-driver/python/tests/test_install_local_signing.py
@@ -47,6 +47,134 @@ def test_strict_local_signing_fails_before_ad_hoc_fallback() -> None:
     assert "unexpected ad-hoc signing" not in result.stderr
 
 
+def test_strict_signing_does_not_implicitly_use_login_keychain(tmp_path: Path) -> None:
+    login_keychain = tmp_path / "Library" / "Keychains" / "login.keychain-db"
+    login_keychain.parent.mkdir(parents=True)
+    login_keychain.touch()
+    result = run_signing_policy(
+        rf"""
+        HOME={tmp_path!s}
+        OS=Darwin
+        CUA_DRIVER_REQUIRE_STABLE_SIGNING=1
+        unset CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN
+        codesign() {{ :; }}
+        security() {{ echo "unexpected security access" >&2; return 99; }}
+        printf 'identity=%s\n' "$(ensure_local_signing_identity)"
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "identity=-\n"
+    assert "will not use the login Keychain implicitly" in result.stderr
+    assert "password dialog" in result.stderr
+    assert "unexpected security access" not in result.stderr
+
+
+def test_strict_signing_uses_default_dedicated_keychain(tmp_path: Path) -> None:
+    signing_keychain = (
+        tmp_path / "Library" / "Keychains" / "cua-driver-signing.keychain-db"
+    )
+    signing_keychain.parent.mkdir(parents=True)
+    signing_keychain.touch()
+    result = run_signing_policy(
+        rf"""
+        HOME={tmp_path!s}
+        OS=Darwin
+        CUA_DRIVER_REQUIRE_STABLE_SIGNING=1
+        unset CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN
+        codesign() {{ :; }}
+        security() {{
+            echo '  1) ABCDEF "CuaDriver Local Signing (cua-driver-rs)"'
+        }}
+        printf 'identity=%s\n' "$(ensure_local_signing_identity)"
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "identity=ABCDEF\n"
+    assert "login Keychain implicitly" not in result.stderr
+
+
+def test_explicit_login_keychain_warns_before_codesign() -> None:
+    result = run_signing_policy(
+        r"""
+        HOME=/tmp/test-home
+        OS=Darwin
+        RED= GREEN= YELLOW= NORMAL=
+        CUA_DRIVER_REQUIRE_STABLE_SIGNING=1
+        CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN=/tmp/test-home/Library/Keychains/login.keychain-db
+        ensure_local_signing_identity() { printf '%s' ABCDEF; }
+        codesign_bounded() { return 0; }
+        codesign() {
+            if [ "$1" = "-d" ]; then
+                echo 'designated => anchor trusted and certificate leaf[subject.CN] = "Cua Local Dev"' >&2
+            fi
+            return 0
+        }
+        sign_staged_local_app /staged.app /missing-live.app
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "key in the login Keychain" in result.stderr
+    assert "not browser content" in result.stderr
+    assert "Always Allow only for a dedicated local-development key" in result.stderr
+
+
+def test_signing_timeout_explains_stale_password_dialog() -> None:
+    result = run_signing_policy(
+        r"""
+        HOME=/tmp/test-home
+        OS=Darwin
+        RED= GREEN= YELLOW= NORMAL=
+        CUA_DRIVER_REQUIRE_STABLE_SIGNING=1
+        CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN=/tmp/dedicated.keychain-db
+        ensure_local_signing_identity() { printf '%s' ABCDEF; }
+        codesign_bounded() { return 142; }
+        clean_partial_bundle_signature() { :; }
+        if sign_staged_local_app /staged.app /missing-live.app; then exit 90; fi
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "timed out while waiting for keychain authorization" in result.stderr
+    assert "Deny or close any password dialog that remains" in result.stderr
+    assert "live installation was not changed" in result.stderr
+
+
+def test_non_strict_signing_timeout_falls_back_without_claiming_install_is_unchanged() -> None:
+    result = run_signing_policy(
+        r"""
+        HOME=/tmp/test-home
+        OS=Darwin
+        RED= GREEN= YELLOW= NORMAL=
+        CUA_DRIVER_REQUIRE_STABLE_SIGNING=0
+        CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN=/tmp/dedicated.keychain-db
+        ensure_local_signing_identity() { printf '%s' ABCDEF; }
+        attempts=0
+        codesign_bounded() {
+            attempts=$((attempts + 1))
+            if [ "$attempts" -eq 1 ]; then return 142; fi
+            return 0
+        }
+        clean_partial_bundle_signature() { :; }
+        codesign() {
+            if [ "$1" = "-d" ]; then
+                echo '# designated => cdhash H"0123456789ABCDEF"'
+            fi
+            return 0
+        }
+        sign_staged_local_app /staged.app /missing-live.app
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "timed out while waiting for keychain authorization" in result.stderr
+    assert "staged signing attempt was canceled" in result.stderr
+    assert "live installation was not changed" not in result.stderr
+    assert "WARNING: CuaDriverLocal.app was signed ad-hoc" in result.stderr
+
+
 def test_ad_hoc_fallback_is_prominent_and_reports_cdhash() -> None:
     result = run_signing_policy(
         r"""

--- a/libs/cua-driver/scripts/README.md
+++ b/libs/cua-driver/scripts/README.md
@@ -31,7 +31,10 @@ bash libs/cua-driver/scripts/install-local.sh \
 
 `CUA_DRIVER_REQUIRE_STABLE_SIGNING=1` is the environment equivalent. Strict
 mode stops before replacing the live app when no usable certificate-backed
-identity is available.
+identity is available. It also refuses to select the login Keychain implicitly:
+an older key there can interrupt an unattended run with a macOS password
+dialog. Released Cua Driver installations do not need local signing; they
+install an already signed bundle and verify it on the Mac.
 
 For the most reliable non-interactive rebuilds, use a dedicated keychain:
 
@@ -61,15 +64,18 @@ code-signing tools:
 ```bash
 read -r -s -p 'Keychain password: ' KEYCHAIN_PASSWORD; echo
 security set-key-partition-list \
-  -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" \
+  -S apple-tool:,apple:,codesign: -t private -s \
+  -l 'CuaDriver Local Signing (cua-driver-rs)' \
+  -k "$KEYCHAIN_PASSWORD" \
   "$SIGNING_KEYCHAIN"
 unset KEYCHAIN_PASSWORD
 ```
 
-Then rerun the strict installer and grant Accessibility and Screen Recording
-once. When the dedicated default keychain above exists, the installer prefers
-it automatically; exporting `CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN` remains the
-most explicit choice.
+This command updates only the dedicated Cua Driver local-development key. Do
+not paste the password into test output. Then rerun the strict installer and
+grant Accessibility and Screen Recording once. When the dedicated default
+keychain above exists, the installer prefers it automatically; exporting
+`CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN` remains the most explicit choice.
 
 Released installers show a telemetry notice before asking the installed binary
 to record anything. Telemetry is enabled by default and can be persistently

--- a/libs/cua-driver/scripts/_local-signing.sh
+++ b/libs/cua-driver/scripts/_local-signing.sh
@@ -26,8 +26,28 @@ print_local_signing_bootstrap() {
     echo "  security unlock-keychain \"\$SIGNING_KEYCHAIN\"" >&2
     echo "  export CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN=\"\$SIGNING_KEYCHAIN\"" >&2
     echo "  bash libs/cua-driver/scripts/install-local.sh --require-stable-signing" >&2
-    echo "If the certificate is newly created, authorize its private key for codesign as described in:" >&2
+    echo "If macOS asks for the keychain password during codesign, the key is not ready for unattended E2E." >&2
+    echo "Authorize only the dedicated local-development key once as described in:" >&2
     echo "  libs/cua-driver/scripts/README.md#stable-macos-local-signing" >&2
+}
+
+# Unattended E2E must not discover a stale login-key ACL by opening
+# SecurityAgent halfway through an install.
+strict_signing_would_use_implicit_login_keychain() {
+    [ "${CUA_DRIVER_REQUIRE_STABLE_SIGNING:-0}" = "1" ] \
+        && [ -z "${CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN:-}" ] \
+        && [ ! -f "$HOME/Library/Keychains/cua-driver-signing.keychain-db" ]
+}
+
+local_signing_keychain_is_login() {
+    case "$1" in
+        "$HOME/Library/Keychains/login.keychain"|"$HOME/Library/Keychains/login.keychain-db")
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 # Echoes the `codesign --sign` argument: a matching identity's SHA-1 when
@@ -35,6 +55,13 @@ print_local_signing_bootstrap() {
 ensure_local_signing_identity() {
     { [ "$OS" = "Darwin" ] && command -v codesign >/dev/null 2>&1; } \
         || { printf -- '-'; return; }
+    if strict_signing_would_use_implicit_login_keychain; then
+        echo "Stable source builds will not use the login Keychain implicitly." >&2
+        echo "That fallback can interrupt unattended E2E with a macOS password dialog." >&2
+        echo "Configure the dedicated signing keychain, or explicitly select a prepared keychain." >&2
+        printf -- '-'
+        return
+    fi
     local kc
     kc="$(local_signing_keychain)"
     [ -f "$kc" ] || { printf -- '-'; return; }
@@ -178,18 +205,32 @@ reset_local_tcc_after_ad_hoc_change() {
 sign_staged_local_app() {
     local app_stage="$1"
     local app_dest="$2"
-    local sign_id requirement signing_class
+    local sign_id requirement signing_class signing_keychain sign_status
     sign_id="$(ensure_local_signing_identity)"
 
-    if [ "$sign_id" != "-" ] \
-       && codesign_bounded 20 --force --deep --sign "$sign_id" "$app_stage" 2>/dev/null; then
-        requirement="$(designated_requirement "$app_stage")"
-        signing_class="$(classify_designated_requirement "$requirement")"
-        if [ "$signing_class" = "certificate-backed" ]; then
-            echo "${GREEN}signed staged app with a stable local identity — TCC grants survive future install-local rebuilds${NORMAL}"
-            return 0
+    if [ "$sign_id" != "-" ]; then
+        signing_keychain="$(local_signing_keychain)"
+        if local_signing_keychain_is_login "$signing_keychain"; then
+            echo "${YELLOW}Signing CuaDriverLocal.app with a key in the login Keychain.${NORMAL}" >&2
+            echo "This should not open a password dialog. If one appears, it is the local-build signing step, not browser content." >&2
+            echo "Choose Always Allow only for a dedicated local-development key; otherwise choose Deny and use the setup below." >&2
         fi
-        echo "${YELLOW}warning: the requested stable identity produced a non-certificate designated requirement${NORMAL}" >&2
+        sign_status=0
+        if codesign_bounded 20 --force --deep --sign "$sign_id" "$app_stage" 2>/dev/null; then
+            requirement="$(designated_requirement "$app_stage")"
+            signing_class="$(classify_designated_requirement "$requirement")"
+            if [ "$signing_class" = "certificate-backed" ]; then
+                echo "${GREEN}signed staged app with a stable local identity — TCC grants survive future install-local rebuilds${NORMAL}"
+                return 0
+            fi
+            echo "${YELLOW}warning: the requested stable identity produced a non-certificate designated requirement${NORMAL}" >&2
+        else
+            sign_status=$?
+            if [ "$sign_status" = "124" ] || [ "$sign_status" = "142" ]; then
+                echo "${YELLOW}warning: stable signing timed out while waiting for keychain authorization.${NORMAL}" >&2
+                echo "Deny or close any password dialog that remains; the staged signing attempt was canceled." >&2
+            fi
+        fi
     fi
 
     if [ "${CUA_DRIVER_REQUIRE_STABLE_SIGNING:-0}" = "1" ]; then


### PR DESCRIPTION
## Summary

Strict macOS source installs could find an older signing identity in the user's
login Keychain and unexpectedly open a password dialog during unattended tests.
The test then appeared stuck, and the dialog did not make it clear that local
code signing—not the website—caused the prompt.

This PR makes strict local signing noninteractive by default and gives clearer
instructions when a user deliberately chooses a keychain that may prompt.

## What changes

- Do not select the login Keychain automatically during strict source signing.
- Prefer the dedicated Cua Driver development keychain when it is available.
- Continue to support an explicitly selected signing identity and keychain.
- When the login Keychain was selected explicitly, explain that any prompt is
  for local-build signing and should not be approved for an unrelated key.
- Stop waiting for keychain-backed signing after 20 seconds.
- In normal non-strict installs, preserve the existing ad-hoc signing fallback.
  In strict installs, report an error before replacing the working app.
- Limit setup guidance to the dedicated development identity rather than
  changing permissions for every key in a keychain.

This does not teach the agent to enter passwords or approve system dialogs.

## Validation

Nineteen focused policy tests cover automatic keychain selection, explicit
login-keychain guidance, timeouts, strict and non-strict results, ad-hoc
fallback, signing requirements, and preservation of the installed signed app.

## Definition of Done

- [x] Keep unattended strict signing noninteractive by default.
- [x] Prefer a dedicated, reusable local-development keychain.
- [x] Preserve explicitly configured signing identities and keychains.
- [x] Bound unexpected authorization waits to 20 seconds.
- [x] Leave the installed app unchanged when strict signing cannot finish.
- [x] Scope keychain authorization guidance to the intended identity.
- [ ] Exercise the real macOS first-use and stale-key dialogs.
- [ ] Receive maintainer review for the installer behavior.
