### PR TITLE
feat(sandbox): add an optional compatible Driver SDK extra

### DIFF
--- a/libs/python/cua-sandbox/README.md
+++ b/libs/python/cua-sandbox/README.md
@@ -13,6 +13,17 @@ Install from the Cua wheel index when resolving dependencies with pip:
 pip install --extra-index-url https://wheels.cua.ai/simple cua-sandbox
 ```
 
+For typed desktop control of a Fleet sandbox through `sb.driver.connect()`,
+install the optional Driver SDK:
+
+```bash
+pip install --extra-index-url https://wheels.cua.ai/simple 'cua-sandbox[driver]'
+```
+
+The `driver` extra pins `cua-driver==0.25.0`, which provides the compatible remote
+channel bridge. It requires that version to be published for your platform.
+The sandbox image must also run a compatible Driver service.
+
 ## Ephemeral sandbox
 
 Created on enter, destroyed on exit.

--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -43,6 +43,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+driver = [
+    "cua-driver==0.25.0",
+]
 auth = [
     "webbrowser-open>=0.0.1",
 ]

--- a/libs/python/cua-sandbox/tests/test_driver_dependency.py
+++ b/libs/python/cua-sandbox/tests/test_driver_dependency.py
@@ -1,0 +1,12 @@
+"""Keep the native Driver an explicit, version-matched install option."""
+
+import tomllib
+from pathlib import Path
+
+
+def test_driver_extra_is_exact_and_optional():
+    package = Path(__file__).resolve().parents[1]
+    sandbox = tomllib.loads((package / "pyproject.toml").read_text())["project"]
+
+    assert sandbox["optional-dependencies"]["driver"] == ["cua-driver==0.25.0"]
+    assert not any(item.startswith("cua-driver") for item in sandbox["dependencies"])

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -568,6 +568,18 @@ provides-extras = ["otel", "telemetry"]
 dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
+name = "cua-driver"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/ce/5bab14083ccdc3f09db61407bd6201e252b5f0ae890b772f56871fb79874/cua_driver-0.25.0-py3-none-macosx_13_0_universal2.whl", hash = "sha256:8a37aeadd8bee3354ca5f659b4b5e4ee1a22f9ac689cdd39146e0d2cf4d422b9", size = 39345544, upload-time = "2026-09-09T07:47:07.918Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/14/e2fcabc9ba413fd68198d4b7bc8ebd369d95fa4674b8943c16cad784548d/cua_driver-0.25.0-py3-none-manylinux_2_31_aarch64.whl", hash = "sha256:87ab081c00ef49467071ed690ff19976f9e7117c0840fbb0e1f49e5219588221", size = 28335568, upload-time = "2026-09-09T07:47:11.556Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/6e/cdd76d455a19c239d6faee4543677621ce4853a1e5e60b52076d7436359b/cua_driver-0.25.0-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:5b03042e4b668fdb6d1d4c85deec95c690961dc18cd08068e5f6cedecae6838d", size = 28168423, upload-time = "2026-09-09T07:47:14.85Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/3a/72f5a21fb78801b4f540497b9857477514c9048db44a1cb1d409672ea9ba/cua_driver-0.25.0-py3-none-win_amd64.whl", hash = "sha256:1f652d348b3338f052d377078afffa29860e2a071262e9f2b1c3a058c40a7c8c", size = 25728886, upload-time = "2026-09-09T07:47:18.845Z" },
+    { url = "https://files.pythonhosted.org/packages/07/dc/f1c863f6a3a97115f5a62a3254ae15fab8a1f504d7e817a881f08f9f9e12/cua_driver-0.25.0-py3-none-win_arm64.whl", hash = "sha256:c5799032f0e3f8429558222e8d5befb6cef09d62384e89a8ab58350b9f433837", size = 23973769, upload-time = "2026-09-09T07:47:22.134Z" },
+]
+
+[[package]]
 name = "cua-fleet"
 version = "0.1.16"
 source = { registry = "https://wheels.cua.ai/simple" }
@@ -608,6 +620,9 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
+driver = [
+    { name = "cua-driver" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -622,6 +637,7 @@ dev = [
 requires-dist = [
     { name = "cua-auto", specifier = ">=0.1.2" },
     { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
+    { name = "cua-driver", marker = "extra == 'driver'", specifier = "==0.25.0" },
     { name = "cua-fleet", specifier = "==0.1.16" },
     { name = "grpcio", specifier = "==1.78.0" },
     { name = "httpx", specifier = ">=0.27.0" },
@@ -638,7 +654,7 @@ requires-dist = [
     { name = "webbrowser-open", marker = "extra == 'auth'", specifier = ">=0.0.1" },
     { name = "websockets", specifier = ">=12.0" },
 ]
-provides-extras = ["auth", "dev"]
+provides-extras = ["driver", "auth", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Sandbox's typed Fleet connection needs the compatible generated Driver SDK. This adds `cua-sandbox[driver]` with `cua-driver==0.25.0`, the public-registry lock entries, a packaging regression test, and a short install example. Base dependencies and the Release Please-managed Sandbox version (`0.4.3`) remain unchanged.

Refs #2512.

Validation on `c9cbf88e2c21c33408c409fd6316f26053eeaf2c` (Python 3.12, macOS arm64):

- Built a wheel and sdist; strict Twine checks pass.
- Fresh base-wheel install imports from the isolated environment without Driver installed: 45 packaging and typed-connection tests pass.
- Fresh extra install uses public `cua-driver==0.25.0`, not a locally built Driver candidate. Both modules import from installed wheels. With `CUA_SANDBOX_REQUIRE_NATIVE_DRIVER=1`, isolated Python and pytest importlib mode: 238 typed-connection, native bridge, pool, transport, lifecycle, and cleanup tests pass, with no skips.
- `uv lock` adds only Driver and its optional dependency metadata; all five wheel hashes match the exact Driver release checksums. `uv lock --check` passes.
- Ruff lint/format, Black, isort, dependency consistency checks, and `git diff --check` pass.

The Driver release and its five-platform wheel build/install gates passed in [SDK publication](https://github.com/trycua/cua/actions/runs/34325485181). The local Sandbox/native bridge results above qualify the installed macOS package and simulated transport, not a live Fleet guest or Windows/Linux Sandbox extra execution.

Fresh PR CI and independent review remain the merge gates. Once merged, this feeds the Sandbox release PR (#3676); Release Please owns the version. The optional package does not deploy a Driver service or enable a hosted endpoint. Live hosted use still requires a compatible service and separately verified routing/isolation. Existing computer-server paths remain unchanged.
