### PR TITLE
fix(cua-driver): bind semantic snapshots to one document

### DIFF
--- a/docs/content/docs/reference/cua-driver/browser-semantic-snapshots.mdx
+++ b/docs/content/docs/reference/cua-driver/browser-semantic-snapshots.mdx
@@ -134,10 +134,18 @@ They do not expose CDP target IDs, backend node IDs, object IDs, or selectors.
 
 - A newer snapshot of the tab invalidates older refs and continuations.
 - Navigation invalidates every snapshot of the tab.
+- Collection and an optional tab screenshot are accepted only when the main
+  frame and every included child frame keep the same document identity across
+  the collection checks. A navigation or identity that becomes unprovable
+  between those checks returns a refusal without publishing refs or image
+  content. These checks detect document replacement; they do not freeze
+  same-document DOM, layout, and pixels at one instant.
 - Browser reconnect or process replacement invalidates the target generation.
 - Ending the driver session removes the complete capability namespace.
 - Continuations are single-use and resolve only in their owning session,
   target, tab, snapshot, and generation.
+- A requested screenshot failure, or cancellation before the operation
+  completes, does not consume its continuation.
 
 Every mutation re-proves the native binding, endpoint ownership, tab target,
 frame loader identity, and backend-node liveness.
@@ -149,6 +157,14 @@ layout snapshot, viewport metrics, and frame tree. They include the main frame,
 author shadow roots, proven same-process frames, and capability-tested
 out-of-process frames. User-agent shadow roots and unprovable frame content are
 omitted.
+
+Cross-process child-frame collection has a bounded frame count and aggregate
+deadline. Content beyond either bound is omitted, reported through
+`omitted.unprovable_frame`, and makes `snapshot.complete` false.
+
+`semantic_v2` refuses when the endpoint cannot report a main-frame document
+identity. The unproven main-frame compatibility path remains limited to
+`dom_refs_v1`.
 
 CSS-hidden retained state is removed before ranking. Active dialogs and focused
 context rank first, followed by visible actions, visible content,

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/cdp_ws.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/cdp_ws.rs
@@ -126,6 +126,17 @@ enum CallOutcome {
     Error { code: Option<i64>, message: String },
 }
 
+struct PendingCallGuard {
+    demux: Arc<Demux>,
+    id: u64,
+}
+
+impl Drop for PendingCallGuard {
+    fn drop(&mut self) {
+        self.demux.pending.lock().unwrap().remove(&self.id);
+    }
+}
+
 /// State shared between the caller side and the reader task.
 struct Demux {
     pending: StdMutex<HashMap<u64, oneshot::Sender<CallOutcome>>>,
@@ -306,7 +317,9 @@ impl CdpConnection {
     /// deterministically (the Target.setAutoAttach pattern).
     pub fn subscribe(&self) -> mpsc::UnboundedReceiver<CdpEvent> {
         let (tx, rx) = mpsc::unbounded_channel();
-        self.demux.subscribers.lock().unwrap().push(tx);
+        let mut subscribers = self.demux.subscribers.lock().unwrap();
+        subscribers.retain(|sender| !sender.is_closed());
+        subscribers.push(tx);
         rx
     }
 
@@ -368,6 +381,12 @@ impl CdpConnection {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = oneshot::channel();
         self.demux.pending.lock().unwrap().insert(id, tx);
+        // A caller may cancel this future before the command-level timeout.
+        // Keep the pending map bounded in that path too.
+        let _pending_call = PendingCallGuard {
+            demux: self.demux.clone(),
+            id,
+        };
         // Close can race the initial check. If the reader cleared the
         // pending map just before this insertion, remove the orphaned
         // sender now instead of waiting for the call timeout.
@@ -687,6 +706,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelling_a_call_removes_its_pending_response_slot() {
+        let server = MockCdpServer::start(StdArc::new(|_| {
+            MockReply::ok(json!({})).with_delay(Duration::from_secs(1))
+        }))
+        .await;
+        let conn = CdpConnection::connect(&server.ws_url()).await.unwrap();
+
+        let cancelled = tokio::time::timeout(
+            Duration::from_millis(20),
+            conn.call(None, "Slow.command", json!({})),
+        )
+        .await;
+        assert!(cancelled.is_err(), "fixture must cancel the CDP call");
+        assert!(
+            conn.demux.pending.lock().unwrap().is_empty(),
+            "cancelled calls must not retain a pending response sender"
+        );
+    }
+
+    #[tokio::test]
     async fn claimed_existing_profile_socket_is_generation_owned() {
         let server = MockCdpServer::start(StdArc::new(|_| MockReply::ok(json!({})))).await;
         let url = server.ws_url();
@@ -856,6 +895,19 @@ mod tests {
         assert_eq!(second.session_id.as_deref(), Some("child-sess"));
         assert_eq!(second.params["n"], 2);
         assert!(events.try_recv().is_err(), "no phantom events");
+    }
+
+    #[tokio::test]
+    async fn subscribing_prunes_closed_receivers_without_waiting_for_an_event() {
+        let server = MockCdpServer::start(StdArc::new(|_| MockReply::ok(json!({})))).await;
+        let conn = CdpConnection::connect(&server.ws_url()).await.unwrap();
+
+        for _ in 0..100 {
+            drop(conn.subscribe());
+        }
+        let _live = conn.subscribe();
+
+        assert_eq!(conn.demux.subscribers.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/download.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/download.rs
@@ -380,7 +380,7 @@ impl Tool for BrowserDownloadTool {
         let resolved = match validated
             .conn
             .call(
-                Some(&ref_session),
+                Some(ref_session.as_str()),
                 "DOM.resolveNode",
                 json!({ "backendNodeId": entry.backend_node_id }),
             )
@@ -436,7 +436,7 @@ impl Tool for BrowserDownloadTool {
         let trigger = validated
             .conn
             .call(
-                Some(&ref_session),
+                Some(ref_session.as_str()),
                 "Runtime.callFunctionOn",
                 json!({
                     "objectId": object_id,

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
@@ -25,6 +25,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, Weak};
+use std::time::Duration;
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use serde_json::{json, Value};
@@ -37,7 +38,7 @@ use super::binding::{
     cardinality_exact_candidate, correlate, selected_tab_target_id, BindingOutcome,
     CdpWindowCandidate,
 };
-use super::cdp_ws::{CdpConnection, CdpPool};
+use super::cdp_ws::{CdpConnection, CdpEvent, CdpPool};
 use super::grant::{ExistingProfileGrant, ExistingProfileGrants, GrantLookup};
 use super::mutation::{MutationGates, MutationKey};
 use super::platform::{
@@ -54,7 +55,7 @@ use super::semantic::{
 };
 use super::store::{
     format_ref, BrowserStore, FrameIdentity, FrameKind, FrameRef, RefEntry, SemanticContinuation,
-    SnapshotRecord, TabRecord, TargetRecord,
+    SemanticScope, SnapshotRecord, TabRecord, TargetRecord,
 };
 use super::types::{
     BindingQuality, BrowserClassification, BrowserEngineFamily, BrowserProcessRole,
@@ -71,6 +72,19 @@ pub const MAX_REFS_PER_SNAPSHOT: usize = 300;
 /// Hard cap for decoded tab screenshots returned through MCP. This bounds a
 /// compromised or malformed endpoint before its response reaches consumers.
 const MAX_BROWSER_SCREENSHOT_BYTES: usize = 16 * 1024 * 1024;
+/// Semantic reads inspect only a bounded number of cross-process child frames;
+/// every attached session is still owned and cleaned up even when its content
+/// is omitted from the result.
+pub(crate) const MAX_SEMANTIC_OOPIF_FRAMES: usize = 16;
+/// Aggregate wall-clock budget for semantic work across the bounded child set.
+const SEMANTIC_OOPIF_COLLECTION_TIMEOUT: Duration = Duration::from_secs(8);
+/// A dropped semantic read gets one short, best-effort opportunity to undo
+/// the child-target attachment state it owned before releasing the socket.
+const OOPIF_DROP_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+/// A failed auto-attach shutdown falls back to per-session detach, but a bad
+/// endpoint must not multiply the command timeout by the number of children.
+const OOPIF_FALLBACK_DETACH_TIMEOUT: Duration = Duration::from_secs(5);
+const OOPIF_FALLBACK_DETACH_CONCURRENCY: usize = 8;
 
 pub struct BrowserEngine {
     pub(crate) platform: Arc<dyn BrowserPlatform>,
@@ -398,6 +412,7 @@ pub(crate) struct SemanticSnapshotOutcome {
     pub omissions: OmissionCounts,
     pub continuation: Option<String>,
     pub oopif: OopifStatus,
+    pub screenshot: Option<BrowserTabScreenshot>,
 }
 
 pub(crate) struct BrowserTabScreenshot {
@@ -569,11 +584,307 @@ pub(crate) enum FrameTreeError {
 }
 
 /// One OOPIF child target attached (flattened) beneath a tab session.
+#[derive(Debug, Clone)]
 pub(crate) struct AttachedChildFrame {
     pub session_id: String,
     pub target_id: String,
     #[allow(dead_code)]
     pub url: String,
+}
+
+struct OopifAttachmentCleanup {
+    conn: Arc<CdpConnection>,
+    tab_session: String,
+    events: Option<tokio::sync::mpsc::UnboundedReceiver<CdpEvent>>,
+    children: Vec<AttachedChildFrame>,
+    auto_attach_maybe_enabled: bool,
+}
+
+impl OopifAttachmentCleanup {
+    fn drain_children(&mut self) {
+        let Some(events) = self.events.as_mut() else {
+            return;
+        };
+        while let Ok(event) = events.try_recv() {
+            if event.method != "Target.attachedToTarget"
+                || event.session_id.as_deref() != Some(self.tab_session.as_str())
+            {
+                continue;
+            }
+            let info = &event.params["targetInfo"];
+            if info["type"].as_str() != Some("iframe") {
+                continue;
+            }
+            let (Some(session_id), Some(target_id)) = (
+                event.params["sessionId"].as_str(),
+                info["targetId"].as_str(),
+            ) else {
+                continue;
+            };
+            if self
+                .children
+                .iter()
+                .any(|child| child.session_id == session_id)
+            {
+                continue;
+            }
+            self.children.push(AttachedChildFrame {
+                session_id: session_id.to_owned(),
+                target_id: target_id.to_owned(),
+                url: info["url"].as_str().unwrap_or("").to_owned(),
+            });
+        }
+    }
+
+    async fn stop_discovery(&mut self) -> anyhow::Result<()> {
+        if !self.auto_attach_maybe_enabled {
+            self.events = None;
+            return Ok(());
+        }
+        let result = self
+            .conn
+            .call(
+                Some(&self.tab_session),
+                "Target.setAutoAttach",
+                json!({
+                    "autoAttach": false,
+                    "waitForDebuggerOnStart": false,
+                    "flatten": true
+                }),
+            )
+            .await;
+        // A reply, including an error reply, orders after earlier event frames
+        // on this socket. Retain every announced child even when shutdown
+        // failed so detach is still attempted below and on the Drop retry.
+        self.drain_children();
+        if result.is_ok() {
+            self.auto_attach_maybe_enabled = false;
+            self.events = None;
+            // CDP defines disabling auto-attach to detach every target that
+            // setting attached. Do not issue redundant per-session detaches
+            // after the successful acknowledgement.
+            self.children.clear();
+        }
+        result.map(|_| ())
+    }
+
+    async fn detach_children(&mut self) -> anyhow::Result<()> {
+        let conn = self.conn.clone();
+        let tab_session = self.tab_session.clone();
+        let mut attempts = tokio::task::JoinSet::new();
+        let spawn = |attempts: &mut tokio::task::JoinSet<_>, session_id: String| {
+            let conn = conn.clone();
+            let tab_session = tab_session.clone();
+            attempts.spawn(async move {
+                let result = conn
+                    .call(
+                        Some(&tab_session),
+                        "Target.detachFromTarget",
+                        json!({ "sessionId": session_id }),
+                    )
+                    .await;
+                (session_id, result)
+            });
+        };
+        let mut next_index = 0;
+        while next_index < self.children.len() && attempts.len() < OOPIF_FALLBACK_DETACH_CONCURRENCY
+        {
+            spawn(&mut attempts, self.children[next_index].session_id.clone());
+            next_index += 1;
+        }
+
+        // Keep both work and time bounded. Normally every observed child gets
+        // an individual attempt; if the endpoint stalls or the list is too
+        // large for this deadline, cleanup tears down the owned parent session
+        // below rather than allocating one task per child.
+        let mut detached = HashSet::new();
+        let mut first_error = None;
+        let deadline = tokio::time::Instant::now() + OOPIF_FALLBACK_DETACH_TIMEOUT;
+        let completed = tokio::time::timeout_at(deadline, async {
+            while let Some(attempt) = attempts.join_next().await {
+                match attempt {
+                    Ok((session_id, Ok(_))) => {
+                        detached.insert(session_id);
+                    }
+                    Ok((_, Err(error))) => {
+                        if first_error.is_none() {
+                            first_error = Some(error);
+                        }
+                    }
+                    Err(error) => {
+                        if first_error.is_none() {
+                            first_error = Some(anyhow::Error::from(error));
+                        }
+                    }
+                }
+                if next_index < self.children.len() {
+                    spawn(&mut attempts, self.children[next_index].session_id.clone());
+                    next_index += 1;
+                }
+            }
+        })
+        .await;
+        if completed.is_err() {
+            attempts.abort_all();
+            first_error = Some(anyhow::anyhow!(
+                "child detach cleanup timed out after {OOPIF_FALLBACK_DETACH_TIMEOUT:?}"
+            ));
+        }
+        self.children
+            .retain(|child| !detached.contains(&child.session_id));
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    /// The tab session is minted for this operation. Tearing it down is the
+    /// bounded backstop when child-by-child cleanup cannot be completed; its
+    /// nested auto-attached sessions cannot outlive it.
+    async fn detach_parent_session(&mut self) -> anyhow::Result<()> {
+        tokio::time::timeout(
+            OOPIF_DROP_CLEANUP_TIMEOUT,
+            self.conn.call(
+                None,
+                "Target.detachFromTarget",
+                json!({ "sessionId": self.tab_session }),
+            ),
+        )
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!("parent-session detach timed out after {OOPIF_DROP_CLEANUP_TIMEOUT:?}")
+        })??;
+        self.auto_attach_maybe_enabled = false;
+        self.events = None;
+        self.children.clear();
+        Ok(())
+    }
+
+    async fn cleanup(&mut self) -> anyhow::Result<()> {
+        let stop_error = self.stop_discovery().await.err();
+        // A successful shutdown already detached every auto-attached target.
+        // When shutdown fails, still try to detach every session we observed.
+        let detach_error = self.detach_children().await.err();
+        let parent_error = if stop_error.is_some() {
+            self.detach_parent_session().await.err()
+        } else {
+            None
+        };
+        let errors = [stop_error, detach_error, parent_error]
+            .into_iter()
+            .flatten()
+            .map(|error| error.to_string())
+            .collect::<Vec<_>>();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(errors.join("; ")))
+        }
+    }
+}
+
+/// Owns the temporary auto-attach setting and every child session announced
+/// under it. Explicit cleanup is the normal path; Drop covers cancellation and
+/// does not forget a child unless its detach call succeeds.
+struct OopifAttachmentGuard {
+    cleanup: Option<OopifAttachmentCleanup>,
+}
+
+impl OopifAttachmentGuard {
+    fn new(conn: Arc<CdpConnection>, tab_session: &str) -> Self {
+        let events = conn.subscribe();
+        Self {
+            cleanup: Some(OopifAttachmentCleanup {
+                conn,
+                tab_session: tab_session.to_owned(),
+                events: Some(events),
+                children: Vec::new(),
+                // Arm before the enabling await. If that future is cancelled
+                // after its command is sent, Drop must still send the ordered
+                // disabling command.
+                auto_attach_maybe_enabled: true,
+            }),
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.cleanup = None;
+    }
+
+    fn drain_children(&mut self) {
+        if let Some(cleanup) = self.cleanup.as_mut() {
+            cleanup.drain_children();
+        }
+    }
+
+    fn children(&self) -> &[AttachedChildFrame] {
+        &self
+            .cleanup
+            .as_ref()
+            .expect("live OOPIF attachment guard")
+            .children
+    }
+
+    fn child_for_target(&self, target_id: &str) -> Option<&AttachedChildFrame> {
+        self.children()
+            .iter()
+            .find(|child| child.target_id == target_id)
+    }
+
+    async fn cleanup(&mut self) -> anyhow::Result<()> {
+        let cleanup = self.cleanup.as_mut().expect("live OOPIF attachment guard");
+        cleanup.cleanup().await?;
+        self.cleanup = None;
+        Ok(())
+    }
+}
+
+impl Drop for OopifAttachmentGuard {
+    fn drop(&mut self) {
+        let Some(mut cleanup) = self.cleanup.take() else {
+            return;
+        };
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            tracing::warn!("unable to schedule dropped OOPIF attachment cleanup");
+            return;
+        };
+        runtime.spawn(async move {
+            match tokio::time::timeout(OOPIF_DROP_CLEANUP_TIMEOUT, cleanup.cleanup()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) => tracing::warn!("dropped OOPIF attachment cleanup failed"),
+                Err(_) => tracing::warn!("dropped OOPIF attachment cleanup timed out"),
+            }
+        });
+    }
+}
+
+/// A CDP frame session together with any temporary child attachment that
+/// keeps it usable. The lease must stay live until the caller's operation has
+/// finished; dropping it schedules bounded cleanup for attached child frames.
+#[derive(Clone)]
+pub(crate) struct FrameSessionLease {
+    session_id: String,
+    _attachment: Option<Arc<OopifAttachmentGuard>>,
+}
+
+impl FrameSessionLease {
+    pub(crate) fn tab(session_id: String) -> Self {
+        Self {
+            session_id,
+            _attachment: None,
+        }
+    }
+
+    fn child(session_id: String, attachment: OopifAttachmentGuard) -> Self {
+        Self {
+            session_id,
+            _attachment: Some(Arc::new(attachment)),
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.session_id
+    }
 }
 
 pub(crate) enum AttachError {
@@ -1762,6 +2073,122 @@ impl BrowserEngine {
         }
     }
 
+    /// Semantic output is useful for later mutation, so it must be tied to
+    /// one main-frame document rather than the unproven compatibility path
+    /// retained by `dom_refs_v1`.
+    async fn semantic_frame_tree(
+        &self,
+        conn: &CdpConnection,
+        cdp_session: &str,
+        failure_context: &'static str,
+    ) -> Result<LocalFrameTree, BrowserRefusal> {
+        self.local_frame_tree(conn, cdp_session)
+            .await
+            .map_err(|error| match error {
+                FrameTreeError::Unsupported => refuse(
+                    BrowserRefusalCode::BrowserRouteUnavailable,
+                    "the browser does not report main-frame document identity, so the semantic snapshot cannot be proven",
+                ),
+                FrameTreeError::Failed(error) => route_err(failure_context, error),
+            })
+    }
+
+    fn semantic_frames(document: &SemanticDocument) -> Vec<FrameRef> {
+        let mut frames = Vec::new();
+        for node in &document.nodes {
+            if !frames.contains(&node.frame) {
+                frames.push(node.frame.clone());
+            }
+        }
+        frames
+    }
+
+    async fn reprove_semantic_frames(
+        &self,
+        conn: &Arc<CdpConnection>,
+        local_tree: &LocalFrameTree,
+        attachment: Option<&OopifAttachmentGuard>,
+        frames: &[FrameRef],
+        failure_context: &'static str,
+    ) -> Result<(), BrowserRefusal> {
+        for frame in frames
+            .iter()
+            .filter(|frame| frame.oopif_target_id.is_none())
+        {
+            let identity = frame.identity.as_ref().ok_or_else(|| {
+                refuse(
+                    BrowserRefusalCode::BrowserRefStale,
+                    "semantic frame data has no proven document identity; re-run get_browser_state",
+                )
+            })?;
+            if !local_tree.proves(identity) {
+                return Err(refuse(
+                    BrowserRefusalCode::BrowserRefStale,
+                    "an included same-process frame navigated while semantic state was being collected; re-run get_browser_state",
+                ));
+            }
+        }
+
+        let mut checked_targets = HashSet::new();
+        let deadline = tokio::time::Instant::now() + SEMANTIC_OOPIF_COLLECTION_TIMEOUT;
+        for target_id in frames
+            .iter()
+            .filter_map(|frame| frame.oopif_target_id.as_deref())
+        {
+            if !checked_targets.insert(target_id) {
+                continue;
+            }
+            if checked_targets.len() > MAX_SEMANTIC_OOPIF_FRAMES {
+                return Err(refuse(
+                    BrowserRefusalCode::BrowserRouteUnavailable,
+                    "the semantic snapshot contains more child frames than can be revalidated safely",
+                ));
+            }
+            let child = attachment
+                .and_then(|attachment| attachment.child_for_target(target_id))
+                .ok_or_else(|| {
+                    refuse(
+                        BrowserRefusalCode::BrowserRefStale,
+                        "an included out-of-process frame is no longer attached beneath this tab; re-run get_browser_state",
+                    )
+                })?;
+            let tree =
+                tokio::time::timeout_at(deadline, self.local_frame_tree(conn, &child.session_id))
+                    .await
+                    .map_err(|_| {
+                        route_err(
+                            failure_context,
+                            "the child-frame identity revalidation deadline elapsed",
+                        )
+                    })?;
+            let tree = tree.map_err(|error| match error {
+                FrameTreeError::Unsupported => refuse(
+                    BrowserRefusalCode::BrowserRouteUnavailable,
+                    "the browser no longer reports an included child frame's document identity",
+                ),
+                FrameTreeError::Failed(error) => route_err(failure_context, error),
+            })?;
+            for frame in frames
+                .iter()
+                .filter(|frame| frame.oopif_target_id.as_deref() == Some(target_id))
+            {
+                let identity = frame.identity.as_ref().ok_or_else(|| {
+                    refuse(
+                        BrowserRefusalCode::BrowserRefStale,
+                        "semantic child-frame data has no proven document identity; re-run get_browser_state",
+                    )
+                })?;
+                if !tree.proves(identity) {
+                    return Err(refuse(
+                        BrowserRefusalCode::BrowserRefStale,
+                        "an included out-of-process frame navigated while semantic state was being collected; re-run get_browser_state",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Capability-tested OOPIF discovery: enable flattened auto-attach
     /// on `tab_session` and collect the iframe children Chromium
     /// announces for existing targets *before* the setAutoAttach ack.
@@ -1772,14 +2199,19 @@ impl BrowserEngine {
     /// page target) is ignored. Each operation attaches its own fresh
     /// tab session, so the parent-session filter is per-operation
     /// unique even on the shared pooled connection.
+    ///
+    /// The returned guard keeps auto-attach enabled while the caller uses the
+    /// child sessions. CDP detaches those sessions when auto-attach is disabled,
+    /// so shutdown belongs at the end of the guarded operation, not here.
     async fn attached_iframe_children(
         &self,
-        conn: &CdpConnection,
+        conn: &Arc<CdpConnection>,
         tab_session: &str,
-    ) -> Result<Vec<AttachedChildFrame>, AttachError> {
-        // Subscribe BEFORE issuing the command so pre-ack events are
-        // guaranteed to be queued when the call returns.
-        let mut events = conn.subscribe();
+    ) -> Result<OopifAttachmentGuard, AttachError> {
+        // Arm cleanup and subscribe BEFORE issuing the command. This owns both
+        // pre-ack child events and the uncertain command state if the caller is
+        // cancelled while awaiting the acknowledgement.
+        let mut attachment = OopifAttachmentGuard::new(conn.clone(), tab_session);
         match conn
             .call(
                 Some(tab_session),
@@ -1789,34 +2221,14 @@ impl BrowserEngine {
             .await
         {
             Ok(_) => {}
-            Err(e) if is_method_unsupported(&e) => return Err(AttachError::Unsupported),
+            Err(e) if is_method_unsupported(&e) => {
+                attachment.disarm();
+                return Err(AttachError::Unsupported);
+            }
             Err(e) => return Err(AttachError::Failed(e)),
         }
-        let mut out = Vec::new();
-        while let Ok(event) = events.try_recv() {
-            if event.method != "Target.attachedToTarget" {
-                continue;
-            }
-            if event.session_id.as_deref() != Some(tab_session) {
-                continue; // not contained beneath the proven tab session
-            }
-            let info = &event.params["targetInfo"];
-            if info["type"].as_str() != Some("iframe") {
-                continue; // OOPIF slice covers iframes only, never popups/workers
-            }
-            let (Some(session_id), Some(target_id)) = (
-                event.params["sessionId"].as_str(),
-                info["targetId"].as_str(),
-            ) else {
-                continue;
-            };
-            out.push(AttachedChildFrame {
-                session_id: session_id.to_owned(),
-                target_id: target_id.to_owned(),
-                url: info["url"].as_str().unwrap_or("").to_owned(),
-            });
-        }
-        Ok(out)
+        attachment.drain_children();
+        Ok(attachment)
     }
 
     /// Re-prove a ref's frame/document identity and return the CDP
@@ -1831,7 +2243,7 @@ impl BrowserEngine {
         tab_id: &str,
         validated: &ValidatedTab,
         frame: &FrameRef,
-    ) -> Result<String, BrowserRefusal> {
+    ) -> Result<FrameSessionLease, BrowserRefusal> {
         let conn = &validated.conn;
         let stale = |message: &str| {
             self.store
@@ -1855,14 +2267,14 @@ impl BrowserEngine {
                 // carry no identity to re-check; node liveness (box
                 // model / focus failures map to stale) is the backstop.
                 let Some(identity) = &frame.identity else {
-                    return Ok(validated.cdp_session.clone());
+                    return Ok(FrameSessionLease::tab(validated.cdp_session.clone()));
                 };
                 let tree = self
                     .local_frame_tree(conn, &validated.cdp_session)
                     .await
                     .map_err(tree_err)?;
                 if tree.proves(identity) {
-                    Ok(validated.cdp_session.clone())
+                    Ok(FrameSessionLease::tab(validated.cdp_session.clone()))
                 } else {
                     Err(stale(
                         "the ref's frame navigated or was removed since the snapshot — \
@@ -1879,7 +2291,7 @@ impl BrowserEngine {
                         "the OOPIF ref carries no provable frame identity",
                     ));
                 };
-                let children = self
+                let attachment = self
                     .attached_iframe_children(conn, &validated.cdp_session)
                     .await
                     .map_err(|e| match e {
@@ -1892,8 +2304,7 @@ impl BrowserEngine {
                             route_err("Target.setAutoAttach failed during frame revalidation", err)
                         }
                     })?;
-                let Some(child) = children.into_iter().find(|c| c.target_id == *oopif_target)
-                else {
+                let Some(child) = attachment.child_for_target(oopif_target).cloned() else {
                     return Err(stale(
                         "the ref's cross-process frame is no longer attached beneath the \
                          bound tab — re-run get_browser_state to re-snapshot",
@@ -1904,7 +2315,7 @@ impl BrowserEngine {
                     .await
                     .map_err(tree_err)?;
                 if tree.proves(identity) {
-                    Ok(child.session_id)
+                    Ok(FrameSessionLease::child(child.session_id, attachment))
                 } else {
                     Err(stale(
                         "the ref's cross-process frame navigated since the snapshot — \
@@ -1936,14 +2347,23 @@ impl BrowserEngine {
         })?;
         let conn = self.connection_for_record(session, &record).await?;
         let cdp_session = self.attach(&conn, &tab.cdp_target_id).await?;
+        self.capture_tab_screenshot_on_session(&conn, &cdp_session)
+            .await
+    }
+
+    async fn capture_tab_screenshot_on_session(
+        &self,
+        conn: &CdpConnection,
+        cdp_session: &str,
+    ) -> Result<BrowserTabScreenshot, BrowserRefusal> {
         let metrics = conn
-            .call(Some(&cdp_session), "Page.getLayoutMetrics", json!({}))
+            .call(Some(cdp_session), "Page.getLayoutMetrics", json!({}))
             .await
             .map_err(|error| route_err("Page.getLayoutMetrics failed", error))?;
         let viewport = browser_screenshot_viewport(&metrics)?;
         let response = conn
             .call(
-                Some(&cdp_session),
+                Some(cdp_session),
                 "Page.captureScreenshot",
                 json!({
                     "format": "png",
@@ -2106,9 +2526,9 @@ impl BrowserEngine {
         // session. Anything unprovable is omitted, never guessed.
         let oopif = if local_tree.is_some() {
             match self.attached_iframe_children(&conn, &cdp_session).await {
-                Ok(children) => {
+                Ok(mut attachment) => {
                     let mut attached = 0usize;
-                    for child in &children {
+                    for child in attachment.children() {
                         let Ok(child_tree) = self.local_frame_tree(&conn, &child.session_id).await
                         else {
                             continue; // identity unprovable → omit this frame
@@ -2160,28 +2580,10 @@ impl BrowserEngine {
                         }
                         attached += 1;
                     }
-                    // Contain the child sessions this read minted:
-                    // stop auto-attaching (best effort).
-                    let _ = conn
-                        .call(
-                            Some(&cdp_session),
-                            "Target.setAutoAttach",
-                            json!({
-                                "autoAttach": false,
-                                "waitForDebuggerOnStart": false,
-                                "flatten": true
-                            }),
-                        )
-                        .await;
-                    for child in &children {
-                        let _ = conn
-                            .call(
-                                Some(&cdp_session),
-                                "Target.detachFromTarget",
-                                json!({ "sessionId": child.session_id }),
-                            )
-                            .await;
-                    }
+                    attachment
+                        .cleanup()
+                        .await
+                        .map_err(|error| route_err("Target child-session cleanup failed", error))?;
                     OopifStatus::Attached(attached)
                 }
                 Err(AttachError::Unsupported) => OopifStatus::Unsupported,
@@ -2476,6 +2878,7 @@ impl BrowserEngine {
                 omissions: page.omissions,
                 continuation: page.next_offset.map(|_| format!("bc-{}", Uuid::new_v4())),
                 oopif,
+                screenshot: None,
             },
             stored_refs,
         )
@@ -2489,15 +2892,21 @@ impl BrowserEngine {
         scope_ref: Option<&str>,
         query: Option<&str>,
         continuation: Option<&str>,
+        include_screenshot: bool,
     ) -> Result<SemanticSnapshotOutcome, BrowserRefusal> {
+        if continuation.is_some() && (scope_ref.is_some() || query.is_some()) {
+            return Err(refuse(
+                BrowserRefusalCode::BrowserRefStale,
+                "continuation cannot be combined with a new scope_ref or query",
+            ));
+        }
+        // Semantic collection, optional pixels, and publication share the
+        // existing real-tab gate. Besides excluding mutations, this makes a
+        // continuation a single atomic operation even when separate public
+        // capabilities address the same CDP target.
+        let _tab_guard = self.lock_mutation(session, target_id, tab_id).await?;
         if let Some(token) = continuation {
-            if scope_ref.is_some() || query.is_some() {
-                return Err(refuse(
-                    BrowserRefusalCode::BrowserRefStale,
-                    "continuation cannot be combined with a new scope_ref or query",
-                ));
-            }
-            let (snapshot, continuation) = self
+            let (snapshot, continuation_state) = self
                 .store
                 .resolve_semantic_continuation(session, target_id, tab_id, token)?;
             let record = self.store.get_target(session, target_id)?;
@@ -2507,29 +2916,27 @@ impl BrowserEngine {
                     format!("tab {tab_id} is not known for target {target_id}"),
                 )
             })?;
-            if let Some(identity) = &snapshot.semantic_root_identity {
-                let conn = self.connection_for_record(session, &record).await?;
-                let cdp_session = self.attach(&conn, &tab.cdp_target_id).await?;
-                let tree = self.local_frame_tree(&conn, &cdp_session).await.map_err(|error| {
-                    match error {
-                        FrameTreeError::Unsupported => refuse(
-                            BrowserRefusalCode::BrowserRouteUnavailable,
-                            "the browser no longer reports its frame tree, so the semantic \n+                             continuation's document identity cannot be re-proven",
-                        ),
-                        FrameTreeError::Failed(error) => route_err(
-                            "Page.getFrameTree failed during semantic continuation revalidation",
-                            error,
-                        ),
-                    }
-                })?;
-                if !tree.proves(identity) {
-                    self.store
-                        .invalidate_tab_snapshots(session, target_id, tab_id);
-                    return Err(refuse(
-                        BrowserRefusalCode::BrowserRefStale,
-                        "the page navigated since this semantic continuation was minted; \n+                         re-run get_browser_state to start a fresh snapshot",
-                    ));
-                }
+            let conn = self.connection_for_record(session, &record).await?;
+            let cdp_session = self.attach(&conn, &tab.cdp_target_id).await?;
+            let initial_tree = self
+                .semantic_frame_tree(
+                    &conn,
+                    &cdp_session,
+                    "Page.getFrameTree failed before semantic continuation collection",
+                )
+                .await?;
+            let initial_identity = initial_tree.main_identity();
+            let snapshot_identity = snapshot.semantic_root_identity.as_ref().ok_or_else(|| {
+                refuse(
+                    BrowserRefusalCode::BrowserRefStale,
+                    "the continuation has no proven main-frame document identity; re-run get_browser_state to start a fresh snapshot",
+                )
+            })?;
+            if &initial_identity != snapshot_identity {
+                return Err(refuse(
+                    BrowserRefusalCode::BrowserRefStale,
+                    "the page navigated since this semantic continuation was minted; re-run get_browser_state to start a fresh snapshot",
+                ));
             }
             let document = snapshot.semantic.clone().ok_or_else(|| {
                 refuse(
@@ -2537,11 +2944,42 @@ impl BrowserEngine {
                     "the continuation no longer has semantic snapshot state",
                 )
             })?;
+            let semantic_frames = Self::semantic_frames(&document);
+            let mut attachment = if semantic_frames
+                .iter()
+                .any(|frame| frame.oopif_target_id.is_some())
+            {
+                match self.attached_iframe_children(&conn, &cdp_session).await {
+                    Ok(attachment) => Some(attachment),
+                    Err(AttachError::Unsupported) => {
+                        return Err(refuse(
+                            BrowserRefusalCode::BrowserRouteUnavailable,
+                            "the browser cannot re-prove the continuation's child-frame document identities",
+                        ));
+                    }
+                    Err(AttachError::Failed(error)) => {
+                        return Err(route_err(
+                            "Target.setAutoAttach failed during semantic continuation revalidation",
+                            error,
+                        ));
+                    }
+                }
+            } else {
+                None
+            };
+            self.reprove_semantic_frames(
+                &conn,
+                &initial_tree,
+                attachment.as_ref(),
+                &semantic_frames,
+                "Page.getFrameTree failed while revalidating semantic continuation child frames",
+            )
+            .await?;
             let page = document.page(
-                continuation.offset,
+                continuation_state.offset,
                 DEFAULT_SEMANTIC_NODE_BUDGET,
-                continuation.query.as_deref(),
-                continuation.scope_backend_node_id,
+                continuation_state.query.as_deref(),
+                continuation_state.scope.as_ref(),
             );
             let start_index = snapshot
                 .refs
@@ -2549,13 +2987,13 @@ impl BrowserEngine {
                 .max()
                 .copied()
                 .map_or(0, |value| value.saturating_add(1));
-            let oopif = if continuation.oopif_supported {
-                OopifStatus::Attached(continuation.oopif_frames)
+            let oopif = if continuation_state.oopif_supported {
+                OopifStatus::Attached(continuation_state.oopif_frames)
             } else {
                 OopifStatus::Unsupported
             };
             let next_offset = page.next_offset;
-            let (outcome, new_refs) = self.semantic_outcome(
+            let (mut outcome, new_refs) = self.semantic_outcome(
                 snapshot.id,
                 snapshot.url.clone(),
                 tab.title,
@@ -2565,40 +3003,74 @@ impl BrowserEngine {
                 oopif,
                 start_index,
             );
-            let next_token = outcome.continuation.clone();
-            self.store.update_target(session, target_id, |record| {
-                if let Some(stored) = record
-                    .tabs
-                    .get_mut(tab_id)
-                    .and_then(|tab| tab.snapshots.get_mut(&snapshot.id))
-                {
-                    stored.continuations.remove(token);
-                    stored.refs.extend(new_refs);
-                    if let (Some(token), Some(offset)) = (next_token, next_offset) {
-                        stored.continuations.insert(
-                            token,
-                            SemanticContinuation {
-                                offset,
-                                query: continuation.query.clone(),
-                                scope_backend_node_id: continuation.scope_backend_node_id,
-                                oopif_supported: continuation.oopif_supported,
-                                oopif_frames: continuation.oopif_frames,
-                            },
-                        );
-                    }
-                }
-            });
+            let screenshot = if include_screenshot {
+                Some(
+                    self.capture_tab_screenshot_on_session(&conn, &cdp_session)
+                        .await?,
+                )
+            } else {
+                None
+            };
+            let final_tree = self
+                .semantic_frame_tree(
+                    &conn,
+                    &cdp_session,
+                    "Page.getFrameTree failed after semantic continuation collection",
+                )
+                .await?;
+            let final_identity = final_tree.main_identity();
+            if final_identity != initial_identity {
+                return Err(refuse(
+                    BrowserRefusalCode::BrowserRefStale,
+                    "the page navigated while the semantic continuation was being collected; re-run get_browser_state to start a fresh snapshot",
+                ));
+            }
+            self.reprove_semantic_frames(
+                &conn,
+                &final_tree,
+                attachment.as_ref(),
+                &semantic_frames,
+                "Page.getFrameTree failed after semantic continuation child-frame collection",
+            )
+            .await?;
+            if let Some(attachment) = attachment.as_mut() {
+                attachment
+                    .cleanup()
+                    .await
+                    .map_err(|error| route_err("Target child-session cleanup failed", error))?;
+            }
+            let next = match (outcome.continuation.clone(), next_offset) {
+                (Some(token), Some(offset)) => Some((
+                    token,
+                    SemanticContinuation {
+                        offset,
+                        query: continuation_state.query.clone(),
+                        scope: continuation_state.scope.clone(),
+                        oopif_supported: continuation_state.oopif_supported,
+                        oopif_frames: continuation_state.oopif_frames,
+                    },
+                )),
+                _ => None,
+            };
+            self.store.commit_semantic_continuation(
+                session,
+                target_id,
+                tab_id,
+                snapshot.id,
+                token,
+                new_refs,
+                next,
+            )?;
+            outcome.screenshot = screenshot;
             return Ok(outcome);
         }
 
-        let scope_backend_node_id = match scope_ref {
-            Some(external) => Some(
-                self.store
-                    .resolve_ref(session, target_id, tab_id, external)?
-                    .backend_node_id,
-            ),
-            None => None,
-        };
+        // Keep the complete stored entry until its frame/document identity is
+        // re-proven. A backend node id alone can collide with a node in a
+        // replacement document after navigation.
+        let scope_entry = scope_ref
+            .map(|external| self.store.resolve_ref(session, target_id, tab_id, external))
+            .transpose()?;
         let record = self.store.get_target(session, target_id)?;
         let tab = record.tabs.get(tab_id).cloned().ok_or_else(|| {
             refuse(
@@ -2608,6 +3080,34 @@ impl BrowserEngine {
         })?;
         let conn = self.connection_for_record(session, &record).await?;
         let cdp_session = self.attach(&conn, &tab.cdp_target_id).await?;
+        let initial_tree = self
+            .semantic_frame_tree(
+                &conn,
+                &cdp_session,
+                "Page.getFrameTree failed before semantic snapshot collection",
+            )
+            .await?;
+        let semantic_root_identity = initial_tree.main_identity();
+        if let Some(scope) = scope_entry
+            .as_ref()
+            .filter(|scope| scope.frame.oopif_target_id.is_none())
+        {
+            let identity = scope.frame.identity.as_ref().ok_or_else(|| {
+                refuse(
+                    BrowserRefusalCode::BrowserRefStale,
+                    "scope_ref has no proven frame document identity; re-run get_browser_state to start a fresh snapshot",
+                )
+            })?;
+            if !initial_tree.proves(identity) {
+                return Err(refuse(
+                    BrowserRefusalCode::BrowserRefStale,
+                    "scope_ref is stale because its frame navigated; re-run get_browser_state to start a fresh snapshot",
+                ));
+            }
+        }
+        let mut scope_frame_proven = scope_entry
+            .as_ref()
+            .is_none_or(|scope| scope.frame.oopif_target_id.is_none());
         let (document, document_complete) = self.semantic_document(&conn, &cdp_session).await?;
         let root = document.get("root").cloned().unwrap_or(Value::Null);
         let url = root
@@ -2615,43 +3115,30 @@ impl BrowserEngine {
             .and_then(Value::as_str)
             .unwrap_or(&tab.url)
             .to_owned();
-        let local_tree = match self.local_frame_tree(&conn, &cdp_session).await {
-            Ok(tree) => Some(tree),
-            Err(FrameTreeError::Unsupported) => None,
-            Err(FrameTreeError::Failed(error)) => {
-                return Err(route_err("Page.getFrameTree failed", error))
-            }
-        };
-        let semantic_root_identity = local_tree.as_ref().map(LocalFrameTree::main_identity);
         let mut semantic = self
-            .collect_semantic_session(&conn, &cdp_session, &document, local_tree.as_ref(), None)
+            .collect_semantic_session(&conn, &cdp_session, &document, Some(&initial_tree), None)
             .await?;
         semantic.complete &= document_complete;
 
-        let oopif = if local_tree.is_some() {
-            match self.attached_iframe_children(&conn, &cdp_session).await {
-                Ok(children) => {
-                    let mut attached = 0;
-                    for child in &children {
-                        let child_tree = match self.local_frame_tree(&conn, &child.session_id).await
-                        {
-                            Ok(tree) => tree,
-                            Err(_) => {
-                                semantic.unprovable_frame_count += 1;
-                                semantic.complete = false;
-                                continue;
-                            }
-                        };
-                        let (child_document, child_complete) =
-                            match self.semantic_document(&conn, &child.session_id).await {
-                                Ok(document) => document,
-                                Err(_) => {
-                                    semantic.unprovable_frame_count += 1;
-                                    semantic.complete = false;
-                                    continue;
-                                }
-                            };
-                        match self
+        let (oopif, mut attachment) = match self.attached_iframe_children(&conn, &cdp_session).await
+        {
+            Ok(attachment) => {
+                let mut attached = 0;
+                let children = attachment.children().to_vec();
+                let child_limit = children.len().min(MAX_SEMANTIC_OOPIF_FRAMES);
+                let deadline = tokio::time::Instant::now() + SEMANTIC_OOPIF_COLLECTION_TIMEOUT;
+                let mut omitted = children.len().saturating_sub(child_limit);
+                for (index, child) in children.iter().take(child_limit).enumerate() {
+                    let collected = tokio::time::timeout_at(deadline, async {
+                        let child_tree = self
+                            .local_frame_tree(&conn, &child.session_id)
+                            .await
+                            .map_err(|_| ())?;
+                        let (child_document, child_complete) = self
+                            .semantic_document(&conn, &child.session_id)
+                            .await
+                            .map_err(|_| ())?;
+                        let document = self
                             .collect_semantic_session(
                                 &conn,
                                 &child.session_id,
@@ -2660,55 +3147,60 @@ impl BrowserEngine {
                                 Some(&child.target_id),
                             )
                             .await
-                        {
-                            Ok(document) => {
-                                let mut document = document;
-                                document.complete &= child_complete;
-                                semantic.extend(document);
-                                attached += 1;
-                            }
-                            Err(_) => {
-                                semantic.unprovable_frame_count += 1;
-                                semantic.complete = false;
-                            }
+                            .map_err(|_| ())?;
+                        Ok::<_, ()>((child_tree, document, child_complete))
+                    })
+                    .await;
+                    let (child_tree, mut document, child_complete) = match collected {
+                        Ok(Ok(collected)) => collected,
+                        Ok(Err(())) => {
+                            semantic.unprovable_frame_count += 1;
+                            semantic.complete = false;
+                            continue;
                         }
-                    }
-                    let _ = conn
-                        .call(
-                            Some(&cdp_session),
-                            "Target.setAutoAttach",
-                            json!({
-                                "autoAttach": false,
-                                "waitForDebuggerOnStart": false,
-                                "flatten": true
-                            }),
-                        )
-                        .await;
-                    for child in &children {
-                        let _ = conn
-                            .call(
-                                Some(&cdp_session),
-                                "Target.detachFromTarget",
-                                json!({ "sessionId": child.session_id }),
-                            )
-                            .await;
-                    }
-                    OopifStatus::Attached(attached)
+                        Err(_) => {
+                            omitted += child_limit - index;
+                            break;
+                        }
+                    };
+                    let scoped_child_identity_proven = scope_entry.as_ref().is_some_and(|scope| {
+                        scope.frame.oopif_target_id.as_deref() == Some(child.target_id.as_str())
+                            && scope
+                                .frame
+                                .identity
+                                .as_ref()
+                                .is_some_and(|identity| child_tree.proves(identity))
+                    });
+                    document.complete &= child_complete;
+                    semantic.extend(document);
+                    scope_frame_proven |= scoped_child_identity_proven;
+                    attached += 1;
                 }
-                Err(AttachError::Unsupported) => OopifStatus::Unsupported,
-                Err(AttachError::Failed(error)) => {
-                    return Err(route_err("Target.setAutoAttach failed", error))
+                if omitted > 0 {
+                    semantic.unprovable_frame_count += omitted;
+                    semantic.complete = false;
                 }
+                (OopifStatus::Attached(attached), Some(attachment))
             }
-        } else {
-            OopifStatus::Unsupported
+            Err(AttachError::Unsupported) => (OopifStatus::Unsupported, None),
+            Err(AttachError::Failed(error)) => {
+                return Err(route_err("Target.setAutoAttach failed", error))
+            }
         };
+        if !scope_frame_proven {
+            return Err(refuse(
+                BrowserRefusalCode::BrowserRefStale,
+                "scope_ref is stale because its frame navigated or was removed; re-run get_browser_state to start a fresh snapshot",
+            ));
+        }
+        let semantic_scope = scope_entry.as_ref().map(SemanticScope::from);
+        let semantic_frames = Self::semantic_frames(&semantic);
 
         let page = semantic.page(
             0,
             DEFAULT_SEMANTIC_NODE_BUDGET,
             query,
-            scope_backend_node_id,
+            semantic_scope.as_ref(),
         );
         let next_offset = page.next_offset;
         let snapshot_id = self.store.mint_snapshot_id();
@@ -2719,7 +3211,7 @@ impl BrowserEngine {
         } else {
             "viewport"
         };
-        let (outcome, refs) = self.semantic_outcome(
+        let (mut outcome, refs) = self.semantic_outcome(
             snapshot_id,
             url.clone(),
             tab.title.clone(),
@@ -2729,38 +3221,71 @@ impl BrowserEngine {
             oopif,
             0,
         );
+        let screenshot = if include_screenshot {
+            Some(
+                self.capture_tab_screenshot_on_session(&conn, &cdp_session)
+                    .await?,
+            )
+        } else {
+            None
+        };
+        let final_tree = self
+            .semantic_frame_tree(
+                &conn,
+                &cdp_session,
+                "Page.getFrameTree failed after semantic snapshot collection",
+            )
+            .await?;
+        let final_identity = final_tree.main_identity();
+        if final_identity != semantic_root_identity {
+            return Err(refuse(
+                BrowserRefusalCode::BrowserRefStale,
+                "the page navigated while the semantic snapshot was being collected; re-run get_browser_state to start a fresh snapshot",
+            ));
+        }
+        self.reprove_semantic_frames(
+            &conn,
+            &final_tree,
+            attachment.as_ref(),
+            &semantic_frames,
+            "Page.getFrameTree failed after semantic child-frame collection",
+        )
+        .await?;
+        if let Some(attachment) = attachment.as_mut() {
+            attachment
+                .cleanup()
+                .await
+                .map_err(|error| route_err("Target child-session cleanup failed", error))?;
+        }
         let continuation_token = outcome.continuation.clone();
-        self.store
-            .update_target(session, target_id, |stored_target| {
-                if let Some(stored_tab) = stored_target.tabs.get_mut(tab_id) {
-                    let mut continuations = HashMap::new();
-                    if let (Some(token), Some(offset)) = (continuation_token, next_offset) {
-                        continuations.insert(
-                            token,
-                            SemanticContinuation {
-                                offset,
-                                query: query.map(str::to_owned),
-                                scope_backend_node_id,
-                                oopif_supported: matches!(oopif, OopifStatus::Attached(_)),
-                                oopif_frames: oopif.frames(),
-                            },
-                        );
-                    }
-                    stored_tab.snapshots.clear();
-                    stored_tab.snapshots.insert(
-                        snapshot_id,
-                        SnapshotRecord {
-                            id: snapshot_id,
-                            generation: record.generation,
-                            url,
-                            refs,
-                            semantic: Some(semantic),
-                            semantic_root_identity,
-                            continuations,
-                        },
-                    );
-                }
-            });
+        let mut continuations = HashMap::new();
+        if let (Some(token), Some(offset)) = (continuation_token, next_offset) {
+            continuations.insert(
+                token,
+                SemanticContinuation {
+                    offset,
+                    query: query.map(str::to_owned),
+                    scope: semantic_scope,
+                    oopif_supported: matches!(oopif, OopifStatus::Attached(_)),
+                    oopif_frames: oopif.frames(),
+                },
+            );
+        }
+        self.store.publish_semantic_snapshot(
+            session,
+            target_id,
+            tab_id,
+            SnapshotRecord {
+                id: snapshot_id,
+                generation: record.generation,
+                url,
+                refs,
+                semantic: Some(semantic),
+                semantic_root_identity: Some(semantic_root_identity),
+                continuations,
+            },
+        )?;
+        outcome.screenshot = screenshot;
         Ok(outcome)
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/mock_cdp.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/mock_cdp.rs
@@ -10,6 +10,7 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
 use serde_json::{json, Value};
@@ -34,6 +35,7 @@ pub(crate) struct MockEvent {
 pub(crate) struct MockReply {
     pub events: Vec<MockEvent>,
     pub result: Result<Value, (i64, String)>,
+    pub delay: Option<Duration>,
 }
 
 impl MockReply {
@@ -41,6 +43,7 @@ impl MockReply {
         Self {
             events: Vec::new(),
             result: Ok(result),
+            delay: None,
         }
     }
 
@@ -48,6 +51,7 @@ impl MockReply {
         Self {
             events: Vec::new(),
             result: Err((code, message.to_owned())),
+            delay: None,
         }
     }
 
@@ -58,6 +62,11 @@ impl MockReply {
 
     pub fn with_events(mut self, events: Vec<MockEvent>) -> Self {
         self.events = events;
+        self
+    }
+
+    pub fn with_delay(mut self, delay: Duration) -> Self {
+        self.delay = Some(delay);
         self
     }
 }
@@ -116,6 +125,9 @@ impl MockCdpServer {
                             if ws.send(Message::Text(frame.to_string())).await.is_err() {
                                 return;
                             }
+                        }
+                        if let Some(delay) = reply.delay {
+                            tokio::time::sleep(delay).await;
                         }
                         let mut response = match reply.result {
                             Ok(result) => json!({ "id": id, "result": result }),

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/pointer.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/pointer.rs
@@ -17,7 +17,7 @@ use crate::tool::{ProtectedResourceOwnership, Tool, ToolDef};
 use crate::tool_args::ArgsExt;
 
 use super::cdp_ws::CdpConnection;
-use super::engine::{BrowserEngine, ValidatedTab};
+use super::engine::{BrowserEngine, FrameSessionLease, ValidatedTab};
 use super::platform::BrowserVisualActionKind;
 use super::refusal::{BrowserRefusal, BrowserRefusalCode};
 use super::required_session_schema;
@@ -211,7 +211,7 @@ struct ResolvedRef {
     external: String,
     backend_node_id: i64,
     frame: FrameRef,
-    cdp_session: String,
+    cdp_session: FrameSessionLease,
 }
 
 fn same_exact_frame(left: &FrameRef, right: &FrameRef) -> bool {
@@ -332,6 +332,7 @@ impl BrowserPointerTool {
         validated: &ValidatedTab,
         external: &str,
         action: PointerAction,
+        proven_frame: Option<&ResolvedRef>,
     ) -> Result<ResolvedRef, ToolResult> {
         let entry = self
             .engine
@@ -351,11 +352,20 @@ impl BrowserPointerTool {
             )
             .to_tool_result());
         }
-        let cdp_session = self
-            .engine
-            .frame_session_for_mutation(session, target_id, tab_id, validated, &entry.frame)
-            .await
-            .map_err(|refusal| refusal.to_tool_result())?;
+        // A two-ref action in one exact frame needs only one frame proof and,
+        // for an OOPIF, one owned child attachment. Chromium does not
+        // re-announce an already attached target when auto-attach is enabled
+        // a second time, so share the first lease instead of rediscovering it.
+        let cdp_session = if let Some(proven) =
+            proven_frame.filter(|proven| same_exact_frame(&proven.frame, &entry.frame))
+        {
+            proven.cdp_session.clone()
+        } else {
+            self.engine
+                .frame_session_for_mutation(session, target_id, tab_id, validated, &entry.frame)
+                .await
+                .map_err(|refusal| refusal.to_tool_result())?
+        };
         Ok(ResolvedRef {
             external: external.to_owned(),
             backend_node_id: entry.backend_node_id,
@@ -402,17 +412,19 @@ impl BrowserPointerTool {
     ) -> ToolResult {
         let conn = &validated.conn;
         let object_id =
-            match resolve_object(conn, &origin.cdp_session, origin.backend_node_id).await {
+            match resolve_object(conn, origin.cdp_session.as_str(), origin.backend_node_id).await {
                 Ok(id) => id,
                 Err(result) => return result,
             };
 
-        if let Ok((x, y)) = point_for_ref(conn, &origin.cdp_session, origin.backend_node_id).await {
+        if let Ok((x, y)) =
+            point_for_ref(conn, origin.cdp_session.as_str(), origin.backend_node_id).await
+        {
             self.engine
                 .visualize_browser_action(
                     session,
                     validated,
-                    &origin.cdp_session,
+                    origin.cdp_session.as_str(),
                     x,
                     y,
                     visual_kind(request.action),
@@ -441,7 +453,7 @@ impl BrowserPointerTool {
                 let destination_argument = if let Some(destination) = destination {
                     let object_id = match resolve_object(
                         conn,
-                        &destination.cdp_session,
+                        destination.cdp_session.as_str(),
                         destination.backend_node_id,
                     )
                     .await
@@ -471,7 +483,7 @@ impl BrowserPointerTool {
 
         match conn
             .call(
-                Some(&origin.cdp_session),
+                Some(origin.cdp_session.as_str()),
                 "Runtime.callFunctionOn",
                 json!({
                     "objectId": object_id,
@@ -570,7 +582,13 @@ impl BrowserPointerTool {
         let origin = match (&request.origin, origin_ref) {
             (Location::Coordinates(x, y), None) => (*x, *y),
             (Location::Ref(_), Some(reference)) => {
-                match point_for_ref(conn, &reference.cdp_session, reference.backend_node_id).await {
+                match point_for_ref(
+                    conn,
+                    reference.cdp_session.as_str(),
+                    reference.backend_node_id,
+                )
+                .await
+                {
                     Ok(point) => point,
                     Err(result) => return result,
                 }
@@ -580,7 +598,13 @@ impl BrowserPointerTool {
         let destination = match (&request.destination, destination_ref) {
             (Some(Location::Coordinates(x, y)), None) => Some((*x, *y)),
             (Some(Location::Ref(_)), Some(reference)) => {
-                match point_for_ref(conn, &reference.cdp_session, reference.backend_node_id).await {
+                match point_for_ref(
+                    conn,
+                    reference.cdp_session.as_str(),
+                    reference.backend_node_id,
+                )
+                .await
+                {
                     Ok(point) => Some(point),
                     Err(result) => return result,
                 }
@@ -657,7 +681,7 @@ impl BrowserPointerTool {
             frame: origin_ref
                 .map(|reference| reference.frame.clone())
                 .unwrap_or_else(FrameRef::main_unproven),
-            cdp_session: cdp_session.to_owned(),
+            cdp_session: FrameSessionLease::tab(cdp_session.to_owned()),
         };
         ToolResult::text(format!(
             "dispatched trusted {} in {}",
@@ -804,6 +828,7 @@ impl Tool for BrowserPointerTool {
                     &validated,
                     external,
                     request.action,
+                    None,
                 )
                 .await
             {
@@ -821,6 +846,7 @@ impl Tool for BrowserPointerTool {
                     &validated,
                     external,
                     request.action,
+                    origin_ref.as_ref(),
                 )
                 .await
             {
@@ -832,7 +858,7 @@ impl Tool for BrowserPointerTool {
 
         if let (Some(origin), Some(destination)) = (&origin_ref, &destination_ref) {
             if !same_exact_frame(&origin.frame, &destination.frame)
-                || origin.cdp_session != destination.cdp_session
+                || origin.cdp_session.as_str() != destination.cdp_session.as_str()
             {
                 return BrowserRefusal::new(
                     BrowserRefusalCode::BrowserWrongTargetRefused,

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/semantic.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/semantic.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use serde_json::Value;
 
-use super::store::{BrowserActionKind, BrowserVisibility, FrameRef, RefEntry};
+use super::store::{BrowserActionKind, BrowserVisibility, FrameRef, RefEntry, SemanticScope};
 
 pub(crate) const SEMANTIC_COMPUTED_STYLES: &[&str] = &[
     "display",
@@ -191,9 +191,9 @@ impl SemanticDocument {
         offset: usize,
         budget: usize,
         query: Option<&str>,
-        scope_backend_node_id: Option<i64>,
+        scope: Option<&SemanticScope>,
     ) -> SemanticPage {
-        let mut candidates = scoped_indices(&self.nodes, query, scope_backend_node_id);
+        let mut candidates = scoped_indices(&self.nodes, query, scope);
         candidates.retain(|idx| {
             !matches!(
                 self.nodes[*idx].visibility,
@@ -992,7 +992,7 @@ fn rank(node: &SemanticNode) -> u8 {
 fn scoped_indices(
     nodes: &[SemanticNode],
     query: Option<&str>,
-    scope_backend_node_id: Option<i64>,
+    scope: Option<&SemanticScope>,
 ) -> Vec<usize> {
     let by_ax_id: HashMap<&str, usize> = nodes
         .iter()
@@ -1000,12 +1000,11 @@ fn scoped_indices(
         .map(|(idx, node)| (node.ax_id.as_str(), idx))
         .collect();
     let mut allowed = HashSet::new();
-    if let Some(scope_backend) = scope_backend_node_id {
-        if let Some(scope) = nodes
-            .iter()
-            .find(|node| node.backend_node_id == Some(scope_backend))
-        {
-            let mut stack = vec![scope.ax_id.as_str()];
+    if let Some(scope) = scope {
+        if let Some(scope_root) = nodes.iter().find(|node| {
+            node.backend_node_id == Some(scope.backend_node_id) && node.frame == scope.frame
+        }) {
+            let mut stack = vec![scope_root.ax_id.as_str()];
             while let Some(ax_id) = stack.pop() {
                 if !allowed.insert(ax_id.to_owned()) {
                     continue;
@@ -1017,8 +1016,7 @@ fn scoped_indices(
         }
     }
     let query = query.map(|value| value.trim().to_ascii_lowercase());
-    let in_scope =
-        |node: &SemanticNode| scope_backend_node_id.is_none() || allowed.contains(&node.ax_id);
+    let in_scope = |node: &SemanticNode| scope.is_none() || allowed.contains(&node.ax_id);
     let exact_match_exists = query.as_ref().is_some_and(|query| {
         !query.is_empty()
             && nodes

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/store.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/store.rs
@@ -118,7 +118,7 @@ pub struct FrameIdentity {
 /// - `kind != Main` ⇒ `identity` is `Some` (unprovable frames are
 ///   omitted from snapshots, never guessed).
 /// - `kind == Oopif` ⇔ `oopif_target_id` is `Some`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FrameRef {
     pub kind: FrameKind,
     /// CDP target id of the OOPIF child target (contained beneath the
@@ -181,10 +181,25 @@ pub struct SnapshotRecord {
 }
 
 #[derive(Debug, Clone)]
+pub struct SemanticScope {
+    pub backend_node_id: i64,
+    pub frame: FrameRef,
+}
+
+impl From<&RefEntry> for SemanticScope {
+    fn from(entry: &RefEntry) -> Self {
+        Self {
+            backend_node_id: entry.backend_node_id,
+            frame: entry.frame.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct SemanticContinuation {
     pub offset: usize,
     pub query: Option<String>,
-    pub scope_backend_node_id: Option<i64>,
+    pub scope: Option<SemanticScope>,
     pub oopif_supported: bool,
     pub oopif_frames: usize,
 }
@@ -415,6 +430,101 @@ impl BrowserStore {
                     "the semantic continuation is stale or does not belong to this session and tab",
                 )
             })
+    }
+
+    /// Publish a completed semantic snapshot, refusing rather than reporting
+    /// success if its target, tab, or connection generation changed while CDP
+    /// collection was in flight.
+    pub(crate) fn publish_semantic_snapshot(
+        &self,
+        session: &str,
+        target_id: &str,
+        tab_id: &str,
+        snapshot: SnapshotRecord,
+    ) -> Result<(), BrowserRefusal> {
+        let mut inner = self.inner.lock().unwrap();
+        let target = inner
+            .get_mut(session)
+            .and_then(|session| session.targets.get_mut(target_id))
+            .ok_or_else(|| {
+                BrowserRefusal::new(
+                    BrowserRefusalCode::BrowserBindingStale,
+                    format!(
+                        "target {target_id} is not a live binding in this session — \
+                         re-run get_browser_state with pid + window_id"
+                    ),
+                )
+            })?;
+        if target.generation != snapshot.generation {
+            return Err(BrowserRefusal::new(
+                BrowserRefusalCode::BrowserBindingStale,
+                "the browser connection changed while the semantic snapshot was being collected",
+            ));
+        }
+        let tab = target.tabs.get_mut(tab_id).ok_or_else(|| {
+            BrowserRefusal::new(
+                BrowserRefusalCode::BrowserTabNotFound,
+                format!("tab {tab_id} is not known for target {target_id}"),
+            )
+        })?;
+        tab.snapshots.clear();
+        tab.snapshots.insert(snapshot.id, snapshot);
+        Ok(())
+    }
+
+    /// Commit one continuation page and consume its token in the same store
+    /// critical section. A racing caller can do collection work, but cannot
+    /// consume the same capability or publish a second result.
+    pub(crate) fn commit_semantic_continuation(
+        &self,
+        session: &str,
+        target_id: &str,
+        tab_id: &str,
+        snapshot_id: u64,
+        token: &str,
+        refs: HashMap<u32, RefEntry>,
+        next: Option<(String, SemanticContinuation)>,
+    ) -> Result<(), BrowserRefusal> {
+        let mut inner = self.inner.lock().unwrap();
+        let target = inner
+            .get_mut(session)
+            .and_then(|session| session.targets.get_mut(target_id))
+            .ok_or_else(|| {
+                BrowserRefusal::new(
+                    BrowserRefusalCode::BrowserBindingStale,
+                    format!(
+                        "target {target_id} is not a live binding in this session — \
+                         re-run get_browser_state with pid + window_id"
+                    ),
+                )
+            })?;
+        let generation = target.generation;
+        let tab = target.tabs.get_mut(tab_id).ok_or_else(|| {
+            BrowserRefusal::new(
+                BrowserRefusalCode::BrowserTabNotFound,
+                format!("tab {tab_id} is not known for target {target_id}"),
+            )
+        })?;
+        let snapshot = tab
+            .snapshots
+            .get_mut(&snapshot_id)
+            .filter(|snapshot| {
+                snapshot.generation == generation
+                    && snapshot.semantic.is_some()
+                    && snapshot.continuations.contains_key(token)
+            })
+            .ok_or_else(|| {
+                BrowserRefusal::new(
+                    BrowserRefusalCode::BrowserRefStale,
+                    "the semantic continuation is stale or does not belong to this session and tab",
+                )
+            })?;
+        snapshot.continuations.remove(token);
+        snapshot.refs.extend(refs);
+        if let Some((token, continuation)) = next {
+            snapshot.continuations.insert(token, continuation);
+        }
+        Ok(())
     }
 
     /// Drop every snapshot of one tab (navigation invalidates refs).

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
@@ -16,7 +16,7 @@ use crate::tool_args::ArgsExt;
 
 use super::cdp_ws::CdpConnection;
 use super::download::BrowserDownloadTool;
-use super::engine::{BrowserEngine, BrowserTabScreenshot};
+use super::engine::{BrowserEngine, BrowserTabScreenshot, FrameSessionLease};
 use super::platform::{BrowserVisualActionKind, PrepareProfile, PrepareRequest, PrepareStrategy};
 use super::pointer::BrowserPointerTool;
 use super::refusal::{BrowserRefusal, BrowserRefusalCode};
@@ -382,10 +382,12 @@ impl Tool for GetBrowserStateTool {
                         args.opt_str("scope_ref").as_deref(),
                         args.opt_str("query").as_deref(),
                         args.opt_str("continuation").as_deref(),
+                        include_screenshot,
                     )
                     .await
                 {
                     Ok(outcome) => {
+                        let screenshot = outcome.screenshot;
                         let refs = outcome
                             .refs
                             .iter()
@@ -396,7 +398,7 @@ impl Tool for GetBrowserStateTool {
                             .iter()
                             .map(semantic_ref_value)
                             .collect::<Vec<_>>();
-                        ToolResult::text(format!(
+                        let snapshot = ToolResult::text(format!(
                             "semantic snapshot p{} of {}: {} action ref(s), {} content ref(s)",
                             outcome.snapshot_id,
                             outcome.url,
@@ -438,20 +440,14 @@ impl Tool for GetBrowserStateTool {
                                 "status": outcome.oopif.as_str(),
                                 "frames": outcome.oopif.frames(),
                             },
-                        }))
+                        }));
+                        match screenshot {
+                            Some(screenshot) => with_tab_screenshot(snapshot, screenshot),
+                            None => snapshot,
+                        }
                     }
                     Err(refusal) => return refusal.to_tool_result(),
                 };
-                if include_screenshot {
-                    return match self
-                        .engine
-                        .capture_tab_screenshot(&session, &target_id, &tab_id)
-                        .await
-                    {
-                        Ok(screenshot) => with_tab_screenshot(snapshot, screenshot),
-                        Err(refusal) => refusal.to_tool_result(),
-                    };
-                }
                 return snapshot;
             }
             let snapshot = match self
@@ -1059,7 +1055,11 @@ impl Tool for BrowserClickTool {
                     frame_session,
                 )
             }
-            None => (None, None, validated.cdp_session.clone()),
+            None => (
+                None,
+                None,
+                FrameSessionLease::tab(validated.cdp_session.clone()),
+            ),
         };
 
         let conn = &validated.conn;
@@ -2409,7 +2409,7 @@ impl Tool for BrowserSetInputFilesTool {
         let described = match validated
             .conn
             .call(
-                Some(&cdp_session),
+                Some(cdp_session.as_str()),
                 "DOM.describeNode",
                 json!({ "backendNodeId": entry.backend_node_id }),
             )
@@ -2447,7 +2447,7 @@ impl Tool for BrowserSetInputFilesTool {
         match validated
             .conn
             .call(
-                Some(&cdp_session),
+                Some(cdp_session.as_str()),
                 "DOM.setFileInputFiles",
                 json!({ "backendNodeId": entry.backend_node_id, "files": files }),
             )

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/v2_tests.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/v2_tests.rs
@@ -46,6 +46,10 @@ use super::types::{
 struct FixtureState {
     oopif_supported: bool,
     oopif_present: bool,
+    oopif_frame_count: usize,
+    oopif_auto_attach_enabled: bool,
+    oopif_sessions_live: bool,
+    oopif_two_inputs: bool,
     emit_rogue_attach: bool,
     main_url: String,
     main_loader: String,
@@ -59,7 +63,19 @@ struct FixtureState {
     semantic_full_dom_fails: bool,
     semantic_full_dom_times_out: bool,
     semantic_truncated_dom: bool,
+    main_oopif_backend_collision: bool,
+    fail_oopif_document: bool,
+    fail_oopif_frame_tree: bool,
+    oopif_document_delay: std::time::Duration,
+    fail_disable_auto_attach: bool,
     screenshot_data: String,
+    screenshot_delay: std::time::Duration,
+    fail_screenshot: bool,
+    navigate_after_main_dom: bool,
+    navigate_during_screenshot: bool,
+    navigate_iframe_during_screenshot: bool,
+    navigate_oopif_during_screenshot: bool,
+    unprove_oopif_during_screenshot: bool,
     viewport_css_width: f64,
     viewport_css_height: f64,
     tab_visible: bool,
@@ -72,6 +88,10 @@ impl Default for FixtureState {
         Self {
             oopif_supported: true,
             oopif_present: true,
+            oopif_frame_count: 1,
+            oopif_auto_attach_enabled: false,
+            oopif_sessions_live: false,
+            oopif_two_inputs: false,
             emit_rogue_attach: false,
             main_url: "https://fixture.test/".into(),
             main_loader: "L_MAIN_1".into(),
@@ -85,7 +105,19 @@ impl Default for FixtureState {
             semantic_full_dom_fails: false,
             semantic_full_dom_times_out: false,
             semantic_truncated_dom: false,
+            main_oopif_backend_collision: false,
+            fail_oopif_document: false,
+            fail_oopif_frame_tree: false,
+            oopif_document_delay: std::time::Duration::ZERO,
+            fail_disable_auto_attach: false,
             screenshot_data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9ZJrAAAAAASUVORK5CYII=".into(),
+            screenshot_delay: std::time::Duration::ZERO,
+            fail_screenshot: false,
+            navigate_after_main_dom: false,
+            navigate_during_screenshot: false,
+            navigate_iframe_during_screenshot: false,
+            navigate_oopif_during_screenshot: false,
+            unprove_oopif_during_screenshot: false,
             viewport_css_width: 800.0,
             viewport_css_height: 600.0,
             tab_visible: true,
@@ -188,6 +220,30 @@ fn main_document() -> Value {
             }]
         }
     })
+}
+
+fn main_document_with_oopif_backend_collision() -> Value {
+    let mut document = main_document();
+    document["root"]["children"][0]["children"]
+        .as_array_mut()
+        .unwrap()
+        .push(json!({
+            "nodeType": 1,
+            "nodeName": "BUTTON",
+            "backendNodeId": 100,
+            "attributes": ["aria-label", "Main collision"],
+        }));
+    document
+}
+
+fn main_collision_ax_tree() -> Value {
+    json!({"nodes": [
+        {"nodeId": "main-root", "ignored": false,
+         "role": {"value": "RootWebArea"}, "childIds": ["main-collision"]},
+        {"nodeId": "main-collision", "parentId": "main-root", "ignored": false,
+         "backendDOMNodeId": 100, "role": {"value": "button"},
+         "name": {"value": "Main collision"}, "childIds": []}
+    ]})
 }
 
 /// Large application document used to prove that hidden retained controls do
@@ -389,8 +445,8 @@ fn semantic_layout_snapshot(backends: &[i64], bounds: &[[f64; 4]]) -> Value {
     })
 }
 
-fn oopif_document() -> Value {
-    json!({
+fn oopif_document(two_inputs: bool) -> Value {
+    let mut document = json!({
         "root": {
             "nodeType": 9,
             "nodeName": "#document",
@@ -408,7 +464,19 @@ fn oopif_document() -> Value {
                 }]
             }]
         }
-    })
+    });
+    if two_inputs {
+        document["root"]["children"][0]["children"]
+            .as_array_mut()
+            .expect("OOPIF fixture children")
+            .push(json!({
+                "nodeType": 1,
+                "nodeName": "INPUT",
+                "backendNodeId": 101,
+                "attributes": ["id", "ad-destination", "type", "text"],
+            }));
+    }
+    document
 }
 
 fn fixture_handler(state: SharedState) -> MockHandler {
@@ -422,6 +490,9 @@ fn fixture_handler(state: SharedState) -> MockHandler {
         let sess = call.session_id.clone().unwrap_or_default();
         let is_tab = sess.starts_with("tab-sess-");
         let is_oopif = sess.starts_with("oopif-sess-");
+        if is_oopif && !st.oopif_sessions_live {
+            return MockReply::err(-32000, "detached OOPIF session");
+        }
 
         match call.method.as_str() {
             "Target.getTargets" => MockReply::ok(json!({
@@ -458,18 +529,24 @@ fn fixture_handler(state: SharedState) -> MockHandler {
                     }]
                 }
             })),
-            "Page.getFrameTree" if is_oopif => MockReply::ok(json!({
-                "frameTree": {
-                    "frame": {
-                        "id": "F_OOPIF",
-                        "loaderId": st.oopif_loader.clone(),
-                        "url": "https://ads.example/frame",
-                    }
+            "Page.getFrameTree" if is_oopif => {
+                if st.fail_oopif_frame_tree {
+                    MockReply::err(-32000, "OOPIF frame tree fixture failure")
+                } else {
+                    MockReply::ok(json!({
+                        "frameTree": {
+                            "frame": {
+                                "id": "F_OOPIF",
+                                "loaderId": st.oopif_loader.clone(),
+                                "url": "https://ads.example/frame",
+                            }
+                        }
+                    }))
                 }
-            })),
+            }
             "DOM.getDocument" if is_tab => {
                 let depth = call.params["depth"].as_i64().unwrap_or(-1);
-                if st.semantic_full_dom_times_out && (depth == -1 || depth > 8) {
+                let reply = if st.semantic_full_dom_times_out && (depth == -1 || depth > 8) {
                     MockReply::err(-32000, "CDP DOM.getDocument timed out after 20s")
                 } else if st.semantic_full_dom_fails && (depth == -1 || depth > 8) {
                     MockReply::err(-32000, "Object reference chain is too long")
@@ -478,21 +555,37 @@ fn fixture_handler(state: SharedState) -> MockHandler {
                 } else {
                     MockReply::ok(if st.semantic_large_page {
                         large_semantic_document()
+                    } else if st.main_oopif_backend_collision {
+                        main_document_with_oopif_backend_collision()
                     } else {
                         main_document()
                     })
+                };
+                if st.navigate_after_main_dom {
+                    st.navigate_after_main_dom = false;
+                    st.main_loader = "L_MAIN_AFTER_DOM".into();
                 }
+                reply
             }
             "DOM.describeNode" if is_tab && call.params["backendNodeId"] == 999 => {
                 MockReply::ok(json!({
                     "node": large_semantic_document()["root"]["children"][0].clone()
                 }))
             }
-            "DOM.getDocument" if is_oopif => MockReply::ok(oopif_document()),
+            "DOM.getDocument" if is_oopif => {
+                let reply = if st.fail_oopif_document {
+                    MockReply::err(-32000, "OOPIF document fixture failure")
+                } else {
+                    MockReply::ok(oopif_document(st.oopif_two_inputs))
+                };
+                reply.with_delay(st.oopif_document_delay)
+            }
             "Accessibility.getFullAXTree" if is_tab => {
                 let frame_id = call.params["frameId"].as_str().unwrap_or("F_MAIN");
                 if st.semantic_large_page {
                     MockReply::ok(large_semantic_ax_tree(frame_id))
+                } else if st.main_oopif_backend_collision && frame_id == "F_MAIN" {
+                    MockReply::ok(main_collision_ax_tree())
                 } else {
                     MockReply::ok(json!({"nodes": []}))
                 }
@@ -521,6 +614,11 @@ fn fixture_handler(state: SharedState) -> MockHandler {
                         bounds.push([20.0, 2_000.0 + id as f64 * 40.0, 160.0, 30.0]);
                     }
                     MockReply::ok(semantic_layout_snapshot(&backends, &bounds))
+                } else if st.main_oopif_backend_collision {
+                    MockReply::ok(semantic_layout_snapshot(
+                        &[100],
+                        &[[40.0, 40.0, 180.0, 36.0]],
+                    ))
                 } else {
                     MockReply::ok(semantic_layout_snapshot(&[], &[]))
                 }
@@ -548,7 +646,28 @@ fn fixture_handler(state: SharedState) -> MockHandler {
                 }))
             }
             "Page.captureScreenshot" if is_tab => {
-                MockReply::ok(json!({"data": st.screenshot_data.clone()}))
+                if st.navigate_during_screenshot {
+                    st.navigate_during_screenshot = false;
+                    st.main_loader = "L_MAIN_DURING_SCREENSHOT".into();
+                }
+                if st.navigate_iframe_during_screenshot {
+                    st.navigate_iframe_during_screenshot = false;
+                    st.iframe_loader = "L_IFRAME_DURING_SCREENSHOT".into();
+                }
+                if st.navigate_oopif_during_screenshot {
+                    st.navigate_oopif_during_screenshot = false;
+                    st.oopif_loader = "L_OOPIF_DURING_SCREENSHOT".into();
+                }
+                if st.unprove_oopif_during_screenshot {
+                    st.unprove_oopif_during_screenshot = false;
+                    st.fail_oopif_frame_tree = true;
+                }
+                if st.fail_screenshot {
+                    MockReply::err(-32000, "screenshot fixture failure")
+                } else {
+                    MockReply::ok(json!({"data": st.screenshot_data.clone()}))
+                        .with_delay(st.screenshot_delay)
+                }
             }
             "Page.navigate" if is_tab => MockReply::ok(json!({
                 "frameId": "F_MAIN",
@@ -556,28 +675,48 @@ fn fixture_handler(state: SharedState) -> MockHandler {
             })),
             "Target.setAutoAttach" if is_tab => {
                 if call.params["autoAttach"].as_bool() == Some(false) {
-                    return MockReply::ok(json!({}));
+                    return if st.fail_disable_auto_attach {
+                        MockReply::err(-32000, "auto-attach disable fixture failure")
+                    } else {
+                        st.oopif_auto_attach_enabled = false;
+                        st.oopif_sessions_live = false;
+                        MockReply::ok(json!({}))
+                    };
                 }
                 if !st.oopif_supported {
                     return MockReply::method_not_found("Target.setAutoAttach");
                 }
+                // Chromium treats setting the already-enabled state as a
+                // no-op and does not re-announce existing child targets.
+                if st.oopif_auto_attach_enabled {
+                    return MockReply::ok(json!({}));
+                }
+                st.oopif_auto_attach_enabled = true;
                 let mut events = Vec::new();
                 if st.oopif_present {
-                    st.oopif_sessions += 1;
-                    events.push(MockEvent {
-                        method: "Target.attachedToTarget".into(),
-                        session_id: Some(sess.clone()),
-                        params: json!({
-                            "sessionId": format!("oopif-sess-{}", st.oopif_sessions),
-                            "targetInfo": {
-                                "targetId": "T_OOPIF",
-                                "type": "iframe",
-                                "url": "https://ads.example/frame",
-                                "attached": true,
-                            },
-                            "waitingForDebugger": false,
-                        }),
-                    });
+                    st.oopif_sessions_live = true;
+                    for index in 0..st.oopif_frame_count {
+                        st.oopif_sessions += 1;
+                        let target_id = if index == 0 {
+                            "T_OOPIF".to_owned()
+                        } else {
+                            format!("T_OOPIF_{}", index + 1)
+                        };
+                        events.push(MockEvent {
+                            method: "Target.attachedToTarget".into(),
+                            session_id: Some(sess.clone()),
+                            params: json!({
+                                "sessionId": format!("oopif-sess-{}", st.oopif_sessions),
+                                "targetInfo": {
+                                    "targetId": target_id,
+                                    "type": "iframe",
+                                    "url": "https://ads.example/frame",
+                                    "attached": true,
+                                },
+                                "waitingForDebugger": false,
+                            }),
+                        });
+                    }
                 }
                 if st.emit_rogue_attach {
                     // A child announced on a session we never proved.
@@ -613,11 +752,17 @@ fn fixture_handler(state: SharedState) -> MockHandler {
                 }
                 MockReply::ok(json!({})).with_events(events)
             }
+            "Target.detachFromTarget" if call.session_id.is_none() => {
+                st.oopif_auto_attach_enabled = false;
+                st.oopif_sessions_live = false;
+                MockReply::ok(json!({}))
+            }
+            "Target.detachFromTarget" if is_tab => MockReply::ok(json!({})),
             "DOM.scrollIntoViewIfNeeded" => MockReply::ok(json!({})),
             "DOM.getBoxModel" => {
                 let backend = call.params["backendNodeId"].as_i64().unwrap_or(0);
                 let known = if is_oopif {
-                    backend == 100
+                    backend == 100 || (st.oopif_two_inputs && backend == 101)
                 } else {
                     [10, 20, 21, 30].contains(&backend)
                 };
@@ -1406,6 +1551,22 @@ fn recorded_calls(f: &Fixture, method: &str) -> Vec<(Option<String>, Value)> {
         .collect()
 }
 
+async fn wait_for_auto_attach_disabled(f: &Fixture) {
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            if recorded_calls(f, "Target.setAutoAttach")
+                .iter()
+                .any(|(_, params)| params["autoAttach"] == false)
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for auto-attach cleanup");
+}
+
 // ── Snapshot composition ─────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -1521,17 +1682,33 @@ async fn semantic_snapshot_can_capture_an_inactive_tab_without_activation_calls(
     )));
 
     let state = f.state.lock().unwrap();
-    assert!(state.calls.iter().any(|(_, method, params)| {
-        method == "Page.captureScreenshot"
-            && params["format"] == "png"
-            && params["fromSurface"] == true
-            && params["captureBeyondViewport"] == false
-            && params["clip"]["x"] == 0.0
-            && params["clip"]["y"] == 0.0
-            && params["clip"]["width"] == 800.0
-            && params["clip"]["height"] == 600.0
-            && params["clip"]["scale"] == 1.0
-    }));
+    let capture_session = state
+        .calls
+        .iter()
+        .find_map(|(session, method, params)| {
+            (method == "Page.captureScreenshot"
+                && params["format"] == "png"
+                && params["fromSurface"] == true
+                && params["captureBeyondViewport"] == false
+                && params["clip"]["x"] == 0.0
+                && params["clip"]["y"] == 0.0
+                && params["clip"]["width"] == 800.0
+                && params["clip"]["height"] == 600.0
+                && params["clip"]["scale"] == 1.0)
+                .then(|| session.clone())
+        })
+        .flatten()
+        .expect("tab screenshot call");
+    assert!(state
+        .calls
+        .iter()
+        .filter(|(_, method, _)| { method == "Page.getFrameTree" })
+        .all(|(session, _, _)| {
+            session.as_deref() == Some(capture_session.as_str())
+                || session
+                    .as_deref()
+                    .is_some_and(|session| session.starts_with("oopif-sess-"))
+        }));
     assert!(state.calls.iter().all(|(_, method, _)| {
         method != "Target.activateTarget" && method != "Page.bringToFront"
     }));
@@ -1623,6 +1800,615 @@ async fn requested_tab_screenshot_refuses_malformed_image_data() {
         .content
         .iter()
         .all(|content| !matches!(content, Content::Image { .. })));
+}
+
+#[tokio::test]
+async fn semantic_snapshot_refuses_if_the_main_document_changes_during_collection() {
+    let f = fixture_with(|state| state.navigate_after_main_dom = true).await;
+    let (target, tab) = bind(&f).await;
+
+    let raced = semantic_snapshot(&f, &target, &tab).await;
+    assert_eq!(raced["status"], "refused", "{raced}");
+    assert_eq!(raced["refusal"]["code"], "browser_ref_stale", "{raced}");
+
+    let retry = semantic_snapshot(&f, &target, &tab).await;
+    assert_eq!(retry["status"], "ok", "{retry}");
+}
+
+#[tokio::test]
+async fn semantic_snapshot_does_not_emit_pixels_from_a_different_document() {
+    let f = fixture_with(|state| state.navigate_during_screenshot = true).await;
+    let (target, tab) = bind(&f).await;
+    let result = GetBrowserStateTool::new(f.engine.clone())
+        .invoke(json!({
+            "target_id": target,
+            "tab_id": tab,
+            "session": SESSION,
+            "snapshot_format": "semantic_v2",
+            "include_screenshot": true
+        }))
+        .await;
+    let raced = structured(&result);
+    assert_eq!(raced["status"], "refused", "{raced}");
+    assert_eq!(raced["refusal"]["code"], "browser_ref_stale", "{raced}");
+    assert!(result
+        .content
+        .iter()
+        .all(|content| !matches!(content, Content::Image { .. })));
+
+    let retry = semantic_snapshot(&f, &target, &tab).await;
+    assert_eq!(retry["status"], "ok", "{retry}");
+}
+
+#[tokio::test]
+async fn semantic_snapshot_refuses_if_an_included_same_process_frame_navigates() {
+    let f = fixture_with(|state| {
+        state.semantic_large_page = true;
+        state.navigate_iframe_during_screenshot = true;
+    })
+    .await;
+    let (target, tab) = bind(&f).await;
+    let result = GetBrowserStateTool::new(f.engine.clone())
+        .invoke(json!({
+            "target_id": target,
+            "tab_id": tab,
+            "session": SESSION,
+            "snapshot_format": "semantic_v2",
+            "include_screenshot": true
+        }))
+        .await;
+
+    let refusal = structured(&result);
+    assert_eq!(refusal["status"], "refused", "{refusal}");
+    assert_eq!(refusal["refusal"]["code"], "browser_ref_stale");
+    assert!(result
+        .content
+        .iter()
+        .all(|content| !matches!(content, Content::Image { .. })));
+}
+
+#[tokio::test]
+async fn semantic_snapshot_refuses_if_an_included_oopif_navigates() {
+    let f = fixture_with(|state| state.navigate_oopif_during_screenshot = true).await;
+    let (target, tab) = bind(&f).await;
+    let result = GetBrowserStateTool::new(f.engine.clone())
+        .invoke(json!({
+            "target_id": target,
+            "tab_id": tab,
+            "session": SESSION,
+            "snapshot_format": "semantic_v2",
+            "include_screenshot": true
+        }))
+        .await;
+
+    let refusal = structured(&result);
+    assert_eq!(refusal["status"], "refused", "{refusal}");
+    assert_eq!(refusal["refusal"]["code"], "browser_ref_stale");
+    assert!(result
+        .content
+        .iter()
+        .all(|content| !matches!(content, Content::Image { .. })));
+    wait_for_auto_attach_disabled(&f).await;
+    assert!(recorded_calls(&f, "Target.detachFromTarget").is_empty());
+}
+
+#[tokio::test]
+async fn semantic_snapshot_refuses_if_an_included_oopif_becomes_unprovable() {
+    let f = fixture_with(|state| state.unprove_oopif_during_screenshot = true).await;
+    let (target, tab) = bind(&f).await;
+    let result = GetBrowserStateTool::new(f.engine.clone())
+        .invoke(json!({
+            "target_id": target,
+            "tab_id": tab,
+            "session": SESSION,
+            "snapshot_format": "semantic_v2",
+            "include_screenshot": true
+        }))
+        .await;
+
+    let refusal = structured(&result);
+    assert_eq!(refusal["status"], "refused", "{refusal}");
+    assert_eq!(
+        refusal["refusal"]["code"], "browser_route_unavailable",
+        "{refusal}"
+    );
+    assert!(result
+        .content
+        .iter()
+        .all(|content| !matches!(content, Content::Image { .. })));
+    wait_for_auto_attach_disabled(&f).await;
+}
+
+#[tokio::test]
+async fn cancelled_semantic_child_collection_disables_owned_auto_attach() {
+    let f = fixture_with(|state| {
+        state.oopif_frame_count = 3;
+        state.oopif_document_delay = std::time::Duration::from_millis(100);
+    })
+    .await;
+    let (target, tab) = bind(&f).await;
+
+    let cancelled = tokio::time::timeout(
+        std::time::Duration::from_millis(20),
+        GetBrowserStateTool::new(f.engine.clone()).invoke(json!({
+            "target_id": target,
+            "tab_id": tab,
+            "session": SESSION,
+            "snapshot_format": "semantic_v2"
+        })),
+    )
+    .await;
+    assert!(
+        cancelled.is_err(),
+        "fixture must cancel during OOPIF semantic collection"
+    );
+
+    wait_for_auto_attach_disabled(&f).await;
+    assert!(recorded_calls(&f, "Target.setAutoAttach")
+        .iter()
+        .any(|(_, params)| params["autoAttach"] == false));
+    assert!(
+        recorded_calls(&f, "Target.detachFromTarget").is_empty(),
+        "successful auto-attach shutdown already detaches its child sessions"
+    );
+}
+
+#[tokio::test]
+async fn failed_auto_attach_shutdown_still_attempts_every_child_detach() {
+    let f = fixture_with(|state| {
+        state.oopif_frame_count = 3;
+        state.fail_disable_auto_attach = true;
+    })
+    .await;
+    let (target, tab) = bind(&f).await;
+
+    let refusal = semantic_snapshot(&f, &target, &tab).await;
+    assert_eq!(refusal["status"], "refused", "{refusal}");
+    assert_eq!(
+        refusal["refusal"]["code"], "browser_route_unavailable",
+        "{refusal}"
+    );
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            let detaches = recorded_calls(&f, "Target.detachFromTarget");
+            let child_detaches = detaches
+                .iter()
+                .filter(|(_, params)| {
+                    params["sessionId"]
+                        .as_str()
+                        .is_some_and(|session| session.starts_with("oopif-sess-"))
+                })
+                .count();
+            let parent_detaches = detaches
+                .iter()
+                .filter(|(session, params)| {
+                    session.is_none()
+                        && params["sessionId"]
+                            .as_str()
+                            .is_some_and(|session| session.starts_with("tab-sess-"))
+                })
+                .count();
+            if child_detaches == 3 && parent_detaches == 1 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("disable failure must not suppress child detach attempts");
+}
+
+#[tokio::test]
+async fn semantic_oopif_work_is_bounded_but_all_attached_sessions_are_cleaned_up() {
+    let extra_frames = 4;
+    let f = fixture_with(|state| {
+        state.oopif_frame_count = super::engine::MAX_SEMANTIC_OOPIF_FRAMES + extra_frames;
+    })
+    .await;
+    let (target, tab) = bind(&f).await;
+
+    let snapshot = semantic_snapshot(&f, &target, &tab).await;
+    assert_eq!(snapshot["status"], "ok", "{snapshot}");
+    assert_eq!(
+        snapshot["oopif"]["frames"],
+        super::engine::MAX_SEMANTIC_OOPIF_FRAMES
+    );
+    assert_eq!(snapshot["snapshot"]["complete"], false);
+    assert_eq!(
+        snapshot["snapshot"]["omitted"]["unprovable_frame"],
+        extra_frames
+    );
+    assert_eq!(
+        recorded_calls(&f, "DOM.getDocument")
+            .iter()
+            .filter(|(session, _)| session
+                .as_deref()
+                .is_some_and(|session| session.starts_with("oopif-sess-")))
+            .count(),
+        super::engine::MAX_SEMANTIC_OOPIF_FRAMES
+    );
+    assert!(recorded_calls(&f, "Target.setAutoAttach")
+        .iter()
+        .any(|(_, params)| params["autoAttach"] == false));
+    assert!(recorded_calls(&f, "Target.detachFromTarget").is_empty());
+}
+
+#[tokio::test]
+async fn stale_scope_ref_cannot_alias_a_reused_backend_id_after_navigation() {
+    let f = fixture_with(|state| state.semantic_large_page = true).await;
+    let (target, tab) = bind(&f).await;
+    let first = semantic_snapshot(&f, &target, &tab).await;
+    let scope_ref = first["content_refs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["name"] == "Visible message")
+        .and_then(|entry| entry["ref"].as_str())
+        .expect("heading content ref")
+        .to_owned();
+    let dom_calls_before = recorded_calls(&f, "DOM.getDocument").len();
+
+    // The replacement fixture deliberately reuses the same backend node ids.
+    f.state.lock().unwrap().main_loader = "L_MAIN_2".into();
+    let stale = semantic_snapshot_with(&f, &target, &tab, json!({"scope_ref": scope_ref})).await;
+    assert_eq!(stale["status"], "refused", "{stale}");
+    assert_eq!(stale["refusal"]["code"], "browser_ref_stale", "{stale}");
+    assert_eq!(
+        recorded_calls(&f, "DOM.getDocument").len(),
+        dom_calls_before,
+        "stale scope must refuse before collecting the replacement document"
+    );
+    assert!(
+        f.engine
+            .store
+            .resolve_ref(SESSION, &target, &tab, &scope_ref)
+            .is_ok(),
+        "refusal may retain the old namespace because every use re-proves identity"
+    );
+}
+
+#[tokio::test]
+async fn oopif_scope_uses_frame_identity_when_backend_ids_collide() {
+    let f = fixture_with(|state| state.main_oopif_backend_collision = true).await;
+    let (target, tab) = bind(&f).await;
+    let first = semantic_snapshot(&f, &target, &tab).await;
+    let oopif_ref = first["refs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["frame"] == "oopif" && entry["name"] == "Embedded input")
+        .and_then(|entry| entry["ref"].as_str())
+        .expect("OOPIF input ref")
+        .to_owned();
+    assert!(
+        first["refs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["frame"] == "main" && entry["name"] == "Main collision"),
+        "fixture must expose the colliding main-frame node: {first}"
+    );
+
+    let scoped = semantic_snapshot_with(&f, &target, &tab, json!({"scope_ref": oopif_ref})).await;
+    assert_eq!(scoped["status"], "ok", "{scoped}");
+    assert_eq!(scoped["snapshot"]["scope"], "subtree", "{scoped}");
+    assert!(
+        scoped["refs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["frame"] == "oopif" && entry["name"] == "Embedded input"),
+        "the exact OOPIF scope was not selected: {scoped}"
+    );
+    assert!(
+        scoped["refs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|entry| entry["name"] != "Main collision"),
+        "the colliding main-frame backend id escaped the OOPIF scope: {scoped}"
+    );
+}
+
+#[tokio::test]
+async fn oopif_scope_refuses_when_its_exact_child_cannot_be_collected() {
+    let f = fixture_with(|state| state.main_oopif_backend_collision = true).await;
+    let (target, tab) = bind(&f).await;
+    let first = semantic_snapshot(&f, &target, &tab).await;
+    let oopif_ref = first["refs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["frame"] == "oopif" && entry["name"] == "Embedded input")
+        .and_then(|entry| entry["ref"].as_str())
+        .expect("OOPIF input ref")
+        .to_owned();
+    f.state.lock().unwrap().fail_oopif_document = true;
+
+    let scoped = semantic_snapshot_with(&f, &target, &tab, json!({"scope_ref": oopif_ref})).await;
+    assert_eq!(scoped["status"], "refused", "{scoped}");
+    assert_eq!(scoped["refusal"]["code"], "browser_ref_stale", "{scoped}");
+    assert!(
+        f.engine
+            .store
+            .resolve_ref(SESSION, &target, &tab, &oopif_ref)
+            .is_ok(),
+        "failed scoped collection must not replace the prior namespace"
+    );
+}
+
+#[tokio::test]
+async fn failed_continuation_screenshot_leaves_the_token_usable() {
+    let f = fixture_with(|state| state.semantic_large_page = true).await;
+    let (target, tab) = bind(&f).await;
+    let first = semantic_snapshot(&f, &target, &tab).await;
+    let token = first["snapshot"]["continuation"]
+        .as_str()
+        .expect("large fixture continuation")
+        .to_owned();
+    f.state.lock().unwrap().fail_screenshot = true;
+
+    let failed = GetBrowserStateTool::new(f.engine.clone())
+        .invoke(json!({
+            "target_id": target,
+            "tab_id": tab,
+            "session": SESSION,
+            "snapshot_format": "semantic_v2",
+            "continuation": token,
+            "include_screenshot": true
+        }))
+        .await;
+    let refusal = structured(&failed);
+    assert_eq!(refusal["status"], "refused", "{refusal}");
+    assert_eq!(
+        refusal["refusal"]["code"], "browser_route_unavailable",
+        "{refusal}"
+    );
+    assert!(failed
+        .content
+        .iter()
+        .all(|content| !matches!(content, Content::Image { .. })));
+
+    f.state.lock().unwrap().fail_screenshot = false;
+    let retry = semantic_snapshot_with(
+        &f,
+        &target,
+        &tab,
+        json!({"continuation": token, "include_screenshot": true}),
+    )
+    .await;
+    assert_eq!(retry["status"], "ok", "{retry}");
+    assert_eq!(retry["snapshot"]["scope"], "continuation", "{retry}");
+    assert_eq!(retry["screenshot"]["mime_type"], "image/png", "{retry}");
+}
+
+#[tokio::test]
+async fn continuation_navigation_during_screenshot_does_not_consume_the_token() {
+    let f = fixture_with(|state| state.semantic_large_page = true).await;
+    let (target, tab) = bind(&f).await;
+    let first = semantic_snapshot(&f, &target, &tab).await;
+    let token = first["snapshot"]["continuation"]
+        .as_str()
+        .expect("large fixture continuation")
+        .to_owned();
+    f.state.lock().unwrap().navigate_during_screenshot = true;
+
+    let result = GetBrowserStateTool::new(f.engine.clone())
+        .invoke(json!({
+            "target_id": target,
+            "tab_id": tab,
+            "session": SESSION,
+            "snapshot_format": "semantic_v2",
+            "continuation": token,
+            "include_screenshot": true
+        }))
+        .await;
+    let stale = structured(&result);
+    assert_eq!(stale["status"], "refused", "{stale}");
+    assert_eq!(stale["refusal"]["code"], "browser_ref_stale", "{stale}");
+    assert!(result
+        .content
+        .iter()
+        .all(|content| !matches!(content, Content::Image { .. })));
+    assert!(
+        f.engine
+            .store
+            .resolve_semantic_continuation(SESSION, &target, &tab, &token)
+            .is_ok(),
+        "navigation refusal must happen before continuation commit"
+    );
+}
+
+#[tokio::test]
+async fn continuation_refuses_if_an_included_oopif_navigates_during_screenshot() {
+    let f = fixture_with(|state| state.semantic_large_page = true).await;
+    let (target, tab) = bind(&f).await;
+    let first = semantic_snapshot(&f, &target, &tab).await;
+    let token = first["snapshot"]["continuation"]
+        .as_str()
+        .expect("large fixture continuation")
+        .to_owned();
+    f.state.lock().unwrap().calls.clear();
+    f.state.lock().unwrap().navigate_oopif_during_screenshot = true;
+
+    let result = GetBrowserStateTool::new(f.engine.clone())
+        .invoke(json!({
+            "target_id": target,
+            "tab_id": tab,
+            "session": SESSION,
+            "snapshot_format": "semantic_v2",
+            "continuation": token,
+            "include_screenshot": true
+        }))
+        .await;
+    let stale = structured(&result);
+    assert_eq!(stale["status"], "refused", "{stale}");
+    assert_eq!(stale["refusal"]["code"], "browser_ref_stale", "{stale}");
+    assert!(result
+        .content
+        .iter()
+        .all(|content| !matches!(content, Content::Image { .. })));
+    assert!(
+        f.engine
+            .store
+            .resolve_semantic_continuation(SESSION, &target, &tab, &token)
+            .is_ok(),
+        "child-frame navigation refusal must happen before continuation commit"
+    );
+    wait_for_auto_attach_disabled(&f).await;
+}
+
+#[tokio::test]
+async fn failed_fresh_screenshot_preserves_the_existing_snapshot_namespace() {
+    let f = fixture_with(|state| state.semantic_large_page = true).await;
+    let (target, tab) = bind(&f).await;
+    let first = semantic_snapshot(&f, &target, &tab).await;
+    let token = first["snapshot"]["continuation"]
+        .as_str()
+        .expect("large fixture continuation")
+        .to_owned();
+    f.state.lock().unwrap().fail_screenshot = true;
+
+    let failed = GetBrowserStateTool::new(f.engine.clone())
+        .invoke(json!({
+            "target_id": target,
+            "tab_id": tab,
+            "session": SESSION,
+            "snapshot_format": "semantic_v2",
+            "include_screenshot": true
+        }))
+        .await;
+    assert_eq!(structured(&failed)["status"], "refused");
+    assert!(failed
+        .content
+        .iter()
+        .all(|content| !matches!(content, Content::Image { .. })));
+
+    f.state.lock().unwrap().fail_screenshot = false;
+    let retry = semantic_snapshot_with(&f, &target, &tab, json!({"continuation": token})).await;
+    assert_eq!(retry["status"], "ok", "{retry}");
+}
+
+#[tokio::test]
+async fn cancelled_continuation_screenshot_leaves_the_token_usable() {
+    let f = fixture_with(|state| state.semantic_large_page = true).await;
+    let (target, tab) = bind(&f).await;
+    let first = semantic_snapshot(&f, &target, &tab).await;
+    let token = first["snapshot"]["continuation"]
+        .as_str()
+        .expect("large fixture continuation")
+        .to_owned();
+    f.state.lock().unwrap().screenshot_delay = std::time::Duration::from_millis(100);
+
+    let cancelled = tokio::time::timeout(
+        std::time::Duration::from_millis(20),
+        GetBrowserStateTool::new(f.engine.clone()).invoke(json!({
+            "target_id": target,
+            "tab_id": tab,
+            "session": SESSION,
+            "snapshot_format": "semantic_v2",
+            "continuation": token,
+            "include_screenshot": true
+        })),
+    )
+    .await;
+    assert!(
+        cancelled.is_err(),
+        "fixture must cancel during screenshot capture"
+    );
+
+    f.state.lock().unwrap().screenshot_delay = std::time::Duration::ZERO;
+    let retry = semantic_snapshot_with(
+        &f,
+        &target,
+        &tab,
+        json!({"continuation": token, "include_screenshot": true}),
+    )
+    .await;
+    assert_eq!(retry["status"], "ok", "{retry}");
+    assert_eq!(retry["snapshot"]["scope"], "continuation", "{retry}");
+    assert_eq!(retry["screenshot"]["mime_type"], "image/png", "{retry}");
+}
+
+#[tokio::test]
+async fn cancelled_fresh_screenshot_preserves_the_existing_snapshot_namespace() {
+    let f = fixture_with(|state| state.semantic_large_page = true).await;
+    let (target, tab) = bind(&f).await;
+    let first = semantic_snapshot(&f, &target, &tab).await;
+    let token = first["snapshot"]["continuation"]
+        .as_str()
+        .expect("large fixture continuation")
+        .to_owned();
+    f.state.lock().unwrap().screenshot_delay = std::time::Duration::from_millis(100);
+
+    let cancelled = tokio::time::timeout(
+        std::time::Duration::from_millis(20),
+        GetBrowserStateTool::new(f.engine.clone()).invoke(json!({
+            "target_id": target,
+            "tab_id": tab,
+            "session": SESSION,
+            "snapshot_format": "semantic_v2",
+            "include_screenshot": true
+        })),
+    )
+    .await;
+    assert!(
+        cancelled.is_err(),
+        "fixture must cancel during screenshot capture"
+    );
+
+    f.state.lock().unwrap().screenshot_delay = std::time::Duration::ZERO;
+    let retry = semantic_snapshot_with(&f, &target, &tab, json!({"continuation": token})).await;
+    assert_eq!(retry["status"], "ok", "{retry}");
+}
+
+#[tokio::test]
+async fn concurrent_semantic_continuation_has_exactly_one_winner() {
+    let f = fixture_with(|state| {
+        state.semantic_large_page = true;
+        state.screenshot_delay = std::time::Duration::from_millis(50);
+    })
+    .await;
+    let (target, tab) = bind(&f).await;
+    let first = semantic_snapshot(&f, &target, &tab).await;
+    let token = first["snapshot"]["continuation"]
+        .as_str()
+        .expect("large fixture continuation")
+        .to_owned();
+    let args = json!({
+        "target_id": target,
+        "tab_id": tab,
+        "session": SESSION,
+        "snapshot_format": "semantic_v2",
+        "continuation": token,
+        "include_screenshot": true
+    });
+    let left_tool = GetBrowserStateTool::new(f.engine.clone());
+    let right_tool = GetBrowserStateTool::new(f.engine.clone());
+    let (left, right) = tokio::join!(left_tool.invoke(args.clone()), right_tool.invoke(args),);
+    let statuses = [
+        structured(&left)["status"].as_str(),
+        structured(&right)["status"].as_str(),
+    ];
+    assert!(
+        statuses.contains(&Some("ok")),
+        "left={:?}, right={:?}",
+        structured(&left),
+        structured(&right)
+    );
+    assert!(
+        statuses.contains(&Some("refused")),
+        "left={:?}, right={:?}",
+        structured(&left),
+        structured(&right)
+    );
+    let image_count = [&left, &right]
+        .into_iter()
+        .flat_map(|result| &result.content)
+        .filter(|content| matches!(content, Content::Image { .. }))
+        .count();
+    assert_eq!(image_count, 1);
+    assert_eq!(recorded_calls(&f, "Page.captureScreenshot").len(), 1);
 }
 
 #[tokio::test]
@@ -2037,6 +2823,7 @@ async fn click_routes_oopif_refs_through_the_contained_child_session() {
     let (target, tab) = bind(&f).await;
     let snap = snapshot(&f, &target, &tab).await;
     let oopif_ref = ref_of(&snap, "oopif", "ad-input");
+    f.state.lock().unwrap().calls.clear();
 
     let result = BrowserClickTool::new(f.engine.clone())
         .invoke(json!({
@@ -2064,6 +2851,63 @@ async fn click_routes_oopif_refs_through_the_contained_child_session() {
     assert_eq!(focus_emulation[1].1["enabled"], false);
     assert!(recorded_calls(&f, "Page.bringToFront").is_empty());
     assert!(recorded_calls(&f, "Target.activateTarget").is_empty());
+    wait_for_auto_attach_disabled(&f).await;
+    let state = f.state.lock().unwrap();
+    let calls = &state.calls;
+    let last_dispatch = calls
+        .iter()
+        .rposition(|(_, method, _)| method == "Input.dispatchMouseEvent")
+        .expect("mouse dispatch");
+    let cleanup = calls
+        .iter()
+        .position(|(_, method, params)| {
+            method == "Target.setAutoAttach" && params["autoAttach"] == false
+        })
+        .expect("auto-attach cleanup");
+    assert!(
+        cleanup > last_dispatch,
+        "the child-session lease must remain attached through dispatch: {calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn two_ref_drag_in_one_oopif_reuses_one_owned_child_session() {
+    let f = fixture_with(|state| state.oopif_two_inputs = true).await;
+    let (target, tab) = bind(&f).await;
+    let snap = snapshot(&f, &target, &tab).await;
+    let origin = ref_of(&snap, "oopif", "ad-input");
+    let destination = ref_of(&snap, "oopif", "ad-destination");
+    f.state.lock().unwrap().calls.clear();
+
+    let result = BrowserPointerTool::new(f.engine.clone())
+        .invoke(json!({
+            "target_id": target,
+            "tab_id": tab,
+            "session": SESSION,
+            "action": "drag",
+            "ref": origin,
+            "destination_ref": destination.clone()
+        }))
+        .await;
+    let outcome = structured(&result);
+    assert_eq!(outcome["status"], "ok", "{outcome}");
+    assert_eq!(outcome["frame"], "oopif");
+    assert_eq!(outcome["destination_ref"], destination);
+
+    let enables = recorded_calls(&f, "Target.setAutoAttach")
+        .into_iter()
+        .filter(|(_, params)| params["autoAttach"] == true)
+        .count();
+    assert_eq!(
+        enables, 1,
+        "the second ref must reuse the exact frame's live attachment"
+    );
+    let mouse = recorded_calls(&f, "Input.dispatchMouseEvent");
+    assert!(!mouse.is_empty());
+    assert!(mouse.iter().all(|(session, _)| session
+        .as_deref()
+        .is_some_and(|session| session.starts_with("oopif-sess-"))));
+    wait_for_auto_attach_disabled(&f).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Cua Driver can turn the current web page into a structured snapshot that an
agent can read and act on. Before this change, the page could navigate while a
snapshot was being assembled, leaving the text, action references, or optional
screenshot tied to different page versions.

This PR keeps the complete `semantic_v2` snapshot operation tied to one browser
tab and one set of page documents. If the main page or a collected embedded
frame changes during the operation, the Driver refuses the result instead of
publishing stale references.

## What changes

- Collect semantic content and an optional screenshot through the same browser
  connection while holding the existing per-tab operation lock.
- Check the main document and every collected embedded-frame document before
  and after collection.
- Publish only while the original session, browser target, tab, and connection
  are still current.
- Consume a continuation token only when the replacement page is successfully
  published. Two concurrent users of one token have exactly one winner.
- Include the frame and document identity in scoped references, preventing a
  matching node number from another frame from being accepted by mistake.
- Remove cancelled browser requests from the pending-response table.
- Limit embedded-frame collection to 16 frames and eight seconds, with a
  separate bounded cleanup step.

The older `dom_refs_v1` response format is unchanged.

## Validation

Deterministic tests cover navigation during first-page and continuation
collection, screenshot failure, cancellation, concurrent continuation use,
replaced targets, frame-number collisions, stale embedded frames, and bounded
cleanup. The full 625-test core suite passed after the shared frame-lifetime
change; the final cleanup-bound adjustment also passed its focused test.

## Definition of Done

- [x] Refuse a snapshot when a collected document is replaced.
- [x] Keep the screenshot and semantic data in one tab operation.
- [x] Preserve continuation tokens after cancellation or capture failure.
- [x] Allow only one successful use of a continuation token.
- [x] Bind scoped references to the exact frame and document.
- [x] Bound embedded-frame collection and cleanup.
- [ ] Run the supported installed-browser matrix at this exact commit.
- [ ] Receive maintainer review for the snapshot-lifetime contract.

Refs #3136
