### PR TITLE
fix(cua-driver): exclude cursor overlay from foreground verification

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/e2e.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/e2e.rs
@@ -299,6 +299,7 @@ pub enum OracleKind {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RefusalCode {
+    BringToFrontExactWindowUnverified,
     BackgroundUnavailable,
     BackgroundOccluded,
     BackgroundUipiBlocked,
@@ -321,6 +322,9 @@ pub enum RefusalCode {
 impl RefusalCode {
     pub fn from_driver_code(code: &str) -> Option<Self> {
         match code {
+            "bring_to_front_exact_window_unverified" => {
+                Some(Self::BringToFrontExactWindowUnverified)
+            }
             "background_unavailable" => Some(Self::BackgroundUnavailable),
             "background_occluded" => Some(Self::BackgroundOccluded),
             "background_uipi_blocked" => Some(Self::BackgroundUipiBlocked),

--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/e2e.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/e2e.rs
@@ -576,21 +576,30 @@ impl CaseSpec {
             return Err(format!("{}: no external oracle declared", self.cell_id));
         }
         if let ContractExpectation::Refuse { allowed_codes } = &self.expected_behavior {
-            if self.delivery != Delivery::Background {
+            let exact_activation_refusal = self.delivery == Delivery::Foreground
+                && self.scope == Scope::Window
+                && self.driver_route == DriverRoute::WindowState
+                && allowed_codes == &[RefusalCode::BringToFrontExactWindowUnverified];
+            if self.delivery != Delivery::Background && !exact_activation_refusal {
                 return Err(format!(
-                    "{}: only background delivery may declare refusal",
+                    "{}: only background delivery or exact-window activation may declare refusal",
                     self.cell_id
                 ));
             }
             if allowed_codes.is_empty() {
                 return Err(format!("{}: refusal has no allowed code", self.cell_id));
             }
-            for required in [
-                OracleKind::Focus,
-                OracleKind::ZOrder,
-                OracleKind::NoLeakedInput,
-            ] {
-                if !self.oracles.contains(&required) {
+            let required_oracles: &[OracleKind] = if exact_activation_refusal {
+                &[OracleKind::FixtureState]
+            } else {
+                &[
+                    OracleKind::Focus,
+                    OracleKind::ZOrder,
+                    OracleKind::NoLeakedInput,
+                ]
+            };
+            for required in required_oracles {
+                if !self.oracles.contains(required) {
                     return Err(format!(
                         "{}: refusal is missing {:?} oracle",
                         self.cell_id, required

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
@@ -235,27 +235,55 @@ fn harness_appkit_exact_activation_with_agent_cursor() {
         };
         let observer = NativeObserver::new();
         let before = observer.snapshot(target).expect("observe native desktop");
-        let motion = driver.call(
-            "set_agent_cursor_motion",
-            serde_json::json!({"idle_hide_ms": 0, "glide_duration_ms": 0}),
-        );
-        assert!(!motion.is_error(), "cursor motion: {}", motion.text());
-        let moved = driver.call(
-            "move_cursor",
-            serde_json::json!({
-                "target": {"kind": "window", "pid": pid, "window_id": wid},
-                "x": 120,
-                "y": 100
-            }),
-        );
-        assert!(!moved.is_error(), "agent cursor: {}", moved.text());
-        let cursor = driver.call("get_agent_cursor_state", serde_json::json!({}));
-        assert_eq!(cursor.structured()["enabled"], true);
-        assert!(cursor.structured()["position"].is_object());
-        let activated = driver.call(
-            "bring_to_front",
-            serde_json::json!({"pid": pid, "window_id": wid}),
-        );
+        let socket = std::env::var("CUA_E2E_MACOS_DAEMON_SOCKET")
+            .expect("canonical installed daemon socket");
+        let mut peer = McpDriver::spawn_daemon_proxy_unrecorded(&socket)
+            .expect("start concurrent cursor session");
+        let stopped = std::sync::atomic::AtomicBool::new(false);
+        let (ready, started) = std::sync::mpsc::sync_channel(1);
+        let activated = std::thread::scope(|scope| {
+            let moving = scope.spawn(|| {
+                let snapshot = snapshot_elements(&mut peer, pid, wid);
+                assert!(!snapshot.is_error(), "peer snapshot: {}", snapshot.text());
+                let motion = peer.call(
+                    "set_agent_cursor_motion",
+                    serde_json::json!({"idle_hide_ms": 0, "glide_duration_ms": 0}),
+                );
+                assert!(!motion.is_error(), "cursor motion: {}", motion.text());
+                let deadline = std::time::Instant::now() + Duration::from_secs(12);
+                let mut first = true;
+                let mut x = 120;
+                while !stopped.load(std::sync::atomic::Ordering::Relaxed)
+                    && std::time::Instant::now() < deadline
+                {
+                    let moved = peer.call(
+                        "move_cursor",
+                        serde_json::json!({
+                            "target": {"kind": "window", "pid": pid, "window_id": wid},
+                            "x": x,
+                            "y": 100
+                        }),
+                    );
+                    assert!(!moved.is_error(), "agent cursor: {}", moved.text());
+                    if first {
+                        ready.send(()).expect("cursor readiness");
+                        first = false;
+                    }
+                    x = if x == 120 { 121 } else { 120 };
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+            });
+            started
+                .recv_timeout(Duration::from_secs(15))
+                .expect("live cursor ready");
+            let result = driver.call(
+                "bring_to_front",
+                serde_json::json!({"pid": pid, "window_id": wid}),
+            );
+            stopped.store(true, std::sync::atomic::Ordering::Relaxed);
+            moving.join().expect("concurrent cursor transport");
+            result
+        });
         assert!(
             !activated.is_error() && activated.structured()["activated"] == true,
             "active agent cursor must not invalidate exact activation: {}",

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
@@ -33,7 +33,7 @@ use cua_driver_testkit::e2e::{
     execute_case, native_background_case, native_foreground_case, native_readonly_case,
     recording_evidence, DriverRoute, Evidence, Observation, OracleKind, RefusalCode, Targeting,
 };
-use cua_driver_testkit::observer::TargetWindow;
+use cua_driver_testkit::observer::{NativeObserver, ObserverBackend, TargetWindow};
 use cua_driver_testkit::sentinel::run_with_background_oracles;
 use cua_driver_testkit::{Driver, McpDriver, ToolResponse};
 
@@ -215,6 +215,62 @@ fn run_background_case_targeting(
 }
 
 // ── tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[ignore]
+fn harness_appkit_exact_activation_with_agent_cursor() {
+    let mut case = native_foreground_case(
+        "appkit",
+        "exact_activation_with_agent_cursor",
+        Targeting::NotApplicable,
+        DriverRoute::WindowState,
+    );
+    case.oracles.extend([OracleKind::Focus, OracleKind::Cursor]);
+    run_case(case, |pid, wid, driver| {
+        let snapshot = snapshot_elements(driver, pid, wid);
+        assert!(!snapshot.is_error(), "snapshot: {}", snapshot.text());
+        let target = TargetWindow {
+            pid,
+            native_id: wid,
+        };
+        let observer = NativeObserver::new();
+        let before = observer.snapshot(target).expect("observe native desktop");
+        let motion = driver.call(
+            "set_agent_cursor_motion",
+            serde_json::json!({"idle_hide_ms": 0, "glide_duration_ms": 0}),
+        );
+        assert!(!motion.is_error(), "cursor motion: {}", motion.text());
+        let moved = driver.call(
+            "move_cursor",
+            serde_json::json!({
+                "target": {"kind": "window", "pid": pid, "window_id": wid},
+                "x": 120,
+                "y": 100
+            }),
+        );
+        assert!(!moved.is_error(), "agent cursor: {}", moved.text());
+        let cursor = driver.call("get_agent_cursor_state", serde_json::json!({}));
+        assert_eq!(cursor.structured()["enabled"], true);
+        assert!(cursor.structured()["position"].is_object());
+        let activated = driver.call(
+            "bring_to_front",
+            serde_json::json!({"pid": pid, "window_id": wid}),
+        );
+        assert!(
+            !activated.is_error() && activated.structured()["activated"] == true,
+            "active agent cursor must not invalidate exact activation: {}",
+            activated.text()
+        );
+        assert_eq!(
+            activated.structured()["observed"]["focused_window_id"].as_u64(),
+            Some(wid)
+        );
+        let after = observer.snapshot(target).expect("observe activated target");
+        assert_eq!(after.foreground, Some(u64::from(pid)));
+        assert_eq!(after.cursor_pos, before.cursor_pos, "real pointer moved");
+        Observation::delivered_with_fixture_state(vec![OracleKind::Focus, OracleKind::Cursor])
+    });
+}
 
 #[test]
 #[ignore]

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
@@ -330,7 +330,7 @@ fn harness_appkit_exact_activation_refuses_competing_window() {
         DriverRoute::WindowState,
     )
     .expecting_refusal(vec![RefusalCode::BringToFrontExactWindowUnverified]);
-    case.oracles.extend([OracleKind::Focus, OracleKind::Cursor]);
+    case.oracles.push(OracleKind::Cursor);
     run_case(case, |pid, wid, driver| {
         let competitor = Harness::launch_with_options(None, None, true);
         let (competing_wid, _) = driver
@@ -357,6 +357,7 @@ fn harness_appkit_exact_activation_refuses_competing_window() {
             "bring_to_front_exact_window_unverified"
         );
         assert_eq!(response.structured()["activated"], false);
+        assert_eq!(response.structured()["process_activated"], true);
         assert_eq!(
             response.structured()["exact_window_effect"]["focused"],
             true
@@ -368,15 +369,10 @@ fn harness_appkit_exact_activation_refuses_competing_window() {
         let after = observer
             .snapshot(target)
             .expect("observe refused activation");
-        assert_eq!(after.foreground, Some(u64::from(pid)));
         assert_eq!(after.cursor_pos, before.cursor_pos, "real pointer moved");
         Observation::refused(
             RefusalCode::BringToFrontExactWindowUnverified,
-            vec![
-                OracleKind::FixtureState,
-                OracleKind::Focus,
-                OracleKind::Cursor,
-            ],
+            vec![OracleKind::FixtureState, OracleKind::Cursor],
             response.text(),
             Evidence::default(),
         )

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
@@ -250,6 +250,14 @@ fn harness_appkit_exact_activation_with_agent_cursor() {
             .expect("canonical installed daemon socket");
         let mut peer = McpDriver::spawn_daemon_proxy_unrecorded(&socket)
             .expect("start concurrent cursor session");
+        let verifies_target = |response: &ToolResponse| {
+            let state = response.structured();
+            !response.is_error()
+                && state["activated"] == true
+                && state["observed"]["focused_window_id"].as_u64() == Some(wid)
+                && state["observed"]["frontmost_ordinary_window_id"].as_u64() == Some(wid)
+                && state["observed"]["frontmost_pid"].as_u64() == Some(u64::from(pid))
+        };
         let stopped = std::sync::atomic::AtomicBool::new(false);
         let (ready, started) = std::sync::mpsc::sync_channel(1);
         let activated = std::thread::scope(|scope| {
@@ -283,6 +291,10 @@ fn harness_appkit_exact_activation_with_agent_cursor() {
                     x = if x == 120 { 121 } else { 120 };
                     std::thread::sleep(Duration::from_millis(20));
                 }
+                assert!(
+                    stopped.load(std::sync::atomic::Ordering::Relaxed),
+                    "cursor producer expired before the activation interval completed"
+                );
             });
             started
                 .recv_timeout(Duration::from_secs(15))
@@ -292,7 +304,7 @@ fn harness_appkit_exact_activation_with_agent_cursor() {
                 serde_json::json!({"pid": pid, "window_id": wid}),
             );
             for _ in 1..20 {
-                if result.is_error() || result.structured()["activated"] != true {
+                if !verifies_target(&result) {
                     break;
                 }
                 result = driver.call(
@@ -305,13 +317,9 @@ fn harness_appkit_exact_activation_with_agent_cursor() {
             result
         });
         assert!(
-            !activated.is_error() && activated.structured()["activated"] == true,
+            verifies_target(&activated),
             "active agent cursor must not invalidate exact activation: {}",
-            activated.text()
-        );
-        assert_eq!(
-            activated.structured()["observed"]["focused_window_id"].as_u64(),
-            Some(wid)
+            activated.raw
         );
         let after = observer.snapshot(target).expect("observe activated target");
         assert_eq!(after.foreground, Some(u64::from(pid)));

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
@@ -250,7 +250,7 @@ fn harness_appkit_exact_activation_with_agent_cursor() {
                     serde_json::json!({"idle_hide_ms": 0, "glide_duration_ms": 0}),
                 );
                 assert!(!motion.is_error(), "cursor motion: {}", motion.text());
-                let deadline = std::time::Instant::now() + Duration::from_secs(12);
+                let deadline = std::time::Instant::now() + Duration::from_secs(60);
                 let mut first = true;
                 let mut x = 120;
                 while !stopped.load(std::sync::atomic::Ordering::Relaxed)
@@ -276,10 +276,19 @@ fn harness_appkit_exact_activation_with_agent_cursor() {
             started
                 .recv_timeout(Duration::from_secs(15))
                 .expect("live cursor ready");
-            let result = driver.call(
+            let mut result = driver.call(
                 "bring_to_front",
                 serde_json::json!({"pid": pid, "window_id": wid}),
             );
+            for _ in 1..20 {
+                if result.is_error() || result.structured()["activated"] != true {
+                    break;
+                }
+                result = driver.call(
+                    "bring_to_front",
+                    serde_json::json!({"pid": pid, "window_id": wid}),
+                );
+            }
             stopped.store(true, std::sync::atomic::Ordering::Relaxed);
             moving.join().expect("concurrent cursor transport");
             result

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
@@ -70,6 +70,14 @@ impl Harness {
     }
 
     fn launch_with_oracles(command_oracle: Option<&Path>, pointer_oracle: Option<&Path>) -> Self {
+        Self::launch_with_options(command_oracle, pointer_oracle, false)
+    }
+
+    fn launch_with_options(
+        command_oracle: Option<&Path>,
+        pointer_oracle: Option<&Path>,
+        keep_ordered_front: bool,
+    ) -> Self {
         let exe = harness_exe();
         assert!(
             exe.exists(),
@@ -85,6 +93,9 @@ impl Harness {
         }
         if let Some(path) = pointer_oracle {
             command.env("CUA_APPKIT_POINTER_ORACLE", path);
+        }
+        if keep_ordered_front {
+            command.env("CUA_APPKIT_KEEP_ORDERED_FRONT", "1");
         }
         let app = command
             .spawn()
@@ -306,6 +317,69 @@ fn harness_appkit_exact_activation_with_agent_cursor() {
         assert_eq!(after.foreground, Some(u64::from(pid)));
         assert_eq!(after.cursor_pos, before.cursor_pos, "real pointer moved");
         Observation::delivered_with_fixture_state(vec![OracleKind::Focus, OracleKind::Cursor])
+    });
+}
+
+#[test]
+#[ignore]
+fn harness_appkit_exact_activation_refuses_competing_window() {
+    let mut case = native_foreground_case(
+        "appkit",
+        "exact_activation_competing_window",
+        Targeting::NotApplicable,
+        DriverRoute::WindowState,
+    )
+    .expecting_refusal(vec![RefusalCode::BringToFrontExactWindowUnverified]);
+    case.oracles.extend([OracleKind::Focus, OracleKind::Cursor]);
+    run_case(case, |pid, wid, driver| {
+        let competitor = Harness::launch_with_options(None, None, true);
+        let (competing_wid, _) = driver
+            .find_window(competitor.pid as i64, "CuaTestHarness AppKit")
+            .expect("find competing ordinary window");
+        let snapshot = snapshot_elements(driver, pid, wid);
+        assert!(!snapshot.is_error(), "target snapshot: {}", snapshot.text());
+        let observer = NativeObserver::new();
+        let target = TargetWindow {
+            pid,
+            native_id: wid,
+        };
+        let before = observer.snapshot(target).expect("observe competing window");
+        let response = driver.call(
+            "bring_to_front",
+            serde_json::json!({"pid": pid, "window_id": wid}),
+        );
+        assert!(
+            response.is_error(),
+            "competing window must prevent verification"
+        );
+        assert_eq!(
+            response.structured()["code"],
+            "bring_to_front_exact_window_unverified"
+        );
+        assert_eq!(response.structured()["activated"], false);
+        assert_eq!(
+            response.structured()["exact_window_effect"]["focused"],
+            true
+        );
+        assert_eq!(
+            response.structured()["observed"]["frontmost_ordinary_window_id"].as_u64(),
+            Some(competing_wid)
+        );
+        let after = observer
+            .snapshot(target)
+            .expect("observe refused activation");
+        assert_eq!(after.foreground, Some(u64::from(pid)));
+        assert_eq!(after.cursor_pos, before.cursor_pos, "real pointer moved");
+        Observation::refused(
+            RefusalCode::BringToFrontExactWindowUnverified,
+            vec![
+                OracleKind::FixtureState,
+                OracleKind::Focus,
+                OracleKind::Cursor,
+            ],
+            response.text(),
+            Evidence::default(),
+        )
     });
 }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -31,6 +31,7 @@
 
 use std::collections::HashMap;
 use std::ffi::c_void;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -74,6 +75,11 @@ static CMD_TX: OnceLock<std::sync::mpsc::SyncSender<OverlayMsg>> = OnceLock::new
 // Single-consumer slot; receiver is moved into run_on_main_thread().
 static CMD_RX_CELL: Mutex<Option<std::sync::mpsc::Receiver<OverlayMsg>>> = Mutex::new(None);
 static RENDER: Mutex<Option<RenderMap>> = Mutex::new(None);
+static OVERLAY_WINDOW_ID: AtomicU32 = AtomicU32::new(0);
+
+pub(crate) fn is_overlay_window(window_id: u32) -> bool {
+    window_id != 0 && OVERLAY_WINDOW_ID.load(Ordering::Acquire) == window_id
+}
 
 /// The keyed, insertion-ordered collection of owned cursors that the render
 /// loop composites every frame. Insertion order = stable z-order (later keys
@@ -676,6 +682,9 @@ unsafe fn run_appkit(_cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
         }
     }
 
+    let window_number: isize = msg_send![win, windowNumber];
+    OVERLAY_WINDOW_ID.store(u32::try_from(window_number).unwrap_or(0), Ordering::Release);
+
     // ---- Show the window ----
     let _: () = msg_send![win, orderFrontRegardless];
 
@@ -688,6 +697,7 @@ unsafe fn run_appkit(_cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
 
     // ---- NSApplication run loop (blocks until process exits) ----
     let _: () = msg_send![app, run];
+    OVERLAY_WINDOW_ID.store(0, Ordering::Release);
 }
 
 fn render_loop(

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/bring_to_front.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/bring_to_front.rs
@@ -120,7 +120,8 @@ fn classify_exact_outcome(
 }
 
 fn observe_exact_window(pid: i32, window_id: u32) -> ExactWindowObservation {
-    let windows = crate::windows::visible_windows();
+    let mut windows = crate::windows::visible_windows();
+    windows.retain(|window| !crate::cursor::overlay::is_overlay_window(window.window_id));
     let target_visible_ordinary = windows
         .iter()
         .any(|window| window.pid == pid && window.window_id == window_id && window.layer == 0);

--- a/libs/cua-driver/tests/fixtures/apps/macos/appkit/main.swift
+++ b/libs/cua-driver/tests/fixtures/apps/macos/appkit/main.swift
@@ -651,6 +651,11 @@ struct CuaAppKitHarness {
         let controller = HarnessWindowController()
         installMenuBar(target: controller)
         controller.show()
+        if ProcessInfo.processInfo.environment["CUA_APPKIT_KEEP_ORDERED_FRONT"] == "1" {
+            _ = Timer.scheduledTimer(withTimeInterval: 0.01, repeats: true) { [weak window = controller.window] _ in
+                window?.orderFrontRegardless()
+            }
+        }
         if let path = ProcessInfo.processInfo.environment["CUA_APPKIT_POINTER_ORACLE"] {
             let receiver = SingleClickReceiver(
                 frame: controller.window.contentView!.bounds,

--- a/scripts/ci/macos/run-rust-e2e.sh
+++ b/scripts/ci/macos/run-rust-e2e.sh
@@ -354,6 +354,7 @@ if [[ "${SUITE}" == native || "${SUITE}" == all ]]; then
     harness_appkit_scroll_background \
     harness_appkit_counter \
     harness_appkit_counter_px_background \
+    harness_appkit_exact_activation_with_agent_cursor \
     harness_appkit_foreground_single_click_has_one_ordered_native_pair \
     harness_appkit_right_click_px_foreground \
     harness_appkit_right_click_px_background \

--- a/scripts/ci/macos/run-rust-e2e.sh
+++ b/scripts/ci/macos/run-rust-e2e.sh
@@ -355,6 +355,7 @@ if [[ "${SUITE}" == native || "${SUITE}" == all ]]; then
     harness_appkit_counter \
     harness_appkit_counter_px_background \
     harness_appkit_exact_activation_with_agent_cursor \
+    harness_appkit_exact_activation_refuses_competing_window \
     harness_appkit_foreground_single_click_has_one_ordered_native_pair \
     harness_appkit_right_click_px_foreground \
     harness_appkit_right_click_px_background \


### PR DESCRIPTION
Refs #3681

## Summary

Exclude the renderer-owned cursor window from macOS exact-window foreground verification. Only its registered native window ID is excluded; exact focus, foreground process, and genuine competing-window checks remain intact. Windows/Linux product behavior is unchanged by this PR.

## Coverage

- Twenty consecutive exact activations during live peer-cursor overlap; fail on the first mismatch or premature producer expiry.
- A genuine competing window still causes the expected refusal, without moving the real pointer.
- Narrow report support for that foreground refusal; background side-effect requirements remain unchanged.

## Current-candidate validation

Tested head: `2e16e3d84136c3fde6f7df85c2606f0eb634dc13`, based on main `360e8ed62903437f3932517dc13c85ae79380373`. The PR head and main base were rechecked after testing; neither changed. No final executable diff is unaccounted for.

**432/432 desktop cases and 74/74 standalone-browser cases passed**, including expected typed refusals. All reports show zero failed and zero skipped cases. Each full suite was run once; no behavioral retries, permission repairs, or weakened assertions.

| Gate | Result | Evidence |
| --- | --- | --- |
| macOS Lume desktop | 163/163; both overlay/competitor regressions pass | Run `20260911T183239Z-55cc99ea`, exit 0 |
| Windows complete interactive matrix | 138/138: shared 86, native 43, capture 9; installer/update smoke passes | [Run 34633801973](https://github.com/trycua/cua/actions/runs/34633801973) |
| Linux complete X11 matrix | 131/131: shared 85, native 39, capture 7; installer smoke passes | [Run 34633804375](https://github.com/trycua/cua/actions/runs/34633804375) |
| macOS standalone Chrome | 18/18 | Same Lume run, `--standalone-browser` |
| Windows standalone Chrome/Edge | 36/36 | [Run 34633806694](https://github.com/trycua/cua/actions/runs/34633806694) |
| Linux X11 standalone Chrome | 20/20 | [Run 34633806694](https://github.com/trycua/cua/actions/runs/34633806694) |
| Ordinary PR CI | Green, including release metadata, contributor attribution, unit/compile, contract clients and docs | Current-head checks |

The Windows native recording preflight finalized its video and passed before all 43 native cases executed. The previous native-lane evidence gap is closed for this candidate. #3713 remains an unresolved intermittent recorder failure; this passing candidate does not establish that it is fixed.

Native/browser runners enforced their strict evidence checks. On macOS, the standard daemon was restored and the run-owned worker was independently verified stopped and retained. No VM was deleted.

## Environment and evidence limits

- macOS clone source: `cua-driver-browser-baseline-20260908-chrome152`, derived from a stopped #2907 worker and retained #3373 worker. Official Chrome 152.0.7977.83 signature/notarization was verified when the baseline was prepared. This is a worker-derived local baseline, **not a certified immutable private release seed**.
- Windows standalone isolated-launch cases verify the declared hosted-runner-token refusal; passing them does not claim support for protected isolated launch on that runner. Other browser cells and expected ambiguity refusals are recorded individually.
- Linux standalone tests use the documented disposable-browser no-sandbox environment. Linux evidence is X11, not certification of every Wayland compositor.
- Maintainer-local Lume evidence: `/Users/administrator/.local/share/cua-lume-e2e/runs/20260911T183239Z-55cc99ea/`. Downloaded hosted summaries/browser/native evidence: `/Users/administrator/.local/share/cua-repros/3704/certification-2e16e3d84/`. These local paths are not public download links; hosted run artifacts are linked above.

Current-candidate test gates are complete. Maintainer review/approval and merge remain outstanding; no merge or release was performed.

<details>
<summary>Historical evidence and recorder investigation (not current-candidate certification)</summary>


Previously tested candidate: `603d50e6bc76d5cb0538f827b536c4d21f47c6ae`. No behavioral retries.

| Gate | Result |
| --- | --- |
| macOS Lume | 163/163 desktop + 18/18 installed-browser cases pass; strict recordings pass |
| [Linux X11](https://github.com/trycua/cua/actions/runs/34499842745) | All lanes pass: 131 behavior cases and installer smoke |
| [Windows interactive](https://github.com/trycua/cua/actions/runs/34499846099) | Shared (86), capture (9), and installer pass; native preflight blocked |
| Unit/compile checks | 365 macOS tests pass (2 ignored); 95 testkit tests pass; native target compiles |

## Blocker

Tracking the pre-existing recorder failure in #3713, with isolated diagnostic work and results in #3714.

The [Windows native preflight](https://github.com/trycua/cua/actions/runs/34499846099/job/102947618595) failed production FFmpeg recording shutdown before native behavior cases ran.

**This failure predates the stack:** main `bd4c10020cd7cac07c0d19b0f53ba4b007fbcb15` had the [same native preflight failure](https://github.com/trycua/cua/actions/runs/34306620850/job/102324572423), followed by a [successful native run at that identical SHA](https://github.com/trycua/cua/actions/runs/34307741070/job/102327857162). The recorder backend, recording manager, preflight test, and FFmpeg setup script are byte-identical between that baseline and the failing candidate.

This establishes a pre-existing intermittent failure, not a new failure class introduced by these PRs. It does **not** establish a pure harness bug: `stop_recording` itself reports failure. The backend loses the distinction between nonzero exit and its three-second shutdown timeout, with empty stderr. Next diagnosis must retain exit status, shutdown timing, stdin-send errors, and force-kill usage. Existing evidence is preserved; no retry or weakened validation.

<details>
<summary>Evidence provenance</summary>

- Lume run: `20260910T152222Z-6ad05cea`, exact candidate above, `--standalone-browser`, exit 0. Standard daemon restored; worker stopped and retained.
- Maintainer-local evidence: `/Users/administrator/.local/share/cua-lume-e2e/runs/20260910T152222Z-6ad05cea`.
- Baseline: `cua-driver-browser-baseline-20260908-chrome152`, derived from retained #2907/#3373 workers, not an immutable certified seed; official signed/notarized Chrome 152.0.7977.83.
- Original native TDD red: `ab8a4353c9a432bde15148b91da23773ae58515d`; minimal green: `f3acfd8f5b091fd85360f917121e5c57ca72a31e`. Earlier failed/setup evidence remains retained under its original SHA. Authors and commit messages were preserved across stacking.

</details>

</details>
