### PR TITLE
feat(cua-driver): add explicit window-only recording

### DIFF
--- a/docs/content/docs/reference/cua-driver/cli-reference.mdx
+++ b/docs/content/docs/reference/cua-driver/cli-reference.mdx
@@ -150,7 +150,7 @@ Supported clients include claude, codex, cursor, antigravity, openclaw, opencode
 
 ### `cua-driver recording`
 
-Control trajectory recording on a running daemon.
+Control trajectory or explicit window-video recording on a running daemon.
 
 Recording state lives in the required daemon and survives client reconnects.
 
@@ -162,17 +162,34 @@ Recording state lives in the required daemon and survives client reconnects.
 
 #### `cua-driver recording start`
 
-Start trajectory recording to a directory.
+Start recording to a directory.
+
+Defaults to trajectory-only recording. --video adds display video unless both --pid and --window-id select exact window-video mode. Window mode requires --video and a new or empty output directory; it writes MP4 and metadata only. Supported on macOS 15+; other backends refuse without display fallback.
 
 **Arguments:**
 
 | Name | Type | Required | Description |
 | ---- | ---- | -------- | ----------- |
-| `<output-dir>` | String | Yes | Directory to write turn folders into. |
+| `<output-dir>` | String | Yes | Directory to write recording artifacts into. |
+
+**Options:**
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `--pid` | Int32 | — | Positive window-owner PID; requires --window-id and --video. |
+| `--window-id` | UInt64 | — | Positive native window ID from list_windows; requires --pid and --video. |
+
+**Flags:**
+
+| Name | Description |
+| ---- | ----------- |
+| `--video` | Enable video. Required for exact window mode. |
 
 #### `cua-driver recording stop`
 
-Stop trajectory recording.
+Stop the active recorder and finalize video.
+
+Manual stop is daemon-wide. After automatic window termination, call stop to release the retained recorder before starting another.
 
 #### `cua-driver recording status`
 

--- a/docs/content/docs/reference/cua-driver/mcp-tools-linux.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools-linux.mdx
@@ -555,7 +555,9 @@ Start trajectory recording. Every subsequent action-tool invocation (click, righ
 
 Turn folders are named `turn-00001/`, `turn-00002/`, etc.  Turn numbering restarts at 1 each time recording is (re-)started.
 
-**Video is off by default.** Pass `record_video: true` to also capture the main display to `<output_dir>/recording.mp4` (H.264 / 30 fps) for the lifetime of the session. The recording is torn down automatically when the MCP client disconnects.
+With `target: {kind: window, pid, window_id}` and `record_video: true`, record only that native window, with video and bounded metadata only. Window mode requires a new or empty output directory, suppresses all trajectories and cursor sampling, and never falls back to display capture. Only macOS 15+ supports window video; other backends return window_recording_unsupported. Starts involving an active window recording return recording_busy. After automatic termination, call stop_recording to release the retained recorder before starting another. Manual stop remains daemon-wide.
+
+**Video is off by default.** Without `target`, pass `record_video: true` to also capture the main display to `<output_dir>/recording.mp4` (H.264 / 30 fps) for the lifetime of the session. The recording is torn down automatically when the MCP client disconnects.
 
 **macOS uses native ScreenCaptureKit** (daemon-owned SCStream + SCRecordingOutput) so video inherits the daemon's Screen Recording grant — no extra TCC prompt, no ffmpeg subprocess. Requires macOS 15.0+.
 
@@ -565,8 +567,9 @@ State persists for the life of the daemon; a restart resets to disabled with no 
 
 **Arguments:**
 
-- `output_dir` (string, required): Absolute or ~-rooted directory where turn folders and (when enabled) the video file are written.
-- `record_video` (boolean, optional): Capture the main display to &lt;output_dir&gt;/recording.mp4. Default: false. Set to true to also capture the main display to recording.mp4 (otherwise only the per-turn screenshots + JSON are recorded). On macOS this uses native ScreenCaptureKit (no extra TCC prompt, macOS 15.0+); on Windows + Linux it requires ffmpeg on PATH.
+- `output_dir` (string, required): Absolute or ~-rooted output directory. Window mode requires a new or empty directory and writes only video and metadata. Without target, writes trajectory folders and optional display video.
+- `record_video` (boolean, optional): Enable video at &lt;output_dir&gt;/recording.mp4. Default: false. With an exact window target, true is required and only window video plus metadata is recorded (macOS 15+). Without target, adds main-display video to legacy trajectory recording. macOS uses ScreenCaptureKit; Windows and Linux use ffmpeg for legacy display video.
+- `target` (object, optional): Exact native window from list_windows. Requires record_video=true.
 
 ```json
 {"output_dir":"~/cua-trajectories/demo1"}
@@ -574,7 +577,7 @@ State persists for the life of the daemon; a restart resets to disabled with no 
 
 ### `stop_recording`
 
-Stop trajectory recording. Disables further per-turn capture and, when video was enabled, gracefully terminates the ffmpeg subprocess so the mp4's moov atom is finalized (the file is playable). Calling stop on an already-stopped session is a no-op. The response carries `last_video_path` pointing at the finalized mp4 (when video was on).
+Stop the active recorder and finalize its video when enabled. Legacy mode also disables further per-turn capture. Window-video mode joins the native backend, including after automatic termination. Finalization failures are reported as errors. Calling stop on an already-stopped session is a no-op. The response carries `last_video_path` pointing at the finalized mp4 (when video was on).
 
 A manual `stop_recording` is **unconditional** — it stops whatever recording is active regardless of which session started it. Ownership-scoped teardown (so one client disconnecting can't stop a recording a later client started) is handled by the registry's `session_end` lifecycle hook, not by this tool.
 

--- a/docs/content/docs/reference/cua-driver/mcp-tools-windows.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools-windows.mdx
@@ -663,7 +663,9 @@ Start trajectory recording. Every subsequent action-tool invocation (click, righ
 
 Turn folders are named `turn-00001/`, `turn-00002/`, etc.  Turn numbering restarts at 1 each time recording is (re-)started.
 
-**Video is off by default.** Pass `record_video: true` to also capture the main display to `<output_dir>/recording.mp4` (H.264 / 30 fps) for the lifetime of the session. The recording is torn down automatically when the MCP client disconnects.
+With `target: {kind: window, pid, window_id}` and `record_video: true`, record only that native window, with video and bounded metadata only. Window mode requires a new or empty output directory, suppresses all trajectories and cursor sampling, and never falls back to display capture. Only macOS 15+ supports window video; other backends return window_recording_unsupported. Starts involving an active window recording return recording_busy. After automatic termination, call stop_recording to release the retained recorder before starting another. Manual stop remains daemon-wide.
+
+**Video is off by default.** Without `target`, pass `record_video: true` to also capture the main display to `<output_dir>/recording.mp4` (H.264 / 30 fps) for the lifetime of the session. The recording is torn down automatically when the MCP client disconnects.
 
 **macOS uses native ScreenCaptureKit** (daemon-owned SCStream + SCRecordingOutput) so video inherits the daemon's Screen Recording grant — no extra TCC prompt, no ffmpeg subprocess. Requires macOS 15.0+.
 
@@ -673,8 +675,9 @@ State persists for the life of the daemon; a restart resets to disabled with no 
 
 **Arguments:**
 
-- `output_dir` (string, required): Absolute or ~-rooted directory where turn folders and (when enabled) the video file are written.
-- `record_video` (boolean, optional): Capture the main display to &lt;output_dir&gt;/recording.mp4. Default: false. Set to true to also capture the main display to recording.mp4 (otherwise only the per-turn screenshots + JSON are recorded). On macOS this uses native ScreenCaptureKit (no extra TCC prompt, macOS 15.0+); on Windows + Linux it requires ffmpeg on PATH.
+- `output_dir` (string, required): Absolute or ~-rooted output directory. Window mode requires a new or empty directory and writes only video and metadata. Without target, writes trajectory folders and optional display video.
+- `record_video` (boolean, optional): Enable video at &lt;output_dir&gt;/recording.mp4. Default: false. With an exact window target, true is required and only window video plus metadata is recorded (macOS 15+). Without target, adds main-display video to legacy trajectory recording. macOS uses ScreenCaptureKit; Windows and Linux use ffmpeg for legacy display video.
+- `target` (object, optional): Exact native window from list_windows. Requires record_video=true.
 
 ```json
 {"output_dir":"~/cua-trajectories/demo1"}
@@ -682,7 +685,7 @@ State persists for the life of the daemon; a restart resets to disabled with no 
 
 ### `stop_recording`
 
-Stop trajectory recording. Disables further per-turn capture and, when video was enabled, gracefully terminates the ffmpeg subprocess so the mp4's moov atom is finalized (the file is playable). Calling stop on an already-stopped session is a no-op. The response carries `last_video_path` pointing at the finalized mp4 (when video was on).
+Stop the active recorder and finalize its video when enabled. Legacy mode also disables further per-turn capture. Window-video mode joins the native backend, including after automatic termination. Finalization failures are reported as errors. Calling stop on an already-stopped session is a no-op. The response carries `last_video_path` pointing at the finalized mp4 (when video was on).
 
 A manual `stop_recording` is **unconditional** — it stops whatever recording is active regardless of which session started it. Ownership-scoped teardown (so one client disconnecting can't stop a recording a later client started) is handled by the registry's `session_end` lifecycle hook, not by this tool.
 

--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -621,7 +621,9 @@ Start trajectory recording. Every subsequent action-tool invocation (click, righ
 
 Turn folders are named `turn-00001/`, `turn-00002/`, etc.  Turn numbering restarts at 1 each time recording is (re-)started.
 
-**Video is off by default.** Pass `record_video: true` to also capture the main display to `<output_dir>/recording.mp4` (H.264 / 30 fps) for the lifetime of the session. The recording is torn down automatically when the MCP client disconnects.
+With `target: {kind: window, pid, window_id}` and `record_video: true`, record only that native window, with video and bounded metadata only. Window mode requires a new or empty output directory, suppresses all trajectories and cursor sampling, and never falls back to display capture. Only macOS 15+ supports window video; other backends return window_recording_unsupported. Starts involving an active window recording return recording_busy. After automatic termination, call stop_recording to release the retained recorder before starting another. Manual stop remains daemon-wide.
+
+**Video is off by default.** Without `target`, pass `record_video: true` to also capture the main display to `<output_dir>/recording.mp4` (H.264 / 30 fps) for the lifetime of the session. The recording is torn down automatically when the MCP client disconnects.
 
 **macOS uses native ScreenCaptureKit** (daemon-owned SCStream + SCRecordingOutput) so video inherits the daemon's Screen Recording grant — no extra TCC prompt, no ffmpeg subprocess. Requires macOS 15.0+.
 
@@ -631,8 +633,9 @@ State persists for the life of the daemon; a restart resets to disabled with no 
 
 **Arguments:**
 
-- `output_dir` (string, required): Absolute or ~-rooted directory where turn folders and (when enabled) the video file are written.
-- `record_video` (boolean, optional): Capture the main display to &lt;output_dir&gt;/recording.mp4. Default: false. Set to true to also capture the main display to recording.mp4 (otherwise only the per-turn screenshots + JSON are recorded). On macOS this uses native ScreenCaptureKit (no extra TCC prompt, macOS 15.0+); on Windows + Linux it requires ffmpeg on PATH.
+- `output_dir` (string, required): Absolute or ~-rooted output directory. Window mode requires a new or empty directory and writes only video and metadata. Without target, writes trajectory folders and optional display video.
+- `record_video` (boolean, optional): Enable video at &lt;output_dir&gt;/recording.mp4. Default: false. With an exact window target, true is required and only window video plus metadata is recorded (macOS 15+). Without target, adds main-display video to legacy trajectory recording. macOS uses ScreenCaptureKit; Windows and Linux use ffmpeg for legacy display video.
+- `target` (object, optional): Exact native window from list_windows. Requires record_video=true.
 
 ```json
 {"output_dir":"~/cua-trajectories/demo1"}
@@ -640,7 +643,7 @@ State persists for the life of the daemon; a restart resets to disabled with no 
 
 ### `stop_recording`
 
-Stop trajectory recording. Disables further per-turn capture and, when video was enabled, gracefully terminates the ffmpeg subprocess so the mp4's moov atom is finalized (the file is playable). Calling stop on an already-stopped session is a no-op. The response carries `last_video_path` pointing at the finalized mp4 (when video was on).
+Stop the active recorder and finalize its video when enabled. Legacy mode also disables further per-turn capture. Window-video mode joins the native backend, including after automatic termination. Finalization failures are reported as errors. Calling stop on an already-stopped session is a no-op. The response carries `last_video_path` pointing at the finalized mp4 (when video was on).
 
 A manual `stop_recording` is **unconditional** — it stops whatever recording is active regardless of which session started it. Ownership-scoped teardown (so one client disconnecting can't stop a recording a later client started) is handled by the registry's `session_end` lifecycle hook, not by this tool.
 

--- a/libs/cua-driver/rust/Skills/cua-driver/RECORDING.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/RECORDING.md
@@ -1,6 +1,6 @@
-# Recording & replaying trajectories
+# Recording video and replaying trajectories
 
-> **Cross-platform.** Recording is available on macOS (native
+> **Cross-platform legacy mode.** No-target recording is available on macOS (native
 > ScreenCaptureKit), Windows (ffmpeg + `gdigrab`), and Linux (ffmpeg +
 > `x11grab`). Replay is cross-platform as long as the recorded artifacts
 > are present.
@@ -9,7 +9,7 @@ Session-scoped capture of action sequences + pre/post state, suitable
 for demos, regression diffs, and training data. Invoked only when the
 user explicitly asks to record — the skill does not auto-enable this.
 
-`start_recording` turns on a session-scoped trajectory recorder. While
+Without a `target`, `start_recording` turns on a session-scoped trajectory recorder. While
 enabled, every action-tool call (`click`, `right_click`, `scroll`,
 `type_text`, `press_key`, `hotkey`, `set_value`) writes a numbered
 turn folder under a caller-chosen output directory. Read-only tools
@@ -17,10 +17,9 @@ turn folder under a caller-chosen output directory. Read-only tools
 permission probes, agent-cursor getters / setters, and the recording
 controls themselves) are not recorded.
 
-**Video on by default.** `start_recording` also captures the main
+**Video is off by default.** Pass `record_video: true` to also capture the main
 display to `<output_dir>/recording.mp4` (H.264 / 30 fps) for the
-lifetime of the session. The mp4 is finalized on `stop_recording`. Opt
-out with `record_video: false` when you don't want video.
+lifetime of the session. The MP4 is finalized on `stop_recording`.
 
 **macOS — native ScreenCaptureKit, zero-config.** On macOS the daemon's
 recorder uses `SCStream` + `SCRecordingOutput`, so it inherits the daemon's
@@ -43,9 +42,10 @@ tools, or the friendlier `cua-driver recording` subcommand group
 
 ```
 cua-driver recording start ~/cua-trajectories/run-1
+# To include main-display video, add --video.
 # … run the workflow …
 cua-driver recording status    # -> enabled / disabled, next_turn, output_dir
-cua-driver recording stop      # -> "Recording stopped. (video → recording.mp4)"
+cua-driver recording stop      # -> "Recording stopped."
 ```
 
 Raw-tool equivalent:
@@ -61,7 +61,82 @@ serve &`) because recording state is per-process. `output_dir` expands
 `~` and is created (with intermediates) if missing. Turn numbering
 starts at `1` every time recording is (re-)enabled, regardless of any
 existing contents in the directory. State lives in memory only — a
-daemon restart resets to disabled.
+daemon restart resets to disabled. These directory and turn-numbering rules
+describe no-target trajectory mode.
+
+## Window-only video (draft implementation)
+
+The accepted [window-recording RFC](../../../../../rfcs/3644-window-recording.md)
+defines the following opt-in contract. The implementation remains in
+[draft review](https://github.com/trycua/cua/pull/3667); these examples do not
+imply that a released Driver supports it.
+
+Use the PID and window ID from `list_windows` to select one native window.
+Both flags and `--video` are required:
+
+```sh
+cua-driver recording start /tmp/window-demo --video --pid PID --window-id WINDOW_ID
+cua-driver recording status
+cua-driver recording stop
+```
+
+Replace `PID` and `WINDOW_ID` with positive integer IDs. The PID must fit a
+signed 32-bit integer, and the window ID must fit an unsigned 64-bit integer.
+The CLI rejects incomplete, unknown, and duplicate flags.
+
+The equivalent MCP arguments are:
+
+```json
+{
+  "output_dir": "/tmp/window-demo",
+  "record_video": true,
+  "target": {"kind": "window", "pid": 1234, "window_id": 5678}
+}
+```
+
+The numeric IDs in this example are placeholders. With an initialized Python
+SDK client named `driver`, use its generic `call_tool` surface:
+
+```python
+import json
+
+result = await driver.call_tool("start_recording", json.dumps({
+    "output_dir": "/tmp/window-demo",
+    "record_video": True,
+    "target": {"kind": "window", "pid": 1234, "window_id": 5678},
+}))
+```
+
+Window-video mode writes `recording.mp4` and recording metadata only. It does
+not collect trajectory screenshots, accessibility trees, action arguments,
+`turn-*` folders, or `cursor.jsonl`. The stream excludes the system cursor,
+audio, and separate Driver overlay windows. A native browser window includes
+its browser chrome; selecting a window does not select or crop a browser tab.
+
+The macOS 15+ backend uses exact-window ScreenCaptureKit capture, subject to
+OS consent and window shareability. Windows, X11, and Wayland return
+`window_recording_unsupported`. An unsupported or failed window request does
+not fall back to display capture or trajectory recording.
+
+Output dimensions stay fixed. Moving the window is allowed. A detected resize,
+backing-scale change, close, minimize, loss of shareability, or loss of the
+attested owner stops capture and attempts finalization with a classified
+reason. Inspect recording state and `session.json` for mode, target,
+dimensions, backend, termination reason, and finalization outcome.
+
+After automatic termination, call `stop_recording` to join and release the
+retained recorder before starting another. Content queries and recording
+callback waits have deadlines, but the pinned ScreenCaptureKit binding's
+synchronous native start/stop calls do not have a cancellation API. A native
+transport hang can still delay startup or teardown.
+
+Use a new or empty output directory. Validation and
+backend preflight run before the window request creates output. Starting a
+window recording while any recorder is active, or starting another mode while
+a window recorder is active, returns `recording_busy`. There is one recorder:
+manual `stop_recording` remains daemon-wide, and an owning session's disconnect
+stops its recording. Window capture does not provide independent recorder
+control.
 
 ## What each turn folder contains
 
@@ -122,8 +197,8 @@ Each action writes to `turn-NNNNN/` (five-digit zero-padded counter):
 This skill does **not** auto-enable recording. The client invokes
 `start_recording` explicitly when the user asks to capture a session.
 If the user says "record this session" or similar, call
-`start_recording({output_dir:…})` before the first action (video on
-by default; pass `record_video: false` to opt out), and
+`start_recording({output_dir:…})` before the first action (video is off
+by default; pass `record_video: true` to include main-display video), and
 `stop_recording({})` when done.
 
 ## Replaying a recorded trajectory

--- a/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
@@ -1057,7 +1057,8 @@ and training data. Only invoke when the user explicitly asks to
 record a session — the skill does not auto-enable this. CLI surface:
 `cua-driver recording start|stop|status`; raw tools:
 `start_recording` / `stop_recording`. Video capture (main display →
-`recording.mp4`) is on by default; pass `record_video: false` to opt out.
+`recording.mp4`) is off by default; pass `record_video: true` or use
+`cua-driver recording start OUTPUT --video` to include it.
 
 See **`RECORDING.md`** for the full flow: enable/disable, turn folder
 contents, replay via `replay_trajectory`, and the element_index

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/action_target.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/action_target.rs
@@ -28,6 +28,9 @@ fn invalid_target(message: impl Into<String>) -> ToolResult {
 /// dispatch boundary before authorization, so policy/resource checks and the
 /// platform worker see the same exact target.
 pub fn normalize_action_target(tool_name: &str, args: &mut Value) -> Result<(), ToolResult> {
+    if tool_name == "start_recording" {
+        return crate::recording_target::parse_window_target(args).map(|_| ());
+    }
     let Some(object) = args.as_object_mut() else {
         return Ok(());
     };
@@ -142,5 +145,17 @@ mod tests {
         ] {
             assert!(normalize_action_target("click", &mut args).is_err());
         }
+    }
+
+    #[test]
+    fn recording_keeps_its_capture_target_instead_of_becoming_an_input_action() {
+        let mut args = json!({"record_video": true,
+            "target": {"kind": "window", "pid": 42, "window_id": 7}});
+        let original = args.clone();
+        normalize_action_target("start_recording", &mut args).unwrap();
+        assert_eq!(args, original);
+        assert!(!supports_typed_target("start_recording"));
+        args["pid"] = json!(42);
+        assert!(normalize_action_target("start_recording", &mut args).is_err());
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/lib.rs
@@ -73,6 +73,7 @@ pub mod protocol;
 pub mod recording;
 pub mod recording_loader;
 pub mod recording_render;
+pub mod recording_target;
 pub mod recording_tools;
 pub mod recording_zoom;
 pub mod server;

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/recording.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/recording.rs
@@ -18,7 +18,37 @@ use std::time::Instant;
 use serde_json::Value;
 
 use crate::cursor_sampler::CursorSampler;
-use crate::video::{self, VideoBackend, VideoMetadata};
+use crate::video::{
+    self, PreparedWindowVideo, VideoBackend, VideoMetadata, WindowVideoInfo, WindowVideoStatus,
+    WindowVideoTarget,
+};
+
+// Native callbacks never acquire the recorder lock: stop may wait for them.
+struct WindowRecording {
+    status: WindowVideoStatus,
+    metadata: std::fs::File,
+    started_ms: u64,
+}
+
+impl WindowRecording {
+    fn publish(&mut self) -> anyhow::Result<()> {
+        use std::io::{Seek, SeekFrom, Write};
+        let payload = serde_json::json!({
+            "schema_version": 1, "mode": "window_video",
+            "target": self.status.info.target, "info": self.status.info,
+            "status": self.status, "started_at_monotonic_ms": self.started_ms,
+            "video": { "present": self.status.active || self.status.finalized, "path": "recording.mp4",
+                "finalized": self.status.finalized, "duration_ms": self.status.duration_ms,
+                "error": self.status.error, "termination_reason": self.status.termination_reason },
+        });
+        let bytes = serde_json::to_vec_pretty(&payload)?;
+        self.metadata.seek(SeekFrom::Start(0))?;
+        self.metadata.write_all(&bytes)?;
+        self.metadata.set_len(bytes.len() as u64)?;
+        self.metadata.flush()?;
+        Ok(())
+    }
+}
 
 // ── Platform screenshot callback ─────────────────────────────────────────────
 //
@@ -230,6 +260,7 @@ pub struct RecordingSession {
 }
 
 struct RecordingInner {
+    window: Option<Arc<Mutex<WindowRecording>>>,
     enabled: bool,
     generation: u64,
     /// Session that owns the live recording, stamped on every successful
@@ -272,6 +303,10 @@ struct RecordingInner {
 /// Snapshot of the current recording state (cheap to clone).
 #[derive(Debug, Clone)]
 pub struct RecordingState {
+    pub mode: Option<String>,
+    pub target: Option<WindowVideoTarget>,
+    pub info: Option<WindowVideoInfo>,
+    pub status: Option<WindowVideoStatus>,
     pub enabled: bool,
     pub output_dir: Option<String>,
     pub next_turn: u32,
@@ -295,6 +330,7 @@ impl RecordingSession {
         Self {
             pixel_point_fn: OnceLock::new(),
             inner: Mutex::new(RecordingInner {
+                window: None,
                 enabled: false,
                 generation: 0,
                 owner: None,
@@ -347,6 +383,10 @@ impl RecordingSession {
         owner: Option<&str>,
     ) -> anyhow::Result<()> {
         let mut inner = self.inner.lock().unwrap();
+        anyhow::ensure!(
+            !(inner.enabled && inner.window.is_some()),
+            "recording_busy: a window recording is active"
+        );
         // Write-boundary resurrection guard — checked INSIDE the lock so the
         // is_session_ended test is atomic with the enabled/owner write below.
         // An in-flight start_recording that lands after its owning session ended
@@ -442,6 +482,114 @@ impl RecordingSession {
         inner.last_error = video_error;
         inner.last_video = None;
         inner.last_cursor_samples = 0;
+        inner.window = None;
+        Ok(())
+    }
+
+    pub fn start_with_target(
+        &self,
+        output_dir: &str,
+        record_video: bool,
+        owner: Option<&str>,
+        target: Option<WindowVideoTarget>,
+    ) -> anyhow::Result<()> {
+        let Some(target) = target else {
+            return self.start(output_dir, record_video, owner);
+        };
+        target.validate()?;
+        anyhow::ensure!(
+            record_video,
+            "invalid_recording_target: window video requires record_video=true"
+        );
+        let mut inner = self.inner.lock().unwrap();
+        anyhow::ensure!(!inner.enabled, "recording_busy: a recording is active");
+        if let Some(owner) = owner {
+            anyhow::ensure!(
+                !crate::session::is_session_ended(owner),
+                "recording_session_ended: owner session has ended"
+            );
+        }
+        let prepared = video::prepare_window_video(&target)?;
+        Self::start_prepared_window(&mut inner, output_dir, owner, target, prepared)
+    }
+
+    fn start_prepared_window(
+        inner: &mut RecordingInner,
+        output_dir: &str,
+        owner: Option<&str>,
+        target: WindowVideoTarget,
+        prepared: Box<dyn PreparedWindowVideo>,
+    ) -> anyhow::Result<()> {
+        let info = prepared.info();
+        anyhow::ensure!(
+            info.target == target && info.width > 0 && info.height > 0,
+            "invalid_recording_target: backend returned incompatible capture identity"
+        );
+        let dir = expand_tilde(output_dir);
+        if dir.exists() {
+            anyhow::ensure!(
+                std::fs::read_dir(&dir)?.next().is_none(),
+                "recording_output_occupied: window video requires an empty output directory"
+            );
+        }
+        std::fs::create_dir_all(&dir)?;
+        // Claim before encoder creation; never truncate another recording's metadata.
+        let metadata = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(dir.join("session.json"))
+            .map_err(|e| anyhow::anyhow!("recording_output_occupied: cannot claim output: {e}"))?;
+        let state = Arc::new(Mutex::new(WindowRecording {
+            status: WindowVideoStatus {
+                info,
+                active: false,
+                finalized: false,
+                duration_ms: 0,
+                termination_reason: None,
+                error: None,
+            },
+            metadata,
+            started_ms: now_ms(),
+        }));
+        state.lock().unwrap().publish()?;
+        let callback_state = state.clone();
+        let observer = Arc::new(move |status: WindowVideoStatus| {
+            let mut state = callback_state.lock().unwrap();
+            state.status = status;
+            if let Err(error) = state.publish() {
+                state.status.error = Some(format!("recording_metadata_failed: {error}"));
+            }
+        });
+        let backend = match prepared.start(&dir.join("recording.mp4"), observer) {
+            Ok(backend) => backend,
+            Err(error) => {
+                let mut state = state.lock().unwrap();
+                state.status.active = false;
+                state
+                    .status
+                    .termination_reason
+                    .get_or_insert_with(|| "startup_failed".into());
+                state.status.error = Some(error.to_string());
+                let _ = state.publish();
+                return Err(error);
+            }
+        };
+        if let Some(status) = backend.window_status() {
+            let mut state = state.lock().unwrap();
+            state.status = status;
+            let _ = state.publish();
+        }
+        inner.window = Some(state);
+        inner.video = Some(backend);
+        inner.enabled = true;
+        inner.generation = inner.generation.wrapping_add(1);
+        inner.owner = owner.map(str::to_owned);
+        inner.output_dir = Some(dir);
+        inner.next_turn = 1;
+        inner.session_start_ms = now_ms();
+        inner.last_error = None;
+        inner.last_video = None;
+        inner.last_cursor_samples = 0;
         Ok(())
     }
 
@@ -506,7 +654,29 @@ impl RecordingSession {
         // Rewrite session.json with final video metadata + cursor count
         // so the renderer (and any external analysis) sees what actually
         // landed.
-        if let Some(dir) = dir {
+        if let Some(window) = &inner.window {
+            let mut window = window.lock().unwrap();
+            window.status.active = false;
+            if let Some(meta) = &video_meta {
+                window.status.finalized = meta.finalized;
+                window.status.duration_ms = meta.duration_ms;
+            }
+            if let Some(error) = &stop_error {
+                window.status.finalized = false;
+                window.status.error = Some(error.clone());
+            }
+            if window.status.termination_reason.is_none() {
+                window.status.termination_reason = Some(
+                    if stop_error.is_some() {
+                        "finalization_failed"
+                    } else {
+                        "stopped"
+                    }
+                    .into(),
+                );
+            }
+            window.publish()?;
+        } else if let Some(dir) = dir {
             let video_block = if let Some(ref m) = video_meta {
                 video_session_payload(true, None, Some(m))
             } else {
@@ -544,19 +714,50 @@ impl RecordingSession {
     /// Return a snapshot of the current state (non-blocking).
     pub fn current_state(&self) -> RecordingState {
         let inner = self.inner.lock().unwrap();
+        let status = inner
+            .video
+            .as_ref()
+            .and_then(|video| video.window_status())
+            .or_else(|| {
+                inner
+                    .window
+                    .as_ref()
+                    .map(|window| window.lock().unwrap().status.clone())
+            });
+        let last_video_path = inner
+            .last_video
+            .as_ref()
+            .map(|m| m.path.to_string_lossy().into_owned())
+            .or_else(|| {
+                status
+                    .as_ref()
+                    .filter(|s| s.finalized)
+                    .and_then(|_| inner.output_dir.as_ref())
+                    .map(|dir| dir.join("recording.mp4").to_string_lossy().into_owned())
+            });
         RecordingState {
-            enabled: inner.enabled,
+            mode: if status.is_some() {
+                Some("window_video".into())
+            } else if inner.enabled {
+                Some("legacy".into())
+            } else {
+                None
+            },
+            target: status.as_ref().map(|s| s.info.target.clone()),
+            info: status.as_ref().map(|s| s.info.clone()),
+            enabled: inner.enabled && status.as_ref().is_none_or(|s| s.active),
             output_dir: inner
                 .output_dir
                 .as_ref()
                 .map(|p| p.to_string_lossy().into_owned()),
             next_turn: inner.next_turn,
-            last_error: inner.last_error.clone(),
-            video_active: inner.video.is_some(),
-            last_video_path: inner
-                .last_video
+            last_error: status
                 .as_ref()
-                .map(|m| m.path.to_string_lossy().into_owned()),
+                .and_then(|s| s.error.clone())
+                .or_else(|| inner.last_error.clone()),
+            video_active: status.as_ref().map_or(inner.video.is_some(), |s| s.active),
+            status,
+            last_video_path,
             owner: inner.owner.clone(),
         }
     }
@@ -589,7 +790,7 @@ impl RecordingSession {
     ) -> Option<PendingTurn> {
         let (turn_dir, session_start_ms, generation) = {
             let mut inner = self.inner.lock().unwrap();
-            if !inner.enabled {
+            if !inner.enabled || inner.window.is_some() {
                 return None;
             }
             let out = inner.output_dir.clone()?;
@@ -734,6 +935,18 @@ impl RecordingSession {
 impl Default for RecordingSession {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Drop for RecordingSession {
+    fn drop(&mut self) {
+        if self
+            .inner
+            .get_mut()
+            .is_ok_and(|inner| inner.window.is_some())
+        {
+            let _ = self.stop_owner(None);
+        }
     }
 }
 
@@ -1174,6 +1387,226 @@ fn validate_video_metadata(meta: VideoMetadata) -> anyhow::Result<VideoMetadata>
 
 #[cfg(test)]
 mod tests {
+    struct FakeWindow {
+        fail_start: bool,
+        observer: Arc<Mutex<Option<crate::video::WindowVideoObserver>>>,
+        stops: Arc<AtomicUsize>,
+        path: PathBuf,
+    }
+
+    fn window_info() -> WindowVideoInfo {
+        WindowVideoInfo {
+            target: WindowVideoTarget {
+                pid: 123,
+                window_id: 456,
+            },
+            width: 640,
+            height: 480,
+            backend: "fake_window".into(),
+        }
+    }
+
+    fn window_status(active: bool) -> WindowVideoStatus {
+        WindowVideoStatus {
+            info: window_info(),
+            active,
+            finalized: !active,
+            duration_ms: 42,
+            termination_reason: (!active).then(|| "window_closed".into()),
+            error: None,
+        }
+    }
+
+    impl PreparedWindowVideo for FakeWindow {
+        fn info(&self) -> WindowVideoInfo {
+            window_info()
+        }
+        fn start(
+            mut self: Box<Self>,
+            path: &Path,
+            observer: crate::video::WindowVideoObserver,
+        ) -> anyhow::Result<Box<dyn VideoBackend>> {
+            if self.fail_start {
+                anyhow::bail!("window_recording_start_failed: fixture");
+            }
+            self.path = path.to_path_buf();
+            std::fs::write(path, b"fake video")?;
+            observer(window_status(true));
+            *self.observer.lock().unwrap() = Some(observer);
+            Ok(self)
+        }
+    }
+
+    impl VideoBackend for FakeWindow {
+        fn stop(self: Box<Self>) -> anyhow::Result<VideoMetadata> {
+            self.stops.fetch_add(1, Ordering::SeqCst);
+            if let Some(observer) = self.observer.lock().unwrap().as_ref() {
+                observer(window_status(false));
+            }
+            Ok(VideoMetadata {
+                path: self.path.clone(),
+                duration_ms: 42,
+                finalized: true,
+            })
+        }
+    }
+
+    fn start_fake_window(
+        session: &RecordingSession,
+        dir: &Path,
+        fail_start: bool,
+    ) -> (
+        anyhow::Result<()>,
+        Arc<Mutex<Option<crate::video::WindowVideoObserver>>>,
+        Arc<AtomicUsize>,
+    ) {
+        let observer = Arc::new(Mutex::new(None));
+        let stops = Arc::new(AtomicUsize::new(0));
+        let result = RecordingSession::start_prepared_window(
+            &mut session.inner.lock().unwrap(),
+            dir.to_str().unwrap(),
+            Some("window-owner"),
+            window_info().target,
+            Box::new(FakeWindow {
+                fail_start,
+                observer: observer.clone(),
+                stops: stops.clone(),
+                path: PathBuf::new(),
+            }),
+        );
+        (result, observer, stops)
+    }
+
+    #[test]
+    fn window_video_suppresses_turns_and_cursor_and_retains_native_status() {
+        let root = tempfile::tempdir().unwrap();
+        let session = RecordingSession::new();
+        let (result, observer, stops) = start_fake_window(&session, root.path(), false);
+        result.unwrap();
+        assert!(session.current_state().video_active);
+        for owner in ["window-owner", "foreign"] {
+            let args = serde_json::json!({"_session_id": owner, "pid": 123});
+            assert!(session.begin_turn("click", &args, now_ms()).is_none());
+            assert!(session
+                .begin_private_turn("click", &args, now_ms())
+                .is_none());
+        }
+        assert_eq!(session.current_state().next_turn, 1);
+        assert!(!root.path().join("cursor.jsonl").exists());
+        assert!(!root.path().join("turn-00001").exists());
+        session.stop_owner(Some("foreign")).unwrap();
+        assert_eq!(stops.load(Ordering::SeqCst), 0);
+        observer.lock().unwrap().as_ref().unwrap()(window_status(false));
+        let state = session.current_state();
+        assert!(!state.video_active);
+        assert!(!state.enabled);
+        assert_eq!(
+            state.status.unwrap().termination_reason.as_deref(),
+            Some("window_closed")
+        );
+        let payload: Value =
+            serde_json::from_slice(&std::fs::read(root.path().join("session.json")).unwrap())
+                .unwrap();
+        assert_eq!(payload["mode"], "window_video");
+        assert_eq!(payload["target"]["kind"], "window");
+        assert_eq!(payload["status"]["active"], false);
+        assert!(payload.get("cursor").is_none());
+        session.stop_owner(Some("window-owner")).unwrap();
+        assert_eq!(stops.load(Ordering::SeqCst), 1);
+        assert!(session.current_state().status.unwrap().finalized);
+    }
+
+    #[test]
+    fn window_video_busy_does_not_replace_or_mutate_output() {
+        let root = tempfile::tempdir().unwrap();
+        let session = RecordingSession::new();
+        start_fake_window(&session, root.path(), false).0.unwrap();
+        let second = root.path().join("second");
+        assert!(session
+            .start(second.to_str().unwrap(), false, None)
+            .unwrap_err()
+            .to_string()
+            .contains("recording_busy"));
+        assert!(session
+            .start_with_target(
+                second.to_str().unwrap(),
+                true,
+                None,
+                Some(window_info().target)
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("recording_busy"));
+        assert!(!second.exists());
+        assert_eq!(
+            session.current_state().owner.as_deref(),
+            Some("window-owner")
+        );
+    }
+
+    #[test]
+    fn window_video_start_failure_has_no_legacy_fallback() {
+        let root = tempfile::tempdir().unwrap();
+        let session = RecordingSession::new();
+        let (result, _, stops) = start_fake_window(&session, root.path(), true);
+        assert!(result.is_err());
+        assert!(!session.current_state().enabled);
+        assert!(session.inner.lock().unwrap().cursor.is_none());
+        assert_eq!(stops.load(Ordering::SeqCst), 0);
+        let payload: Value =
+            serde_json::from_slice(&std::fs::read(root.path().join("session.json")).unwrap())
+                .unwrap();
+        assert_eq!(payload["status"]["termination_reason"], "startup_failed");
+        assert!(!root.path().join("recording.mp4").exists());
+        assert!(!root.path().join("cursor.jsonl").exists());
+    }
+
+    #[test]
+    fn window_video_preserves_occupied_output_and_legacy_recording() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("recording.mp4"), b"old").unwrap();
+        let session = RecordingSession::new();
+        assert!(start_fake_window(&session, root.path(), false)
+            .0
+            .unwrap_err()
+            .to_string()
+            .contains("recording_output_occupied"));
+        assert_eq!(
+            std::fs::read(root.path().join("recording.mp4")).unwrap(),
+            b"old"
+        );
+        assert!(!root.path().join("session.json").exists());
+        let legacy = tempfile::tempdir().unwrap();
+        session
+            .start(legacy.path().to_str().unwrap(), false, Some("legacy-owner"))
+            .unwrap();
+        assert!(session
+            .start_with_target(
+                root.path().to_str().unwrap(),
+                true,
+                None,
+                Some(window_info().target)
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("recording_busy"));
+        assert_eq!(
+            session.current_state().owner.as_deref(),
+            Some("legacy-owner")
+        );
+        assert!(session.inner.lock().unwrap().cursor.is_some());
+    }
+
+    #[test]
+    fn window_video_drop_finalizes_owned_backend() {
+        let root = tempfile::tempdir().unwrap();
+        let session = RecordingSession::new();
+        let (result, _, stops) = start_fake_window(&session, root.path(), false);
+        result.unwrap();
+        drop(session);
+        assert_eq!(stops.load(Ordering::SeqCst), 1);
+    }
+
     use super::*;
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/recording_target.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/recording_target.rs
@@ -1,0 +1,117 @@
+//! Window-video requests retain their capture target through authorization.
+
+use crate::{protocol::ToolResult, video::WindowVideoTarget};
+use serde_json::{json, Value};
+
+fn invalid(message: &str) -> ToolResult {
+    ToolResult::error(message).with_structured(json!({"code": "invalid_recording_target"}))
+}
+
+pub fn parse_window_target(args: &Value) -> Result<Option<WindowVideoTarget>, ToolResult> {
+    if ["pid", "window_id", "scope"]
+        .iter()
+        .any(|key| args.get(key).is_some())
+    {
+        return Err(invalid(
+            "recording accepts PID/window selection only inside target",
+        ));
+    }
+    let Some(target) = args.get("target") else {
+        return Ok(None);
+    };
+    if args.get("record_video").and_then(Value::as_bool) != Some(true) {
+        return Err(invalid("window recording requires record_video: true"));
+    }
+    serde_json::from_value(target.clone())
+        .map(Some)
+        .map_err(|_| invalid("target must contain only kind: window, a positive 32-bit PID, and a positive window_id"))
+}
+
+pub(crate) fn attested_window_resource(
+    target: &WindowVideoTarget,
+    inventory: &Value,
+) -> Result<Value, String> {
+    let windows = inventory
+        .get("windows")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "window recording target inventory is unavailable".to_owned())?;
+    let mut matching = windows
+        .iter()
+        .filter(|window| window.get("window_id").and_then(Value::as_u64) == Some(target.window_id));
+    let window = matching
+        .next()
+        .ok_or_else(|| "window recording target no longer exists".to_owned())?;
+    if matching.next().is_some()
+        || window.get("pid").and_then(Value::as_i64) != Some(i64::from(target.pid))
+    {
+        return Err("window recording target ownership is unproven".to_owned());
+    }
+    // Do not copy titles, other windows, or account content into grant metadata.
+    Ok(json!({"kind": "window", "pid": target.pid, "window_id": target.window_id}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recording_target_requires_exact_window_and_video_opt_in() {
+        let target = json!({"kind": "window", "pid": 42, "window_id": 7});
+        assert_eq!(
+            parse_window_target(&json!({"record_video": true, "target": target})).unwrap(),
+            Some(WindowVideoTarget {
+                pid: 42,
+                window_id: 7
+            })
+        );
+        for args in [
+            json!({"target": target}),
+            json!({"record_video": false, "target": target}),
+            json!({"record_video": "true", "target": target}),
+            json!({"record_video": true, "target": null}),
+            json!({"record_video": true, "target": {"kind": "desktop", "display_id": "primary"}}),
+            json!({"record_video": true, "target": {"kind": "window", "pid": 0, "window_id": 7}}),
+            json!({"record_video": true, "target": {"kind": "window", "pid": 2147483648_u64, "window_id": 7}}),
+            json!({"record_video": true, "target": {"kind": "window", "pid": 42, "window_id": 0}}),
+            json!({"record_video": true, "target": {"kind": "window", "pid": 42, "window_id": 7, "extra": true}}),
+            json!({"record_video": true, "target": target, "pid": 42}),
+            json!({"pid": 42, "window_id": 7}),
+            json!({"scope": "desktop"}),
+        ] {
+            assert!(parse_window_target(&args).is_err(), "accepted {args}");
+        }
+        assert_eq!(
+            parse_window_target(&json!({"record_video": true})).unwrap(),
+            None
+        );
+        assert_eq!(parse_window_target(&json!({})).unwrap(), None);
+    }
+
+    #[test]
+    fn recording_resource_is_exact_and_excludes_inventory_content() {
+        let target = WindowVideoTarget {
+            pid: 42,
+            window_id: 7,
+        };
+        let resource = attested_window_resource(
+            &target,
+            &json!({"windows": [
+                {"pid": 42, "window_id": 7, "title": "private fixture title"},
+                {"pid": 42, "window_id": 8, "title": "unrelated fixture"}
+            ]}),
+        )
+        .unwrap();
+        assert_eq!(
+            resource,
+            json!({"kind": "window", "pid": 42, "window_id": 7})
+        );
+        for inventory in [
+            json!({}),
+            json!({"windows": []}),
+            json!({"windows": [{"pid": 43, "window_id": 7}]}),
+            json!({"windows": [{"pid": 42, "window_id": 7}, {"pid": 42, "window_id": 7}]}),
+        ] {
+            assert!(attested_window_resource(&target, &inventory).is_err());
+        }
+    }
+}

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/recording_tools.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/recording_tools.rs
@@ -64,7 +64,16 @@ impl Tool for StartRecordingTool {
                   resolution is explicitly not applicable instead.\n\n\
                 Turn folders are named `turn-00001/`, `turn-00002/`, etc.  Turn \
                 numbering restarts at 1 each time recording is (re-)started.\n\n\
-                **Video is off by default.** Pass `record_video: true` to also \
+                With `target: {kind: window, pid, window_id}` and `record_video: true`, \
+                record only that native window, with video and bounded metadata only. \
+                Window mode requires a new or empty output directory, suppresses all \
+                trajectories and cursor sampling, and never falls back to display capture. \
+                Only macOS 15+ supports window video; other backends return \
+                window_recording_unsupported. Starts involving an active window recording \
+                return recording_busy. After automatic termination, call stop_recording \
+                to release the retained recorder before starting another. Manual stop \
+                remains daemon-wide.\n\n\
+                **Video is off by default.** Without `target`, pass `record_video: true` to also \
                 capture the main display to `<output_dir>/recording.mp4` (H.264 / \
                 30 fps) for the lifetime of the session. The recording is torn \
                 down automatically when the MCP client disconnects.\n\n\
@@ -88,17 +97,28 @@ impl Tool for StartRecordingTool {
                 "properties": {
                     "output_dir": {
                         "type": "string",
-                        "description": "Absolute or ~-rooted directory where turn folders \
-                            and (when enabled) the video file are written."
+                        "description": "Absolute or ~-rooted output directory. Window mode \
+                            requires a new or empty directory and writes only video and metadata. \
+                            Without target, writes trajectory folders and optional display video."
                     },
                     "record_video": {
                         "type": "boolean",
-                        "description": "Capture the main display to <output_dir>/recording.mp4. \
-                            Default: false. Set to true to also capture the main \
-                            display to recording.mp4 (otherwise only the per-turn \
-                            screenshots + JSON are recorded). On macOS this uses native \
-                            ScreenCaptureKit (no extra TCC prompt, macOS 15.0+); on \
-                            Windows + Linux it requires ffmpeg on PATH."
+                        "description": "Enable video at <output_dir>/recording.mp4. Default: false. \
+                            With an exact window target, true is required and only window video \
+                            plus metadata is recorded (macOS 15+). Without target, adds main-display \
+                            video to legacy trajectory recording. macOS uses ScreenCaptureKit; \
+                            Windows and Linux use ffmpeg for legacy display video."
+                    },
+                    "target": {
+                        "type": "object",
+                        "required": ["kind", "pid", "window_id"],
+                        "properties": {
+                            "kind": {"type": "string", "const": "window"},
+                            "pid": {"type": "integer", "minimum": 1, "maximum": 2147483647},
+                            "window_id": {"type": "integer", "minimum": 1}
+                        },
+                        "additionalProperties": false,
+                        "description": "Exact native window from list_windows. Requires record_video=true."
                     }
                 },
                 "additionalProperties": false
@@ -112,6 +132,11 @@ impl Tool for StartRecordingTool {
 
     async fn invoke(&self, args: Value) -> ToolResult {
         use crate::tool_args::ArgsExt;
+        let target = match crate::recording_target::parse_window_target(&args) {
+            Ok(target) => target,
+            Err(error) => return error,
+        };
+        let window_video = target.is_some();
         let output_dir = args.opt_str("output_dir");
         if output_dir.as_deref().map(str::is_empty).unwrap_or(true) {
             return ToolResult::error("`output_dir` is required.");
@@ -122,10 +147,11 @@ impl Tool for StartRecordingTool {
         // (session_end) only stops the recording its own session started.
         let owner = args.opt_str("_session_id");
 
-        match self.session.start(
+        match self.session.start_with_target(
             output_dir.as_deref().unwrap(),
             record_video,
             owner.as_deref(),
+            target,
         ) {
             Ok(()) => {
                 let state = self.session.current_state();
@@ -133,7 +159,7 @@ impl Tool for StartRecordingTool {
                 // ffmpeg TCC prompt deadlock), surface the actual error
                 // prominently — the per-turn capture still runs, but the
                 // caller deserves to know the mp4 won't materialize.
-                let video_failed = record_video && !state.video_active;
+                let video_failed = record_video && !state.video_active && !window_video;
                 let video_note = if record_video && state.video_active {
                     " (video → recording.mp4)".to_string()
                 } else if video_failed {
@@ -155,7 +181,16 @@ impl Tool for StartRecordingTool {
                 );
                 ToolResult::text(msg).with_structured(recording_state_json(&state))
             }
-            Err(e) => ToolResult::error(format!("Failed to start recording: {e}")),
+            Err(e) => {
+                let message = e.to_string();
+                let code = message
+                    .split(':')
+                    .next()
+                    .filter(|code| code.chars().all(|c| c.is_ascii_lowercase() || c == '_'))
+                    .unwrap_or("recording_start_failed");
+                ToolResult::error(format!("Failed to start recording: {message}"))
+                    .with_structured(json!({"code": code, "message": message}))
+            }
         }
     }
 }
@@ -179,9 +214,10 @@ impl Tool for StopRecordingTool {
     fn def(&self) -> &ToolDef {
         STOP_REC_DEF.get_or_init(|| ToolDef {
             name: "stop_recording".into(),
-            description: "Stop trajectory recording. Disables further per-turn capture \
-                and, when video was enabled, gracefully terminates the ffmpeg subprocess \
-                so the mp4's moov atom is finalized (the file is playable). Calling \
+            description: "Stop the active recorder and finalize its video when enabled. \
+                Legacy mode also disables further per-turn capture. Window-video mode \
+                joins the native backend, including after automatic termination. \
+                Finalization failures are reported as errors. Calling \
                 stop on an already-stopped session is a no-op. The response carries \
                 `last_video_path` pointing at the finalized mp4 (when video was on).\n\n\
                 A manual `stop_recording` is **unconditional** — it stops whatever \
@@ -496,6 +532,10 @@ fn recording_state_json(state: &RecordingState) -> Value {
     json!({
         // "recording" mirrors the Swift field name for parity.
         "recording": state.enabled,
+        "mode": state.mode,
+        "target": state.target,
+        "info": state.info,
+        "status": state.status,
         "enabled": state.enabled,
         "output_dir": state.output_dir,
         "next_turn": state.next_turn,

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -1748,6 +1748,11 @@ impl ToolRegistry {
             return Err(crate::consent::ConsentError::Provider(
                 "browser observation did not attest a live top-level origin".to_owned(),
             ));
+        } else if tool_name == "start_recording" && args.get("target").is_some() {
+            (
+                self.recording_window_resource(args).await?,
+                "Allow Cua to record only the selected native window".to_owned(),
+            )
         } else if tool_name == "escalate_session" {
             (
                 serde_json::json!({
@@ -1849,6 +1854,32 @@ impl ToolRegistry {
             )
             .await?;
         Ok(())
+    }
+
+    async fn recording_window_resource(
+        &self,
+        args: &Value,
+    ) -> Result<Value, crate::consent::ConsentError> {
+        use crate::consent::ConsentError;
+        let target = crate::recording_target::parse_window_target(args)
+            .map_err(|_| ConsentError::Provider("invalid window recording target".into()))?
+            .ok_or_else(|| ConsentError::Provider("window recording target is missing".into()))?;
+        let inventory = self
+            .tools
+            .get("list_windows")
+            .ok_or_else(|| ConsentError::Provider("window identity is unavailable".into()))?
+            .invoke(serde_json::json!({"pid": target.pid}))
+            .await;
+        if inventory.is_error == Some(true) {
+            return Err(ConsentError::Provider(
+                "window identity could not be read".into(),
+            ));
+        }
+        let inventory = inventory
+            .structured_content
+            .ok_or_else(|| ConsentError::Provider("window identity was not returned".into()))?;
+        crate::recording_target::attested_window_resource(&target, &inventory)
+            .map_err(ConsentError::Provider)
     }
 
     async fn authorize_desktop_input(
@@ -2093,15 +2124,23 @@ impl ToolRegistry {
             "start_recording" => {
                 let output = canonical_proposed_path(required_path_arg(args, "output_dir")?)?;
                 args["output_dir"] = Value::String(output.clone());
+                let mut resource = serde_json::json!({
+                    "kind": "recording_output",
+                    "direction": "driver_to_local",
+                    "canonical_output_directory": output,
+                    "record_video": args.get("record_video").and_then(Value::as_bool).unwrap_or(false),
+                });
+                if let Some(target) = args.get("target") {
+                    resource["target"] = target.clone();
+                }
                 (
-                    serde_json::json!({
-                        "kind": "recording_output",
-                        "direction": "driver_to_local",
-                        "canonical_output_directory": output,
-                        "record_video": args.get("record_video").and_then(Value::as_bool).unwrap_or(false),
-                    }),
-                    "Allow Cua to write trajectory evidence to the exact local directory"
-                        .to_owned(),
+                    resource,
+                    if args.get("target").is_some() {
+                        "Allow Cua to write window video and metadata to the exact local directory"
+                    } else {
+                        "Allow Cua to write trajectory evidence to the exact local directory"
+                    }
+                    .to_owned(),
                 )
             }
             "stop_recording" => {
@@ -2868,6 +2907,57 @@ mod runtime_isolation_tests {
         def: super::ToolDef,
     }
 
+    struct WindowInventoryProbe {
+        args: Arc<Mutex<Vec<serde_json::Value>>>,
+        inventory: serde_json::Value,
+        def: super::ToolDef,
+    }
+
+    #[async_trait::async_trait]
+    impl super::Tool for WindowInventoryProbe {
+        fn def(&self) -> &super::ToolDef {
+            &self.def
+        }
+
+        async fn invoke(&self, args: serde_json::Value) -> ToolResult {
+            self.args.lock().unwrap().push(args);
+            ToolResult::text("synthetic window inventory").with_structured(self.inventory.clone())
+        }
+    }
+
+    fn window_recording_registry(
+        provider: Option<Arc<dyn ProtectedConsentProvider>>,
+        recording_hits: Arc<AtomicUsize>,
+        display_hits: Arc<AtomicUsize>,
+        inventory_args: Arc<Mutex<Vec<serde_json::Value>>>,
+        inventory: serde_json::Value,
+    ) -> super::ToolRegistry {
+        let mut registry = super::ToolRegistry::new_with_protected_consent_provider(provider);
+        let definition = |name: &str| super::ToolDef {
+            name: name.into(),
+            description: "synthetic window recording probe".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+            read_only: name != "start_recording",
+            destructive: false,
+            idempotent: false,
+            open_world: false,
+        };
+        registry.register(Box::new(ObservationProbe {
+            hits: recording_hits,
+            def: definition("start_recording"),
+        }));
+        registry.register(Box::new(ObservationProbe {
+            hits: display_hits,
+            def: definition("get_screen_size"),
+        }));
+        registry.register(Box::new(WindowInventoryProbe {
+            args: inventory_args,
+            inventory,
+            def: definition("list_windows"),
+        }));
+        registry
+    }
+
     struct ArgumentProbe {
         hits: Arc<AtomicUsize>,
         last_args: Arc<Mutex<Option<serde_json::Value>>>,
@@ -3605,6 +3695,141 @@ resources:
             0,
             "routine standard recording is promptless"
         );
+    }
+
+    #[tokio::test]
+    async fn window_recording_invalid_targets_fail_before_any_protected_or_platform_call() {
+        let recording_hits = Arc::new(AtomicUsize::new(0));
+        let display_hits = Arc::new(AtomicUsize::new(0));
+        let inventory_args = Arc::new(Mutex::new(Vec::new()));
+        let provider = Arc::new(AcceptingProvider {
+            requests: AtomicUsize::new(0),
+        });
+        let registry = window_recording_registry(
+            Some(provider.clone()),
+            recording_hits.clone(),
+            display_hits.clone(),
+            inventory_args.clone(),
+            serde_json::json!({"windows": [{"pid": 42, "window_id": 7}]}),
+        );
+        for target in [
+            serde_json::Value::Null,
+            serde_json::json!({"kind": "desktop"}),
+            serde_json::json!({"kind": "window", "pid": 0, "window_id": 7}),
+            serde_json::json!({"kind": "window", "pid": 42}),
+            serde_json::json!({"kind": "window", "pid": 42, "window_id": 7, "title": "extra"}),
+        ] {
+            let result = registry
+                .invoke_with_context(
+                    "start_recording",
+                    serde_json::json!({
+                        "record_video": true, "target": target,
+                        "output_dir": "/synthetic/recording", "session": "invalid-recording"
+                    }),
+                    standard_context(),
+                )
+                .await;
+            assert_eq!(result.is_error, Some(true), "accepted {target}");
+            assert_eq!(
+                result
+                    .structured_content
+                    .as_ref()
+                    .and_then(|value| value.get("code")),
+                Some(&serde_json::json!("invalid_recording_target"))
+            );
+        }
+        assert_eq!(recording_hits.load(Ordering::SeqCst), 0);
+        assert_eq!(display_hits.load(Ordering::SeqCst), 0);
+        assert!(inventory_args.lock().unwrap().is_empty());
+        assert_eq!(provider.requests.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn window_recording_resource_attests_exact_inventory_without_titles_or_display() {
+        for (inventory, allowed) in [
+            (
+                serde_json::json!({"windows": [
+                    {"pid": 42, "window_id": 7, "title": "private fixture title"},
+                    {"pid": 99, "window_id": 8, "title": "unrelated fixture"}
+                ]}),
+                true,
+            ),
+            (
+                serde_json::json!({"windows": [{"pid": 43, "window_id": 7}]}),
+                false,
+            ),
+            (
+                serde_json::json!({"windows": [{"pid": 42, "window_id": 8}]}),
+                false,
+            ),
+            (
+                serde_json::json!({"windows": [{"pid": 42, "window_id": 7}, {"pid": 42, "window_id": 7}]}),
+                false,
+            ),
+        ] {
+            let display_hits = Arc::new(AtomicUsize::new(0));
+            let inventory_args = Arc::new(Mutex::new(Vec::new()));
+            let registry = window_recording_registry(
+                None,
+                Arc::new(AtomicUsize::new(0)),
+                display_hits.clone(),
+                inventory_args.clone(),
+                inventory,
+            );
+            let result = registry
+                .recording_window_resource(&serde_json::json!({
+                    "record_video": true, "target": {"kind": "window", "pid": 42, "window_id": 7}
+                }))
+                .await;
+            assert_eq!(result.is_ok(), allowed);
+            if let Ok(resource) = result {
+                assert_eq!(
+                    resource,
+                    serde_json::json!({"kind": "window", "pid": 42, "window_id": 7})
+                );
+            }
+            assert_eq!(
+                *inventory_args.lock().unwrap(),
+                vec![serde_json::json!({"pid": 42})]
+            );
+            assert_eq!(display_hits.load(Ordering::SeqCst), 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn window_recording_manifest_allows_only_the_exact_attested_window() {
+        let output = tempfile::tempdir().unwrap();
+        for (pid, window_id, allowed) in [(42, 7, true), (43, 7, false), (42, 8, false)] {
+            let recording_hits = Arc::new(AtomicUsize::new(0));
+            let display_hits = Arc::new(AtomicUsize::new(0));
+            let inventory_args = Arc::new(Mutex::new(Vec::new()));
+            let registry = window_recording_registry(
+                None,
+                recording_hits.clone(),
+                display_hits.clone(),
+                inventory_args.clone(),
+                serde_json::json!({"windows": [{"pid": pid, "window_id": window_id, "title": "private fixture title"}]}),
+            );
+            let context = bounded_context(&format!(
+                "version: 3\nexpires_after: 1h\nidle_timeout: 30m\nallow:\n  tools: [start_recording]\nresources:\n  desktop:\n    windows:\n      - pid: 42\n        window_id: 7\n  files:\n    write: [{}]\n",
+                serde_json::to_string(&output.path().to_string_lossy()).unwrap()
+            ));
+            let result = registry.invoke_with_context("start_recording", serde_json::json!({
+                "record_video": true, "target": {"kind": "window", "pid": pid, "window_id": window_id},
+                "output_dir": output.path(), "session": "bounded-window-recording"
+            }), context).await;
+            assert_eq!(
+                result.is_error != Some(true),
+                allowed,
+                "{pid}/{window_id}: {result:?}"
+            );
+            assert_eq!(recording_hits.load(Ordering::SeqCst), usize::from(allowed));
+            assert_eq!(display_hits.load(Ordering::SeqCst), 0);
+            assert_eq!(
+                *inventory_args.lock().unwrap(),
+                vec![serde_json::json!({"pid": pid})]
+            );
+        }
     }
 
     #[tokio::test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/video.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/video.rs
@@ -19,7 +19,78 @@
 //! `VideoRecorder::stop` return so the on-disk schema is unchanged.
 
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "WindowTargetWire", into = "WindowTargetWire")]
+pub struct WindowVideoTarget {
+    pub pid: i32,
+    pub window_id: u64,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum WindowTargetWire {
+    Window { pid: i32, window_id: u64 },
+}
+
+impl WindowVideoTarget {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.pid > 0 && self.window_id > 0,
+            "invalid_recording_target: pid and window_id must be positive"
+        );
+        Ok(())
+    }
+}
+
+impl TryFrom<WindowTargetWire> for WindowVideoTarget {
+    type Error = anyhow::Error;
+    fn try_from(wire: WindowTargetWire) -> anyhow::Result<Self> {
+        let WindowTargetWire::Window { pid, window_id } = wire;
+        let target = Self { pid, window_id };
+        target.validate()?;
+        Ok(target)
+    }
+}
+
+impl From<WindowVideoTarget> for WindowTargetWire {
+    fn from(target: WindowVideoTarget) -> Self {
+        Self::Window {
+            pid: target.pid,
+            window_id: target.window_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct WindowVideoInfo {
+    pub target: WindowVideoTarget,
+    pub width: u32,
+    pub height: u32,
+    pub backend: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct WindowVideoStatus {
+    pub info: WindowVideoInfo,
+    pub active: bool,
+    pub finalized: bool,
+    pub duration_ms: u64,
+    pub termination_reason: Option<String>,
+    pub error: Option<String>,
+}
+
+pub type WindowVideoObserver = Arc<dyn Fn(WindowVideoStatus) + Send + Sync>;
+
+pub trait PreparedWindowVideo: Send {
+    fn info(&self) -> WindowVideoInfo;
+    fn start(
+        self: Box<Self>,
+        path: &Path,
+        observer: WindowVideoObserver,
+    ) -> anyhow::Result<Box<dyn VideoBackend>>;
+}
 
 /// Finalized metadata returned by `VideoBackend::stop`. Mirrors the
 /// Swift impl's `FinalMetadata` so `session.json` carries the same
@@ -37,15 +108,36 @@ pub struct VideoMetadata {
 /// session's lifetime; `stop()` consumes it and finalizes the file.
 pub trait VideoBackend: Send {
     fn stop(self: Box<Self>) -> anyhow::Result<VideoMetadata>;
+    fn window_status(&self) -> Option<WindowVideoStatus> {
+        None
+    }
 }
 
 /// Spawns a fresh `VideoBackend` writing to `output_path`. Registered
 /// once at startup via `set_video_backend_factory`.
 pub trait VideoBackendFactory: Send + Sync {
     fn start(&self, output_path: &Path) -> anyhow::Result<Box<dyn VideoBackend>>;
+    fn prepare_window(
+        &self,
+        _target: &WindowVideoTarget,
+    ) -> anyhow::Result<Box<dyn PreparedWindowVideo>> {
+        anyhow::bail!("window_recording_unsupported: this backend does not support window video")
+    }
 }
 
 static VIDEO_BACKEND_FACTORY: OnceLock<Box<dyn VideoBackendFactory>> = OnceLock::new();
+
+pub fn prepare_window_video(
+    target: &WindowVideoTarget,
+) -> anyhow::Result<Box<dyn PreparedWindowVideo>> {
+    target.validate()?;
+    VIDEO_BACKEND_FACTORY
+        .get()
+        .ok_or_else(|| {
+            anyhow::anyhow!("window_recording_unsupported: no video backend registered")
+        })?
+        .prepare_window(target)
+}
 
 /// Register the platform's video backend. Idempotent — subsequent calls
 /// are silently ignored, matching the other recording-callback setters.
@@ -62,4 +154,53 @@ pub fn start_video(output_path: &Path) -> anyhow::Result<Box<dyn VideoBackend>> 
         .get()
         .ok_or_else(|| anyhow::anyhow!("no video backend registered for this platform"))?;
     factory.start(output_path)
+}
+
+#[cfg(test)]
+mod window_tests {
+    use super::*;
+
+    #[test]
+    fn window_target_wire_is_exact_and_validated() {
+        let target = WindowVideoTarget {
+            pid: 12,
+            window_id: 34,
+        };
+        let value = serde_json::json!({"kind":"window", "pid":12, "window_id":34});
+        assert_eq!(serde_json::to_value(&target).unwrap(), value);
+        assert_eq!(
+            serde_json::from_value::<WindowVideoTarget>(value).unwrap(),
+            target
+        );
+        for value in [
+            serde_json::json!({"kind":"display","pid":12,"window_id":34}),
+            serde_json::json!({"kind":"window","pid":0,"window_id":34}),
+            serde_json::json!({"kind":"window","pid":12,"window_id":0}),
+            serde_json::json!({"kind":"window","pid":2147483648u64,"window_id":34}),
+            serde_json::json!({"kind":"window","pid":12}),
+            serde_json::json!({"kind":"window","pid":12,"window_id":34,"scope":"desktop"}),
+        ] {
+            assert!(serde_json::from_value::<WindowVideoTarget>(value).is_err());
+        }
+    }
+
+    struct LegacyFactory;
+    impl VideoBackendFactory for LegacyFactory {
+        fn start(&self, _: &Path) -> anyhow::Result<Box<dyn VideoBackend>> {
+            panic!("window requests must never start a display backend")
+        }
+    }
+
+    #[test]
+    fn legacy_factory_refuses_window_without_display_fallback() {
+        let result = LegacyFactory.prepare_window(&WindowVideoTarget {
+            pid: 12,
+            window_id: 34,
+        });
+        assert!(result
+            .err()
+            .unwrap()
+            .to_string()
+            .starts_with("window_recording_unsupported:"));
+    }
 }

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -480,7 +480,10 @@ fn finite_tool_name_from_args(args: &[String]) -> Option<String> {
 /// independently; we only care about the first non-`--` arg here.
 pub fn parse_command() -> Command {
     let args: Vec<String> = std::env::args().skip(1).collect();
+    parse_command_from(args)
+}
 
+fn parse_command_from(args: Vec<String>) -> Command {
     // Handle --version / -V before any other parsing so they are never
     // silently stripped as "bare flags" and swallowed by MCP mode.
     if args.iter().any(|a| a == "--version" || a == "-V") {
@@ -801,7 +804,11 @@ pub fn parse_command() -> Command {
         }
         Some("recording") => {
             let subcommand = pos.next().unwrap_or("status").to_string();
-            let rest: Vec<String> = pos.map(str::to_owned).collect();
+            let rest: Vec<String> = if subcommand == "start" {
+                recording_start_argv(&args)
+            } else {
+                pos.map(str::to_owned).collect()
+            };
             Command::Recording {
                 subcommand,
                 args: rest,
@@ -2726,12 +2733,111 @@ fn history_daemon_status(socket_path: &str) -> Option<serde_json::Value> {
         .result
 }
 
-/// `cua-driver recording <start|stop|status>` — wrapper around
-/// `start_recording` / `stop_recording` / `get_recording_state` tools
-/// on the running daemon.
-///
-/// Requires a running daemon (`cua-driver serve`) because recording
-/// state lives in the daemon.
+fn recording_start_argv(args: &[String]) -> Vec<String> {
+    // Locate the two command words using the global parser's rules, then keep
+    // recording flags intact. The generic positional scan discards their values.
+    let mut i = 0;
+    let mut command_indices = Vec::new();
+    while i < args.len() && command_indices.len() < 2 {
+        if VALUE_FLAGS.contains(&args[i].as_str()) {
+            i += 2;
+        } else {
+            if !args[i].starts_with('-') {
+                command_indices.push(i);
+            }
+            i += 1;
+        }
+    }
+    let mut tail = Vec::new();
+    i = 0;
+    while i < args.len() {
+        if args[i] == "--socket" {
+            i += 2;
+        } else {
+            if !command_indices.contains(&i) {
+                tail.push(args[i].clone());
+            }
+            i += 1;
+        }
+    }
+    tail
+}
+
+fn recording_start_arguments(args: &[String]) -> Result<serde_json::Value, String> {
+    let output_dir = args.first().filter(|arg| !arg.starts_with('-')).ok_or_else(|| {
+        "Usage: cua-driver recording start <output-dir> [--video [--pid PID --window-id WINDOW_ID]]".to_owned()
+    })?;
+    let mut video = false;
+    let mut pid = None;
+    let mut window_id = None;
+    let mut remaining = args[1..].iter();
+    while let Some(flag) = remaining.next() {
+        match flag.as_str() {
+            "--video" if !video => video = true,
+            "--pid" if pid.is_none() => {
+                pid = Some(
+                    remaining
+                        .next()
+                        .and_then(|value| value.parse::<i32>().ok())
+                        .filter(|value| *value > 0)
+                        .ok_or_else(|| "--pid requires a positive 32-bit integer".to_owned())?,
+                );
+            }
+            "--window-id" if window_id.is_none() => {
+                window_id = Some(
+                    remaining
+                        .next()
+                        .and_then(|value| value.parse::<u64>().ok())
+                        .filter(|value| *value > 0)
+                        .ok_or_else(|| {
+                            "--window-id requires a positive 64-bit integer".to_owned()
+                        })?,
+                );
+            }
+            _ => {
+                return Err(format!(
+                    "Unknown or duplicate recording start argument: {flag}"
+                ))
+            }
+        }
+    }
+    let mut arguments = serde_json::json!({"output_dir": output_dir});
+    if video {
+        arguments["record_video"] = serde_json::json!(true);
+    }
+    match (pid, window_id) {
+        (Some(pid), Some(window_id)) if video => {
+            arguments["target"] =
+                serde_json::json!({"kind": "window", "pid": pid, "window_id": window_id});
+        }
+        (None, None) => {}
+        _ => {
+            return Err(
+                "Window recording requires --video, --pid, and --window-id together".to_owned(),
+            )
+        }
+    }
+    Ok(arguments)
+}
+
+fn recording_tool_error(result: Option<&serde_json::Value>) -> Option<String> {
+    let result = result?;
+    if !result
+        .get("isError")
+        .or_else(|| result.get("is_error"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    // Keep structured classifications and text diagnostics visible to CLI callers.
+    Some(
+        serde_json::to_string_pretty(result).unwrap_or_else(|_| "Recording tool failed".to_owned()),
+    )
+}
+
+/// `cua-driver recording <start|stop|status>` wraps recording tools on the
+/// running daemon, where recording state lives.
 pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>) {
     // `render` is pure file-to-file work that doesn't need the daemon;
     // dispatch it before the daemon-running check so it works without
@@ -2740,6 +2846,15 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
         run_recording_render(args);
         return;
     }
+
+    let start_arguments = if subcommand == "start" {
+        Some(recording_start_arguments(args).unwrap_or_else(|error| {
+            eprintln!("{error}");
+            process::exit(64);
+        }))
+    } else {
+        None
+    };
 
     let socket_path = socket
         .map(str::to_owned)
@@ -2756,6 +2871,7 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
 
     match subcommand {
         "start" => {
+            let mut arguments = start_arguments.expect("start arguments were validated");
             let output_dir = match args.first() {
                 Some(d) => {
                     // Expand ~ manually.
@@ -2772,18 +2888,19 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
                 }
             };
 
-            // Create the directory if it doesn't exist.
-            if let Err(e) = std::fs::create_dir_all(&output_dir) {
-                eprintln!("Failed to create output directory {output_dir}: {e}");
-                process::exit(1);
+            // Window mode defers output creation until core validation and preflight.
+            if arguments.get("target").is_none() {
+                if let Err(e) = std::fs::create_dir_all(&output_dir) {
+                    eprintln!("Failed to create output directory {output_dir}: {e}");
+                    process::exit(1);
+                }
             }
+            arguments["output_dir"] = serde_json::json!(output_dir);
 
             let req = crate::serve::DaemonRequest {
                 method: "call".into(),
                 name: Some("start_recording".into()),
-                args: Some(serde_json::json!({
-                    "output_dir": output_dir
-                })),
+                args: Some(arguments),
                 // CLI `recording start` is anonymous — the recording is owned by
                 // nobody, so only an unconditional stop (CLI / manual) reaps it.
                 session_id: None,
@@ -2792,6 +2909,10 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
             };
             match crate::serve::send_request(&socket_path, &req) {
                 Ok(resp) if resp.ok => {
+                    if let Some(error) = recording_tool_error(resp.result.as_ref()) {
+                        eprintln!("recording start: {error}");
+                        process::exit(1);
+                    }
                     println!("Recording started → {output_dir}");
                     // Query state to show next_turn.
                     let state_req = crate::serve::DaemonRequest {
@@ -2838,7 +2959,13 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
                 client_kind: Some(cua_driver_core::daemon::DaemonClientKind::Cli),
             };
             match crate::serve::send_request(&socket_path, &req) {
-                Ok(resp) if resp.ok => println!("Recording stopped."),
+                Ok(resp) if resp.ok => {
+                    if let Some(error) = recording_tool_error(resp.result.as_ref()) {
+                        eprintln!("recording stop: {error}");
+                        process::exit(1);
+                    }
+                    println!("Recording stopped.");
+                }
                 Ok(resp) => {
                     if let Some(e) = resp.error {
                         eprintln!("{e}");
@@ -2863,6 +2990,10 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
             };
             match crate::serve::send_request(&socket_path, &req) {
                 Ok(resp) if resp.ok => {
+                    if let Some(error) = recording_tool_error(resp.result.as_ref()) {
+                        eprintln!("recording status: {error}");
+                        process::exit(1);
+                    }
                     if let Some(result) = resp.result {
                         let sc = result
                             .get("structuredContent")
@@ -2882,6 +3013,15 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
                         if enabled {
                             println!("  output_dir: {out_dir}");
                             println!("  next_turn:  {next_turn:05}");
+                        }
+                        if sc.get("mode").and_then(|value| value.as_str()) == Some("window_video") {
+                            println!("  mode: window_video");
+                            for key in ["target", "info", "status", "last_video_path", "last_error"]
+                            {
+                                if let Some(value) = sc.get(key).filter(|value| !value.is_null()) {
+                                    println!("  {key}: {value}");
+                                }
+                            }
                         }
                     }
                 }
@@ -3977,7 +4117,7 @@ fn cli_docs_json() -> serde_json::Value {
             },
             {
                 "name": "recording",
-                "abstract": "Control trajectory recording on a running daemon.",
+                "abstract": "Control trajectory or explicit window-video recording on a running daemon.",
                 "discussion": "Recording state lives in the required daemon and survives client reconnects.",
                 "arguments": no_args,
                 "options": [{"name":"socket","short_name":null,"help":"Override the daemon socket or named-pipe path.","type":"String","default_value":null,"is_optional":true}],
@@ -3985,17 +4125,20 @@ fn cli_docs_json() -> serde_json::Value {
                 "subcommands": [
                     {
                         "name":"start",
-                        "abstract":"Start trajectory recording to a directory.",
-                        "discussion":"",
-                        "arguments":[{"name":"output-dir","help":"Directory to write turn folders into.","type":"String","is_optional":false}],
-                        "options":[],
-                        "flags":[],
+                        "abstract":"Start recording to a directory.",
+                        "discussion":"Defaults to trajectory-only recording. --video adds display video unless both --pid and --window-id select exact window-video mode. Window mode requires --video and a new or empty output directory; it writes MP4 and metadata only. Supported on macOS 15+; other backends refuse without display fallback.",
+                        "arguments":[{"name":"output-dir","help":"Directory to write recording artifacts into.","type":"String","is_optional":false}],
+                        "options":[
+                            {"name":"pid","short_name":null,"help":"Positive window-owner PID; requires --window-id and --video.","type":"Int32","default_value":null,"is_optional":true},
+                            {"name":"window-id","short_name":null,"help":"Positive native window ID from list_windows; requires --pid and --video.","type":"UInt64","default_value":null,"is_optional":true}
+                        ],
+                        "flags":[{"name":"video","short_name":null,"help":"Enable video. Required for exact window mode.","default_value":false}],
                         "subcommands":[]
                     },
                     {
                         "name":"stop",
-                        "abstract":"Stop trajectory recording.",
-                        "discussion":"",
+                        "abstract":"Stop the active recorder and finalize video.",
+                        "discussion":"Manual stop is daemon-wide. After automatic window termination, call stop to release the retained recorder before starting another.",
                         "arguments":[],
                         "options":[],
                         "flags":[],
@@ -4752,6 +4895,189 @@ mod tests {
 
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| (*value).to_owned()).collect()
+    }
+
+    #[test]
+    fn recording_start_preserves_trajectory_default_and_display_opt_in() {
+        assert_eq!(
+            recording_start_arguments(&args(&["/tmp/recording"])).unwrap(),
+            serde_json::json!({"output_dir": "/tmp/recording"})
+        );
+        assert_eq!(
+            recording_start_arguments(&args(&["/tmp/recording", "--video"])).unwrap(),
+            serde_json::json!({"output_dir": "/tmp/recording", "record_video": true})
+        );
+    }
+
+    #[test]
+    fn recording_full_cli_keeps_window_flags_through_global_parsing() {
+        let command = parse_command_from(args(&[
+            "--socket",
+            "/tmp/synthetic.sock",
+            "recording",
+            "start",
+            "/tmp/recording",
+            "--video",
+            "--pid",
+            "42",
+            "--window-id",
+            "7",
+        ]));
+        let Command::Recording {
+            subcommand,
+            args: parsed,
+            socket,
+        } = command
+        else {
+            panic!("expected recording command");
+        };
+        assert_eq!(subcommand, "start");
+        assert_eq!(socket.as_deref(), Some("/tmp/synthetic.sock"));
+        assert_eq!(
+            recording_start_arguments(&parsed).unwrap(),
+            serde_json::json!({"output_dir": "/tmp/recording", "record_video": true,
+                "target": {"kind": "window", "pid": 42, "window_id": 7}})
+        );
+        let command = parse_command_from(args(&[
+            "recording",
+            "start",
+            "/tmp/recording",
+            "--socket",
+            "/tmp/synthetic.sock",
+            "--window-id",
+            "7",
+        ]));
+        let Command::Recording { args: parsed, .. } = command else {
+            panic!("expected recording command");
+        };
+        assert!(recording_start_arguments(&parsed).is_err());
+        let command = parse_command_from(args(&[
+            "--pid",
+            "42",
+            "recording",
+            "start",
+            "/tmp/recording",
+            "--video",
+        ]));
+        let Command::Recording { args: parsed, .. } = command else {
+            panic!("expected recording command");
+        };
+        assert!(recording_start_arguments(&parsed).is_err());
+    }
+
+    #[test]
+    fn recording_cli_reference_advertises_all_window_flags() {
+        let docs = cli_docs_json();
+        let recording = docs["commands"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|command| command["name"] == "recording")
+            .unwrap();
+        let start = &recording["subcommands"][0];
+        assert_eq!(start["name"], "start");
+        assert_eq!(start["flags"][0]["name"], "video");
+        assert_eq!(start["options"][0]["name"], "pid");
+        assert_eq!(start["options"][1]["name"], "window-id");
+    }
+
+    #[test]
+    fn recording_start_accepts_exact_window_target_and_numeric_limits() {
+        assert_eq!(
+            recording_start_arguments(&args(&[
+                "/tmp/recording",
+                "--window-id",
+                "18446744073709551615",
+                "--video",
+                "--pid",
+                "2147483647"
+            ]))
+            .unwrap(),
+            serde_json::json!({
+                "output_dir": "/tmp/recording", "record_video": true,
+                "target": {"kind": "window", "pid": i32::MAX, "window_id": u64::MAX}
+            })
+        );
+    }
+
+    #[test]
+    fn recording_start_rejects_incomplete_unknown_and_duplicate_arguments() {
+        for values in [
+            vec![],
+            vec!["--video"],
+            vec!["/tmp/r", "--pid", "1"],
+            vec!["/tmp/r", "--video", "--window-id", "1"],
+            vec!["/tmp/r", "--pid", "1", "--window-id", "2"],
+            vec!["/tmp/r", "--video", "--video"],
+            vec!["/tmp/r", "--unknown"],
+            vec!["/tmp/r", "extra"],
+            vec!["/tmp/r", "--pid"],
+            vec!["/tmp/r", "--window-id"],
+            vec![
+                "/tmp/r",
+                "--video",
+                "--pid",
+                "1",
+                "--pid",
+                "2",
+                "--window-id",
+                "3",
+            ],
+            vec![
+                "/tmp/r",
+                "--video",
+                "--pid",
+                "1",
+                "--window-id",
+                "2",
+                "--window-id",
+                "3",
+            ],
+        ] {
+            assert!(
+                recording_start_arguments(&args(&values)).is_err(),
+                "{values:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn recording_start_rejects_invalid_and_overflowing_ids() {
+        for pid in ["0", "-1", "2147483648", "abc", "1.5"] {
+            assert!(recording_start_arguments(&args(&[
+                "/tmp/r",
+                "--video",
+                "--pid",
+                pid,
+                "--window-id",
+                "1"
+            ]))
+            .is_err());
+        }
+        for window_id in ["0", "-1", "18446744073709551616", "abc", "1.5"] {
+            assert!(recording_start_arguments(&args(&[
+                "/tmp/r",
+                "--video",
+                "--pid",
+                "1",
+                "--window-id",
+                window_id
+            ]))
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn recording_tool_errors_preserve_structured_diagnostics() {
+        for key in ["isError", "is_error"] {
+            let mut result = serde_json::json!({"structuredContent": {"error": "recording_busy"}});
+            result[key] = serde_json::json!(true);
+            assert!(recording_tool_error(Some(&result))
+                .unwrap()
+                .contains("recording_busy"));
+        }
+        assert!(recording_tool_error(Some(&serde_json::json!({"isError": false}))).is_none());
+        assert!(recording_tool_error(None).is_none());
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/tests/window_recording_macos_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/window_recording_macos_test.rs
@@ -13,6 +13,16 @@ use std::{
     time::{Duration, Instant},
 };
 
+const RECORDING_CASES: &[(&str, &str)] = &[
+    ("stop", "stop"),
+    ("repeat_1", "stop"),
+    ("repeat_2", "stop"),
+    ("minimize", "minimize"),
+    ("close", "close"),
+    ("resize", "resize"),
+    ("disconnect", "disconnect"),
+];
+
 struct Fixture {
     child: Child,
     replies: Receiver<Value>,
@@ -104,6 +114,21 @@ fn wait_finalized(driver: &mut McpDriver) -> Value {
     }
 }
 
+fn descriptor_count(pid: u64) -> usize {
+    let output = Command::new("/usr/sbin/lsof")
+        .args(["-n", "-a", "-p", &pid.to_string(), "-Ff"])
+        .output()
+        .expect("inspect only the attested test daemon's descriptors");
+    assert!(output.status.success(), "could not inspect test daemon");
+    let count = String::from_utf8(output.stdout)
+        .unwrap()
+        .lines()
+        .filter_map(|line| line.strip_prefix('f')?.parse::<u32>().ok())
+        .count();
+    assert!(count > 0, "test daemon has no observable descriptors");
+    count
+}
+
 fn verify_video(output_dir: &Path, identity: &Value, state: &Value) {
     let mut files: Vec<_> = fs::read_dir(output_dir)
         .unwrap()
@@ -124,7 +149,14 @@ fn verify_video(output_dir: &Path, identity: &Value, state: &Value) {
     );
     let video = output_dir.join("recording.mp4");
     let probe = Command::new("ffprobe")
-        .args(["-v", "error", "-show_streams", "-of", "json"])
+        .args([
+            "-v",
+            "error",
+            "-show_streams",
+            "-show_frames",
+            "-of",
+            "json",
+        ])
         .arg(&video)
         .output()
         .expect("ffprobe must be installed in the authorized test environment");
@@ -137,20 +169,39 @@ fn verify_video(output_dir: &Path, identity: &Value, state: &Value) {
     let streams = probe["streams"].as_array().unwrap();
     assert_eq!(streams.len(), 1, "unexpected audio or extra video stream");
     assert_eq!(streams[0]["codec_type"], "video");
+    assert_eq!(streams[0]["codec_name"], "h264");
+    let frames = probe["frames"].as_array().expect("decoded frame metadata");
+    let timestamps: Vec<f64> = frames
+        .iter()
+        .map(|frame| {
+            frame["best_effort_timestamp_time"]
+                .as_str()
+                .expect("frame timestamp")
+                .parse()
+                .expect("numeric frame timestamp")
+        })
+        .collect();
+    assert!(timestamps.len() >= 3, "too few native frames");
+    assert!(timestamps.iter().all(|timestamp| timestamp.is_finite()));
+    assert!(timestamps.windows(2).all(|pair| pair[1] > pair[0]));
+    assert!(timestamps.last().unwrap() - timestamps[0] >= 1.5);
     for dimension in ["width", "height"] {
-        let expected =
-            (identity[dimension].as_f64().unwrap() * identity["scale"].as_f64().unwrap()) as u64;
+        let pixels = (identity[dimension].as_f64().unwrap() * identity["scale"].as_f64().unwrap())
+            .ceil() as u64;
+        let expected = pixels.div_ceil(2) * 2;
         assert_eq!(streams[0][dimension].as_u64(), Some(expected));
         assert_eq!(state["info"][dimension].as_u64(), Some(expected));
     }
-    // Decode every half-second into RGB. A desktop crop or application-wide
+    // Decode every frame into RGB. A desktop crop or application-wide
     // filter reveals the red sibling; exact-window capture retains the marker.
     let decoded = Command::new("ffmpeg")
-        .args(["-v", "error", "-i"])
+        .args(["-v", "error", "-xerror", "-i"])
         .arg(&video)
         .args([
             "-vf",
-            "fps=2,scale=32:24",
+            "scale=32:24",
+            "-fps_mode",
+            "passthrough",
             "-f",
             "rawvideo",
             "-pix_fmt",
@@ -167,6 +218,7 @@ fn verify_video(output_dir: &Path, identity: &Value, state: &Value) {
     const FRAME: usize = 32 * 24 * 3;
     assert!(decoded.stdout.len() >= FRAME * 3, "too few decoded samples");
     assert_eq!(decoded.stdout.len() % FRAME, 0);
+    assert_eq!(decoded.stdout.len() / FRAME, timestamps.len());
     let distinct: std::collections::HashSet<_> = decoded.stdout.chunks_exact(FRAME).collect();
     assert!(distinct.len() > 1, "recording contains only a frozen frame");
     for frame in decoded.stdout.chunks_exact(FRAME) {
@@ -231,14 +283,10 @@ fn exact_window_recording_isolation_and_lifecycle() {
     );
     assert!(root.is_absolute(), "evidence root must be absolute");
     fs::create_dir_all(&root).unwrap();
-    for name in [
-        "test-environment.json",
-        "stop",
-        "minimize",
-        "close",
-        "resize",
-        "disconnect",
-    ] {
+    for name in ["test-environment.json", "native-diagnostics.json"]
+        .into_iter()
+        .chain(RECORDING_CASES.iter().map(|(name, _)| *name))
+    {
         assert!(
             fs::symlink_metadata(root.join(name))
                 .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound),
@@ -275,6 +323,9 @@ fn exact_window_recording_isolation_and_lifecycle() {
     let config = call(&mut driver, "get_config", json!({}));
     assert_eq!(config["source_sha"].as_str(), Some(expected_sha.as_str()));
     assert_eq!(config["version"].as_str(), Some(env!("CARGO_PKG_VERSION")));
+    let permissions = call(&mut driver, "check_permissions", json!({"prompt": false}));
+    assert_eq!(permissions["source"]["attribution"], "driver-daemon");
+    let daemon_pid = permissions["source"]["pid"].as_u64().unwrap();
     serde_json::to_writer_pretty(
         fs::OpenOptions::new()
             .write(true)
@@ -293,9 +344,13 @@ fn exact_window_recording_isolation_and_lifecycle() {
         initial["enabled"], true,
         "another recording owns the daemon"
     );
-    for ending in ["stop", "minimize", "close", "resize", "disconnect"] {
+    let descriptors_before_warmup = descriptor_count(daemon_pid);
+    let mut descriptor_samples = Vec::new();
+    let mut native_scales = Vec::new();
+    for &(case, ending) in RECORDING_CASES {
         let mut fixture = Fixture::launch();
-        let output = root.join(ending);
+        native_scales.push(fixture.identity["scale"].clone());
+        let output = root.join(case);
         assert!(
             !output.exists(),
             "use a fresh output root; never overwrite evidence"
@@ -313,6 +368,9 @@ fn exact_window_recording_isolation_and_lifecycle() {
             }),
             "fixture identity absent from public list_windows: {windows}"
         );
+        let before_start = fixture.command("state");
+        assert_eq!(before_start["sibling_visible"], true);
+        assert_eq!(before_start["sibling_adjacent"], true);
         let args = json!({"output_dir": output, "record_video": true, "target": target});
         if ending == "stop" {
             let mut invalid = args.clone();
@@ -325,6 +383,11 @@ fn exact_window_recording_isolation_and_lifecycle() {
         let started = call(&mut driver, "start_recording", args.clone());
         assert_eq!(started["status"]["active"], true, "{started}");
         assert_eq!(started["info"]["backend"], "screencapturekit_window");
+        assert_eq!(
+            fixture.command("state")["ui_state"],
+            before_start["ui_state"],
+            "{case}: starting capture changed focus, window order, or the real cursor"
+        );
         if ending == "stop" {
             assert!(
                 driver.call("start_recording", args).is_error(),
@@ -355,6 +418,7 @@ fn exact_window_recording_isolation_and_lifecycle() {
             true,
             "movement or occlusion ended capture"
         );
+        let before_end = fixture.command("state");
         if ending == "stop" {
             call(&mut driver, "stop_recording", json!({}));
         } else if ending == "disconnect" {
@@ -371,6 +435,13 @@ fn exact_window_recording_isolation_and_lifecycle() {
             }
         }
         let state = wait_finalized(&mut driver);
+        if matches!(ending, "stop" | "disconnect") {
+            assert_eq!(
+                fixture.command("state")["ui_state"],
+                before_end["ui_state"],
+                "{case}: ending capture changed focus, window order, or the real cursor"
+            );
+        }
         let reason = state["status"]["termination_reason"]
             .as_str()
             .expect("termination reason");
@@ -382,7 +453,30 @@ fn exact_window_recording_isolation_and_lifecycle() {
             _ => unreachable!(),
         }
         verify_video(&output, &fixture.identity, &state);
+        eprintln!("verified native window recording: {case} ({reason})");
         let stopped_again = call(&mut driver, "stop_recording", json!({}));
         assert_eq!(stopped_again["status"]["finalized"], true);
+        descriptor_samples.push(descriptor_count(daemon_pid));
     }
+    serde_json::to_writer_pretty(
+        fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(root.join("native-diagnostics.json"))
+            .unwrap(),
+        &json!({
+            "descriptors_before_warmup": descriptors_before_warmup,
+            "warmup_case": "stop",
+            "descriptor_samples": descriptor_samples,
+            "native_scales": native_scales,
+        }),
+    )
+    .unwrap();
+    let baseline = descriptor_samples[0];
+    assert!(
+        descriptor_samples
+            .iter()
+            .all(|sample| *sample <= baseline + 2),
+        "descriptor growth after recorder warmup: {descriptor_samples:?}"
+    );
 }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/window_recording_macos_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/window_recording_macos_test.rs
@@ -129,7 +129,7 @@ fn descriptor_count(pid: u64) -> usize {
     count
 }
 
-fn verify_video(output_dir: &Path, identity: &Value, state: &Value) {
+fn verify_video(output_dir: &Path, identity: &Value, state: &Value, ending: &str) {
     let mut files: Vec<_> = fs::read_dir(output_dir)
         .unwrap()
         .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
@@ -202,6 +202,8 @@ fn verify_video(output_dir: &Path, identity: &Value, state: &Value) {
             "scale=32:24",
             "-fps_mode",
             "passthrough",
+            "-enc_time_base",
+            "demux",
             "-f",
             "rawvideo",
             "-pix_fmt",
@@ -221,23 +223,55 @@ fn verify_video(output_dir: &Path, identity: &Value, state: &Value) {
     assert_eq!(decoded.stdout.len() / FRAME, timestamps.len());
     let distinct: std::collections::HashSet<_> = decoded.stdout.chunks_exact(FRAME).collect();
     assert!(distinct.len() > 1, "recording contains only a frozen frame");
-    for frame in decoded.stdout.chunks_exact(FRAME) {
+    let mut bright_timestamps = Vec::new();
+    for (index, frame) in decoded.stdout.chunks_exact(FRAME).enumerate() {
+        let terminal_fade = matches!(ending, "close" | "minimize")
+            && timestamps[index] - timestamps[0] >= 1.5
+            && timestamps.last().unwrap() - timestamps[index] <= 0.5;
         let green = frame
             .chunks_exact(3)
             .filter(|p| p[1] > 170 && p[0] < 80 && p[2] < 80)
             .count();
         let red = frame
             .chunks_exact(3)
-            .filter(|p| p[0] > 170 && p[1] < 80 && p[2] < 80)
+            .filter(|p| p[0] > 20 && u16::from(p[0]) > 2 * u16::from(p[1].max(p[2])))
             .count();
-        assert!(green > 600, "target green field absent: {green}");
         assert_eq!(red, 0, "sibling/desktop pixels leaked into window video");
+        // AppKit can fade the source before WindowServer marks it removed.
+        // Permit only a bounded terminal fade, never unrelated or missing body frames.
+        if terminal_fade && frame.iter().all(|channel| *channel <= 8) {
+            continue;
+        }
+        let green_present = if terminal_fade {
+            frame
+                .chunks_exact(3)
+                .filter(|p| p[1] > 8 && u16::from(p[1]) > 2 * u16::from(p[0].max(p[2])))
+                .count()
+        } else {
+            green
+        };
+        assert!(
+            green_present > 600,
+            "target green field absent: {green_present}"
+        );
         let center = &frame[(12 * 32 + 16) * 3..][..3];
         assert!(
-            center[2] > 170 && center[0] < 80 && center[1] < 80,
+            if terminal_fade {
+                center[2] > 8 && u16::from(center[2]) > 2 * u16::from(center[0].max(center[1]))
+            } else {
+                center[2] > 170 && center[0] < 80 && center[1] < 80
+            },
             "blue target marker absent: {center:?}"
         );
+        if green > 600 && center[2] > 170 {
+            bright_timestamps.push(timestamps[index]);
+        }
     }
+    assert!(
+        bright_timestamps.len() >= 3,
+        "too few full-brightness target frames"
+    );
+    assert!(bright_timestamps.last().unwrap() - bright_timestamps[0] >= 1.5);
 }
 
 fn host_run_authorized(vm: Option<&str>, host: Option<&str>) -> Result<bool, &'static str> {
@@ -458,7 +492,7 @@ fn exact_window_recording_isolation_and_lifecycle() {
             "stop" | "disconnect" => assert_eq!(reason, "stopped"),
             _ => unreachable!(),
         }
-        verify_video(&output, &fixture.identity, &state);
+        verify_video(&output, &fixture.identity, &state, ending);
         eprintln!("verified native window recording: {case} ({reason})");
         let stopped_again = call(&mut driver, "stop_recording", json!({}));
         assert_eq!(stopped_again["status"]["finalized"], true);

--- a/libs/cua-driver/rust/crates/cua-driver/tests/window_recording_macos_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/window_recording_macos_test.rs
@@ -129,6 +129,21 @@ fn descriptor_count(pid: u64) -> usize {
     count
 }
 
+fn foreign_red(pixel: &[u8]) -> bool {
+    // The fixture palette has R <= min(G, B); allow only small codec noise.
+    u16::from(pixel[0]) > u16::from(pixel[1].min(pixel[2])) + 8
+}
+
+#[test]
+fn red_contamination_is_rejected_even_during_a_dim_fade() {
+    for pixel in [[255, 0, 0], [20, 41, 0], [20, 0, 41]] {
+        assert!(foreign_red(&pixel));
+    }
+    for pixel in [[0, 255, 0], [2, 0, 255], [40, 40, 40], [0, 0, 0]] {
+        assert!(!foreign_red(&pixel));
+    }
+}
+
 fn verify_video(output_dir: &Path, identity: &Value, state: &Value, ending: &str) {
     let mut files: Vec<_> = fs::read_dir(output_dir)
         .unwrap()
@@ -232,10 +247,7 @@ fn verify_video(output_dir: &Path, identity: &Value, state: &Value, ending: &str
             .chunks_exact(3)
             .filter(|p| p[1] > 170 && p[0] < 80 && p[2] < 80)
             .count();
-        let red = frame
-            .chunks_exact(3)
-            .filter(|p| p[0] > 20 && u16::from(p[0]) > 2 * u16::from(p[1].max(p[2])))
-            .count();
+        let red = frame.chunks_exact(3).filter(|p| foreign_red(p)).count();
         assert_eq!(red, 0, "sibling/desktop pixels leaked into window video");
         // AppKit can fade the source before WindowServer marks it removed.
         // Permit only a bounded terminal fade, never unrelated or missing body frames.

--- a/libs/cua-driver/rust/crates/cua-driver/tests/window_recording_macos_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/window_recording_macos_test.rs
@@ -447,7 +447,13 @@ fn exact_window_recording_isolation_and_lifecycle() {
             .expect("termination reason");
         match ending {
             "minimize" => assert!(matches!(reason, "window_not_visible" | "window_resized")),
-            "close" => assert!(matches!(reason, "window_closed" | "window_not_visible")),
+            "close" => assert!(
+                matches!(
+                    reason,
+                    "window_closed" | "window_not_visible" | "window_resized"
+                ),
+                "unexpected close transition: {reason}"
+            ),
             "resize" => assert_eq!(reason, "window_resized"),
             "stop" | "disconnect" => assert_eq!(reason, "stopped"),
             _ => unreachable!(),

--- a/libs/cua-driver/rust/crates/cua-driver/tests/window_recording_macos_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/window_recording_macos_test.rs
@@ -1,0 +1,299 @@
+//! Native exact-window video evidence. See the window-recording fixture README.
+#![cfg(target_os = "macos")]
+
+use cua_driver_testkit::{Driver, McpDriver};
+use serde_json::{json, Value};
+use std::{
+    fs,
+    io::{BufRead, BufReader, Write},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::mpsc::{self, Receiver},
+    thread::{self, sleep},
+    time::{Duration, Instant},
+};
+
+struct Fixture {
+    child: Child,
+    replies: Receiver<Value>,
+    identity: Value,
+}
+
+impl Fixture {
+    fn launch() -> Self {
+        let binary = std::env::var_os("CUA_WINDOW_RECORDING_FIXTURE")
+            .expect("set CUA_WINDOW_RECORDING_FIXTURE to the source-built AppKit fixture");
+        let mut child = Command::new(binary)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("launch synthetic window fixture");
+        let stdout = child.stdout.take().unwrap();
+        let (tx, replies) = mpsc::channel();
+        thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                let Ok(line) = line else { break };
+                let Ok(value) = serde_json::from_str(&line) else {
+                    break;
+                };
+                if tx.send(value).is_err() {
+                    break;
+                }
+            }
+        });
+        let identity = replies
+            .recv_timeout(Duration::from_secs(10))
+            .expect("fixture ready");
+        Self {
+            child,
+            replies,
+            identity,
+        }
+    }
+
+    fn command(&mut self, command: &str) -> Value {
+        writeln!(self.child.stdin.as_mut().unwrap(), "{command}").unwrap();
+        self.child.stdin.as_mut().unwrap().flush().unwrap();
+        let reply = self
+            .replies
+            .recv_timeout(Duration::from_secs(10))
+            .expect("fixture command ack");
+        assert_eq!(reply["command"], command, "{reply}");
+        reply
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn call(driver: &mut McpDriver, method: &str, args: Value) -> Value {
+    let response = driver.call(method, args);
+    assert!(
+        !response.is_error(),
+        "{method}: {} / {}",
+        response.text(),
+        response.raw
+    );
+    response.structured().clone()
+}
+
+fn wait_finalized(driver: &mut McpDriver) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let state = call(driver, "get_recording_state", json!({}));
+        if state["status"]["active"] == false && state["status"]["finalized"] == true {
+            assert!(state["status"]["error"].is_null(), "{state}");
+            return state;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "native finalization timed out: {state}"
+        );
+        sleep(Duration::from_millis(100));
+    }
+}
+
+fn verify_video(output_dir: &Path, identity: &Value, state: &Value) {
+    let mut files: Vec<_> = fs::read_dir(output_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    files.sort();
+    assert_eq!(
+        files,
+        ["recording.mp4", "session.json"],
+        "unexpected trajectory/cursor artifacts"
+    );
+    let session: Value =
+        serde_json::from_slice(&fs::read(output_dir.join("session.json")).unwrap()).unwrap();
+    assert_eq!(session["status"]["finalized"], true, "{session}");
+    assert_eq!(
+        session["status"]["termination_reason"],
+        state["status"]["termination_reason"]
+    );
+    let video = output_dir.join("recording.mp4");
+    let probe = Command::new("ffprobe")
+        .args(["-v", "error", "-show_streams", "-of", "json"])
+        .arg(&video)
+        .output()
+        .expect("ffprobe must be installed in the disposable VM");
+    assert!(
+        probe.status.success(),
+        "{}",
+        String::from_utf8_lossy(&probe.stderr)
+    );
+    let probe: Value = serde_json::from_slice(&probe.stdout).unwrap();
+    let streams = probe["streams"].as_array().unwrap();
+    assert_eq!(streams.len(), 1, "unexpected audio or extra video stream");
+    assert_eq!(streams[0]["codec_type"], "video");
+    for dimension in ["width", "height"] {
+        let expected =
+            (identity[dimension].as_f64().unwrap() * identity["scale"].as_f64().unwrap()) as u64;
+        assert_eq!(streams[0][dimension].as_u64(), Some(expected));
+        assert_eq!(state["info"][dimension].as_u64(), Some(expected));
+    }
+    // Decode every half-second into RGB. A desktop crop or application-wide
+    // filter reveals the red sibling; exact-window capture retains the marker.
+    let decoded = Command::new("ffmpeg")
+        .args(["-v", "error", "-i"])
+        .arg(&video)
+        .args([
+            "-vf",
+            "fps=2,scale=32:24",
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "rgb24",
+            "pipe:1",
+        ])
+        .output()
+        .expect("decode native MP4");
+    assert!(
+        decoded.status.success(),
+        "{}",
+        String::from_utf8_lossy(&decoded.stderr)
+    );
+    const FRAME: usize = 32 * 24 * 3;
+    assert!(decoded.stdout.len() >= FRAME * 3, "too few decoded samples");
+    assert_eq!(decoded.stdout.len() % FRAME, 0);
+    let distinct: std::collections::HashSet<_> = decoded.stdout.chunks_exact(FRAME).collect();
+    assert!(distinct.len() > 1, "recording contains only a frozen frame");
+    for frame in decoded.stdout.chunks_exact(FRAME) {
+        let green = frame
+            .chunks_exact(3)
+            .filter(|p| p[1] > 170 && p[0] < 80 && p[2] < 80)
+            .count();
+        let red = frame
+            .chunks_exact(3)
+            .filter(|p| p[0] > 170 && p[1] < 80 && p[2] < 80)
+            .count();
+        assert!(green > 600, "target green field absent: {green}");
+        assert_eq!(red, 0, "sibling/desktop pixels leaked into window video");
+        let center = &frame[(12 * 32 + 16) * 3..][..3];
+        assert!(
+            center[2] > 170 && center[0] < 80 && center[1] < 80,
+            "blue target marker absent: {center:?}"
+        );
+    }
+}
+
+#[test]
+#[ignore = "requires disposable Lume GUI VM, authorized installed daemon, AppKit fixture and ffmpeg"]
+fn exact_window_recording_isolation_and_lifecycle() {
+    assert_eq!(
+        std::env::var("CUA_WINDOW_RECORDING_DISPOSABLE_VM").as_deref(),
+        Ok("1"),
+        "VM-only test"
+    );
+    assert!(
+        std::env::var_os("CUA_E2E_RECORDINGS_ROOT").is_none(),
+        "unset legacy trajectory recording root"
+    );
+    let root = PathBuf::from(
+        std::env::var_os("CUA_WINDOW_RECORDING_OUTPUT_ROOT").expect("set fresh evidence root"),
+    );
+    fs::create_dir_all(&root).unwrap();
+    let mut driver =
+        McpDriver::spawn_macos_daemon_proxy().expect("installed authorized daemon must be running");
+    let initial = call(&mut driver, "get_recording_state", json!({}));
+    assert_ne!(
+        initial["enabled"], true,
+        "another recording owns the daemon"
+    );
+    for ending in ["stop", "minimize", "close", "resize", "disconnect"] {
+        let mut fixture = Fixture::launch();
+        let output = root.join(ending);
+        assert!(
+            !output.exists(),
+            "use a fresh output root; never overwrite evidence"
+        );
+        let target = json!({"kind": "window", "pid": fixture.identity["pid"], "window_id": fixture.identity["window_id"]});
+        let windows = call(
+            &mut driver,
+            "list_windows",
+            json!({"pid": fixture.identity["pid"]}),
+        );
+        assert!(
+            windows["windows"].as_array().unwrap().iter().any(|window| {
+                window["window_id"] == fixture.identity["window_id"]
+                    && window["is_on_screen"] == true
+            }),
+            "fixture identity absent from public list_windows: {windows}"
+        );
+        let args = json!({"output_dir": output, "record_video": true, "target": target});
+        if ending == "stop" {
+            let mut invalid = args.clone();
+            invalid["target"]["pid"] = json!(2147483647);
+            assert!(
+                driver.call("start_recording", invalid).is_error(),
+                "wrong PID accepted"
+            );
+        }
+        let started = call(&mut driver, "start_recording", args.clone());
+        assert_eq!(started["status"]["active"], true, "{started}");
+        assert_eq!(started["info"]["backend"], "screencapturekit_window");
+        if ending == "stop" {
+            assert!(
+                driver.call("start_recording", args).is_error(),
+                "busy start accepted"
+            );
+            assert_eq!(
+                call(&mut driver, "get_recording_state", json!({}))["status"]["active"],
+                true
+            );
+        }
+        let occluded = fixture.command("occlude");
+        for field in [
+            "sibling_visible",
+            "sibling_covers_target",
+            "sibling_in_front",
+        ] {
+            assert_eq!(
+                occluded[field], true,
+                "fixture did not establish occlusion: {occluded}"
+            );
+        }
+        sleep(Duration::from_secs(1));
+        let moved = fixture.command("move");
+        assert_eq!(moved["x"].as_f64(), Some(190.0));
+        sleep(Duration::from_secs(2));
+        assert_eq!(
+            call(&mut driver, "get_recording_state", json!({}))["status"]["active"],
+            true,
+            "movement or occlusion ended capture"
+        );
+        if ending == "stop" {
+            call(&mut driver, "stop_recording", json!({}));
+        } else if ending == "disconnect" {
+            drop(driver);
+            driver =
+                McpDriver::spawn_macos_daemon_proxy().expect("reconnect after owner disconnect");
+        } else {
+            let changed = fixture.command(ending);
+            match ending {
+                "minimize" => assert_eq!(changed["miniaturized"], true),
+                "close" => assert_eq!(changed["visible"], false),
+                "resize" => assert_eq!(changed["width"].as_f64(), Some(360.0)),
+                _ => unreachable!(),
+            }
+        }
+        let state = wait_finalized(&mut driver);
+        let reason = state["status"]["termination_reason"]
+            .as_str()
+            .expect("termination reason");
+        match ending {
+            "minimize" => assert_eq!(reason, "window_not_visible"),
+            "close" => assert!(matches!(reason, "window_closed" | "window_not_visible")),
+            "resize" => assert_eq!(reason, "window_resized"),
+            "stop" | "disconnect" => assert_eq!(reason, "stopped"),
+            _ => unreachable!(),
+        }
+        verify_video(&output, &fixture.identity, &state);
+        let stopped_again = call(&mut driver, "stop_recording", json!({}));
+        assert_eq!(stopped_again["status"]["finalized"], true);
+    }
+}

--- a/libs/cua-driver/rust/crates/cua-driver/tests/window_recording_macos_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/window_recording_macos_test.rs
@@ -446,7 +446,7 @@ fn exact_window_recording_isolation_and_lifecycle() {
             .as_str()
             .expect("termination reason");
         match ending {
-            "minimize" => assert_eq!(reason, "window_not_visible"),
+            "minimize" => assert!(matches!(reason, "window_not_visible" | "window_resized")),
             "close" => assert!(matches!(reason, "window_closed" | "window_not_visible")),
             "resize" => assert_eq!(reason, "window_resized"),
             "stop" | "disconnect" => assert_eq!(reason, "stopped"),

--- a/libs/cua-driver/rust/crates/cua-driver/tests/window_recording_macos_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/window_recording_macos_test.rs
@@ -41,14 +41,21 @@ impl Fixture {
                 }
             }
         });
-        let identity = replies
-            .recv_timeout(Duration::from_secs(10))
-            .expect("fixture ready");
-        Self {
+        let mut fixture = Self {
             child,
             replies,
-            identity,
-        }
+            identity: Value::Null,
+        };
+        fixture.identity = fixture
+            .replies
+            .recv_timeout(Duration::from_secs(10))
+            .expect("fixture ready");
+        assert_eq!(
+            fixture.identity["pid"].as_u64(),
+            Some(u64::from(fixture.child.id())),
+            "fixture must identify its own child process"
+        );
+        fixture
     }
 
     fn command(&mut self, command: &str) -> Value {
@@ -120,7 +127,7 @@ fn verify_video(output_dir: &Path, identity: &Value, state: &Value) {
         .args(["-v", "error", "-show_streams", "-of", "json"])
         .arg(&video)
         .output()
-        .expect("ffprobe must be installed in the disposable VM");
+        .expect("ffprobe must be installed in the authorized test environment");
     assert!(
         probe.status.success(),
         "{}",
@@ -181,14 +188,40 @@ fn verify_video(output_dir: &Path, identity: &Value, state: &Value) {
     }
 }
 
+fn host_run_authorized(vm: Option<&str>, host: Option<&str>) -> Result<bool, &'static str> {
+    match (vm, host) {
+        (Some("1"), None) => Ok(false),
+        (None, Some("1")) => Ok(true),
+        _ => Err("select exactly one: disposable VM or explicitly authorized host diagnostics"),
+    }
+}
+
 #[test]
-#[ignore = "requires disposable Lume GUI VM, authorized installed daemon, AppKit fixture and ffmpeg"]
+fn recording_environment_requires_one_explicit_opt_in() {
+    assert_eq!(host_run_authorized(Some("1"), None), Ok(false));
+    assert_eq!(host_run_authorized(None, Some("1")), Ok(true));
+    for (vm, host) in [
+        (None, None),
+        (Some("1"), Some("1")),
+        (Some("0"), None),
+        (None, Some("true")),
+    ] {
+        assert!(host_run_authorized(vm, host).is_err());
+    }
+}
+
+#[test]
+#[ignore = "requires explicitly authorized GUI environment, installed daemon, AppKit fixture and ffmpeg"]
 fn exact_window_recording_isolation_and_lifecycle() {
-    assert_eq!(
-        std::env::var("CUA_WINDOW_RECORDING_DISPOSABLE_VM").as_deref(),
-        Ok("1"),
-        "VM-only test"
-    );
+    let host = host_run_authorized(
+        std::env::var("CUA_WINDOW_RECORDING_DISPOSABLE_VM")
+            .ok()
+            .as_deref(),
+        std::env::var("CUA_WINDOW_RECORDING_HOST_AUTHORIZED")
+            .ok()
+            .as_deref(),
+    )
+    .expect("native recording environment must be explicitly selected");
     assert!(
         std::env::var_os("CUA_E2E_RECORDINGS_ROOT").is_none(),
         "unset legacy trajectory recording root"
@@ -196,9 +229,65 @@ fn exact_window_recording_isolation_and_lifecycle() {
     let root = PathBuf::from(
         std::env::var_os("CUA_WINDOW_RECORDING_OUTPUT_ROOT").expect("set fresh evidence root"),
     );
+    assert!(root.is_absolute(), "evidence root must be absolute");
     fs::create_dir_all(&root).unwrap();
+    for name in [
+        "test-environment.json",
+        "stop",
+        "minimize",
+        "close",
+        "resize",
+        "disconnect",
+    ] {
+        assert!(
+            fs::symlink_metadata(root.join(name))
+                .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound),
+            "use a fresh output root; never overwrite evidence"
+        );
+    }
+    let socket = PathBuf::from(
+        std::env::var_os("CUA_E2E_MACOS_DAEMON_SOCKET")
+            .expect("select an explicit test daemon socket; never use the released daemon default"),
+    );
+    assert!(socket.is_absolute(), "daemon socket must be absolute");
+    let expected_sha =
+        std::env::var("CUA_E2E_SOURCE_SHA").expect("set the exact candidate source SHA");
+    assert!(
+        expected_sha.len() == 40 && expected_sha.bytes().all(|b| b.is_ascii_hexdigit()),
+        "candidate source SHA must be a full commit"
+    );
+    if host {
+        assert_eq!(
+            fs::canonicalize(&socket).expect("test daemon socket must exist"),
+            fs::canonicalize(&root).unwrap().join("driver.sock"),
+            "host diagnostics require a dedicated driver.sock inside the evidence root"
+        );
+        let binary = std::env::var_os("CUA_TEST_DRIVER_BIN")
+            .expect("host diagnostics require the explicitly installed local Driver");
+        assert_eq!(
+            fs::canonicalize(binary).unwrap(),
+            Path::new("/Applications/CuaDriverLocal.app/Contents/MacOS/cua-driver-local"),
+            "do not connect the host recording test through the released Driver"
+        );
+    }
     let mut driver =
         McpDriver::spawn_macos_daemon_proxy().expect("installed authorized daemon must be running");
+    let config = call(&mut driver, "get_config", json!({}));
+    assert_eq!(config["source_sha"].as_str(), Some(expected_sha.as_str()));
+    assert_eq!(config["version"].as_str(), Some(env!("CARGO_PKG_VERSION")));
+    serde_json::to_writer_pretty(
+        fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(root.join("test-environment.json"))
+            .expect("never overwrite test-environment evidence"),
+        &json!({
+            "environment": if host { "explicitly-authorized-host" } else { "disposable-vm" },
+            "source_sha": expected_sha,
+            "version": config["version"],
+        }),
+    )
+    .unwrap();
     let initial = call(&mut driver, "get_recording_state", json!({}));
     assert_ne!(
         initial["enabled"], true,

--- a/libs/cua-driver/rust/crates/platform-macos/Cargo.toml
+++ b/libs/cua-driver/rust/crates/platform-macos/Cargo.toml
@@ -60,7 +60,7 @@ objc2-quartz-core = { version = "0.2", features = ["CALayer"] }
 # ffmpeg subprocess on macOS. `macos_15_0` enables the `SCRecordingOutput`
 # convenience that finalises an mp4 in-process, removing the per-binary
 # Screen Recording TCC prompt that subprocess capture would otherwise trip.
-screencapturekit = { version = "6", features = ["macos_15_0"] }
+screencapturekit = { version = "6", features = ["macos_15_0", "async"] }
 security-framework = { version = "3.7.0", default-features = false, features = ["OSX_10_15"] }
 zeroize = { workspace = true }
 getrandom = { workspace = true }

--- a/libs/cua-driver/rust/crates/platform-macos/src/video_sckit.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/video_sckit.rs
@@ -191,6 +191,8 @@ const HEALTH_INTERVAL: Duration = Duration::from_millis(250);
 struct WindowFingerprint {
     pid: i32,
     layer: i32,
+    native_width: f64,
+    native_height: f64,
     width: f64,
     height: f64,
     content_width: f64,
@@ -202,6 +204,7 @@ impl WindowFingerprint {
     fn new(
         pid: i32,
         layer: i32,
+        native_size: (f64, f64),
         frame: screencapturekit::cg::CGRect,
         content: screencapturekit::cg::CGRect,
         scale: f64,
@@ -209,6 +212,8 @@ impl WindowFingerprint {
         Self {
             pid,
             layer,
+            native_width: native_size.0,
+            native_height: native_size.1,
             width: frame.size.width,
             height: frame.size.height,
             content_width: content.size.width,
@@ -311,20 +316,23 @@ impl WindowPlan {
             .ok_or_else(|| anyhow::anyhow!("window_owner_changed"))?;
         anyhow::ensure!(owner.process_id() == target.pid, "window_owner_changed");
         let frame = window.frame();
-        tracing::debug!(
-            native_layer = native.layer,
-            capture_layer = window.window_layer(),
-            native_width = native.bounds.width,
-            native_height = native.bounds.height,
-            capture_width = frame.size.width,
-            capture_height = frame.size.height,
-            "window recording geometry attestation"
-        );
         anyhow::ensure!(
-            window.window_layer() == native.layer
-                && frame.size.width == native.bounds.width
-                && frame.size.height == native.bounds.height,
+            window.window_layer() == native.layer,
             "window_identity_changed"
+        );
+        // WindowServer and ScreenCaptureKit can expose different bounds for the
+        // same window. Keep both sizes in the fingerprint, but compare each
+        // only against later readings from its own API.
+        anyhow::ensure!(
+            [
+                native.bounds.width,
+                native.bounds.height,
+                frame.size.width,
+                frame.size.height
+            ]
+            .into_iter()
+            .all(|dimension| dimension.is_finite() && dimension > 0.0),
+            "window_geometry_invalid"
         );
         let filter = SCContentFilter::create().with_window(&window).build();
         let rect = filter.content_rect();
@@ -349,7 +357,14 @@ impl WindowPlan {
                 height,
                 backend: "screencapturekit_window".into(),
             },
-            fingerprint: WindowFingerprint::new(target.pid, native.layer, frame, rect, scale),
+            fingerprint: WindowFingerprint::new(
+                target.pid,
+                native.layer,
+                (native.bounds.width, native.bounds.height),
+                frame,
+                rect,
+                scale,
+            ),
             filter,
         })
     }
@@ -722,6 +737,8 @@ mod window_video_tests {
         WindowFingerprint {
             pid: 42,
             layer: 0,
+            native_width: 803.0,
+            native_height: 603.0,
             width: 801.0,
             height: 601.0,
             content_width: 801.0,
@@ -764,6 +781,12 @@ mod window_video_tests {
             Some("window_scale_changed")
         );
         current = original.clone();
+        current.native_width += 1.0;
+        assert_eq!(original.changed_reason(&current), Some("window_resized"));
+        current = original.clone();
+        current.native_height += 1.0;
+        assert_eq!(original.changed_reason(&current), Some("window_resized"));
+        current = original.clone();
         current.width += 1.0;
         assert_eq!(original.changed_reason(&current), Some("window_resized"));
         current = original.clone();
@@ -788,8 +811,8 @@ mod window_video_tests {
             },
             ..frame
         };
-        let original = WindowFingerprint::new(42, 0, frame, frame, 2.0);
-        let current = WindowFingerprint::new(42, 0, moved, moved, 2.0);
+        let original = WindowFingerprint::new(42, 0, (803.0, 603.0), frame, frame, 2.0);
+        let current = WindowFingerprint::new(42, 0, (803.0, 603.0), moved, moved, 2.0);
         assert_eq!(original.changed_reason(&current), None);
     }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/video_sckit.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/video_sckit.rs
@@ -344,11 +344,11 @@ impl WindowPlan {
             .ok_or_else(|| anyhow::anyhow!("window_closed"))?;
         anyhow::ensure!(latest.pid == target.pid, "window_owner_changed");
         anyhow::ensure!(latest.is_on_screen, "window_not_visible");
+        anyhow::ensure!(latest.layer == native.layer, "window_identity_changed");
         anyhow::ensure!(
-            latest.layer == native.layer
-                && latest.bounds.width == native.bounds.width
+            latest.bounds.width == native.bounds.width
                 && latest.bounds.height == native.bounds.height,
-            "window_identity_changed"
+            "window_resized"
         );
         Ok(Self {
             info: WindowVideoInfo {

--- a/libs/cua-driver/rust/crates/platform-macos/src/video_sckit.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/video_sckit.rs
@@ -311,6 +311,15 @@ impl WindowPlan {
             .ok_or_else(|| anyhow::anyhow!("window_owner_changed"))?;
         anyhow::ensure!(owner.process_id() == target.pid, "window_owner_changed");
         let frame = window.frame();
+        tracing::debug!(
+            native_layer = native.layer,
+            capture_layer = window.window_layer(),
+            native_width = native.bounds.width,
+            native_height = native.bounds.height,
+            capture_width = frame.size.width,
+            capture_height = frame.size.height,
+            "window recording geometry attestation"
+        );
         anyhow::ensure!(
             window.window_layer() == native.layer
                 && frame.size.width == native.bounds.width

--- a/libs/cua-driver/rust/crates/platform-macos/src/video_sckit.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/video_sckit.rs
@@ -22,17 +22,22 @@
 //!   3. `stop()` calls `stop_capture()` (which finalises the mp4 moov
 //!      atom) and returns the elapsed-time metadata.
 
-use std::path::Path;
-use std::time::Instant;
+use std::path::{Path, PathBuf};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
-use cua_driver_core::video::{VideoBackend, VideoBackendFactory, VideoMetadata};
+use cua_driver_core::video::{
+    PreparedWindowVideo, VideoBackend, VideoBackendFactory, VideoMetadata, WindowVideoInfo,
+    WindowVideoObserver, WindowVideoStatus, WindowVideoTarget,
+};
 
 use screencapturekit::prelude::{
     SCContentFilter, SCShareableContent, SCStream, SCStreamConfiguration,
 };
 use screencapturekit::recording_output::{
     SCRecordingOutput, SCRecordingOutputCodec, SCRecordingOutputConfiguration,
-    SCRecordingOutputFileType,
+    SCRecordingOutputDelegate, SCRecordingOutputFileType,
 };
 
 pub struct SckitVideoBackendFactory;
@@ -40,6 +45,21 @@ pub struct SckitVideoBackendFactory;
 impl VideoBackendFactory for SckitVideoBackendFactory {
     fn start(&self, output_path: &Path) -> anyhow::Result<Box<dyn VideoBackend>> {
         SckitVideoBackend::start(output_path).map(|b| Box::new(b) as Box<dyn VideoBackend>)
+    }
+
+    fn prepare_window(
+        &self,
+        target: &WindowVideoTarget,
+    ) -> anyhow::Result<Box<dyn PreparedWindowVideo>> {
+        anyhow::ensure!(
+            objc2::runtime::AnyClass::get("SCRecordingOutput").is_some(),
+            "window_recording_unsupported: macOS 15 or newer is required"
+        );
+        let plan = WindowPlan::resolve(target)?;
+        Ok(Box::new(PreparedSckitWindow {
+            info: plan.info,
+            fingerprint: plan.fingerprint,
+        }))
     }
 }
 
@@ -159,5 +179,668 @@ impl VideoBackend for SckitVideoBackend {
             duration_ms: elapsed.as_millis() as u64,
             finalized,
         })
+    }
+}
+
+const CALLBACK_TIMEOUT: Duration = Duration::from_secs(10);
+const CONTENT_TIMEOUT: Duration = Duration::from_secs(2);
+const HEALTH_INTERVAL: Duration = Duration::from_millis(250);
+
+// Unlike screenshot identity, this deliberately excludes window position.
+#[derive(Debug, Clone, PartialEq)]
+struct WindowFingerprint {
+    pid: i32,
+    layer: i32,
+    width: f64,
+    height: f64,
+    content_width: f64,
+    content_height: f64,
+    scale: f64,
+}
+
+impl WindowFingerprint {
+    fn new(
+        pid: i32,
+        layer: i32,
+        frame: screencapturekit::cg::CGRect,
+        content: screencapturekit::cg::CGRect,
+        scale: f64,
+    ) -> Self {
+        Self {
+            pid,
+            layer,
+            width: frame.size.width,
+            height: frame.size.height,
+            content_width: content.size.width,
+            content_height: content.size.height,
+            scale,
+        }
+    }
+
+    fn changed_reason(&self, current: &Self) -> Option<&'static str> {
+        if self.pid != current.pid || self.layer != current.layer {
+            Some("window_identity_changed")
+        } else if self.scale != current.scale {
+            Some("window_scale_changed")
+        } else if self != current {
+            Some("window_resized")
+        } else {
+            None
+        }
+    }
+}
+
+fn check_window_recheck(
+    expected: &WindowFingerprint,
+    resolved: anyhow::Result<WindowFingerprint>,
+) -> Result<(), String> {
+    let current = resolved.map_err(|error| error.to_string())?;
+    match expected.changed_reason(&current) {
+        Some(reason) => Err(reason.to_owned()),
+        None => Ok(()),
+    }
+}
+
+fn even_pixel_dimension(points: f64, scale: f64) -> anyhow::Result<u32> {
+    let pixels = (points * scale).ceil();
+    anyhow::ensure!(
+        points.is_finite()
+            && points > 0.0
+            && scale.is_finite()
+            && scale > 0.0
+            && pixels > 0.0
+            && pixels <= f64::from(u32::MAX - 1),
+        "window_geometry_invalid"
+    );
+    // Round upwards so H.264's even dimensions never trim edge content.
+    Ok((pixels as u32 + 1) & !1)
+}
+
+fn wait_future<F: std::future::Future>(future: F, timeout: Duration) -> anyhow::Result<F::Output> {
+    struct WakeThread(std::thread::Thread);
+    impl std::task::Wake for WakeThread {
+        fn wake(self: Arc<Self>) {
+            self.0.unpark();
+        }
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.unpark();
+        }
+    }
+    let waker = std::task::Waker::from(Arc::new(WakeThread(std::thread::current())));
+    let mut context = std::task::Context::from_waker(&waker);
+    let mut future = std::pin::pin!(future);
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let std::task::Poll::Ready(result) = future.as_mut().poll(&mut context) {
+            return Ok(result);
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        anyhow::ensure!(!remaining.is_zero(), "window_health_timeout");
+        std::thread::park_timeout(remaining);
+    }
+}
+
+struct WindowPlan {
+    info: WindowVideoInfo,
+    fingerprint: WindowFingerprint,
+    filter: SCContentFilter,
+}
+
+impl WindowPlan {
+    fn resolve(target: &WindowVideoTarget) -> anyhow::Result<Self> {
+        target.validate()?;
+        let window_id = u32::try_from(target.window_id).map_err(|_| {
+            anyhow::anyhow!("invalid_recording_target: window_id exceeds CGWindowID")
+        })?;
+        let native = crate::windows::window_info_by_id(window_id)
+            .ok_or_else(|| anyhow::anyhow!("window_closed"))?;
+        anyhow::ensure!(native.pid == target.pid, "window_owner_changed");
+        anyhow::ensure!(native.is_on_screen, "window_not_visible");
+        let content = wait_future(
+            screencapturekit::async_api::AsyncSCShareableContent::get(),
+            CONTENT_TIMEOUT,
+        )?
+        .map_err(|_| anyhow::anyhow!("window_not_shareable"))?;
+        let window = content
+            .windows()
+            .into_iter()
+            .find(|w| w.window_id() == window_id)
+            .ok_or_else(|| anyhow::anyhow!("window_not_shareable"))?;
+        let owner = window
+            .owning_application()
+            .ok_or_else(|| anyhow::anyhow!("window_owner_changed"))?;
+        anyhow::ensure!(owner.process_id() == target.pid, "window_owner_changed");
+        let frame = window.frame();
+        anyhow::ensure!(
+            window.window_layer() == native.layer
+                && frame.size.width == native.bounds.width
+                && frame.size.height == native.bounds.height,
+            "window_identity_changed"
+        );
+        let filter = SCContentFilter::create().with_window(&window).build();
+        let rect = filter.content_rect();
+        let scale = f64::from(filter.point_pixel_scale());
+        let width = even_pixel_dimension(rect.size.width, scale)?;
+        let height = even_pixel_dimension(rect.size.height, scale)?;
+        // Recheck WindowServer after the asynchronous enumeration, including visibility.
+        let latest = crate::windows::window_info_by_id(window_id)
+            .ok_or_else(|| anyhow::anyhow!("window_closed"))?;
+        anyhow::ensure!(latest.pid == target.pid, "window_owner_changed");
+        anyhow::ensure!(latest.is_on_screen, "window_not_visible");
+        anyhow::ensure!(
+            latest.layer == native.layer
+                && latest.bounds.width == native.bounds.width
+                && latest.bounds.height == native.bounds.height,
+            "window_identity_changed"
+        );
+        Ok(Self {
+            info: WindowVideoInfo {
+                target: target.clone(),
+                width,
+                height,
+                backend: "screencapturekit_window".into(),
+            },
+            fingerprint: WindowFingerprint::new(target.pid, native.layer, frame, rect, scale),
+            filter,
+        })
+    }
+}
+
+struct PreparedSckitWindow {
+    info: WindowVideoInfo,
+    fingerprint: WindowFingerprint,
+}
+
+#[derive(Debug)]
+enum WindowEvent {
+    Started,
+    Finished,
+    Failed,
+    StreamStopped,
+    Stop,
+}
+
+fn wait_recording_start(
+    events: &mpsc::Receiver<WindowEvent>,
+    timeout: Duration,
+) -> Result<(), &'static str> {
+    match events.recv_timeout(timeout) {
+        Ok(WindowEvent::Started) => Ok(()),
+        Ok(WindowEvent::Failed) => Err("window_recording_failed"),
+        Err(mpsc::RecvTimeoutError::Timeout) => Err("window_recording_start_timeout"),
+        _ => Err("window_recording_start_failed"),
+    }
+}
+
+fn wait_recording_finish(
+    events: &mpsc::Receiver<WindowEvent>,
+    timeout: Duration,
+) -> Result<(), &'static str> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match events.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
+            Ok(WindowEvent::Finished) => return Ok(()),
+            Ok(WindowEvent::Failed) => return Err("window_recording_failed"),
+            Ok(_) => {}
+            Err(_) => return Err("window_recording_finalize_timeout"),
+        }
+    }
+}
+
+struct RecordingDelegate(mpsc::Sender<WindowEvent>);
+impl SCRecordingOutputDelegate for RecordingDelegate {
+    fn recording_did_start(&self) {
+        let _ = self.0.send(WindowEvent::Started);
+    }
+    fn recording_did_finish(&self) {
+        let _ = self.0.send(WindowEvent::Finished);
+    }
+    fn recording_did_fail(&self, _error: String) {
+        let _ = self.0.send(WindowEvent::Failed);
+    }
+}
+
+struct StreamDelegate(mpsc::Sender<WindowEvent>);
+impl screencapturekit::stream::delegate_trait::SCStreamDelegateTrait for StreamDelegate {
+    fn did_stop_with_error(&self, _error: screencapturekit::error::SCError) {
+        let _ = self.0.send(WindowEvent::StreamStopped);
+    }
+    fn stream_did_stop(&self, _error: Option<String>) {
+        let _ = self.0.send(WindowEvent::StreamStopped);
+    }
+    fn stream_did_become_inactive(&self) {
+        let _ = self.0.send(WindowEvent::StreamStopped);
+    }
+}
+
+struct WindowState {
+    status: Mutex<WindowVideoStatus>,
+    observer: WindowVideoObserver,
+}
+
+impl WindowState {
+    fn publish(&self, change: impl FnOnce(&mut WindowVideoStatus)) {
+        let status = {
+            let mut status = self.status.lock().unwrap_or_else(|p| p.into_inner());
+            change(&mut status);
+            status.clone()
+        };
+        (self.observer)(status);
+    }
+    fn snapshot(&self) -> WindowVideoStatus {
+        self.status
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
+    }
+}
+
+impl PreparedWindowVideo for PreparedSckitWindow {
+    fn info(&self) -> WindowVideoInfo {
+        self.info.clone()
+    }
+
+    fn start(
+        self: Box<Self>,
+        path: &Path,
+        observer: WindowVideoObserver,
+    ) -> anyhow::Result<Box<dyn VideoBackend>> {
+        let plan = WindowPlan::resolve(&self.info.target)?;
+        if let Some(reason) = self.fingerprint.changed_reason(&plan.fingerprint) {
+            anyhow::bail!("{reason}");
+        }
+        // Core reserves the directory; the backend never removes or replaces a video.
+        match std::fs::symlink_metadata(path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            _ => anyhow::bail!("recording_output_exists"),
+        }
+        let state = Arc::new(WindowState {
+            status: Mutex::new(WindowVideoStatus {
+                info: self.info.clone(),
+                active: false,
+                finalized: false,
+                duration_ms: 0,
+                termination_reason: None,
+                error: None,
+            }),
+            observer,
+        });
+        let (events_tx, events_rx) = mpsc::channel();
+        let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+        let worker_state = state.clone();
+        let worker_events = events_tx.clone();
+        let output_path = path.to_path_buf();
+        let worker_path = output_path.clone();
+        let worker = std::thread::Builder::new()
+            .name("window-video".into())
+            .spawn(move || {
+                run_window_worker(
+                    plan,
+                    worker_path,
+                    worker_state,
+                    worker_events,
+                    events_rx,
+                    ready_tx,
+                );
+            })?;
+        let backend = WindowVideoBackend {
+            output_path,
+            state,
+            events: events_tx,
+            worker: Some(worker),
+        };
+        // Native transport calls in screencapturekit 6.0.1 are synchronous and have
+        // no cancellation API. Callback and content waits below are bounded, but
+        // a framework transport hang can still delay startup or joining this worker.
+        match ready_rx.recv() {
+            Ok(Ok(())) => Ok(Box::new(backend)),
+            Ok(Err(reason)) => {
+                drop(backend);
+                anyhow::bail!("{reason}")
+            }
+            Err(_) => {
+                drop(backend);
+                anyhow::bail!("window_recording_worker_failed")
+            }
+        }
+    }
+}
+
+struct WindowVideoBackend {
+    output_path: PathBuf,
+    state: Arc<WindowState>,
+    events: mpsc::Sender<WindowEvent>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl WindowVideoBackend {
+    fn shutdown(&mut self) {
+        let _ = self.events.send(WindowEvent::Stop);
+        if let Some(worker) = self.worker.take() {
+            if worker.join().is_err() {
+                self.state.publish(|status| {
+                    status.active = false;
+                    status.finalized = false;
+                    status.error = Some("window_recording_worker_failed".into());
+                    status.termination_reason = Some("window_recording_worker_failed".into());
+                });
+            }
+        }
+    }
+}
+
+impl Drop for WindowVideoBackend {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+impl VideoBackend for WindowVideoBackend {
+    fn stop(mut self: Box<Self>) -> anyhow::Result<VideoMetadata> {
+        self.shutdown();
+        let status = self.state.snapshot();
+        Ok(VideoMetadata {
+            path: self.output_path.clone(),
+            duration_ms: status.duration_ms,
+            finalized: status.finalized,
+        })
+    }
+    fn window_status(&self) -> Option<WindowVideoStatus> {
+        Some(self.state.snapshot())
+    }
+}
+
+fn run_window_worker(
+    plan: WindowPlan,
+    path: PathBuf,
+    state: Arc<WindowState>,
+    events_tx: mpsc::Sender<WindowEvent>,
+    events: mpsc::Receiver<WindowEvent>,
+    ready: mpsc::SyncSender<Result<(), String>>,
+) {
+    let config = SCStreamConfiguration::new()
+        .with_width(plan.info.width)
+        .with_height(plan.info.height)
+        .with_minimum_frame_interval(&screencapturekit::cm::CMTime::new(1, 30))
+        .with_shows_cursor(false)
+        .with_captures_audio(false)
+        .with_captures_microphone(false);
+    let recording_config = SCRecordingOutputConfiguration::new()
+        .with_output_url(&path)
+        .with_video_codec(SCRecordingOutputCodec::H264)
+        .with_output_file_type(SCRecordingOutputFileType::MP4);
+    let Some(recording) = SCRecordingOutput::new_with_delegate(
+        &recording_config,
+        RecordingDelegate(events_tx.clone()),
+    ) else {
+        let _ = ready.send(Err("window_recording_unsupported".into()));
+        return;
+    };
+    let stream = SCStream::new_with_delegate(&plan.filter, &config, StreamDelegate(events_tx));
+    let mut attached = false;
+    let mut capture_attempted = false;
+    let startup = (|| -> Result<(), String> {
+        stream
+            .add_recording_output(&recording)
+            .map_err(|_| "window_recording_attach_failed".to_owned())?;
+        attached = true;
+        // Check the target again immediately before asking the native stream to start.
+        check_window_recheck(
+            &plan.fingerprint,
+            WindowPlan::resolve(&plan.info.target).map(|current| current.fingerprint),
+        )?;
+        capture_attempted = true;
+        stream
+            .start_capture()
+            .map_err(|_| "window_recording_start_failed".to_owned())?;
+        wait_recording_start(&events, CALLBACK_TIMEOUT).map_err(str::to_owned)
+    })();
+    if let Err(reason) = startup {
+        state.publish(|status| {
+            status.termination_reason = Some(reason.clone());
+            status.error = Some(reason.clone());
+        });
+        if capture_attempted {
+            finish_window_stream(&stream, &recording, &events, &state, None);
+        } else if attached {
+            let _ = stream.remove_recording_output(&recording);
+        }
+        let _ = ready.send(Err(reason));
+        return;
+    }
+    let started = Instant::now();
+    state.publish(|status| {
+        status.active = true;
+    });
+    if ready.send(Ok(())).is_err() {
+        state.publish(|status| {
+            status.termination_reason = Some("recording_dropped".into());
+        });
+        finish_window_stream(&stream, &recording, &events, &state, Some(started));
+        return;
+    }
+    let mut next_health = Instant::now() + HEALTH_INTERVAL;
+    let (reason, error, already_finished) = loop {
+        match events.recv_timeout(next_health.saturating_duration_since(Instant::now())) {
+            Ok(WindowEvent::Stop) => break ("stopped".to_owned(), None, false),
+            Ok(WindowEvent::Failed) => {
+                break (
+                    "window_recording_failed".into(),
+                    Some("window_recording_failed".into()),
+                    false,
+                )
+            }
+            Ok(WindowEvent::StreamStopped) => {
+                break (
+                    "window_stream_stopped".into(),
+                    Some("window_stream_stopped".into()),
+                    false,
+                )
+            }
+            Ok(WindowEvent::Finished) => break ("window_recording_finished".into(), None, true),
+            Ok(WindowEvent::Started) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                break ("recording_dropped".into(), None, false)
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+        }
+        match WindowPlan::resolve(&plan.info.target) {
+            Ok(current) => {
+                if let Some(reason) = plan.fingerprint.changed_reason(&current.fingerprint) {
+                    break (reason.into(), None, false);
+                }
+            }
+            Err(error) => break (error.to_string(), None, false),
+        }
+        state.publish(|status| {
+            status.duration_ms = started.elapsed().as_millis() as u64;
+        });
+        next_health = Instant::now() + HEALTH_INTERVAL;
+    };
+    state.publish(|status| {
+        status.active = false;
+        status.duration_ms = started.elapsed().as_millis() as u64;
+        status.termination_reason = Some(reason);
+        status.error = error;
+        status.finalized = already_finished;
+    });
+    finish_window_stream(&stream, &recording, &events, &state, Some(started));
+}
+
+fn finish_window_stream(
+    stream: &SCStream,
+    recording: &SCRecordingOutput,
+    events: &mpsc::Receiver<WindowEvent>,
+    state: &WindowState,
+    started: Option<Instant>,
+) {
+    let transport_ok = stream.stop_capture().is_ok();
+    let status = state.snapshot();
+    let mut finalized = status.finalized;
+    let mut failure = (status.error.as_deref() == Some("window_recording_failed"))
+        .then_some("window_recording_failed");
+    if !finalized && failure.is_none() {
+        match wait_recording_finish(events, CALLBACK_TIMEOUT) {
+            Ok(()) => finalized = true,
+            Err(reason) => failure = Some(reason),
+        }
+    }
+    if !transport_ok && failure.is_none() && !finalized {
+        failure = Some("window_recording_stop_failed");
+    }
+    // Keep the output alive through its finish callback, then detach before both
+    // wrappers drop. No native resource is stored in the returned status handle.
+    let _ = stream.remove_recording_output(recording);
+    state.publish(|status| {
+        status.active = false;
+        status.finalized = finalized;
+        if let Some(started) = started {
+            if status.duration_ms == 0 {
+                status.duration_ms = started.elapsed().as_millis() as u64;
+            }
+        }
+        if let Some(failure) = failure {
+            status.error.get_or_insert_with(|| failure.into());
+        }
+    });
+}
+
+#[cfg(test)]
+mod window_video_tests {
+    use super::*;
+
+    fn fingerprint() -> WindowFingerprint {
+        WindowFingerprint {
+            pid: 42,
+            layer: 0,
+            width: 801.0,
+            height: 601.0,
+            content_width: 801.0,
+            content_height: 601.0,
+            scale: 2.0,
+        }
+    }
+
+    #[test]
+    fn encoder_dimensions_round_up_without_trimming() {
+        assert_eq!(even_pixel_dimension(801.0, 1.0).unwrap(), 802);
+        assert_eq!(even_pixel_dimension(801.0, 2.0).unwrap(), 1602);
+        assert_eq!(even_pixel_dimension(800.25, 1.0).unwrap(), 802);
+        for bad in [0.0, -1.0, f64::NAN, f64::INFINITY, f64::from(u32::MAX)] {
+            assert!(even_pixel_dimension(bad, 1.0).is_err());
+            assert!(even_pixel_dimension(1.0, bad).is_err());
+        }
+    }
+
+    #[test]
+    fn fixed_geometry_classifies_owner_scale_and_resize() {
+        let original = fingerprint();
+        assert_eq!(original.changed_reason(&fingerprint()), None);
+        let mut current = original.clone();
+        current.pid += 1;
+        assert_eq!(
+            original.changed_reason(&current),
+            Some("window_identity_changed")
+        );
+        current = original.clone();
+        current.layer += 1;
+        assert_eq!(
+            original.changed_reason(&current),
+            Some("window_identity_changed")
+        );
+        current = original.clone();
+        current.scale = 1.0;
+        assert_eq!(
+            original.changed_reason(&current),
+            Some("window_scale_changed")
+        );
+        current = original.clone();
+        current.width += 1.0;
+        assert_eq!(original.changed_reason(&current), Some("window_resized"));
+        current = original.clone();
+        current.content_height += 1.0;
+        assert_eq!(original.changed_reason(&current), Some("window_resized"));
+    }
+
+    #[test]
+    fn origin_movement_does_not_change_capture_identity() {
+        use screencapturekit::cg::{CGPoint, CGRect, CGSize};
+        let frame = CGRect {
+            origin: CGPoint { x: 10.0, y: 20.0 },
+            size: CGSize {
+                width: 801.0,
+                height: 601.0,
+            },
+        };
+        let moved = CGRect {
+            origin: CGPoint {
+                x: -200.0,
+                y: 900.0,
+            },
+            ..frame
+        };
+        let original = WindowFingerprint::new(42, 0, frame, frame, 2.0);
+        let current = WindowFingerprint::new(42, 0, moved, moved, 2.0);
+        assert_eq!(original.changed_reason(&current), None);
+    }
+
+    #[test]
+    fn actual_recording_callback_is_required_for_startup() {
+        let (sender, events) = mpsc::channel();
+        assert_eq!(
+            wait_recording_start(&events, Duration::ZERO),
+            Err("window_recording_start_timeout")
+        );
+        sender.send(WindowEvent::Started).unwrap();
+        assert_eq!(wait_recording_start(&events, Duration::ZERO), Ok(()));
+        sender.send(WindowEvent::Failed).unwrap();
+        assert_eq!(
+            wait_recording_start(&events, Duration::ZERO),
+            Err("window_recording_failed")
+        );
+    }
+
+    #[test]
+    fn only_recording_finish_callback_proves_finalization() {
+        let (sender, events) = mpsc::channel();
+        sender.send(WindowEvent::StreamStopped).unwrap();
+        assert_eq!(
+            wait_recording_finish(&events, Duration::ZERO),
+            Err("window_recording_finalize_timeout")
+        );
+        sender.send(WindowEvent::Finished).unwrap();
+        assert_eq!(wait_recording_finish(&events, Duration::ZERO), Ok(()));
+        sender.send(WindowEvent::Failed).unwrap();
+        assert_eq!(
+            wait_recording_finish(&events, Duration::ZERO),
+            Err("window_recording_failed")
+        );
+    }
+
+    #[test]
+    fn content_future_deadline_is_bounded() {
+        let result = wait_future(std::future::pending::<()>(), Duration::from_millis(1));
+        assert_eq!(result.unwrap_err().to_string(), "window_health_timeout");
+        assert_eq!(
+            wait_future(std::future::ready(42), Duration::ZERO).unwrap(),
+            42
+        );
+    }
+
+    #[test]
+    fn prestart_recheck_preserves_classified_resolution_failures() {
+        for reason in [
+            "window_closed",
+            "window_not_visible",
+            "window_not_shareable",
+            "window_owner_changed",
+            "window_health_timeout",
+        ] {
+            assert_eq!(
+                check_window_recheck(&fingerprint(), Err(anyhow::anyhow!(reason))),
+                Err(reason.to_owned())
+            );
+        }
+        assert!(check_window_recheck(&fingerprint(), Ok(fingerprint())).is_ok());
     }
 }

--- a/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
+++ b/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
@@ -74,6 +74,8 @@ both windows move. Every decoded frame must retain the target colors
 without red contamination, and at least two frames must differ. Frame timestamps
 must increase and span at least 1.5 seconds. The fixture acknowledges minimization
 after AppKit completes the asynchronous transition, with a three-second deadline.
+Minimization may first expose changing bounds or invisibility; either
+`window_resized` or `window_not_visible` is a valid automatic stop reason.
 At launch, the fixture waits for 20 consecutive 50-ms WindowServer samples matching
 its intended borderless dimensions, with a five-second deadline, so a transient
 expanded launch frame does not become the capture baseline.

--- a/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
+++ b/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
@@ -74,6 +74,9 @@ both windows move. Every decoded frame must retain the target colors
 without red contamination, and at least two frames must differ. Frame timestamps
 must increase and span at least 1.5 seconds. The fixture acknowledges minimization
 after AppKit completes the asynchronous transition, with a three-second deadline.
+At launch, the fixture waits for three consecutive WindowServer samples matching
+its intended borderless dimensions, with a five-second deadline, so a transient
+expanded launch frame does not become the capture baseline.
 Stream dimensions must match the fixture's native point dimensions and observed
 display scale, rounded up to even physical pixels. Seven recordings cover three
 explicit stops, minimize, close, resize, and owner disconnect. Each verifies native finalization,

--- a/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
+++ b/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
@@ -74,7 +74,7 @@ both windows move. Every decoded frame must retain the target colors
 without red contamination, and at least two frames must differ. Frame timestamps
 must increase and span at least 1.5 seconds. The fixture acknowledges minimization
 after AppKit completes the asynchronous transition, with a three-second deadline.
-At launch, the fixture waits for three consecutive WindowServer samples matching
+At launch, the fixture waits for 20 consecutive 50-ms WindowServer samples matching
 its intended borderless dimensions, with a five-second deadline, so a transient
 expanded launch frame does not become the capture baseline.
 Stream dimensions must match the fixture's native point dimensions and observed

--- a/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
+++ b/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
@@ -1,15 +1,17 @@
 # Exact-window recording fixture
 
 This AppKit fixture and `window_recording_macos_test` provide focused native
-ScreenCaptureKit diagnostics. Run only in a disposable, logged-in Lume macOS
-15+ worker prepared by the canonical macOS harness. This focused test does not
-replace the complete harness certification.
+ScreenCaptureKit diagnostics. Prefer a disposable, logged-in Lume macOS 15+
+worker prepared by the canonical macOS harness. An explicitly authorized host
+run is also available with the isolation requirements below. This focused test
+does not replace the complete harness certification.
 
-Prerequisites: the exact candidate source and signed, TCC-authorized installed
-daemon, its unrestricted session, Rust, Swift, `ffmpeg`, and `ffprobe`. Preserve
-the source SHA and dirty diff alongside the evidence. Use the same installed
-driver and daemon socket verified by the canonical Lume runner. Do not run on
-the developer's desktop or start a separate raw unsigned daemon.
+Prerequisites: a clean, committed candidate and its signed, TCC-authorized
+installed daemon, an unrestricted session, Rust, Swift, `ffmpeg`, and `ffprobe`.
+Preserve the source SHA alongside the evidence. Commit intended changes before
+installing; the test rejects the installer's `-dirty` provenance marker. Use the same installed
+driver and daemon socket verified by the canonical Lume runner for VM runs.
+Never start a raw unsigned daemon or use the released Driver for host diagnostics.
 
 From the repository root **inside the disposable VM**, with a fresh task-owned
 absolute evidence directory in `CUA_WINDOW_RECORDING_OUTPUT_ROOT`:
@@ -24,10 +26,40 @@ xcrun swiftc libs/cua-driver/tests/fixtures/apps/macos/window-recording/main.swi
 export CUA_WINDOW_RECORDING_FIXTURE="$CUA_WINDOW_RECORDING_OUTPUT_ROOT/build/window-recording-fixture"
 export CUA_TEST_DRIVER_BIN=/absolute/path/to/verified/installed/cua-driver
 export CUA_E2E_MACOS_DAEMON_SOCKET=/absolute/path/to/verified/daemon.sock
+export CUA_E2E_SOURCE_SHA=FULL_CANDIDATE_COMMIT_SHA
 unset CUA_E2E_RECORDINGS_ROOT
 cargo test --manifest-path libs/cua-driver/rust/Cargo.toml -p cua-driver \
   --test window_recording_macos_test -- --ignored --nocapture --test-threads=1
 ```
+
+### Explicitly authorized host diagnostics
+
+Obtain the host owner's explicit approval before this lane. Install the exact
+candidate as the separate, certificate-signed `CuaDriverLocal.app`; preserve
+the released Driver and its daemon. The host owner grants macOS permissions
+through the normal app-owned prompt flow. Do not use VM-only TCC helpers.
+
+Create a fresh absolute evidence root, then launch that local app in unrestricted
+mode with `--dangerously-bypass-approvals` and an explicit socket at
+`$CUA_WINDOW_RECORDING_OUTPUT_ROOT/driver.sock`. Do not enable autostart or point
+other clients at this task-owned socket. Verify the app signature, installed
+version, source SHA, socket owner, and daemon permission mode before proceeding.
+
+Use the build and test commands above, but unset
+`CUA_WINDOW_RECORDING_DISPOSABLE_VM` and set
+`CUA_WINDOW_RECORDING_HOST_AUTHORIZED=1`. Set `CUA_TEST_DRIVER_BIN` to
+`/Applications/CuaDriverLocal.app/Contents/MacOS/cua-driver-local` and
+`CUA_E2E_MACOS_DAEMON_SOCKET` to that task-owned `driver.sock`. The test rejects
+ambiguous opt-ins, default socket paths, other host CLI binary paths, and a
+daemon whose version or source SHA differs from the candidate. This does not
+attest the socket listener's executable or ownership: the operator must verify
+those separately before the run. It also verifies that the
+fixture-reported PID is the child it launched before requesting capture.
+
+The fixture briefly activates and moves its own synthetic windows. Keep the
+host idle during the run. Stop only the task-owned local daemon afterward;
+leave the released Driver unchanged. `test-environment.json` labels the result
+as host diagnostics, not canonical Lume certification.
 
 `CUA_E2E_RECORDINGS_ROOT` must be unset: the generic testkit trajectory mode
 records a full desktop and is deliberately forbidden in this test. The test
@@ -47,9 +79,10 @@ plus `session.json`. The same daemon also rejects wrong-PID and busy starts,
 and starts subsequent recordings after finalization.
 
 Artifacts remain in `stop/`, `minimize/`, `close/`, `resize/`, and `disconnect/`; there is no
-bulk cleanup. Reusing an existing case directory fails to preserve evidence.
+bulk cleanup. An existing case path or environment report is rejected before
+connecting, and the environment report is created without overwrite.
 The fixture child is killed and reaped on normal return or Rust assertion
-unwind. The test does not install software, grant permissions, change desktop
+unwind, including an invalid or missing initial reply. The test does not install software, grant permissions, change desktop
 settings, capture the desktop, or enable legacy trajectory recording.
 
 This lane does not prove display-scale changes, display reconfiguration,

--- a/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
+++ b/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
@@ -70,8 +70,11 @@ a capture implementation or substitute for native video proof.
 
 The 321-by-241-point green target has a blue center marker and a pulsing white
 bar. A larger red sibling starts visible beside it, then fully covers it before
-both windows move. Every decoded frame must retain the target colors
-without red contamination, and at least two frames must differ. Frame timestamps
+both windows move. Every decoded frame must exclude red contamination, and at
+least two frames must differ. At least three full-brightness target frames must
+span 1.5 seconds. Only close/minimize cases may include a hue-preserving fade or
+black frames in the final half-second, after at least 1.5 seconds of video.
+All other frames must retain the full-brightness target colors. Frame timestamps
 must increase and span at least 1.5 seconds. The fixture acknowledges minimization
 after AppKit completes the asynchronous transition, with a three-second deadline.
 Minimize and close animations may expose changing bounds before invisibility or

--- a/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
+++ b/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
@@ -70,8 +70,9 @@ a capture implementation or substitute for native video proof.
 
 The 321-by-241-point green target has a blue center marker and a pulsing white
 bar. A larger red sibling starts visible beside it, then fully covers it before
-both windows move. Every decoded frame must exclude red contamination, and at
-least two frames must differ. At least three full-brightness target frames must
+both windows move. Every decoded frame is checked for red outside the fixture's
+palette (`R <= min(G, B)`, with eight levels of codec tolerance), including dim
+fades. At least two frames must differ. At least three full-brightness target frames must
 span 1.5 seconds. Only close/minimize cases may include a hue-preserving fade or
 black frames in the final half-second, after at least 1.5 seconds of video.
 All other frames must retain the full-brightness target colors. Frame timestamps

--- a/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
+++ b/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
@@ -1,0 +1,58 @@
+# Exact-window recording fixture
+
+This AppKit fixture and `window_recording_macos_test` provide focused native
+ScreenCaptureKit diagnostics. Run only in a disposable, logged-in Lume macOS
+15+ worker prepared by the canonical macOS harness. This focused test does not
+replace the complete harness certification.
+
+Prerequisites: the exact candidate source and signed, TCC-authorized installed
+daemon, its unrestricted session, Rust, Swift, `ffmpeg`, and `ffprobe`. Preserve
+the source SHA and dirty diff alongside the evidence. Use the same installed
+driver and daemon socket verified by the canonical Lume runner. Do not run on
+the developer's desktop or start a separate raw unsigned daemon.
+
+From the repository root **inside the disposable VM**, with a fresh task-owned
+absolute evidence directory in `CUA_WINDOW_RECORDING_OUTPUT_ROOT`:
+
+```bash
+export CUA_WINDOW_RECORDING_DISPOSABLE_VM=1
+export CUA_WINDOW_RECORDING_OUTPUT_ROOT=/tmp/window-recording-evidence-unique-run
+mkdir -p "$CUA_WINDOW_RECORDING_OUTPUT_ROOT/build"
+xcrun swiftc libs/cua-driver/tests/fixtures/apps/macos/window-recording/main.swift \
+  -framework AppKit \
+  -o "$CUA_WINDOW_RECORDING_OUTPUT_ROOT/build/window-recording-fixture"
+export CUA_WINDOW_RECORDING_FIXTURE="$CUA_WINDOW_RECORDING_OUTPUT_ROOT/build/window-recording-fixture"
+export CUA_TEST_DRIVER_BIN=/absolute/path/to/verified/installed/cua-driver
+export CUA_E2E_MACOS_DAEMON_SOCKET=/absolute/path/to/verified/daemon.sock
+unset CUA_E2E_RECORDINGS_ROOT
+cargo test --manifest-path libs/cua-driver/rust/Cargo.toml -p cua-driver \
+  --test window_recording_macos_test -- --ignored --nocapture --test-threads=1
+```
+
+`CUA_E2E_RECORDINGS_ROOT` must be unset: the generic testkit trajectory mode
+records a full desktop and is deliberately forbidden in this test. The test
+uses the existing `McpDriver` daemon proxy and public recording APIs with an
+explicit `{kind: "window", pid, window_id}` on every start. Fixture stdin is
+only an external control for changing its synthetic native windows; it is not
+a capture implementation or substitute for native video proof.
+
+The green target has a blue center marker and a pulsing white bar. A larger red sibling fully covers
+it before both windows move. Every decoded half-second sample must retain the
+target colors without red contamination, and at least two samples must differ.
+Stream dimensions must match the fixture's native point dimensions and display
+scale. Five recordings cover explicit stop, minimize, close, resize, and owner
+disconnect. Each verifies native finalization,
+the termination reason, a decoded playable MP4, and exactly `recording.mp4`
+plus `session.json`. The same daemon also rejects wrong-PID and busy starts,
+and starts subsequent recordings after finalization.
+
+Artifacts remain in `stop/`, `minimize/`, `close/`, `resize/`, and `disconnect/`; there is no
+bulk cleanup. Reusing an existing case directory fails to preserve evidence.
+The fixture child is killed and reaped on normal return or Rust assertion
+unwind. The test does not install software, grant permissions, change desktop
+settings, capture the desktop, or enable legacy trajectory recording.
+
+This lane does not prove display-scale changes, display reconfiguration,
+cross-process occlusion, session ownership races, permission revocation, or
+encoder failure recovery. Native execution is required before reporting the
+test as passing; successful compilation alone proves no GUI behavior.

--- a/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
+++ b/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
@@ -74,8 +74,10 @@ both windows move. Every decoded frame must retain the target colors
 without red contamination, and at least two frames must differ. Frame timestamps
 must increase and span at least 1.5 seconds. The fixture acknowledges minimization
 after AppKit completes the asynchronous transition, with a three-second deadline.
-Minimization may first expose changing bounds or invisibility; either
-`window_resized` or `window_not_visible` is a valid automatic stop reason.
+Minimize and close animations may expose changing bounds before invisibility or
+removal. `window_resized` is therefore a valid first-observed automatic stop
+reason for either transition, alongside `window_not_visible` and, for close,
+`window_closed`.
 At launch, the fixture waits for 20 consecutive 50-ms WindowServer samples matching
 its intended borderless dimensions, with a five-second deadline, so a transient
 expanded launch frame does not become the capture baseline.

--- a/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
+++ b/libs/cua-driver/tests/fixtures/apps/macos/window-recording/README.md
@@ -68,24 +68,38 @@ explicit `{kind: "window", pid, window_id}` on every start. Fixture stdin is
 only an external control for changing its synthetic native windows; it is not
 a capture implementation or substitute for native video proof.
 
-The green target has a blue center marker and a pulsing white bar. A larger red sibling fully covers
-it before both windows move. Every decoded half-second sample must retain the
-target colors without red contamination, and at least two samples must differ.
-Stream dimensions must match the fixture's native point dimensions and display
-scale. Five recordings cover explicit stop, minimize, close, resize, and owner
-disconnect. Each verifies native finalization,
+The 321-by-241-point green target has a blue center marker and a pulsing white
+bar. A larger red sibling starts visible beside it, then fully covers it before
+both windows move. Every decoded frame must retain the target colors
+without red contamination, and at least two frames must differ. Frame timestamps
+must increase and span at least 1.5 seconds. The fixture acknowledges minimization
+after AppKit completes the asynchronous transition, with a three-second deadline.
+Stream dimensions must match the fixture's native point dimensions and observed
+display scale, rounded up to even physical pixels. Seven recordings cover three
+explicit stops, minimize, close, resize, and owner disconnect. Each verifies native finalization,
 the termination reason, a decoded playable MP4, and exactly `recording.mp4`
 plus `session.json`. The same daemon also rejects wrong-PID and busy starts,
-and starts subsequent recordings after finalization.
+and starts subsequent recordings after finalization. Starting capture and
+explicitly stopping or disconnecting must preserve the foreground process,
+fixture window order, key window, and physical cursor position. The test samples
+the attested daemon's open descriptor count before capture and after each
+finalized recording. The first `stop` case warms the native capture frameworks;
+subsequent cases permit at most two additional descriptors above that warmed
+sample. This detects repeated growth, not a one-time resource retained at warmup.
 
-Artifacts remain in `stop/`, `minimize/`, `close/`, `resize/`, and `disconnect/`; there is no
-bulk cleanup. An existing case path or environment report is rejected before
+Artifacts remain in `stop/`, `repeat_1/`, `repeat_2/`, `minimize/`, `close/`,
+`resize/`, and `disconnect/`; there is no bulk cleanup. The root
+`native-diagnostics.json` records descriptor counts and observed native scales,
+not descriptor paths or other application state. An existing case path or report is rejected before
 connecting, and the environment report is created without overwrite.
 The fixture child is killed and reaped on normal return or Rust assertion
 unwind, including an invalid or missing initial reply. The test does not install software, grant permissions, change desktop
 settings, capture the desktop, or enable legacy trajectory recording.
 
-This lane does not prove display-scale changes, display reconfiguration,
+Only the scales reported in `native-diagnostics.json` are exercised natively;
+a scale-1 run does not certify Retina capture. Shared geometry tests separately
+cover scale arithmetic and scale-change policy. This lane does not prove
+display-scale changes, display reconfiguration,
 cross-process occlusion, session ownership races, permission revocation, or
 encoder failure recovery. Native execution is required before reporting the
 test as passing; successful compilation alone proves no GUI behavior.

--- a/libs/cua-driver/tests/fixtures/apps/macos/window-recording/main.swift
+++ b/libs/cua-driver/tests/fixtures/apps/macos/window-recording/main.swift
@@ -24,7 +24,7 @@ func reply(_ value: [String: Any]) {
 
 let app = NSApplication.shared
 app.setActivationPolicy(.regular)
-let frame = NSRect(x: 140, y: 180, width: 320, height: 240)
+let frame = NSRect(x: 140, y: 180, width: 321, height: 241)
 let target = NSWindow(contentRect: frame,
                       styleMask: [.borderless, .miniaturizable], backing: .buffered, defer: false)
 target.title = "Cua Recording Target"
@@ -42,8 +42,37 @@ sibling.title = "Cua Recording Red Sibling"
 sibling.isReleasedWhenClosed = false
 sibling.hasShadow = false
 sibling.backgroundColor = NSColor(srgbRed: 1, green: 0, blue: 0, alpha: 1)
+sibling.setFrameOrigin(NSPoint(x: frame.maxX + 20, y: frame.minY))
+sibling.orderFrontRegardless()
 target.orderFrontRegardless()
 app.activate(ignoringOtherApps: true)
+
+func replyState(_ command: String) {
+    let cursor = NSEvent.mouseLocation
+    reply(["command": command, "miniaturized": target.isMiniaturized,
+           "visible": target.isVisible, "x": target.frame.minX,
+           "width": target.frame.width,
+           "sibling_visible": sibling.isVisible,
+           "sibling_adjacent": !sibling.frame.intersects(target.frame),
+           "sibling_covers_target": sibling.frame.contains(target.frame),
+           "sibling_in_front": NSApp.orderedWindows.first === sibling,
+           "ui_state": [
+               "frontmost_pid": NSWorkspace.shared.frontmostApplication?.processIdentifier ?? -1,
+               "key_window": NSApp.keyWindow?.windowNumber ?? -1,
+               "ordered_windows": NSApp.orderedWindows.map { $0.windowNumber },
+               "cursor_x": cursor.x, "cursor_y": cursor.y,
+           ]])
+}
+
+func replyAfterMinimize(until deadline: TimeInterval) {
+    if target.isMiniaturized || ProcessInfo.processInfo.systemUptime >= deadline {
+        replyState("minimize")
+        return
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+        replyAfterMinimize(until: deadline)
+    }
+}
 
 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
     reply(["pid": ProcessInfo.processInfo.processIdentifier,
@@ -55,6 +84,7 @@ DispatchQueue.global().async {
     while let command = readLine() {
         DispatchQueue.main.async {
             switch command {
+            case "state": break
             case "occlude":
                 sibling.setFrame(target.frame.insetBy(dx: -20, dy: -20), display: true)
                 sibling.orderFrontRegardless()
@@ -64,18 +94,17 @@ DispatchQueue.global().async {
                 sibling.orderFrontRegardless()
             case "resize":
                 target.setContentSize(NSSize(width: 360, height: 260))
-            case "minimize": target.miniaturize(nil)
+            case "minimize":
+                target.miniaturize(nil)
+                // AppKit completes minimization asynchronously, after this handler.
+                replyAfterMinimize(until: ProcessInfo.processInfo.systemUptime + 3)
+                return
             case "close": target.close()
             default:
                 reply(["error": "unknown command"])
                 return
             }
-            reply(["command": command, "miniaturized": target.isMiniaturized,
-                   "visible": target.isVisible, "x": target.frame.minX,
-                   "width": target.frame.width,
-                   "sibling_visible": sibling.isVisible,
-                   "sibling_covers_target": sibling.frame.contains(target.frame),
-                   "sibling_in_front": NSApp.orderedWindows.first === sibling])
+            replyState(command)
         }
     }
     DispatchQueue.main.async { app.terminate(nil) }

--- a/libs/cua-driver/tests/fixtures/apps/macos/window-recording/main.swift
+++ b/libs/cua-driver/tests/fixtures/apps/macos/window-recording/main.swift
@@ -1,0 +1,83 @@
+import AppKit
+
+// The stdin protocol changes only this process's synthetic windows.
+final class MarkerView: NSView {
+    var pulse = false
+
+    override func draw(_ dirtyRect: NSRect) {
+        NSColor(srgbRed: 0, green: 1, blue: 0, alpha: 1).setFill()
+        bounds.fill()
+        NSColor(srgbRed: 0, green: 0, blue: 1, alpha: 1).setFill()
+        NSRect(x: bounds.width * 0.375, y: bounds.height * 0.375,
+               width: bounds.width * 0.25, height: bounds.height * 0.25).fill()
+        NSColor.white.setFill()
+        NSRect(x: 0, y: bounds.height * 0.05,
+               width: bounds.width * (pulse ? 0.65 : 0.15),
+               height: bounds.height * 0.06).fill()
+    }
+}
+
+func reply(_ value: [String: Any]) {
+    let data = try! JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+    FileHandle.standardOutput.write(data + Data([10]))
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.regular)
+let frame = NSRect(x: 140, y: 180, width: 320, height: 240)
+let target = NSWindow(contentRect: frame,
+                      styleMask: [.borderless, .miniaturizable], backing: .buffered, defer: false)
+target.title = "Cua Recording Target"
+target.isReleasedWhenClosed = false
+target.hasShadow = false
+let marker = MarkerView(frame: NSRect(origin: .zero, size: frame.size))
+target.contentView = marker
+let animationTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: true) { _ in
+    marker.pulse.toggle()
+    marker.needsDisplay = true
+}
+let sibling = NSWindow(contentRect: frame.insetBy(dx: -20, dy: -20),
+                       styleMask: .borderless, backing: .buffered, defer: false)
+sibling.title = "Cua Recording Red Sibling"
+sibling.isReleasedWhenClosed = false
+sibling.hasShadow = false
+sibling.backgroundColor = NSColor(srgbRed: 1, green: 0, blue: 0, alpha: 1)
+target.orderFrontRegardless()
+app.activate(ignoringOtherApps: true)
+
+DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+    reply(["pid": ProcessInfo.processInfo.processIdentifier,
+           "window_id": target.windowNumber, "sibling_id": sibling.windowNumber,
+           "width": frame.width, "height": frame.height,
+           "scale": target.backingScaleFactor])
+}
+DispatchQueue.global().async {
+    while let command = readLine() {
+        DispatchQueue.main.async {
+            switch command {
+            case "occlude":
+                sibling.setFrame(target.frame.insetBy(dx: -20, dy: -20), display: true)
+                sibling.orderFrontRegardless()
+            case "move":
+                target.setFrameOrigin(NSPoint(x: target.frame.minX + 50, y: target.frame.minY + 30))
+                sibling.setFrame(target.frame.insetBy(dx: -20, dy: -20), display: true)
+                sibling.orderFrontRegardless()
+            case "resize":
+                target.setContentSize(NSSize(width: 360, height: 260))
+            case "minimize": target.miniaturize(nil)
+            case "close": target.close()
+            default:
+                reply(["error": "unknown command"])
+                return
+            }
+            reply(["command": command, "miniaturized": target.isMiniaturized,
+                   "visible": target.isVisible, "x": target.frame.minX,
+                   "width": target.frame.width,
+                   "sibling_visible": sibling.isVisible,
+                   "sibling_covers_target": sibling.frame.contains(target.frame),
+                   "sibling_in_front": NSApp.orderedWindows.first === sibling])
+        }
+    }
+    DispatchQueue.main.async { app.terminate(nil) }
+}
+app.run()

--- a/libs/cua-driver/tests/fixtures/apps/macos/window-recording/main.swift
+++ b/libs/cua-driver/tests/fixtures/apps/macos/window-recording/main.swift
@@ -74,11 +74,30 @@ func replyAfterMinimize(until deadline: TimeInterval) {
     }
 }
 
-DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-    reply(["pid": ProcessInfo.processInfo.processIdentifier,
-           "window_id": target.windowNumber, "sibling_id": sibling.windowNumber,
-           "width": frame.width, "height": frame.height,
-           "scale": target.backingScaleFactor])
+func replyWhenReady(until deadline: TimeInterval, stableSamples: Int = 0) {
+    let windows = CGWindowListCopyWindowInfo(.optionIncludingWindow,
+                                            CGWindowID(target.windowNumber)) as? [[String: Any]]
+    let bounds = windows?.first?[kCGWindowBounds as String] as? [String: Any]
+    let settled = (bounds?["Width"] as? Double) == frame.width
+        && (bounds?["Height"] as? Double) == frame.height
+        && (windows?.first?[kCGWindowIsOnscreen as String] as? Bool) == true
+    let samples = settled ? stableSamples + 1 : 0
+    if samples >= 3 {
+        reply(["pid": ProcessInfo.processInfo.processIdentifier,
+               "window_id": target.windowNumber, "sibling_id": sibling.windowNumber,
+               "width": frame.width, "height": frame.height,
+               "scale": target.backingScaleFactor])
+    } else if ProcessInfo.processInfo.systemUptime >= deadline {
+        reply(["error": "fixture_geometry_unsettled"])
+    } else {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            replyWhenReady(until: deadline, stableSamples: samples)
+        }
+    }
+}
+// WindowServer can briefly expose an expanded launch frame after AppKit returns.
+DispatchQueue.main.async {
+    replyWhenReady(until: ProcessInfo.processInfo.systemUptime + 5)
 }
 DispatchQueue.global().async {
     while let command = readLine() {

--- a/libs/cua-driver/tests/fixtures/apps/macos/window-recording/main.swift
+++ b/libs/cua-driver/tests/fixtures/apps/macos/window-recording/main.swift
@@ -82,7 +82,7 @@ func replyWhenReady(until deadline: TimeInterval, stableSamples: Int = 0) {
         && (bounds?["Height"] as? Double) == frame.height
         && (windows?.first?[kCGWindowIsOnscreen as String] as? Bool) == true
     let samples = settled ? stableSamples + 1 : 0
-    if samples >= 3 {
+    if samples >= 20 {
         reply(["pid": ProcessInfo.processInfo.processIdentifier,
                "window_id": target.windowNumber, "sibling_id": sibling.windowNumber,
                "width": frame.width, "height": frame.height,

--- a/rfcs/3644-window-recording.md
+++ b/rfcs/3644-window-recording.md
@@ -4,10 +4,11 @@ authors:
   - f-trycua
 created: 2026-09-08
 last_updated: 2026-09-08
-status: review
+status: accepted
 discussion: https://github.com/trycua/cua/issues/3644
-rfc_pr:
-implementation: []
+rfc_pr: https://github.com/trycua/cua/pull/3667
+implementation:
+  - https://github.com/trycua/cua/pull/3667
 supersedes:
 superseded_by:
 ---
@@ -119,6 +120,9 @@ are additive and do not reinterpret old recordings.
 
 The shared core owns target parsing, validation, mode selection, artifact
 policy, and status. The platform backend receives a typed capture request.
+Use a recording-specific target validator before authorization; do not route
+recording through the input-action target normalizer. Both the observation
+resource and backend request must retain the same validated PID/window pair.
 
 Window-video mode suppresses trajectory turn reservation and global cursor
 sampling from the start, including calls from the initiating session. It does
@@ -129,6 +133,9 @@ enabled during Driver actions, but is not included in this recording mode.
 Use a new output directory or refuse if recorder artifacts already exist in
 it. Do not overwrite an older recording or mix files from different modes.
 Validation and capability checks must precede output mutation and teardown.
+A failed window-video start is an error, not a successful trajectory-only
+recording. Reserve the destination against competing recording starts before
+creating encoder output; recheck the prepared target before stream start.
 
 Keep one recorder. Starting a window recording while any recording is active,
 or starting another mode while a window recording is active, returns
@@ -145,6 +152,10 @@ Resolve and validate the exact PID/window pair using the existing capture
 identity logic. Use `SCContentFilter::with_window`, not a display crop or an
 application-wide filter. Derive even-sized encoder dimensions from the
 filter's content rectangle and pixel scale without discarding edge content.
+The requested PID must match both WindowServer and ScreenCaptureKit ownership.
+The retained health fingerprint excludes position so ordinary movement is not
+mistaken for a replacement window; ownership, layer, dimensions, and scale
+remain checked.
 
 An ordinary position change does not change the target. Occluding windows,
 desktop, Dock, menu bar, and separate overlay windows are excluded. Content
@@ -256,6 +267,22 @@ not block evaluation of this video-only increment.
 
 ## Decision record
 
-The workstream is selected for scoped RFC review and macOS-first development.
-Contract review and the maintainer decision must be recorded on #3644 before
-implementation begins. This document does not mark #3644 complete.
+Accepted for the selected macOS-first implementation, not for release. The
+additive window-video contract preserves no-target behavior and intentionally
+defers concurrent recorders, owner-only manual stop, scoped trajectories, and
+cursor compositing. It does not mark #3644 complete.
+
+Independent contract and native-feasibility review identified four required
+implementation safeguards: recording-specific pre-authorization target
+validation, transactional startup without trajectory fallback, requested-PID
+checks against both native ownership sources, and callback-backed live status
+and finalization. These requirements are incorporated above. Ordinary window
+movement must not invalidate a geometry fingerprint merely because its origin
+changed. The selected resize policy is explicit termination, not a dynamic
+encoder-size change.
+
+Remaining risks are native shareability/permission behavior, finite health
+check latency, same-process window-ID reuse, and callback failure or timeout.
+They require synthetic native evidence and explicit limitations before the
+draft can be considered ready. The decision is recorded on the discussion
+issue; the draft PR remains the execution and evidence record.

--- a/rfcs/3644-window-recording.md
+++ b/rfcs/3644-window-recording.md
@@ -146,6 +146,11 @@ boundary, not independent recorder control. A foreign stop can end a recording
 but cannot widen its capture target. The broader ownership decision stays in
 #3644.
 
+After automatic termination, state reports `active: false`, but the singleton
+remains reserved until `stop_recording` or owner teardown joins the backend.
+Call `stop_recording` before starting another recording. This avoids overlapping
+resource teardown with a new stream.
+
 ### Native macOS behavior
 
 Resolve and validate the exact PID/window pair using the existing capture
@@ -169,10 +174,18 @@ stops capture. A missing, minimized, invalid, or unshareable initial target
 fails before recording starts. A changed or reused window identity never
 causes automatic retargeting.
 
-Capture has a bounded health check and retains the recording output until
-finalization completes. Native recording completion/error callbacks, rather
-than transport success alone, determine finalization. Stop, disconnect,
-startup failure, and health-check termination release owned stream resources.
+Capture checks health every 250 ms, with a two-second shareable-content query
+deadline. Recording-start and finalization callback waits have ten-second
+deadlines. Native recording completion/error callbacks, rather than transport
+success alone, determine finalization. Stop, disconnect, startup failure, and
+health-check termination release owned stream resources.
+
+The pinned `screencapturekit` 6.0.1 binding has synchronous, uncancellable
+attach/start/stop/detach calls. Those native transport waits can still delay
+startup or teardown indefinitely; the callback deadlines are not a hard
+end-to-end timeout. Resolving this requires a cancellable upstream binding or
+another reviewed transport implementation. Do not claim fully bounded teardown
+from this increment.
 
 ### Platform behavior
 

--- a/rfcs/3644-window-recording.md
+++ b/rfcs/3644-window-recording.md
@@ -1,0 +1,261 @@
+---
+title: Explicit window-only video recording
+authors:
+  - f-trycua
+created: 2026-09-08
+last_updated: 2026-09-08
+status: review
+discussion: https://github.com/trycua/cua/issues/3644
+rfc_pr:
+implementation: []
+supersedes:
+superseded_by:
+---
+
+# RFC: Explicit window-only video recording
+
+## Summary
+
+Add an opt-in window-video mode to `start_recording`. The caller selects one
+native window by PID and window ID. The macOS adapter records that window with
+a desktop-independent ScreenCaptureKit filter. This mode writes video and
+bounded recording metadata only: no trajectory screenshots, accessibility
+trees, action arguments, or global cursor samples. Unsupported backends refuse
+the request before capture. No failure widens capture to a display.
+
+This is the capture-scope increment of #3644. It does not claim to resolve the
+broader recorder-control and concurrent-recorders questions in that issue.
+
+## Motivation
+
+Recording one application should not require collecting the surrounding
+desktop. Cropping a display recording does not provide the same boundary:
+another window can cover the selected rectangle, and the original file still
+contains unrelated pixels. A target-window stream avoids collecting those
+pixels in the first place.
+
+## Goals
+
+- Produce a finalized H.264 MP4 containing only the selected native window.
+- Keep capture in the daemon's existing OS permission identity.
+- Preserve existing recording calls that omit `target`.
+- Make capture scope, unsupported cases, and termination reasons observable.
+- Verify exclusion of occluding and adjacent windows with synthetic fixtures.
+
+## Non-goals
+
+- Multiple simultaneous recorders or an owner-only replacement/stop redesign.
+- Window-scoped trajectory recording, replay, or human demonstration capture.
+- Agent-cursor compositing, audio, microphone capture, or browser-tab capture.
+- Cropping out browser chrome or redacting content inside the selected window.
+- Window-video implementations for Windows, X11, or Wayland in this increment.
+- Installing, replacing, or restarting the released Driver to run development
+  tests; release and local builds remain separate.
+
+## Terminology
+
+- **Legacy mode:** a call without `target`; its trajectory and optional display
+  video behavior is unchanged.
+- **Window-video mode:** a call with an explicit window target and
+  `record_video: true`; only that window's video and recording metadata are
+  collected.
+- **Capture identity:** platform-attested window ownership and capture geometry,
+  not a title match or a screen rectangle.
+
+## Current state
+
+At `4bc38a79237cc842a5039c310ab40132485b01cf`,
+[`recording_tools.rs`](../libs/cua-driver/rust/crates/cua-driver-core/src/recording_tools.rs)
+accepts `output_dir` and `record_video`. Video defaults to false. The shared
+[`VideoBackendFactory`](../libs/cua-driver/rust/crates/cua-driver-core/src/video.rs)
+receives only an output path.
+
+The macOS
+[`video_sckit.rs`](../libs/cua-driver/rust/crates/platform-macos/src/video_sckit.rs)
+selects a display and records it with `SCStream` and `SCRecordingOutput`.
+[`capture.rs`](../libs/cua-driver/rust/crates/platform-macos/src/capture.rs)
+already validates window capture identity and uses a desktop-independent
+`SCContentFilter::with_window` for screenshots.
+
+The recorder is a singleton. Legacy manual stop is unconditional; session
+disconnect teardown is owner-aware. PR #3632 separately addresses trajectory
+turn attribution. This RFC neither duplicates nor supersedes that work.
+
+## Proposal
+
+### Public input and output
+
+Extend `start_recording` with an optional `target`:
+
+```json
+{
+  "output_dir": "/tmp/window-demo",
+  "record_video": true,
+  "target": {"kind": "window", "pid": 1234, "window_id": 5678}
+}
+```
+
+The example IDs are placeholders for values from `list_windows`. Require a
+positive, representable PID and window ID. Reject missing fields, unknown
+target kinds, extra target fields, and a target combined with missing or false
+`record_video`. Reject ambiguous legacy top-level PID/window fields rather
+than guessing. Omitting `target` keeps the existing behavior; a new desktop
+selector is not needed for this increment.
+
+Add equivalent CLI flags to `recording start`: `--video --pid PID --window-id
+WINDOW_ID`. Require the two window flags together and require `--video` for a
+window request. Preserve the existing bare command's trajectory-only default.
+Keep the generic SDK `call_tool` surface working and add a typed convenience
+only where the SDK already exposes recording configuration.
+
+Recording state and `session.json` identify `mode: "window_video"` and the
+requested/resolved window target. Include pixel dimensions, backend identity,
+whether finalization succeeded, and a stable termination/error classification.
+Do not report video active merely because an in-memory backend exists after
+its capture stream has stopped. Legacy metadata remains readable; new fields
+are additive and do not reinterpret old recordings.
+
+### Shared ownership and artifact boundary
+
+The shared core owns target parsing, validation, mode selection, artifact
+policy, and status. The platform backend receives a typed capture request.
+
+Window-video mode suppresses trajectory turn reservation and global cursor
+sampling from the start, including calls from the initiating session. It does
+not write `turn-*` directories or `cursor.jsonl`. Disable system-cursor and
+audio capture for the window stream. The live input-safety overlay remains
+enabled during Driver actions, but is not included in this recording mode.
+
+Use a new output directory or refuse if recorder artifacts already exist in
+it. Do not overwrite an older recording or mix files from different modes.
+Validation and capability checks must precede output mutation and teardown.
+
+Keep one recorder. Starting a window recording while any recording is active,
+or starting another mode while a window recording is active, returns
+`recording_busy` without replacing it. Legacy-to-legacy replacement remains
+unchanged. Manual stop remains explicitly daemon-wide; session disconnect
+stops only its owned recording. Therefore window-video isolation is a content
+boundary, not independent recorder control. A foreign stop can end a recording
+but cannot widen its capture target. The broader ownership decision stays in
+#3644.
+
+### Native macOS behavior
+
+Resolve and validate the exact PID/window pair using the existing capture
+identity logic. Use `SCContentFilter::with_window`, not a display crop or an
+application-wide filter. Derive even-sized encoder dimensions from the
+filter's content rectangle and pixel scale without discarding edge content.
+
+An ordinary position change does not change the target. Occluding windows,
+desktop, Dock, menu bar, and separate overlay windows are excluded. Content
+inside the selected window, including tab bars, is included.
+
+For this first version, output dimensions are fixed. A detected resize or
+backing-scale change stops and finalizes the recording with a classified
+reason; it does not silently distort the capture or start another file.
+Closing, minimizing, losing shareability, or losing the attested owner also
+stops capture. A missing, minimized, invalid, or unshareable initial target
+fails before recording starts. A changed or reused window identity never
+causes automatic retargeting.
+
+Capture has a bounded health check and retains the recording output until
+finalization completes. Native recording completion/error callbacks, rather
+than transport success alone, determine finalization. Stop, disconnect,
+startup failure, and health-check termination release owned stream resources.
+
+### Platform behavior
+
+| Backend | Window-video mode | Existing no-target mode |
+| --- | --- | --- |
+| macOS 15+ ScreenCaptureKit | Native exact-window capture, subject to OS consent and shareability | Unchanged |
+| Windows | Explicit `window_recording_unsupported` | Unchanged |
+| Linux X11 | Explicit `window_recording_unsupported` | Unchanged |
+| Linux Wayland | Explicit `window_recording_unsupported` | Unchanged |
+
+No unsupported backend substitutes display recording. Shared tests cover the
+refusal; native support requires a later implementation and evidence.
+
+## Alternatives considered
+
+- **Display capture followed by cropping:** rejected because it collects
+  unrelated desktop pixels and includes occluders.
+- **A separate recorder executable:** rejected for the product feature because
+  it creates another macOS capture-permission identity and duplicates lifecycle.
+- **Window video plus legacy trajectory/global cursor collection:** rejected
+  because the resulting artifact directory is not window-scoped.
+- **Full per-session recorders and cursor compositing now:** deferred to avoid
+  coupling the first exact-window stream to a larger concurrency redesign.
+- **Dynamic stream resizing:** deferred; explicit termination is testable and
+  avoids changing the dimensions of an active MP4 encoder.
+
+## Compatibility and migration
+
+The change is opt-in and requires no migration for no-target calls. Calls with
+invalid or unsupported targets fail instead of entering legacy mode. CLI,
+MCP, and SDK contracts expose the same semantics. Update skills and generated
+tool documentation together, including the existing video-default wording.
+Rollback removes the opt-in capability; it must not reinterpret window
+requests as display requests. Keep the RFC and implementation in review until
+the native evidence is attached; no release is implied by a draft PR.
+
+## Security, privacy, and telemetry
+
+Bind observation authorization to the platform-attested window and output
+authorization to the exact destination. A window grant does not authorize
+display discovery/capture. Preserve managed/user policy and OS consent gates.
+Do not weaken permission checks or use unrestricted mode as a substitute for
+capture-scope validation.
+
+Do not collect window titles, URLs, page text, screenshots, or process command
+lines in telemetry. Local metadata contains only the capture identifiers and
+geometry needed to explain the file. Synthetic test evidence must not contain
+real account data. Native window capture cannot redact sensitive information
+that appears inside the selected window; callers remain responsible for its
+content. The daemon-wide manual-stop limitation remains documented.
+
+## Implementation plan
+
+1. Review and record this scoped decision before implementation.
+2. Extend common request/state/backend contracts and add fail-closed tests.
+3. Implement macOS window selection, health checks, and finalization. Keep
+   other backend refusals explicit.
+4. Wire CLI/SDK/docs and add synthetic native capture tests. These changes can
+   proceed in parallel after the shared contract is fixed.
+5. Review the integrated diff, run focused tests, and verify native isolation
+   on the exact candidate. Keep the PR draft; a later ready/merge action needs
+   the repository's canonical platform certification and review gates.
+
+## Test and acceptance plan
+
+- Invalid targets, missing video opt-in, ownership mismatch, unsupported
+  platforms, and occupied output directories cause no recorder replacement or
+  out-of-scope capture.
+- Window mode creates video/metadata only. Owner and foreign actions create no
+  turns or global cursor data, including in-flight calls across mode changes.
+- Two independent sessions prove the busy rule, daemon-wide manual stop,
+  owner-disconnect teardown, and preservation of legacy no-target behavior.
+- A synthetic moving window produces changing frames while an adjacent and
+  occluding window has a distinct test marker absent from every captured
+  frame. The input focus, window order, and real cursor remain unchanged by
+  starting/stopping capture.
+- Verify Retina dimensions, odd dimensions, movement, resize, close/minimize,
+  stale target, and backing-scale policy with explicit result classifications.
+- Decode the entire MP4 with ffmpeg, inspect representative frames, and verify
+  its dimensions, timestamps, duration, and lack of audio with ffprobe.
+- Repeated start/stop, failed starts, and disconnect leave no live capture
+  workers or growing descriptor count attributable to the recorder.
+- Shared/contract and macOS focused evidence is required for the draft's
+  implementation claim. Full affected-platform certification is required
+  before ready/merge, not replaced by a manual capture.
+
+## Unresolved questions
+
+Owner-only control, simultaneous recorders, agent-cursor compositing, dynamic
+resizing, and additional native backends remain explicitly deferred. They do
+not block evaluation of this video-only increment.
+
+## Decision record
+
+The workstream is selected for scoped RFC review and macOS-first development.
+Contract review and the maintainer decision must be recorded on #3644 before
+implementation begins. This document does not mark #3644 complete.


### PR DESCRIPTION
## Scope

Refs #3644. Implements the accepted window-video increment in `rfcs/3644-window-recording.md`; it does not close the broader recorder ownership/concurrency issue or duplicate #3632's trajectory attribution work.

The implementation and focused native macOS diagnostics pass at `98485717048e0b52ad1ea7e96cd551faf0909c3c`. This PR remains a draft for review and complete affected-platform certification. No merge or release is requested.

## Implementation

- Add `target: {kind: "window", pid, window_id}` to `start_recording`, requiring `record_video: true`, and equivalent `recording start DIR --video --pid PID --window-id WINDOW_ID` CLI flags.
- Validate before authorization and recorder mutation; attest the exact window for observation grants. Reject invalid/ambiguous targets and refuse unsupported backends without display or trajectory fallback.
- Write only `recording.mp4` and bounded `session.json` metadata in window mode. Suppress trajectory turns, global cursor logs, system cursor, separate agent overlay windows, audio, and microphone capture. The live input-safety overlay remains enabled.
- Use macOS 15+ ScreenCaptureKit's desktop-independent window filter, dual PID checks, fixed encoder geometry, callback-backed live state and finalization, and explicit termination on resize, scale change, close/minimize, or lost shareability. Track each native API's dimensions separately because WindowServer and ScreenCaptureKit can report different bounds.
- Keep singleton busy protection and existing daemon-wide manual stop. After automatic termination, `stop_recording` or owner teardown joins/releases the retained recorder. No-target legacy replacement behavior stays unchanged.
- Update skills and generated CLI/MCP references. Add a synthetic native test and fixture covering exact-window isolation, lifecycle, finalized MP4s, and repeated descriptor counts.

## Validation at the candidate SHA

Source and installed Local version: **0.24.0**. The source-built Local app passed strict certificate-backed signature verification and runtime source-SHA readback. Accessibility, Screen Recording, and native capture were verified on the explicitly authorized macOS host. The separate released 0.23.2 executable and its existing daemon were preserved.

- Native `exact_window_recording_isolation_and_lifecycle`: **passed all seven cases**: manual stop, two repeat recordings, minimize, close, resize, and owner disconnect. Each produced a finalized, fully decoded H.264 MP4 with no audio and exactly two recording artifacts.
- All seven recordings excluded the adjacent and occluding red sibling window while retaining the animated target. Every decoded frame passed the color-isolation oracle; frame counts matched `ffprobe`, timestamps increased, and full-brightness changing content spanned at least 1.5 seconds. Representative final-candidate frames were visually inspected.
- Movement preserved recording. Start and explicit stop/disconnect preserved the foreground PID, fixture window order, key window, and physical cursor. Wrong-PID and busy requests were rejected. Descriptor counts were 11 before native warm-up and 12 after each of the seven recordings, with no repeated growth.
- Native environment: macOS 26.6.1 build 25G76, backing scale 1, Rust 1.97.1, Swift 6.3.3, FFmpeg/FFprobe 8.1.2. A 321-by-241-point fixture produced 322-by-242-pixel video, rounding up to even encoder dimensions.
- Separate installed-CLI smoke: `recording start ... --video --pid ... --window-id ...` survived the start command's exit; `recording stop` finalized a 21.47-second H.264 MP4. All 72 decoded frame timestamps strictly increased. Before/after Driver snapshots matched the synthetic target, with no trajectory or cursor-log artifacts.
- `cargo test -p cua-driver-core --lib`: **617 passed**.
- `cargo test -p platform-macos window_video_tests --lib`: **7 passed**.
- `cargo test -p cua-driver --bin cua-driver cli::tests::recording_`: **7 passed**.
- Non-GUI `window_recording_macos_test` checks: **2 passed**; the native case was separately executed with explicit host opt-in, as reported above.
- Release build, signed installation through `install-local.sh --release --require-stable-signing`, Swift fixture compilation, `cargo fmt --all -- --check`, `git diff --check`, and `npx tsx scripts/docs-generators/cua-driver.ts --check`: passed.
- Independent integrated and focused native-geometry/test reviews completed; findings were corrected with regression coverage. Build output contains duplicate CoreMedia Swift-symbol dependency and existing dead-code warnings; successful exit is not a warning-free claim.

The fixture README contains reproducible setup, host opt-in and isolation requirements, and artifact expectations. These focused host diagnostics do not replace canonical desktop certification. Use the live PR checks for CI status at this SHA.

## Remaining proof and limitations

- Before a later ready/merge action, the maintainer must review the native evidence and run the canonical complete affected-platform matrix at the exact candidate SHA. This draft does not claim that certification.
- Native capture was exercised at scale 1 only. Retina, live scale changes, display reconfiguration, cross-process occlusion, session ownership races, permission revocation, and encoder failure recovery remain unverified by this focused lane. Shared tests cover scale arithmetic and scale-change policy.
- Windows, X11, and Wayland explicitly return `window_recording_unsupported`; this increment adds no native window-video implementation for them.
- Closing and minimizing can change native bounds before disappearance. The tested macOS animations reported `window_resized` as the first observed stop reason; the test separately confirmed close/minimize and successful finalization. A bounded terminal source fade is accepted only for those cases, without weakening foreign-color rejection.
- Shareable-content queries have a two-second deadline and recording callbacks have ten-second deadlines. The pinned `screencapturekit` 6.0.1 synchronous attach/start/stop/detach calls have no cancellation API and can still hang. This is not a hard end-to-end timeout guarantee.
- Browser chrome inside the selected window is included. Cursor compositing, tab-only capture, dynamic resizing, and independent concurrent recorders are out of scope.
