### PR TITLE
fix(cua-driver): normalize repeated macOS consent labels

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/browser/consent_ui.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/browser/consent_ui.rs
@@ -23,7 +23,8 @@ fn refusal(code: BrowserRefusalCode, message: impl Into<String>) -> BrowserRefus
 }
 
 fn normalized_text(node: &AXNode) -> String {
-    [
+    let mut parts = Vec::new();
+    for text in [
         node.title.as_deref(),
         node.value.as_deref(),
         node.description.as_deref(),
@@ -31,10 +32,13 @@ fn normalized_text(node: &AXNode) -> String {
     ]
     .into_iter()
     .flatten()
-    .collect::<Vec<_>>()
-    .join(" ")
-    .trim()
-    .to_ascii_lowercase()
+    {
+        let text = text.trim().to_ascii_lowercase();
+        if !text.is_empty() && !parts.contains(&text) {
+            parts.push(text);
+        }
+    }
+    parts.join(" ")
 }
 
 fn release_actionable_nodes(nodes: &[AXNode]) {


### PR DESCRIPTION
Refs #3705

## Rebase status

Current head: `a38d903dfd4293ee84867db9825a6ef10d40b065`. Rebased onto main `b4e3caecd709311d613dde29ddac03e29468bb38`, preserving native GitHub stack #3710. All contribution commits remain patch-equivalent; authors and trailers are preserved.

Validation below belongs to the **pre-rebase SHAs**, not this head. Main adds Linux product/build and release-version changes; affected evidence and new CI must be checked before readiness. No E2E retry was performed. The unresolved Windows native recording-preflight blocker remains.

## Summary

Chrome can expose the same Allow/Cancel label in both AXTitle and AXDescription. Concatenating these fields produces `allow allow` or `cancel cancel`, rejecting valid consent controls.

Deduplicate identical normalized AX text fields before exact matching. Distinct text remains combined; ownership, sheet ancestry, action capability, and ambiguity checks are unchanged. This changes only the existing macOS normalizer. Localization work in #3409/#3140 remains separate.

## Validation

Previously tested PR head: `b3622764fdca6df606164f00d1c23b207bcaf42c`.

- **Native red → green:** the unchanged `standalone_browser_existing_profile_setup` test fails on `2af494c005220411ac3852f93dd1a79f1771aff1` and passes on that pre-rebase head after only the normalizer change.
- The public lifecycle verifies setup, exact binding, browser actions, and `end_session` cleanup: listener closed, consent UI gone, browser window preserved. All five external oracles and strict recording validation pass.
- **365 macOS unit tests pass**, 2 existing ignored, including existing ambiguity and cancel-matcher coverage. Formatting and diff checks pass. Pre-rebase PR CI and release metadata passed.

### Stack integration evidence

Tested stack tip: `603d50e6bc76d5cb0538f827b536c4d21f47c6ae` (includes #3704). These results are integration evidence, not a separate full run of this PR head.

| Gate | Result |
| --- | --- |
| macOS Lume | 163/163 desktop + 18/18 installed-browser cases pass; strict recordings pass |
| [Linux X11](https://github.com/trycua/cua/actions/runs/34499842745) | All lanes pass: 131 behavior cases and installer smoke |
| [Windows interactive](https://github.com/trycua/cua/actions/runs/34499846099) | Shared (86), capture (9), and installer pass; native preflight blocked |

## Readiness

Tracking the pre-existing recorder failure in #3713, with isolated diagnostic work and results in #3714.

**Validation gap:** the stack's Windows native preflight failed production recording shutdown before behavior cases ran. Investigation in #3704 verified the same failure on an earlier main SHA, with a successful native run at that identical SHA; it predates this stack. The exact exit/timeout cause remains unresolved, so this is not yet classified as a pure harness bug. No automatic retry or validation weakening.

Successful session cleanup is covered; interrupted preparation and localized/stacked-dialog cancellation are not independently certified by this change.

<details>
<summary>Evidence provenance</summary>

- Exact-head focused receipt: `consent-green-b3622764f`, official Chrome 152.0.7977.83 in disposable profiles, GUI-launched signed daemon with canonical authorization/restoration helpers. Failed evidence retained; standard daemon restored and worker stopped.
- Full stack Lume run: `20260910T152222Z-6ad05cea`, `--standalone-browser`, exit 0, no behavioral retries; evidence collected and worker restored/stopped.
- Lume baseline: `cua-driver-browser-baseline-20260908-chrome152`, derived from retained #2907/#3373 workers rather than a certified immutable private seed.
- Maintainer-local full-run evidence: `/Users/administrator/.local/share/cua-lume-e2e/runs/20260910T152222Z-6ad05cea`.

</details>
