### PR TITLE
feat(sandbox): use shared Driver MCP client

### DIFF
--- a/.github/workflows/ci-cua-driver-contract-clients.yml
+++ b/.github/workflows/ci-cua-driver-contract-clients.yml
@@ -300,6 +300,7 @@ jobs:
               libs/python/cua-sandbox/tests/test_typed_driver_native.py \
               libs/python/cua-sandbox/tests/test_typed_driver.py \
               libs/python/cua-sandbox/tests/test_driver_mcp.py \
+              libs/python/cua-sandbox/tests/test_driver_mcp_shared.py \
               libs/python/cua-sandbox/tests/test_driver_mcp_native.py \
               libs/python/cua-sandbox/tests/test_pool.py \
               libs/python/cua-sandbox/tests/test_fleet_transport.py \

--- a/libs/python/cua-sandbox/README.md
+++ b/libs/python/cua-sandbox/README.md
@@ -27,6 +27,14 @@ The sandbox image must also run a compatible Driver service.
 
 ### Optional MCP envelope carrier
 
+This migration branch delegates the typed MCP client to the shared Driver Rust
+implementation in [Driver PR #3715](https://github.com/trycua/cua/pull/3715).
+It requires the matching candidate bindings/native library. The optional extra
+still pins Driver 0.26.0, which does not contain that connector: do not release
+this migration until a containing Driver release is published and the exact
+dependency and lockfile are updated and tested. The existing direct-envelope
+path remains compatible with its pinned Driver dependency.
+
 The SDK can carry the same typed Driver interface through a named
 MCP service. This requires the guest's explicit typed-envelope extension, not
 just an ordinary MCP tools endpoint:

--- a/libs/python/cua-sandbox/README.md
+++ b/libs/python/cua-sandbox/README.md
@@ -20,20 +20,12 @@ install the optional Driver SDK:
 pip install --extra-index-url https://wheels.cua.ai/simple 'cua-sandbox[driver]'
 ```
 
-The `driver` extra pins `cua-driver==0.26.0`, which provides the typed-window API
+The `driver` extra pins `cua-driver==0.27.0`, which provides the typed-window API
 and compatible remote channel bridge. It requires that version to be published
 for your platform.
 The sandbox image must also run a compatible Driver service.
 
 ### Optional MCP envelope carrier
-
-This migration branch delegates the typed MCP client to the shared Driver Rust
-implementation in [Driver PR #3715](https://github.com/trycua/cua/pull/3715).
-It requires the matching candidate bindings/native library. The optional extra
-still pins Driver 0.26.0, which does not contain that connector: do not release
-this migration until a containing Driver release is published and the exact
-dependency and lockfile are updated and tested. The existing direct-envelope
-path remains compatible with its pinned Driver dependency.
 
 The SDK can carry the same typed Driver interface through a named
 MCP service. This requires the guest's explicit typed-envelope extension, not
@@ -65,11 +57,10 @@ local desktop. On exit, the SDK attempts bounded receiver and MCP-session
 cleanup. An unconfirmed cleanup warns; it is not proof of rollback or guest
 deletion.
 
-See the [candidate wire and launcher contract](../../cua-driver/docs/mcp-envelope-carrier.md)
-for the opt-in and limits. No existing Fleet image is qualified by this example.
-Test the exact image and matching bindings/native library before advertising
-support. Driver 0.25.0 does not provide this typed-window API; use the pinned
-Driver 0.26.0 package and a compatible guest runtime.
+See the [wire and launcher contract](../../cua-driver/docs/mcp-envelope-carrier.md)
+for the opt-in and limits. Test the exact image and matching bindings/native
+library before advertising support; use the pinned optional extra and a
+compatible guest runtime.
 
 ## Ephemeral sandbox
 

--- a/libs/python/cua-sandbox/cua_sandbox/interfaces/_driver_mcp.py
+++ b/libs/python/cua-sandbox/cua_sandbox/interfaces/_driver_mcp.py
@@ -1,236 +1,79 @@
-"""Explicit, non-reconnecting MCP carrier for the canonical Driver envelopes."""
+"""Fleet byte transport and ownership adapter for the shared Rust MCP client."""
 
 from __future__ import annotations
 
-import json
-import re
-import uuid
+import asyncio
+import logging
 from typing import Any
 
-import httpx
-
-_PROTOCOL = "2025-06-18"
-_CAPABILITY = "ai.cua.driver.envelopes"
-_PREFIX = "cua/driver/v1/"
-_REQUEST_LIMIT = 1024 * 1024
-_RESPONSE_LIMIT = 16 * 1024 * 1024
-_SESSION = re.compile(r"[\x21-\x7e]{1,256}\Z")
+logger = logging.getLogger(__name__)
 
 
-class McpCarrierError(RuntimeError):
-    """A bounded reason, never a remote body or transport exception."""
+def shared_channel(sdk: Any, transport: Any, service: str, principal: str) -> Any:
+    from cua_sandbox.interfaces.driver import DriverConnectionError
 
-
-def _json(text: str) -> Any:
-    def pairs(items):
-        result = {}
-        for key, value in items:
-            if key in result:
-                raise ValueError("duplicate JSON member")
-            result[key] = value
-        return result
-
-    def constant(_):
-        raise ValueError("non-finite JSON value")
-
-    return json.loads(text, object_pairs_hook=pairs, parse_constant=constant)
-
-
-def _response(response: httpx.Response, request_id: str) -> Any:
-    """Decode one bounded JSON or buffered SSE response with exact correlation."""
-    try:
-        if len(response.content) > _RESPONSE_LIMIT:
-            raise ValueError
-        text = response.content.decode("utf-8", errors="strict")
-        media = response.headers.get("content-type", "").split(";", 1)[0].strip().lower()
-        if media == "application/json":
-            messages = [_json(text)]
-        elif media == "text/event-stream":
-            messages = []
-            blocks = text.replace("\r\n", "\n").replace("\r", "\n").split("\n\n")
-            if blocks[-1].strip() or len(blocks) > 128:
-                raise ValueError
-            for block in blocks[:-1]:
-                data = []
-                for line in block.split("\n"):
-                    if not line or line.startswith(":"):
-                        continue
-                    field, _, value = line.partition(":")
-                    value = value.removeprefix(" ")
-                    if field == "data":
-                        data.append(value)
-                    elif field == "event" and value not in ("message", ""):
-                        raise ValueError
-                    elif field not in ("event", "id", "retry"):
-                        raise ValueError
-                if data:
-                    messages.append(_json("\n".join(data)))
-        else:
-            raise ValueError
-        # This carrier has no unsolicited event stream and never follows SSE
-        # reconnect instructions. More than one RPC response is ambiguous.
-        if len(messages) != 1:
-            raise ValueError
-        message = messages[0]
-        if (
-            not isinstance(message, dict)
-            or message.get("jsonrpc") != "2.0"
-            or type(message.get("id")) is not str
-            or message["id"] != request_id
-            or ("result" in message) == ("error" in message)
-        ):
-            raise ValueError
-        if "error" in message:
-            error = message["error"]
-            if not isinstance(error, dict) or type(error.get("code")) is not int:
-                raise ValueError
-            code = error["code"]
-            if code in (-32404, -32409):
-                raise McpCarrierError("MCP Driver connection is stale or unavailable")
-            if code == -32601:
-                raise McpCarrierError("MCP endpoint does not support typed Driver envelopes")
-            raise McpCarrierError("MCP Driver request failed; completion is unknown")
-        return message["result"]
-    except (ValueError, KeyError, TypeError, UnicodeError, RecursionError):
-        raise McpCarrierError("MCP Driver response is malformed; completion is unknown") from None
-
-
-class McpCarrier:
-    """One stateful MCP session owned by one typed channel, with no retry."""
-
-    def __init__(self, transport: Any, service: str):
-        self.transport = transport
-        self.service = service
-        self.session: str | None = None
-        self.ready = False
-        self.broken = False
-        self.session_closed = False
-
-    async def _http(self, method: str, body=None, *, timeout=None, initializing=False):
-        headers = {"Accept": "application/json, text/event-stream"}
-        if self.session is not None:
-            headers["Mcp-Session-Id"] = self.session
-            headers["MCP-Protocol-Version"] = _PROTOCOL
-        try:
-            if (
-                body is not None
-                and len(json.dumps(body, allow_nan=False).encode()) > _REQUEST_LIMIT
-            ):
-                raise McpCarrierError("MCP Driver request exceeds the size limit")
-            response = await self.transport.request_service(
-                self.service,
-                method=method,
-                path="/mcp",
-                json_body=body,
-                headers=headers,
-                **({"timeout": timeout} if timeout is not None else {}),
-            )
-        except McpCarrierError:
-            raise
-        except Exception as error:
-            self.broken = True
-            if getattr(error, "status", None) in (401, 403):
-                raise McpCarrierError("Driver service authorization denied") from None
-            raise McpCarrierError("MCP Driver transport failed; completion is unknown") from None
-        if response.status_code in (401, 403):
-            self.broken = True
-            raise McpCarrierError("Driver service authorization denied")
-        if not 200 <= response.status_code < 300:
-            self.broken = True
-            if response.status_code in (404, 409):
-                raise McpCarrierError("MCP Driver session is stale or unavailable")
-            raise McpCarrierError("MCP Driver request failed; completion is unknown")
-        sessions = response.headers.get_list("mcp-session-id")
-        if initializing:
-            if len(sessions) != 1 or not _SESSION.fullmatch(sessions[0]):
-                self.broken = True
-                raise McpCarrierError("MCP Driver session negotiation is malformed")
-            # Retain an allocated session before parsing the body, so malformed
-            # negotiation can still perform bounded HTTP-session cleanup.
-            self.session = sessions[0]
-        elif sessions and sessions != [self.session]:
-            self.broken = True
-            raise McpCarrierError("MCP Driver session changed unexpectedly")
-        if len(response.content) > _RESPONSE_LIMIT:
-            self.broken = True
-            raise McpCarrierError("MCP Driver response exceeds the size limit")
-        return response
-
-    async def _rpc(self, method: str, params: Any, *, timeout=None, initializing=False):
-        if self.broken or self.session_closed:
-            raise McpCarrierError("MCP Driver carrier is closed")
-        request_id = uuid.uuid4().hex
-        body = {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
-        response = await self._http("POST", body, timeout=timeout, initializing=initializing)
-        try:
-            return _response(response, request_id)
-        except McpCarrierError:
-            self.broken = True
-            raise
-
-    async def initialize(self):
-        if self.session is not None or self.ready:
-            raise McpCarrierError("MCP Driver carrier cannot reconnect")
-        result = await self._rpc(
-            "initialize",
-            {
-                "protocolVersion": _PROTOCOL,
-                "capabilities": {},
-                "clientInfo": {"name": "cua-sandbox-driver", "version": "1"},
-            },
-            initializing=True,
+    required = (
+        "open_mcp_driver_channel",
+        "DriverServiceTransport",
+        "DriverServiceHeader",
+        "DriverServiceResponse",
+        "DriverServiceTransportError",
+    )
+    if not all(hasattr(sdk, name) for name in required):
+        raise DriverConnectionError(
+            "Install a cua-driver version providing open_mcp_driver_channel to use MCP"
         )
-        try:
-            extension = result["capabilities"]["experimental"][_CAPABILITY]
-            if (
-                result["protocolVersion"] != _PROTOCOL
-                or type(extension["version"]) is not int
-                or extension["version"] != 1
-            ):
-                raise ValueError
-        except (ValueError, KeyError, TypeError):
-            self.broken = True
-            raise McpCarrierError(
-                "MCP endpoint does not support typed Driver envelopes v1"
-            ) from None
-        response = await self._http(
-            "POST", {"jsonrpc": "2.0", "method": "notifications/initialized"}
-        )
-        if response.status_code not in (202, 204) or response.content:
-            self.broken = True
-            raise McpCarrierError("MCP Driver initialization acknowledgement is incompatible")
-        self.ready = True
+    loop = asyncio.get_running_loop()
 
-    async def request(self, method, suffix, body, connection_id, generation, *, timeout=None):
-        if not self.ready:
-            raise McpCarrierError("MCP Driver carrier is not initialized")
-        if connection_id is None:
-            operation, params = "open", {}
-        else:
-            params = {"connection_id": connection_id, "generation": generation}
-            if method == "DELETE":
-                operation = "close"
-            elif suffix == "/exchange":
-                operation = "exchange"
-                params["envelope"] = body
-            elif suffix == "/cancel":
-                operation = "cancel"
-                params["request_id"] = body["request_id"]
-            else:
-                raise McpCarrierError("Invalid MCP Driver operation")
-        result = await self._rpc(_PREFIX + operation, params, timeout=timeout)
-        if operation in ("close", "cancel") and (
-            not isinstance(result, dict) or set(result) != {"ok"} or result["ok"] is not True
-        ):
-            self.broken = True
-            raise McpCarrierError("MCP Driver cleanup acknowledgement is malformed")
-        return httpx.Response(200, json=result)
+    class ServiceTransport(sdk.DriverServiceTransport):
+        async def send(self, request):
+            try:
+                if asyncio.get_running_loop() is not loop or not transport._connected:
+                    raise RuntimeError
+                response = await transport.request_service(
+                    service,
+                    method=request.method,
+                    path=request.path,
+                    body=request.body,
+                    headers=[(header.name, header.value) for header in request.headers],
+                    timeout=request.timeout_ms / 1000,
+                )
+                return sdk.DriverServiceResponse(
+                    status=response.status_code,
+                    headers=[
+                        sdk.DriverServiceHeader(name=name, value=value)
+                        for name, value in response.headers.multi_items()
+                    ],
+                    body=response.content,
+                )
+            except Exception:
+                raise sdk.DriverServiceTransportError.Failed(
+                    "Fleet Driver service transport failed; completion is unknown"
+                ) from None
 
-    async def close_session(self):
-        if self.session is None or self.session_closed:
-            return
-        # DELETE is teardown, not action replay. It remains available when a
-        # failed exchange has made the carrier unusable for further requests.
-        await self._http("DELETE")
-        self.session_closed = True
-        self.ready = False
+    class Connection:
+        shared_mcp = True
+
+        def __init__(self):
+            self.closed = False
+            self._transport = ServiceTransport()
+            self._channel = sdk.open_mcp_driver_channel(self._transport, principal)
+
+        @property
+        def public_session(self):
+            return self._channel.public_session()
+
+        async def open(self):
+            await self._channel.open()
+
+        def driver(self):
+            return self._channel.driver()
+
+        async def close(self):
+            self.closed = True
+            try:
+                await self._channel.close()
+            except Exception:
+                logger.warning("Driver cleanup failed; remote session cleanup is unconfirmed")
+
+    return Connection()

--- a/libs/python/cua-sandbox/cua_sandbox/interfaces/_driver_mcp.py
+++ b/libs/python/cua-sandbox/cua_sandbox/interfaces/_driver_mcp.py
@@ -8,6 +8,8 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_FLEET_DRIVER_MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+
 
 def shared_channel(sdk: Any, transport: Any, service: str, principal: str) -> Any:
     from cua_sandbox.interfaces.driver import DriverConnectionError
@@ -37,7 +39,10 @@ def shared_channel(sdk: Any, transport: Any, service: str, principal: str) -> An
                     body=request.body,
                     headers=[(header.name, header.value) for header in request.headers],
                     timeout=request.timeout_ms / 1000,
+                    max_response_bytes=_FLEET_DRIVER_MAX_RESPONSE_BYTES,
                 )
+                if len(response.content) > _FLEET_DRIVER_MAX_RESPONSE_BYTES:
+                    raise RuntimeError("Fleet Driver response exceeds the configured size limit")
                 return sdk.DriverServiceResponse(
                     status=response.status_code,
                     headers=[

--- a/libs/python/cua-sandbox/cua_sandbox/interfaces/driver.py
+++ b/libs/python/cua-sandbox/cua_sandbox/interfaces/driver.py
@@ -128,7 +128,12 @@ class Driver:
                     "Fleet sandbox does not expose the requested Driver service"
                 )
             sdk = _sdk()
-            channel = _channel(sdk, self._transport, service, self._principal, mode=transport)
+            if transport == "mcp":
+                from cua_sandbox.interfaces._driver_mcp import shared_channel
+
+                channel = shared_channel(sdk, self._transport, service, self._principal)
+            else:
+                channel = _channel(sdk, self._transport, service, self._principal)
 
             async def open_channel():
                 try:
@@ -147,7 +152,9 @@ class Driver:
             async with self._lock:
                 if self._closed or channel.closed:
                     raise DriverConnectionError("Sandbox Driver accessor is disconnected")
-                driver = sdk.connect_remote_channel(channel)
+                driver = (
+                    channel.driver() if transport == "mcp" else sdk.connect_remote_channel(channel)
+                )
                 self._connections[channel] = driver
             yield driver
         finally:
@@ -163,6 +170,9 @@ class Driver:
                 channel.closed = True
 
                 async def cleanup():
+                    if getattr(channel, "shared_mcp", False):
+                        await channel.close()
+                        return
                     if not opening.done():
                         await _bounded_cleanup(opening)
                     await channel.close()
@@ -195,11 +205,7 @@ class Driver:
         )
 
 
-def _channel(
-    sdk: Any, transport: FleetTransport, service: str, principal: str, *, mode="envelope"
-) -> Any:
-    from cua_sandbox.interfaces._driver_mcp import McpCarrier, McpCarrierError
-
+def _channel(sdk: Any, transport: FleetTransport, service: str, principal: str) -> Any:
     class Channel(sdk.ForeignDriverEnvelopeChannel):
         def __init__(self):
             self.connection_id = None
@@ -211,7 +217,6 @@ def _channel(
             self._close_task = None
             self.cancelled: set[str] = set()
             self._exchanges: dict[str, asyncio.Task] = {}
-            self.carrier = McpCarrier(transport, service) if mode == "mcp" else None
 
         def fail(self, reason: str):
             return sdk.ForeignDriverChannelError.Failed(reason)
@@ -223,22 +228,14 @@ def _channel(
                 path += "/" + self.connection_id + suffix
                 headers = {"X-Cua-Driver-Generation": self.generation}
             try:
-                if self.carrier is not None:
-                    response = await self.carrier.request(
-                        method, suffix, body, self.connection_id, self.generation, timeout=timeout
-                    )
-                else:
-                    response = await transport.request_service(
-                        service,
-                        method=method,
-                        path=path,
-                        json_body=body,
-                        headers=headers,
-                        **({"timeout": timeout} if timeout is not None else {}),
-                    )
-            except McpCarrierError as error:
-                self.closed = True
-                raise self.fail(str(error)) from None
+                response = await transport.request_service(
+                    service,
+                    method=method,
+                    path=path,
+                    json_body=body,
+                    headers=headers,
+                    **({"timeout": timeout} if timeout is not None else {}),
+                )
             except Exception as error:
                 if getattr(error, "status", None) in (401, 403):
                     raise self.fail("Driver service authorization denied") from None
@@ -264,13 +261,6 @@ def _channel(
             return response
 
         async def open(self):
-            if self.carrier is not None:
-                try:
-                    await self.carrier.initialize()
-                except McpCarrierError as error:
-                    raise self.fail(str(error)) from None
-                if self.closed:
-                    raise self.fail("Driver connection was closed during initialization")
             response = await self.request("POST", body={})
             try:
                 data = response.json()
@@ -344,13 +334,7 @@ def _channel(
             timeout = min(deadline - int(time.time() * 1000), 120000) / 1000
             if timeout <= 0:
                 raise self.fail("Driver request deadline has expired")
-            # The caller's deadline still bounds the operation. MCP gets a
-            # small HTTP grace period to receive its cancellation response;
-            # aborting that stream before teardown can strand a stdio bridge.
-            http_timeout = timeout + 2 * _CLEANUP_TIMEOUT if self.carrier else timeout
-            exchange = asyncio.create_task(
-                self.request("POST", "/exchange", body, timeout=http_timeout)
-            )
+            exchange = asyncio.create_task(self.request("POST", "/exchange", body, timeout=timeout))
             self._exchanges[request.request_id] = exchange
             exchange.add_done_callback(lambda done: self._exchanges.pop(request.request_id, None))
             exchange.add_done_callback(_consume_result)
@@ -360,8 +344,7 @@ def _channel(
                     raise TimeoutError("Driver request deadline has expired; completion is unknown")
                 return await self.decode_response(request, exchange.result())
             except BaseException:
-                if self.carrier is None:
-                    exchange.cancel()
+                exchange.cancel()
                 await self.cancel(request.request_id)
                 await self.close()
                 raise
@@ -410,11 +393,6 @@ def _channel(
 
         async def cancel(self, request_id):
             self.cancelled.add(request_id)
-            if self.carrier is not None:
-                # A native future can cancel its callback and invoke cancel()
-                # concurrently. One shielded close task owns wire teardown.
-                await self.close()
-                return
             if not self.closed:
                 self.closed = True
                 try:
@@ -427,57 +405,16 @@ def _channel(
         async def close(self):
             self.closed = True
             # Do not memoize a no-op before an in-flight open reveals its ID.
-            if self.connection_id is None and (
-                self.carrier is None or self.carrier.session is None
-            ):
+            if self.connection_id is None:
                 return
             if self._close_task is None:
 
                 async def cleanup():
-                    if self.carrier is not None:
-                        pending = dict(self._exchanges)
-                        ids = self.cancelled | set(pending)
-                        if ids:
-                            cancellation_finished = await _bounded_cleanup(
-                                asyncio.gather(
-                                    *(
-                                        self.request("POST", "/cancel", {"request_id": request_id})
-                                        for request_id in ids
-                                    ),
-                                    return_exceptions=True,
-                                ),
-                                cancel_on_timeout=False,
-                            )
-                            if not cancellation_finished:
-                                return
-                        if pending:
-                            _, undrained = await asyncio.wait(
-                                set(pending.values()), timeout=_CLEANUP_TIMEOUT
-                            )
-                            if undrained:
-                                # Do not abort a live response or destroy its
-                                # HTTP session. Cleanup remains unconfirmed;
-                                # request timeouts still bound the HTTP work.
-                                logger.warning(
-                                    "Driver response drain timed out; remote session cleanup "
-                                    "is unconfirmed"
-                                )
-                                return
                     receiver_closed = self.connection_id is None
                     if self.connection_id is not None:
                         receiver_close = asyncio.create_task(self.request("DELETE"))
-                        receiver_closed = await _bounded_cleanup(
-                            receiver_close, cancel_on_timeout=self.carrier is None
-                        )
-                        if self.carrier is not None and not receiver_close.done():
-                            return
-                    if self.carrier is not None:
-                        session_closed = await _bounded_cleanup(
-                            self.carrier.close_session(), cancel_on_timeout=False
-                        )
-                        self.cleanup_confirmed = receiver_closed and session_closed
-                    else:
-                        self.cleanup_confirmed = receiver_closed
+                        receiver_closed = await _bounded_cleanup(receiver_close)
+                    self.cleanup_confirmed = receiver_closed
 
                 self._close_task = asyncio.create_task(cleanup())
             await asyncio.shield(self._close_task)

--- a/libs/python/cua-sandbox/cua_sandbox/transport/base.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/base.py
@@ -73,7 +73,10 @@ class Transport(ABC):
         method: str,
         path: str,
         json_body: Any = None,
+        body: bytes | None = None,
         headers: Any = None,
+        timeout: float | None = None,
+        max_response_bytes: int | None = None,
     ) -> Any:
         """Request an auxiliary named service exposed by this sandbox."""
         raise NotImplementedError(f"{type(self).__name__} does not support named service requests.")

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
@@ -27,6 +27,7 @@ def build_http_request(
     headers: Optional[List[Any]] = None,
     body: Optional[bytes] = None,
     timeout_secs: Optional[int] = None,
+    max_response_bytes: Optional[int] = None,
 ) -> HttpRequest:
     """Construct ``fleet_sdk.HttpRequest`` through the builder API.
 
@@ -39,6 +40,8 @@ def build_http_request(
         builder = builder.body(body)
     if timeout_secs is not None:
         builder = builder.timeout_secs(timeout_secs)
+    if max_response_bytes is not None:
+        builder = builder.max_response_bytes(max_response_bytes)
     return builder.build()
 
 
@@ -93,6 +96,7 @@ class FleetTransport(Transport):
         body: bytes | None = None,
         headers: dict[str, str] | list[tuple[str, str]] | None = None,
         timeout: float | None = None,
+        max_response_bytes: int | None = None,
     ) -> httpx.Response:
         if name not in self._bound.services:
             raise ValueError(f"Fleet sandbox does not expose service {name!r}")
@@ -104,6 +108,7 @@ class FleetTransport(Transport):
             service_name=name,
             extra_headers=headers,
             timeout=timeout,
+            max_response_bytes=max_response_bytes,
         )
 
     async def create_signed_service_url(
@@ -139,6 +144,7 @@ class FleetTransport(Transport):
         service_name: str | None = None,
         extra_headers: dict[str, str] | list[tuple[str, str]] | None = None,
         timeout: float | None = None,
+        max_response_bytes: int | None = None,
     ) -> httpx.Response:
         assert self._connected, "Transport not connected"
         if body is not None and json_body is not None:
@@ -163,8 +169,11 @@ class FleetTransport(Transport):
                 headers=headers,
                 body=body,
                 timeout_secs=_whole_seconds(self._timeout if timeout is None else timeout),
+                max_response_bytes=max_response_bytes,
             ),
         )
+        if max_response_bytes is not None and len(result.body) > max_response_bytes:
+            raise RuntimeError("Fleet service response exceeds the configured size limit")
         request = httpx.Request(method, f"https://service.invalid{path}")
         return httpx.Response(
             result.status,

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
@@ -90,7 +90,8 @@ class FleetTransport(Transport):
         method: str,
         path: str,
         json_body: Any = None,
-        headers: dict[str, str] | None = None,
+        body: bytes | None = None,
+        headers: dict[str, str] | list[tuple[str, str]] | None = None,
         timeout: float | None = None,
     ) -> httpx.Response:
         if name not in self._bound.services:
@@ -99,6 +100,7 @@ class FleetTransport(Transport):
             method,
             path,
             json_body=json_body,
+            body=body,
             service_name=name,
             extra_headers=headers,
             timeout=timeout,
@@ -133,16 +135,23 @@ class FleetTransport(Transport):
         path: str,
         *,
         json_body: Any = None,
+        body: bytes | None = None,
         service_name: str | None = None,
-        extra_headers: dict[str, str] | None = None,
+        extra_headers: dict[str, str] | list[tuple[str, str]] | None = None,
         timeout: float | None = None,
     ) -> httpx.Response:
         assert self._connected, "Transport not connected"
-        body = None if json_body is None else json.dumps(json_body).encode()
+        if body is not None and json_body is not None:
+            raise ValueError("Specify either body or json_body, not both")
+        if json_body is not None:
+            body = json.dumps(json_body).encode()
         headers = (
-            [] if body is None else [HttpHeader(name="content-type", value="application/json")]
+            [] if json_body is None else [HttpHeader(name="content-type", value="application/json")]
         )
-        for name, value in (extra_headers or {}).items():
+        header_items = (
+            extra_headers.items() if isinstance(extra_headers, dict) else (extra_headers or [])
+        )
+        for name, value in header_items:
             headers.append(HttpHeader(name=name, value=value))
         result = await self._sdk.service_request(
             self._bound,
@@ -159,7 +168,7 @@ class FleetTransport(Transport):
         request = httpx.Request(method, f"https://service.invalid{path}")
         return httpx.Response(
             result.status,
-            headers={header.name: header.value for header in result.headers},
+            headers=[(header.name, header.value) for header in result.headers],
             content=result.body,
             request=request,
         )

--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">=3.11,<3.14"
 dependencies = [
     "cua-core>=0.3.0,<0.4.0",
     "cua-auto>=0.1.2",
-    "cua-fleet==0.1.16",
+    "cua-fleet==0.1.17",
     "pydantic>=2.11,<3.0",
     "jsonschema>=4.23,<5.0",
     "websockets>=12.0",
@@ -44,7 +44,7 @@ dependencies = [
 
 [project.optional-dependencies]
 driver = [
-    "cua-driver==0.26.0",
+    "cua-driver==0.27.0",
 ]
 auth = [
     "webbrowser-open>=0.0.1",

--- a/libs/python/cua-sandbox/tests/test_driver_dependency.py
+++ b/libs/python/cua-sandbox/tests/test_driver_dependency.py
@@ -8,5 +8,5 @@ def test_driver_extra_is_exact_and_optional():
     package = Path(__file__).resolve().parents[1]
     sandbox = tomllib.loads((package / "pyproject.toml").read_text())["project"]
 
-    assert sandbox["optional-dependencies"]["driver"] == ["cua-driver==0.26.0"]
+    assert sandbox["optional-dependencies"]["driver"] == ["cua-driver==0.27.0"]
     assert not any(item.startswith("cua-driver") for item in sandbox["dependencies"])

--- a/libs/python/cua-sandbox/tests/test_driver_mcp.py
+++ b/libs/python/cua-sandbox/tests/test_driver_mcp.py
@@ -32,8 +32,18 @@ class McpTransport(Transport):
         self.cancel_received = asyncio.Event()
 
     async def request_service(
-        self, name, *, method, path, body=None, json_body=None, headers=None, timeout=None
+        self,
+        name,
+        *,
+        method,
+        path,
+        body=None,
+        json_body=None,
+        headers=None,
+        timeout=None,
+        max_response_bytes=None,
     ):
+        assert max_response_bytes == 16 * 1024 * 1024
         if body:
             json_body = json.loads(body)
         headers = httpx.Headers(headers)

--- a/libs/python/cua-sandbox/tests/test_driver_mcp.py
+++ b/libs/python/cua-sandbox/tests/test_driver_mcp.py
@@ -5,14 +5,13 @@ import json
 
 import httpx
 import pytest
-from cua_sandbox.interfaces._driver_mcp import McpCarrierError, _response
 from cua_sandbox.interfaces.driver import DriverConnectionError
 from cua_sandbox.sandbox import Sandbox
 
-from .test_typed_driver import ChannelError, Transport, envelope
-from .test_typed_driver import native as _native_fixture
+from .test_typed_driver import Transport
+from .test_typed_driver_native import sdk as _sdk_fixture
 
-native = _native_fixture
+sdk = _sdk_fixture
 
 
 class McpTransport(Transport):
@@ -33,8 +32,11 @@ class McpTransport(Transport):
         self.cancel_received = asyncio.Event()
 
     async def request_service(
-        self, name, *, method, path, json_body=None, headers=None, timeout=None
+        self, name, *, method, path, body=None, json_body=None, headers=None, timeout=None
     ):
+        if body:
+            json_body = json.loads(body)
+        headers = httpx.Headers(headers)
         self.events.append((name, method, path, json_body, headers))
         assert name == "mcp" and path == "/mcp"
         assert headers["Accept"] == "application/json, text/event-stream"
@@ -110,22 +112,15 @@ async def sandbox(transport):
 
 
 @pytest.mark.parametrize("sse", [False, True])
-async def test_explicit_mcp_preserves_canonical_driver_and_computer_server(native, sse):
+async def test_explicit_mcp_preserves_canonical_driver_and_computer_server(sdk, sse):
     transport = McpTransport(sse=sse)
     sb = await sandbox(transport)
     try:
         async with sb.driver.connect(service="mcp", transport="mcp") as driver:
-            assert isinstance(driver, native.CuaDriver)
+            assert type(driver) is sdk.CuaDriver
             assert all(interface._t is transport for interface in (sb.shell, sb.files, sb.mouse))
             assert transport._service_name == "server"
-            channel = driver.channel
-            result = await channel.exchange(envelope())
-            assert json.loads(result.result_json) == {"width": 1280}
-            assert channel.identity().connection_generation == "gen-http-session-1"
-            assert (await channel.negotiate()).supports_cancellation is True
             assert sb.driver.session_name(driver) == "session-1"
-        assert channel.cleanup_confirmed
-        assert driver.shutdowns == 1
         assert not transport.sessions
         assert transport.events[-2][3]["method"] == "cua/driver/v1/close"
         assert transport.events[-1][1] == "DELETE"
@@ -134,10 +129,10 @@ async def test_explicit_mcp_preserves_canonical_driver_and_computer_server(nativ
         await sb.disconnect()
 
 
-async def test_old_tools_only_endpoint_fails_before_open_and_cleans_http_session(native):
+async def test_old_tools_only_endpoint_fails_before_open_and_cleans_http_session(sdk):
     transport = McpTransport(supported=False)
     sb = await sandbox(transport)
-    with pytest.raises(ChannelError, match="does not support typed"):
+    with pytest.raises(sdk.DriverError.Remote):
         async with sb.driver.connect(service="mcp", transport="mcp"):
             pytest.fail("must not yield a facade")
     assert [event[3]["method"] for event in transport.events if event[3]] == ["initialize"]
@@ -145,20 +140,19 @@ async def test_old_tools_only_endpoint_fails_before_open_and_cleans_http_session
     await sb.disconnect()
 
 
-async def test_two_channels_keep_distinct_mcp_sessions_and_close_independently(native):
+async def test_two_channels_keep_distinct_mcp_sessions_and_close_independently(sdk):
     transport = McpTransport()
     sb = await sandbox(transport)
     async with sb.driver.connect(service="mcp", transport="mcp") as first:
         async with sb.driver.connect(service="mcp", transport="mcp") as second:
-            assert first.channel.generation != second.channel.generation
+            assert first is not second
             assert len(transport.sessions) == 2
         assert len(transport.sessions) == 1
-        assert (await first.channel.exchange(envelope())).ok
     assert not transport.sessions
     await sb.disconnect()
 
 
-async def test_unknown_transport_rejected_before_any_service_request(native):
+async def test_unknown_transport_rejected_before_any_service_request(sdk):
     transport = McpTransport()
     sb = await sandbox(transport)
     with pytest.raises(DriverConnectionError, match="transport must"):
@@ -168,17 +162,23 @@ async def test_unknown_transport_rejected_before_any_service_request(native):
     await sb.disconnect()
 
 
-async def test_lost_exchange_never_retries_or_reinitializes(native, caplog):
+async def test_lost_exchange_never_retries_or_reinitializes(sdk, caplog):
     transport = McpTransport()
     sb = await sandbox(transport)
     async with sb.driver.connect(service="mcp", transport="mcp") as driver:
         transport.fail_exchange = True
-        with pytest.raises(ChannelError, match="completion is unknown"):
-            await driver.channel.exchange(envelope())
-        with pytest.raises(ChannelError, match="closed"):
-            await driver.channel.exchange(envelope(request_id="second"))
-        assert driver.channel.closed
-        assert not driver.channel.cleanup_confirmed
+        with pytest.raises(sdk.DriverError.ActionInterrupted) as interrupted:
+            await driver.get_screen_size(sdk.GetScreenSizeInput(session=None))
+        assert interrupted.value.completion == sdk.ActionCompletion.UNKNOWN
+        with pytest.raises(sdk.DriverError.Remote, match="closed"):
+            sb.driver.session_name(driver)
+        before = len(transport.events)
+        with pytest.raises(sdk.DriverError.Remote):
+            await driver.get_screen_size(sdk.GetScreenSizeInput(session=None))
+        assert not any(
+            (event[3] or {}).get("method") == "cua/driver/v1/exchange"
+            for event in transport.events[before:]
+        )
     methods = [event[3]["method"] for event in transport.events if event[3]]
     assert methods.count("initialize") == 1
     assert methods.count("cua/driver/v1/exchange") == 1
@@ -188,7 +188,7 @@ async def test_lost_exchange_never_retries_or_reinitializes(native, caplog):
 
 
 @pytest.mark.parametrize("mutation", ["wrong-id", "bad-version", "rpc-error", "wrong-inner-id"])
-async def test_malformed_or_failed_response_closes_without_replay(native, mutation):
+async def test_malformed_or_failed_response_closes_without_replay(sdk, mutation):
     transport = McpTransport()
     sb = await sandbox(transport)
 
@@ -208,88 +208,53 @@ async def test_malformed_or_failed_response_closes_without_replay(native, mutati
 
     async with sb.driver.connect(service="mcp", transport="mcp") as driver:
         transport.mutate = mutate
-        with pytest.raises(ChannelError) as error:
-            await driver.channel.exchange(envelope())
+        with pytest.raises(sdk.DriverError.ActionInterrupted) as error:
+            await driver.get_screen_size(sdk.GetScreenSizeInput(session=None))
+        assert error.value.completion == sdk.ActionCompletion.UNKNOWN
         assert "private" not in str(error.value)
     assert not transport.sessions
     await sb.disconnect()
 
 
-async def test_cancel_can_overtake_exchange_and_prevents_late_result(native):
+async def test_malformed_initialize_still_deletes_allocated_session(sdk):
     transport = McpTransport()
-    transport.exchange_wait = asyncio.Event()
+    transport.mutate = lambda method, response: dict(response, id="wrong")
     sb = await sandbox(transport)
-    async with sb.driver.connect(service="mcp", transport="mcp") as driver:
-        task = asyncio.create_task(driver.channel.exchange(envelope()))
-        await asyncio.wait_for(transport.exchange_started.wait(), 1)
-        await asyncio.wait_for(driver.channel.cancel("request-1"), 1)
-        transport.exchange_wait.set()
-        with pytest.raises(ChannelError, match="after close or cancellation"):
-            await task
-        assert not transport.sessions
-    methods = [event[3]["method"] for event in transport.events if event[3]]
-    assert methods.index("cua/driver/v1/cancel") < methods.index("cua/driver/v1/close")
+    with pytest.raises(sdk.DriverError.Remote):
+        async with sb.driver.connect(service="mcp", transport="mcp"):
+            pass
+    assert not transport.sessions
+    assert transport.events[-1][1] == "DELETE"
     await sb.disconnect()
 
 
-@pytest.mark.parametrize("finish", ["cancel", "close", "callback-cancel"])
-async def test_mcp_teardown_drains_pending_response_before_closing_session(native, finish):
+async def test_disconnect_during_initialization_cleans_late_session(sdk, monkeypatch):
     transport = McpTransport()
-    transport.exchange_wait = asyncio.Event()
-    transport.cancel_releases_exchange = False
-    sb = await sandbox(transport)
-    async with sb.driver.connect(service="mcp", transport="mcp") as driver:
-        channel = driver.channel
-        task = asyncio.create_task(channel.exchange(envelope()))
-        await transport.exchange_started.wait()
-        if finish == "callback-cancel":
-            task.cancel()
-            closing = task
-        else:
-            closing = asyncio.create_task(
-                channel.cancel("request-1") if finish == "cancel" else channel.close()
-            )
-        await asyncio.wait_for(transport.cancel_received.wait(), 1)
-        await asyncio.sleep(0)
-        assert not closing.done()
-        assert not transport.exchange_aborted
-        assert transport.sessions
-        assert not any(
-            (event[3] or {}).get("method") == "cua/driver/v1/close" for event in transport.events
-        )
-        transport.exchange_wait.set()
-        if finish == "callback-cancel":
-            with pytest.raises(asyncio.CancelledError):
-                await closing
-        else:
-            await closing
-            with pytest.raises(ChannelError, match="after close or cancellation"):
-                await task
-        assert transport.exchange_finished.is_set()
-        assert not transport.exchange_aborted
-        assert channel.cleanup_confirmed
-        assert not transport.sessions
-    await sb.disconnect()
+    entered, released = asyncio.Event(), asyncio.Event()
+    original = transport.request_service
 
+    async def delayed(*args, **kwargs):
+        if json.loads(kwargs.get("body") or b"{}").get("method") == "initialize":
+            entered.set()
+            await released.wait()
+        return await original(*args, **kwargs)
 
-async def test_mcp_drain_timeout_is_bounded_unconfirmed_and_does_not_abort(native, monkeypatch):
-    monkeypatch.setattr("cua_sandbox.interfaces.driver._CLEANUP_TIMEOUT", 0.02)
-    transport = McpTransport()
-    transport.exchange_wait = asyncio.Event()
-    transport.cancel_releases_exchange = False
+    monkeypatch.setattr(transport, "request_service", delayed)
     sb = await sandbox(transport)
-    async with sb.driver.connect(service="mcp", transport="mcp") as driver:
-        channel = driver.channel
-        task = asyncio.create_task(channel.exchange(envelope()))
-        await transport.exchange_started.wait()
-        await asyncio.wait_for(channel.cancel("request-1"), 0.5)
-        assert channel.closed and not channel.cleanup_confirmed
-        assert not transport.exchange_aborted
-        assert transport.sessions
-        assert transport.events[-1][3]["method"] == "cua/driver/v1/cancel"
-        transport.exchange_wait.set()
-        with pytest.raises(ChannelError, match="after close or cancellation"):
-            await task
+
+    async def connect():
+        async with sb.driver.connect(service="mcp", transport="mcp"):
+            pytest.fail("disconnected accessor must not yield")
+
+    opening = asyncio.create_task(connect())
+    await asyncio.wait_for(entered.wait(), 2)
+    closing = asyncio.create_task(sb.driver.close())
+    await asyncio.sleep(0)
+    released.set()
+    await closing
+    with pytest.raises((sdk.DriverError.Remote, DriverConnectionError)):
+        await opening
+    assert not transport.sessions
     await sb.disconnect()
 
 
@@ -307,49 +272,28 @@ async def test_mcp_drain_timeout_is_bounded_unconfirmed_and_does_not_abort(nativ
         ('{"jsonrpc":"2.0","id":true,"result":{}}', "application/json"),
     ],
 )
-def test_decoder_refuses_ambiguous_incomplete_or_non_json_responses(body, media):
-    with pytest.raises(McpCarrierError, match="malformed"):
-        _response(httpx.Response(200, content=body, headers={"Content-Type": media}), "expected")
-
-
-async def test_malformed_initialize_still_deletes_allocated_session(native):
+async def test_shared_decoder_refuses_ambiguous_incomplete_or_non_json_responses(
+    sdk, monkeypatch, body, media
+):
     transport = McpTransport()
-    transport.mutate = lambda method, response: dict(response, id="wrong")
-    sb = await sandbox(transport)
-    with pytest.raises(ChannelError, match="malformed"):
-        async with sb.driver.connect(service="mcp", transport="mcp"):
-            pass
-    assert not transport.sessions
-    assert transport.events[-1][1] == "DELETE"
-    await sb.disconnect()
-
-
-async def test_disconnect_during_initialization_cleans_late_session(native, monkeypatch):
-    transport = McpTransport()
-    entered, released = asyncio.Event(), asyncio.Event()
     original = transport.request_service
 
-    async def delayed(*args, **kwargs):
-        if (kwargs.get("json_body") or {}).get("method") == "initialize":
-            entered.set()
-            await released.wait()
-        return await original(*args, **kwargs)
+    async def malformed(*args, **kwargs):
+        request = json.loads(kwargs.get("body") or b"{}")
+        response = await original(*args, **kwargs)
+        if request.get("method") == "cua/driver/v1/exchange":
+            return httpx.Response(
+                200,
+                content=body.replace("expected", request["id"]),
+                headers={"Content-Type": media},
+            )
+        return response
 
-    monkeypatch.setattr(transport, "request_service", delayed)
+    monkeypatch.setattr(transport, "request_service", malformed)
     sb = await sandbox(transport)
-
-    async def connect():
-        async with sb.driver.connect(service="mcp", transport="mcp"):
-            pytest.fail("disconnected accessor must not yield")
-
-    opening = asyncio.create_task(connect())
-    await entered.wait()
-    closing = asyncio.create_task(sb.driver.close())
-    await asyncio.sleep(0)
-    released.set()
-    await closing
-    with pytest.raises(ChannelError, match="closed during"):
-        await opening
+    async with sb.driver.connect(service="mcp", transport="mcp") as driver:
+        with pytest.raises(sdk.DriverError.ActionInterrupted) as error:
+            await driver.get_screen_size(sdk.GetScreenSizeInput(session=None))
+        assert error.value.completion == sdk.ActionCompletion.UNKNOWN
     assert not transport.sessions
-    assert all((event[3] or {}).get("method") != "cua/driver/v1/open" for event in transport.events)
     await sb.disconnect()

--- a/libs/python/cua-sandbox/tests/test_driver_mcp_native.py
+++ b/libs/python/cua-sandbox/tests/test_driver_mcp_native.py
@@ -116,3 +116,87 @@ async def test_actual_native_future_cancellation_reaches_mcp_receiver(sdk):
     finally:
         transport.exchange_wait.set()
         await sb.disconnect()
+
+
+@pytest.mark.parametrize("finish", ["cancel", "close"])
+async def test_shared_native_teardown_drains_pending_response_before_session_close(sdk, finish):
+    transport = McpTransport()
+    transport.exchange_wait = asyncio.Event()
+    transport.cancel_releases_exchange = False
+    sb = await sandbox(transport)
+    try:
+        async with sb.driver.connect(service="mcp", transport="mcp") as driver:
+            task = asyncio.create_task(driver.get_screen_size(sdk.GetScreenSizeInput(session=None)))
+            await asyncio.wait_for(transport.exchange_started.wait(), 2)
+            if finish == "cancel":
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+                closing = asyncio.create_task(sb.driver.close())
+            else:
+                closing = asyncio.create_task(sb.driver.close())
+            await asyncio.wait_for(transport.cancel_received.wait(), 2)
+            assert not transport.exchange_aborted
+            assert transport.sessions
+            assert not any(
+                (event[3] or {}).get("method") == "cua/driver/v1/close"
+                for event in transport.events
+            )
+            transport.exchange_wait.set()
+            await asyncio.wait_for(closing, 5)
+            if finish == "close":
+                with pytest.raises(sdk.DriverError.ActionInterrupted) as error:
+                    await task
+                assert error.value.completion == sdk.ActionCompletion.UNKNOWN
+            assert transport.exchange_finished.is_set()
+            assert not transport.exchange_aborted
+            assert not transport.sessions
+    finally:
+        transport.exchange_wait.set()
+        await sb.disconnect()
+
+
+async def test_shared_native_sandbox_rejects_use_from_another_event_loop(sdk):
+    transport = McpTransport()
+    sb = await sandbox(transport)
+    try:
+        async with sb.driver.connect(service="mcp", transport="mcp") as driver:
+
+            def other_loop():
+                async def get_session():
+                    return sb.driver.session_name(driver)
+
+                return asyncio.run(get_session())
+
+            from cua_sandbox.interfaces.driver import DriverConnectionError
+
+            with pytest.raises(DriverConnectionError, match="different event loop"):
+                await asyncio.to_thread(other_loop)
+    finally:
+        await sb.disconnect()
+
+
+async def test_shared_native_drain_timeout_is_bounded_and_does_not_abort(sdk, caplog):
+    transport = McpTransport()
+    transport.exchange_wait = asyncio.Event()
+    transport.cancel_releases_exchange = False
+    sb = await sandbox(transport)
+    try:
+        async with sb.driver.connect(service="mcp", transport="mcp") as driver:
+            task = asyncio.create_task(driver.get_screen_size(sdk.GetScreenSizeInput(session=None)))
+            await asyncio.wait_for(transport.exchange_started.wait(), 2)
+            await asyncio.wait_for(sb.driver.close(), 5)
+            assert not transport.exchange_aborted
+            assert transport.sessions
+            assert "cleanup is unconfirmed" in caplog.text
+            assert not any(
+                (event[3] or {}).get("method") == "cua/driver/v1/close"
+                for event in transport.events
+            )
+            transport.exchange_wait.set()
+            with pytest.raises(sdk.DriverError.ActionInterrupted) as error:
+                await task
+            assert error.value.completion == sdk.ActionCompletion.UNKNOWN
+    finally:
+        transport.exchange_wait.set()
+        await sb.disconnect()

--- a/libs/python/cua-sandbox/tests/test_driver_mcp_shared.py
+++ b/libs/python/cua-sandbox/tests/test_driver_mcp_shared.py
@@ -1,0 +1,133 @@
+"""Sandbox ownership and byte mapping; protocol safety uses real-binding tests."""
+
+import asyncio
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from cua_sandbox.interfaces._driver_mcp import shared_channel
+from cua_sandbox.interfaces.driver import DriverConnectionError
+
+from .test_typed_driver import native as _native_fixture
+from .test_driver_mcp import McpTransport, sandbox
+
+native = _native_fixture
+
+
+@pytest.fixture
+def shared(native):
+    channels = []
+
+    class Channel:
+        def __init__(self, transport, principal):
+            self.transport, self.principal = transport, principal
+            self.opened, self.closes = False, 0
+            self.canonical = native.CuaDriver(self)
+            channels.append(self)
+
+        async def open(self):
+            self.opened = True
+
+        def driver(self):
+            assert self.opened
+            return self.canonical
+
+        def public_session(self):
+            return "host-selected"
+
+        async def close(self):
+            self.closes += 1
+
+    native.DriverServiceTransport = object
+    native.DriverServiceHeader = SimpleNamespace
+    native.DriverServiceResponse = SimpleNamespace
+    native.DriverServiceTransportError = SimpleNamespace(Failed=RuntimeError)
+    native.open_mcp_driver_channel = Channel
+    return native, channels
+
+
+async def test_shared_channel_is_canonical_and_closes_before_fleet(shared):
+    sdk, channels = shared
+    transport = McpTransport()
+    sb = await sandbox(transport)
+    async with sb.driver.connect(service="mcp", transport="mcp") as driver:
+        assert driver is channels[0].canonical
+        assert sb.driver.session_name(driver) == "host-selected"
+        assert channels[0].principal == sb.driver._principal
+        await sb.disconnect()
+        assert channels[0].closes >= 1
+        assert not transport._connected
+        with pytest.raises(DriverConnectionError, match="inactive"):
+            sb.driver.session_name(driver)
+    assert driver.shutdowns == 0
+    assert not transport.sessions
+
+
+async def test_missing_shared_api_never_falls_back_to_envelope(native):
+    transport = McpTransport()
+    sb = await sandbox(transport)
+    with pytest.raises(DriverConnectionError, match="open_mcp_driver_channel"):
+        async with sb.driver.connect(service="mcp", transport="mcp"):
+            pytest.fail("old SDK must not silently fall back")
+    assert not transport.events
+    await sb.disconnect()
+
+
+async def test_callback_preserves_bytes_headers_and_timeout(shared):
+    sdk, channels = shared
+    seen = []
+
+    async def request_service(service, **request):
+        seen.append((service, request))
+        return httpx.Response(207, content=b"\x00\xff", headers=[("x-one", "a"), ("x-one", "b")])
+
+    transport = SimpleNamespace(_connected=True, request_service=request_service)
+    connection = shared_channel(sdk, transport, "mcp", "principal")
+    request = SimpleNamespace(
+        method="POST",
+        path="/mcp",
+        body=b"\xff\x00",
+        headers=[SimpleNamespace(name="x-test", value="v")],
+        timeout_ms=1234,
+    )
+    response = await channels[0].transport.send(request)
+    assert seen == [
+        (
+            "mcp",
+            dict(
+                method="POST",
+                path="/mcp",
+                body=b"\xff\x00",
+                headers=[("x-test", "v")],
+                timeout=1.234,
+            ),
+        )
+    ]
+    assert response.status == 207 and response.body == b"\x00\xff"
+    assert [(h.name, h.value) for h in response.headers if h.name == "x-one"] == [
+        ("x-one", "a"),
+        ("x-one", "b"),
+    ]
+    await connection.close()
+
+
+async def test_callback_sanitizes_failure_and_preserves_cancellation(shared):
+    sdk, channels = shared
+
+    async def fail(*args, **kwargs):
+        raise RuntimeError("private diagnostic")
+
+    transport = SimpleNamespace(_connected=True, request_service=fail)
+    shared_channel(sdk, transport, "mcp", "principal")
+    request = SimpleNamespace(method="POST", path="/mcp", body=b"", headers=[], timeout_ms=1)
+    with pytest.raises(RuntimeError, match="completion is unknown") as error:
+        await channels[0].transport.send(request)
+    assert "private" not in str(error.value)
+
+    async def cancel(*args, **kwargs):
+        raise asyncio.CancelledError
+
+    transport.request_service = cancel
+    with pytest.raises(asyncio.CancelledError):
+        await channels[0].transport.send(request)

--- a/libs/python/cua-sandbox/tests/test_driver_mcp_shared.py
+++ b/libs/python/cua-sandbox/tests/test_driver_mcp_shared.py
@@ -5,12 +5,11 @@ from types import SimpleNamespace
 
 import httpx
 import pytest
-
 from cua_sandbox.interfaces._driver_mcp import shared_channel
 from cua_sandbox.interfaces.driver import DriverConnectionError
 
-from .test_typed_driver import native as _native_fixture
 from .test_driver_mcp import McpTransport, sandbox
+from .test_typed_driver import native as _native_fixture
 
 native = _native_fixture
 

--- a/libs/python/cua-sandbox/tests/test_driver_mcp_shared.py
+++ b/libs/python/cua-sandbox/tests/test_driver_mcp_shared.py
@@ -100,6 +100,7 @@ async def test_callback_preserves_bytes_headers_and_timeout(shared):
                 body=b"\xff\x00",
                 headers=[("x-test", "v")],
                 timeout=1.234,
+                max_response_bytes=16 * 1024 * 1024,
             ),
         )
     ]
@@ -109,6 +110,43 @@ async def test_callback_preserves_bytes_headers_and_timeout(shared):
         ("x-one", "b"),
     ]
     await connection.close()
+
+
+async def test_callback_accepts_response_exactly_at_limit(shared):
+    sdk, channels = shared
+    body = bytes(16 * 1024 * 1024)
+
+    async def request_service(service, **request):
+        assert service == "mcp"
+        assert request["max_response_bytes"] == len(body)
+        return httpx.Response(200, content=body)
+
+    transport = SimpleNamespace(_connected=True, request_service=request_service)
+    shared_channel(sdk, transport, "mcp", "principal")
+    request = SimpleNamespace(method="POST", path="/mcp", body=b"", headers=[], timeout_ms=1)
+
+    response = await channels[0].transport.send(request)
+
+    assert response.body == body
+
+
+async def test_callback_sanitizes_oversized_response(shared):
+    sdk, channels = shared
+    secret = b"private-response-fragment"
+
+    async def request_service(service, **request):
+        assert service == "mcp"
+        limit = request["max_response_bytes"]
+        return httpx.Response(200, content=secret + bytes(limit + 1 - len(secret)))
+
+    transport = SimpleNamespace(_connected=True, request_service=request_service)
+    shared_channel(sdk, transport, "mcp", "principal")
+    request = SimpleNamespace(method="POST", path="/mcp", body=b"", headers=[], timeout_ms=1)
+
+    with pytest.raises(RuntimeError, match="completion is unknown") as error:
+        await channels[0].transport.send(request)
+
+    assert secret.decode() not in str(error.value)
 
 
 async def test_callback_sanitizes_failure_and_preserves_cancellation(shared):

--- a/libs/python/cua-sandbox/tests/test_fleet_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_transport.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 from cua_sandbox.transport.fleet import FleetTransport, build_http_request
-from fleet_sdk import HttpRequest, HttpResponse, Sandbox
+from fleet_sdk import HttpHeader, HttpRequest, HttpResponse, Sandbox
 
 
 class FakeSDK:
@@ -106,3 +106,47 @@ async def test_service_timeout_override_does_not_change_existing_callers(default
 
     assert [call[3].timeout_secs for call in sdk.calls] == [120, default_timeout, default_timeout]
     assert transport._timeout == default_timeout
+
+
+@pytest.mark.asyncio
+async def test_raw_service_bytes_and_duplicate_headers_are_preserved():
+    sdk = FakeSDK(
+        [
+            HttpResponse(
+                status=200,
+                headers=[
+                    HttpHeader(name="mcp-session-id", value="first"),
+                    HttpHeader(name="mcp-session-id", value="second"),
+                ],
+                body=b"raw response",
+            )
+        ]
+    )
+    transport = FleetTransport(sdk=sdk, bound=sandbox())
+    await transport.connect()
+    result = await transport.request_service(
+        "api",
+        method="POST",
+        path="/mcp",
+        body=b"\x00raw bytes",
+        headers=[("content-type", "application/octet-stream"), ("x-test", "a"), ("x-test", "b")],
+    )
+    request = sdk.calls[0][3]
+    assert request.body == b"\x00raw bytes"
+    assert [(h.name, h.value) for h in request.headers] == [
+        ("content-type", "application/octet-stream"),
+        ("x-test", "a"),
+        ("x-test", "b"),
+    ]
+    assert result.content == b"raw response"
+    assert result.headers.get_list("mcp-session-id") == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_raw_body_and_json_are_mutually_exclusive():
+    sdk = FakeSDK([])
+    transport = FleetTransport(sdk=sdk, bound=sandbox())
+    await transport.connect()
+    with pytest.raises(ValueError, match="either body or json_body"):
+        await transport.request_service("api", method="POST", path="/mcp", body=b"", json_body={})
+    assert not sdk.calls

--- a/libs/python/cua-sandbox/tests/test_fleet_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_transport.py
@@ -2,8 +2,8 @@ import base64
 import json
 from types import SimpleNamespace
 
-import pytest
 import cua_sandbox.transport.fleet as fleet_transport
+import pytest
 from cua_sandbox.transport.fleet import FleetTransport, build_http_request
 from fleet_sdk import HttpHeader, HttpRequest, HttpResponse, Sandbox
 

--- a/libs/python/cua-sandbox/tests/test_fleet_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_transport.py
@@ -1,7 +1,9 @@
 import base64
 import json
+from types import SimpleNamespace
 
 import pytest
+import cua_sandbox.transport.fleet as fleet_transport
 from cua_sandbox.transport.fleet import FleetTransport, build_http_request
 from fleet_sdk import HttpHeader, HttpRequest, HttpResponse, Sandbox
 
@@ -67,15 +69,53 @@ async def test_connect_rejects_missing_service():
 
 
 def test_build_http_request_constructs_the_record_through_the_builder():
-    bounded = build_http_request(
-        method="GET", url="https://service.invalid/status", timeout_secs=30
-    )
     unbounded = build_http_request(method="GET", url="https://service.invalid/status")
 
-    assert isinstance(bounded, HttpRequest)
+    assert isinstance(unbounded, HttpRequest)
+    assert (unbounded.method, unbounded.headers, unbounded.body) == ("GET", [], None)
+    assert unbounded.timeout_secs is None
+
+
+def test_build_http_request_forwards_response_limit_to_the_builder(monkeypatch):
+    class Builder:
+        def __init__(self):
+            self.request = SimpleNamespace(body=None, timeout_secs=None, max_response_bytes=None)
+
+        def method(self, value):
+            self.request.method = value
+            return self
+
+        def url(self, value):
+            self.request.url = value
+            return self
+
+        def headers(self, value):
+            self.request.headers = value
+            return self
+
+        def timeout_secs(self, value):
+            self.request.timeout_secs = value
+            return self
+
+        def max_response_bytes(self, value):
+            self.request.max_response_bytes = value
+            return self
+
+        def build(self):
+            return self.request
+
+    monkeypatch.setattr(fleet_transport, "HttpRequestBuilder", Builder)
+
+    bounded = build_http_request(
+        method="GET",
+        url="https://service.invalid/status",
+        timeout_secs=30,
+        max_response_bytes=4096,
+    )
+
     assert (bounded.method, bounded.headers, bounded.body) == ("GET", [], None)
     assert bounded.timeout_secs == 30
-    assert unbounded.timeout_secs is None
+    assert bounded.max_response_bytes == 4096
 
 
 @pytest.mark.asyncio
@@ -91,6 +131,45 @@ async def test_requests_are_bounded_by_the_transport_timeout():
 
     assert sdk.calls[0][3].timeout_secs == 30
     assert sdk.calls[1][3].timeout_secs == 1
+
+
+@pytest.mark.asyncio
+async def test_service_response_limit_is_forwarded_and_exact_limit_is_accepted(monkeypatch):
+    seen = []
+
+    def build_request(**request):
+        seen.append(request)
+        return SimpleNamespace(**request)
+
+    monkeypatch.setattr(fleet_transport, "build_http_request", build_request)
+    sdk = FakeSDK([response(body=b"four")])
+    transport = FleetTransport(sdk=sdk, bound=sandbox())
+    await transport.connect()
+
+    result = await transport.request_service(
+        "api", method="GET", path="/status", max_response_bytes=4
+    )
+
+    assert seen[0]["max_response_bytes"] == 4
+    assert result.content == b"four"
+
+
+@pytest.mark.asyncio
+async def test_service_response_over_limit_is_rejected_without_exposing_contents(monkeypatch):
+    monkeypatch.setattr(
+        fleet_transport, "build_http_request", lambda **request: SimpleNamespace(**request)
+    )
+    secret = b"private-response-fragment"
+    sdk = FakeSDK([response(body=secret)])
+    transport = FleetTransport(sdk=sdk, bound=sandbox())
+    await transport.connect()
+
+    with pytest.raises(RuntimeError, match="configured size limit") as error:
+        await transport.request_service(
+            "api", method="GET", path="/status", max_response_bytes=len(secret) - 1
+        )
+
+    assert secret.decode() not in str(error.value)
 
 
 @pytest.mark.asyncio

--- a/libs/python/cua-sandbox/tests/test_typed_driver.py
+++ b/libs/python/cua-sandbox/tests/test_typed_driver.py
@@ -88,9 +88,20 @@ class Transport(FleetTransport):
         self.status = 200
 
     async def request_service(
-        self, name, *, method, path, json_body=None, headers=None, timeout=None
+        self,
+        name,
+        *,
+        method,
+        path,
+        json_body=None,
+        body=None,
+        headers=None,
+        timeout=None,
+        max_response_bytes=None,
     ):
         assert self._connected
+        assert body is None
+        assert max_response_bytes is None
         self.events.append((name, method, path, json_body, headers))
         data = self.open_data if path == "/v1/connections" else self.response_data
         return httpx.Response(self.status, json=data)

--- a/libs/python/cua-sandbox/tests/test_typed_driver_native.py
+++ b/libs/python/cua-sandbox/tests/test_typed_driver_native.py
@@ -43,10 +43,26 @@ class NativeTransport(Transport):
         )
 
     async def request_service(
-        self, name, *, method, path, json_body=None, headers=None, timeout=None
+        self,
+        name,
+        *,
+        method,
+        path,
+        json_body=None,
+        body=None,
+        headers=None,
+        timeout=None,
+        max_response_bytes=None,
     ):
         response = await super().request_service(
-            name, method=method, path=path, json_body=json_body, headers=headers, timeout=timeout
+            name,
+            method=method,
+            path=path,
+            json_body=json_body,
+            body=body,
+            headers=headers,
+            timeout=timeout,
+            max_response_bytes=max_response_bytes,
         )
         if path.endswith("/exchange"):
             self.exchange_timeouts.append(timeout)

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -569,26 +569,26 @@ dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
 name = "cua-driver"
-version = "0.26.0"
+version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/d5/7f6b8cdde9a811df3f9afc60047af96ae762e379584964cd62f64f12dca2/cua_driver-0.26.0-py3-none-macosx_13_0_universal2.whl", hash = "sha256:88096916df0fac0e95c6a0b329f6580cf089ec91afb0f8bc5d32c8d8cece6a78", size = 39952632, upload-time = "2026-09-10T05:01:28.64Z" },
-    { url = "https://files.pythonhosted.org/packages/06/c1/c9608fdbc5b28fcc69672f6f235d4af7339fc3c30391d3fcc7b533b2aed7/cua_driver-0.26.0-py3-none-manylinux_2_31_aarch64.whl", hash = "sha256:29d11f0742ffa3bc5d0c0e8771c7696e9ae73f568bd676010e3ec953861ccf7d", size = 28699682, upload-time = "2026-09-10T05:01:31.181Z" },
-    { url = "https://files.pythonhosted.org/packages/91/b9/2ccf0e357ac5a2e362d7ff138c82675774dd0bf96dfcc2d48db21b7f1ebf/cua_driver-0.26.0-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:f9c8c2aaf5b66175d19b08e9a46b5ba3e5d8936bcb71ad0ca30f98ceba762ffa", size = 28509643, upload-time = "2026-09-10T05:01:33.688Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/cc/ea4d020c635c1ee35173d877ed04920a0ee7560b87cd6263985c9fc6bb6f/cua_driver-0.26.0-py3-none-win_amd64.whl", hash = "sha256:a8982d37d962ea483c3b5e7b4b9a1a780e13922621845bec4435d69b7106db89", size = 26127135, upload-time = "2026-09-10T05:01:36.321Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/b6/52c7fe067e9c301e688ab29881a2b6312e02a05ac0170f47156d4d536348/cua_driver-0.26.0-py3-none-win_arm64.whl", hash = "sha256:f10ea9ea123102c30df0639cd5436b720563eca40398a237c092b3bf88a29700", size = 24387149, upload-time = "2026-09-10T05:01:38.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/77/649d5df6d4d18cd1d38f48f7f3a9dc2d57c15b5fcec95bbf0cf04c29473f/cua_driver-0.27.0-py3-none-macosx_13_0_universal2.whl", hash = "sha256:7f1e2ee3c399283e2a9547ca24905fbcba45cb8d8be796f3c443e7766529aedd", size = 40214706, upload-time = "2026-09-11T04:32:07.638Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/bba9e02dc5c95758c2f01b072f46dbb3e7e521f60a421d65464810236a4c/cua_driver-0.27.0-py3-none-manylinux_2_31_aarch64.whl", hash = "sha256:eadc58d6865baee512f3e516fe6f94c516946b1ced8a7e6275552748a74d30b0", size = 28815419, upload-time = "2026-09-11T04:32:11.246Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e2/58667850662489ad3225c44145c229a8b0a6b4c832c25b71eccfdb8a7568/cua_driver-0.27.0-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:d716791555881544aa71ba7062bd79883b06cbc6a862db9ee3748964385afc3a", size = 28642908, upload-time = "2026-09-11T04:32:14.657Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/35/5ef6ea10b18b07c552d487962bbc5c42ccc3609741299e83be08a9c779d4/cua_driver-0.27.0-py3-none-win_amd64.whl", hash = "sha256:d4c34098f23eb3bc50592b0d6f1b449d3e884f4ecc07fa7095d006b8a801e646", size = 26243560, upload-time = "2026-09-11T04:32:18.053Z" },
+    { url = "https://files.pythonhosted.org/packages/25/40/6188588e951a489f061886a4132f7c8fe772557ed7268f8d4cca29b4e556/cua_driver-0.27.0-py3-none-win_arm64.whl", hash = "sha256:aea1a51e9dbd293912009ba0e32ea27231690c84ad5dbaadc6f061b944b20630", size = 24501303, upload-time = "2026-09-11T04:32:21.345Z" },
 ]
 
 [[package]]
 name = "cua-fleet"
-version = "0.1.16"
+version = "0.1.17"
 source = { registry = "https://wheels.cua.ai/simple" }
 wheels = [
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:27a8621170df2a14d4af8912f902266a0cc32c1ed91ebb592f6ddb3bcf600bb1" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:31d0373884f2d04dac8c3a88d06da7669491e5cb0c9d7c47ec839f8e42dc4e76" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.16-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:d29cc4cc2768ce2e9b48df9180ab1e544c5b659416f9d130af99f002fa9dd2f2" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.16-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:6d1b2b2095b5cb629a303cdc314b8223c1205a49b0647a0d50a966f9a572131e" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.16-py3-none-win_amd64.whl", hash = "sha256:ccd088f6a3d167a48f106518d24d3c601e3190d946f663f4c4ccec160b33ac8e" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a8908b5c7f0f3c75d09b908b58867d43270f69d3726bb0d90316443f2265d0e3" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6aea577f21343326aeb06df03c07df65df8dd2f3b0097e02f25a7bc6b9d2c458" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.17-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:bda49298c77c65eb349e8420f9237f6b7fb2fd25203747df98a9513b98fd5d73" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.17-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:4cdbc89e850d841481713abf1e8bf9719b2e33b3c31f26bbea5f63e1ead3c6c0" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.17-py3-none-win_amd64.whl", hash = "sha256:ee4c139b1c0cebe1702114a34fd0fd60d216c5862d9fdc3472bb8b9879ac9eae" },
 ]
 
 [[package]]
@@ -637,8 +637,8 @@ dev = [
 requires-dist = [
     { name = "cua-auto", specifier = ">=0.1.2" },
     { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
-    { name = "cua-driver", marker = "extra == 'driver'", specifier = "==0.26.0" },
-    { name = "cua-fleet", specifier = "==0.1.16" },
+    { name = "cua-driver", marker = "extra == 'driver'", specifier = "==0.27.0" },
+    { name = "cua-fleet", specifier = "==0.1.17" },
     { name = "grpcio", specifier = "==1.78.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jsonschema", specifier = ">=4.23,<5.0" },


### PR DESCRIPTION
## Scope

Refs #2512.

Preserve Python `sb.driver.connect(service="mcp", transport="mcp")` while moving its MCP protocol and session implementation into the shared Rust Driver connector released in `cua-driver==0.27.0`.

- Replace the duplicate Python MCP parser/state machine with a byte-and-lifetime adapter.
- Preserve the existing direct-envelope path, computer-server behavior, and close-before-Fleet-disconnect ordering.
- Forward raw request and response bytes, repeated HTTP headers, and request deadlines through the named Fleet service.
- Bound Driver-over-Fleet responses to 16 MiB before Python buffering through `cua-fleet==0.1.17`, with a sanitized defensive post-return check.
- Keep exact optional pins for the released Driver and Fleet packages.
- Exercise the real generated native binding for protocol safety, cancellation, drain ordering, independent sessions, stale-session refusal, and event-loop ownership.

No TypeScript Sandbox SDK, computer-server API change, Fleet authorization change, guest image change, or automatic local fallback is introduced.

## Validation

Candidate `8cbf114c67761e541bf154d74b79c2b064643daf`:

- 276 affected Sandbox tests pass on Python 3.13 with the public `cua-driver==0.27.0` and `cua-fleet==0.1.17` packages installed.
- The same 276 tests pass on Python 3.11 with those public packages.
- Exact 16 MiB Driver service responses are accepted; 16 MiB + 1 is rejected without exposing response content.
- Targeted Ruff lint and formatting checks pass; `git diff --check` passes.
- The source distribution and wheel build successfully. The wheel metadata contains `cua-fleet==0.1.17` and optional `cua-driver==0.27.0`.
- A clean Python 3.11 install from the built wheel resolves both public dependencies and completes a real shared-channel initialize, typed `get_screen_size`, close, and MCP session deletion smoke.
- The final follow-up only sorts one test-file import after the first fresh CI run exposed the repository's isort ordering; it does not change runtime behavior.

Fresh GitHub CI is required on the retargeted `main` diff before merge. Live Linux Omarchy and Windows 2022 Fleet desktop qualification follows the public Sandbox release so it can test the exact user-installable package set.

## Release and rollback

The Driver and Fleet dependencies are now public, so the earlier stacked-branch release blocker is resolved. Release Please should prepare the next Sandbox minor release after merge.

Rollback is to revert this delegation and retain the existing released Sandbox package. The direct-envelope path, computer-server requests, Fleet claim lifecycle, and cleanup APIs are unchanged.
