### PR TITLE
ci(cua-driver): build exact MCP candidates for guest qualification

### DIFF
--- a/.github/workflows/ci-driver-mcp-candidate.yml
+++ b/.github/workflows/ci-driver-mcp-candidate.yml
@@ -1,0 +1,120 @@
+name: "CI: Driver MCP candidate"
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ci-driver-mcp-candidate.yml"
+      - "libs/cua-driver/rust/crates/cua-driver/src/mcp_envelope.rs"
+      - "libs/cua-driver/rust/crates/cua-driver/src/driver_service_http.rs"
+      - "libs/cua-driver/rust/crates/cua-driver/src/proxy.rs"
+      - "libs/cua-driver/rust/crates/cua-driver/src/serve.rs"
+      - "libs/python/cua-sandbox/cua_sandbox/interfaces/_driver_mcp.py"
+      - "libs/python/cua-sandbox/cua_sandbox/interfaces/driver.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: driver-mcp-candidate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  candidate:
+    name: MCP candidate (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-latest]
+    defaults:
+      run:
+        shell: bash
+    env:
+      EXPECTED_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CUA_TELEMETRY_ENABLED: "false"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Verify exact source
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_SOURCE_SHA"
+          test -z "$(git status --porcelain)"
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+        with:
+          workspaces: "libs/cua-driver/rust -> target"
+          key: mcp-candidate
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang pkg-config libdbus-1-dev libpipewire-0.3-dev libspa-0.2-dev \
+            libei-dev libxkbcommon-dev libx11-dev libxi-dev libxtst-dev libxext-dev
+      - name: Run envelope receiver and service tests
+        working-directory: libs/cua-driver/rust
+        run: |
+          set -euo pipefail
+          cargo test -p cua-driver --bin cua-driver mcp_envelope --locked
+          cargo test -p cua-driver --bin cua-driver driver_service_http --locked
+      - name: Build disposable-test binaries
+        working-directory: libs/cua-driver/rust
+        run: |
+          set -euo pipefail
+          if [[ "$RUNNER_OS" == Linux ]]; then
+            cargo build --locked -p cua-driver -p cursor-theme-cli --features cua-driver/portal-input
+          else
+            cargo build --locked -p cua-driver -p cursor-theme-cli -p cua-driver-uia
+          fi
+      - name: Bundle exact binaries and provenance
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+          import subprocess
+          import tarfile
+
+          source = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+          assert source == os.environ["EXPECTED_SOURCE_SHA"]
+          assert not subprocess.check_output(["git", "status", "--porcelain"], text=True).strip()
+          windows = os.environ["RUNNER_OS"] == "Windows"
+          names = ["cua-driver", "cua-cursor-theme"] + (["cua-driver-uia"] if windows else [])
+          binaries = [Path("libs/cua-driver/rust/target/debug") / (name + (".exe" if windows else "")) for name in names]
+          assert all(path.is_file() and path.stat().st_size > 0 for path in binaries)
+          bundle = Path("mcp-candidate")
+          bundle.mkdir()
+          metadata = {
+              "source_sha": source,
+              "runner_os": os.environ["RUNNER_OS"],
+              "profile": "dev, debug=0",
+              "features": ["cua-driver/portal-input"] if not windows else [],
+              "rustc": subprocess.check_output(["rustc", "--version"], text=True).strip(),
+              "version": subprocess.check_output([str(binaries[0].resolve()), "--version"], text=True).strip(),
+              "files": {path.name: hashlib.file_digest(path.open("rb"), "sha256").hexdigest() for path in binaries},
+              "qualification": "Test-only unsigned candidate; not a release or image qualification.",
+          }
+          provenance = bundle / "provenance.json"
+          provenance.write_text(json.dumps(metadata, indent=2) + "\n")
+          with tarfile.open(bundle / "candidate.tar.gz", "w:gz") as archive:
+              for path in binaries:
+                  archive.add(path, arcname=path.name)
+              archive.add(provenance, arcname=provenance.name)
+          print(json.dumps(metadata, indent=2))
+          PY
+      - name: Upload candidate for separately authorized tests
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: driver-mcp-candidate-${{ runner.os }}-${{ github.event.pull_request.head.sha || github.sha }}
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            mcp-candidate/candidate.tar.gz
+            mcp-candidate/provenance.json

--- a/libs/cua-driver/docs/mcp-candidate-qualification.md
+++ b/libs/cua-driver/docs/mcp-candidate-qualification.md
@@ -1,0 +1,42 @@
+# MCP candidate qualification
+
+The `CI: Driver MCP candidate` workflow builds the exact pull-request head
+on hosted Linux and Windows runners. It runs the envelope receiver and service
+tests, then uploads unsigned development binaries with their source SHA,
+toolchain, build profile, version, and SHA256 hashes. It has read-only repository
+permissions and no Fleet credentials. It does not publish a release, install a
+product, change an image, or connect to a Fleet computer.
+
+These artifacts support separately authorized disposable-guest tests. Check the
+workflow repository, source SHA, successful jobs, and every binary hash before
+using an artifact. Do not select an artifact by version alone: an unreleased
+source build can report the same package version as a released binary.
+
+## Live test gate
+
+For each selected Linux and Windows Fleet image:
+
+1. Record the immutable image reference and installed Driver, computer-server,
+   and MCP-wrapper versions. Use an owned disposable claim and namespace with
+   explicit resource limits and verified cleanup ownership.
+2. Stage the exact candidate separately. Preserve computer-server. Start Driver
+   in the guest's interactive desktop session through its existing socket or
+   named pipe. Enable the envelope opt-in in both the daemon and MCP proxy.
+3. Disable raw request/response logging before action-bearing tests. Reuse the
+   existing named MCP service and access boundary; do not introduce a new
+   network endpoint or substitute the operator's local desktop.
+4. Use matching generated bindings with
+   `sb.driver.connect(service="mcp", transport="mcp")`. Prove a useful guest
+   effect with fresh before/after Driver state and an independent guest
+   postcondition. A successful call alone is not the oracle.
+5. Verify independent sessions, cancellation without claiming rollback, stale
+   session rejection after replacement, access rejection, and continued
+   computer-server functionality. Verify receiver and MCP-session cleanup
+   independently from Fleet resource cleanup.
+6. Delete only the task-owned resources and confirm their absence. Preserve
+   failure and cleanup evidence, including any incomplete result.
+
+A staged development-binary result is not packaged-image certification or the
+full canonical desktop matrix. A release/image enablement decision still needs
+the applicable exact-candidate desktop harness evidence, packaged-image replay,
+and separate rollout approval. Keep existing defaults and images unchanged.


### PR DESCRIPTION
## Summary

Landed after #3693. Refs #2512, #3691, and #3692.

Add an exact-head Linux/Windows CI lane for the opt-in MCP receiver. It executes the receiver and service tests on both operating systems, builds development binaries, and uploads an explicit archive plus source/toolchain/profile/version/hash provenance for separately authorized disposable tests.

This fills the candidate-binary acquisition gap without invoking a release workflow. No secrets, self-hosted runners, cloud credentials, release permissions, installation, image publication, or deployment. Artifacts expire after seven days and are labeled unsigned test candidates.

## Validation

- Actionlint 1.7.7 passed for this workflow and the updated parent SDK workflow (ShellCheck integration disabled because that optional local tool is unavailable; each run block separately passed `bash -n`).
- YAML permissions/event/matrix assertions and inline Python syntax validation passed.
- Prettier and `git diff --check` passed.
- Linux and Windows hosted development builds passed at this PR's `aebe471ac249272565797e2a823d6613a2d8e93b` and follow-up #3695's `16e6728696b0d0f36e1e3d2f0afa39000d2da16c`. Guest archive/binary hashes matched workflow provenance.
- Live qualification found and fixed missing window observation (#3695) and MCP cancellation teardown ordering (#3696). Their final staged candidate passed typed window clicks with independent effects, cancellation/session lifecycle, and owned-resource cleanup on disposable Linux and Windows guests. See #3696 for exact source pairs and the older Linux computer-server idle-session caveat.
- This is supporting staged-candidate evidence, not published-image certification. The canonical desktop-matrix status is recorded below.

## Scope and gate

Two files: the CI workflow and a contributor qualification note. No product code changes beyond the parent stack. Merged after fresh current checks passed. These development artifacts are not approved for production. Removing the workflow removes this test-artifact lane and does not affect existing images or SDK defaults.

## Final merge qualification

Exact complete-stack candidate: `99123862c0a707d07c3818a34bb2a665ad3e814f`.

- [Linux canonical all-lanes run](https://github.com/trycua/cua/actions/runs/34426190500): all lanes, installer, and consolidated report passed. 89 delivered actions + 42 expected refusals; zero failures/skips. Ready X11/Openbox environment and exact source confirmed.
- [Windows canonical all-lanes run](https://github.com/trycua/cua/actions/runs/34426192349): all lanes, installer, and consolidated report passed. 112 delivered actions + 26 expected refusals; zero failures/skips. Ready interactive Windows environment and exact source confirmed.
- Fresh focused Sandbox selection: 256 passed with source-matched bindings. This overlaps earlier selections and is not added to their counts.
- All six Cua stack PRs (#3691–#3696) are merged. Before each merge, current CI, the exact-head diff and ancestry, and unresolved review findings were checked. Admin bypass was limited to missing review approval; no failed check was bypassed. Final main `07e36a3f05d88ca8be3a04454b8738f81c9d92f6` has identical product, workflow, script, and RFC contents to the qualified complete candidate.
- Final-main verification: **265 Sandbox tests** passed with matching source-built native bindings, plus **nine read-only release-wiring/request tests**. These overlap earlier selections and are not added to their counts.
- Post-merge capture diagnostics passed on [Linux](https://github.com/trycua/cua/actions/runs/34431230893) (7 delivered) and [Windows](https://github.com/trycua/cua/actions/runs/34431232109) (9 delivered), with zero refused/failed/skipped cases and successful consolidated reports. Both used merged Rust source `e08829b8e5b53c69e83f256541b660024e0e71a9`; final main has identical Rust, runners, and workflow inputs. These capture-only runs supplement, not replace, the full candidate matrix above.
- The Sandbox optional extra still pins published Driver 0.25.0, which does not contain the candidate's newer typed-window API. The release owner must align qualified package versions before advertising this opt-in path. No future version is guessed here.
- Missing/invalid credential rejection is not cross-account isolation certification. No macOS GUI or packaged-image qualification is claimed.
