### PR TITLE
fix(cua-driver): admit typed remote window observation

### DIFF
--- a/.github/workflows/ci-driver-mcp-candidate.yml
+++ b/.github/workflows/ci-driver-mcp-candidate.yml
@@ -8,6 +8,7 @@ on:
       - "libs/cua-driver/rust/crates/cua-driver/src/driver_service_http.rs"
       - "libs/cua-driver/rust/crates/cua-driver/src/proxy.rs"
       - "libs/cua-driver/rust/crates/cua-driver/src/serve.rs"
+      - "libs/cua-driver/rust/crates/cua-driver-sdk/src/remote_receiver*.rs"
       - "libs/python/cua-sandbox/cua_sandbox/interfaces/_driver_mcp.py"
       - "libs/python/cua-sandbox/cua_sandbox/interfaces/driver.py"
   workflow_dispatch:
@@ -63,6 +64,7 @@ jobs:
           set -euo pipefail
           cargo test -p cua-driver --bin cua-driver mcp_envelope --locked
           cargo test -p cua-driver --bin cua-driver driver_service_http --locked
+          cargo test -p cua-driver-sdk remote_receiver::tests --locked
       - name: Build disposable-test binaries
         working-directory: libs/cua-driver/rust
         run: |

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/remote_receiver.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/remote_receiver.rs
@@ -382,6 +382,8 @@ fn remote_tool(name: &str) -> bool {
     matches!(
         name,
         "get_desktop_state"
+            | "list_windows"
+            | "get_window_state"
             | "get_screen_size"
             | "get_cursor_position"
             | "click"

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/remote_receiver_tests.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/remote_receiver_tests.rs
@@ -158,6 +158,82 @@ async fn preserves_native_results_and_arguments_for_each_operation() {
 }
 
 #[tokio::test]
+async fn window_observation_is_advertised_and_dispatches_without_changing_results() {
+    use cua_driver_contract::{GetWindowStateInput, ListWindowsInput, ToolInput};
+
+    let native = json!({
+        "content": [{"type": "image", "data": "synthetic", "mimeType": "image/png"}],
+        "structuredContent": {"snapshot_id": "s1", "elements": []},
+        "isError": false
+    });
+    let executor = FakeExecutor::new(native.clone(), false);
+    let receiver = DriverEnvelopeReceiver::new(executor.clone());
+    let calls = [
+        (
+            ListWindowsInput::TOOL_NAME,
+            json!({"pid": 42, "on_screen_only": true}),
+        ),
+        (
+            GetWindowStateInput::TOOL_NAME,
+            json!({
+                "pid": 42,
+                "window_id": 7,
+                "session": "observation",
+                "include_accessibility_tree": true,
+                "include_screenshot": true,
+                "screenshot_out_file": null,
+                "max_elements": 100
+            }),
+        ),
+    ];
+    for (name, arguments) in &calls {
+        assert!(cua_driver_contract::tool_contract(name).is_some());
+        // NativeExecutor::list_tools uses this same predicate to advertise tools.
+        assert!(
+            remote_tool(name),
+            "{name} must appear in remote tool discovery"
+        );
+        let mut envelope = request(name);
+        envelope.name = Some((*name).into());
+        envelope.arguments = Some(arguments.clone());
+        let response = receiver.exchange(receiver.generation(), envelope).await;
+        assert!(response.ok, "{response:?}");
+        assert!(response.completion_known);
+        assert_eq!(response.result.as_ref(), Some(&native));
+    }
+    assert_eq!(
+        *executor.calls.lock().unwrap(),
+        calls.map(|(name, arguments)| (name.to_string(), arguments))
+    );
+}
+
+#[tokio::test]
+async fn window_observation_rejects_local_paths_and_private_fields_before_dispatch() {
+    let executor = FakeExecutor::new(Value::Null, false);
+    let receiver = DriverEnvelopeReceiver::new(executor.clone());
+    for name in ["list_windows", "get_window_state"] {
+        for (field, value) in [
+            ("screenshot_out_file", json!("/tmp/receiver-test.png")),
+            ("image_path", json!("/tmp/receiver-test.png")),
+            ("file_path", json!("/tmp/receiver-test.txt")),
+            ("_session_id", json!("untrusted")),
+            ("_permission_mode", json!("unrestricted")),
+            ("_private", Value::Null),
+        ] {
+            let mut arguments = json!({"pid": 42, "window_id": 7});
+            arguments[field] = value;
+            let mut envelope = request("rejected-observation");
+            envelope.name = Some(name.into());
+            envelope.arguments = Some(arguments);
+            let response = receiver.exchange(receiver.generation(), envelope).await;
+            assert_refusal(&response, "invalid_request", true);
+        }
+    }
+    assert_eq!(executor.count(), 0);
+    assert!(receiver.state.lock().unwrap().requests.is_empty());
+}
+
+#[tokio::test]
 async fn preserves_native_tool_error_code_and_message() {
     let executor = FakeExecutor::new(Value::Null, false);
     let error = DriverError::Tool {
@@ -209,7 +285,19 @@ async fn invalid_envelopes_never_reach_executor() {
         envelope.arguments = Some(arguments);
         invalid.push(envelope);
     }
-    for name in ["execute_shell", "session_end", "unknown_tool"] {
+    for name in [
+        "execute_shell",
+        "launch_app",
+        "kill_app",
+        "read_file",
+        "write_file",
+        "start_session",
+        "escalate_session",
+        "end_session",
+        "session_end",
+        "unknown_tool",
+    ] {
+        assert!(!remote_tool(name), "{name} must not be advertised remotely");
         let mut envelope = request("unsupported");
         envelope.name = Some(name.into());
         invalid.push(envelope);


### PR DESCRIPTION
## Summary

Landed after #3694. Refs #2512, #3691, #3692, and #3693.

Allow the canonical `list_windows` and `get_window_state` observation methods through the existing remote envelope receiver. The generated SDK already exposes these typed methods, but the receiver's earlier desktop-only allowlist rejects them before dispatch. Without window observation, callers cannot perform the normal snapshot-before-action loop.

Keep the existing receiver restrictions: no remote process management, shell, file operations, local screenshot output paths, private session fields, or caller-selected permission escalation. No new listener, routing, authentication, fallback, or reconnect behavior.

Extend the candidate CI path filter and test selection so this receiver change produces exact-head Linux and Windows development artifacts.

## Validation

- 14 focused remote receiver tests passed, including new typed-tool discovery/dispatch, result preservation, forbidden-path/private-field rejection, and denied-tool regression tests.
- Rustfmt and `git diff --check` passed.
- All reported CI passed at `16e6728696b0d0f36e1e3d2f0afa39000d2da16c`, including both hosted candidate builds. The complete remote SDK selection passed 21 tests.
- Both disposable Linux and Windows guests passed typed `list_windows`, `get_window_state`, and background accessibility `click`, with fresh before/after snapshots and independent counter readback. Both owned namespaces were deleted and verified absent.
- Live testing also exposed a separate carrier cancellation issue, fixed and tested in #3696. Include that follow-up in the review; the stack is not qualified without it. See #3696 for final source pairs, native cancellation evidence, and the existing Linux computer-server idle-session packaging caveat.

Three changed files: receiver allowlist, its regression tests, and the existing candidate workflow. No generated API changes or compatibility signature changes.

## Gate and rollback

Merged after the complete candidate and current PR checks passed. Package release, image publication, deployment, and production enablement remain outside this change. The live test uses staged development candidates, not release packages. Remove this follow-up to restore the prior allowlist; existing SDK defaults and computer-server behavior remain unchanged.

## Final merge qualification

Exact complete-stack candidate: `99123862c0a707d07c3818a34bb2a665ad3e814f`.

- [Linux canonical all-lanes run](https://github.com/trycua/cua/actions/runs/34426190500): all lanes, installer, and consolidated report passed. 89 delivered actions + 42 expected refusals; zero failures/skips. Ready X11/Openbox environment and exact source confirmed.
- [Windows canonical all-lanes run](https://github.com/trycua/cua/actions/runs/34426192349): all lanes, installer, and consolidated report passed. 112 delivered actions + 26 expected refusals; zero failures/skips. Ready interactive Windows environment and exact source confirmed.
- Fresh focused Sandbox selection: 256 passed with source-matched bindings. This overlaps earlier selections and is not added to their counts.
- All six Cua stack PRs (#3691–#3696) are merged. Before each merge, current CI, the exact-head diff and ancestry, and unresolved review findings were checked. Admin bypass was limited to missing review approval; no failed check was bypassed. Final main `07e36a3f05d88ca8be3a04454b8738f81c9d92f6` has identical product, workflow, script, and RFC contents to the qualified complete candidate.
- Final-main verification: **265 Sandbox tests** passed with matching source-built native bindings, plus **nine read-only release-wiring/request tests**. These overlap earlier selections and are not added to their counts.
- Post-merge capture diagnostics passed on [Linux](https://github.com/trycua/cua/actions/runs/34431230893) (7 delivered) and [Windows](https://github.com/trycua/cua/actions/runs/34431232109) (9 delivered), with zero refused/failed/skipped cases and successful consolidated reports. Both used merged Rust source `e08829b8e5b53c69e83f256541b660024e0e71a9`; final main has identical Rust, runners, and workflow inputs. These capture-only runs supplement, not replace, the full candidate matrix above.
- The Sandbox optional extra still pins published Driver 0.25.0, which does not contain the candidate's newer typed-window API. The release owner must align qualified package versions before advertising this opt-in path. No future version is guessed here.
- Missing/invalid credential rejection is not cross-account isolation certification. No macOS GUI or packaged-image qualification is claimed.
