### PR TITLE
ci(cua-driver): add a hosted macOS E2E environment probe

### DIFF
--- a/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
+++ b/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
@@ -1,0 +1,77 @@
+"""Contract tests for the manually dispatched GitHub-hosted macOS probe."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text()
+
+
+def test_hosted_macos_probe_is_manual_exact_sha_and_least_privilege() -> None:
+    workflow = read(".github/workflows/e2e-rust-macos.yml")
+
+    trigger = workflow.split("permissions:", 1)[0]
+    assert "workflow_dispatch:" in trigger
+    assert "pull_request:" not in trigger
+    assert "push:" not in trigger
+    assert "source_sha:" in trigger
+    assert "permissions:\n  contents: read\n" in workflow
+    assert "id-token: write" not in workflow
+    assert "secrets." not in workflow
+    assert "runs-on: macos-26" in workflow
+    assert "ref: ${{ inputs.source_sha }}" in workflow
+    assert "^[0-9a-fA-F]{40}$" in workflow
+    assert "persist-credentials: false" in workflow
+
+    for action in ("actions/checkout", "actions/upload-artifact"):
+        line = next(line for line in workflow.splitlines() if f"uses: {action}@" in line)
+        revision = line.split("@", 1)[1].split()[0]
+        assert len(revision) == 40
+        assert all(character in "0123456789abcdef" for character in revision)
+
+
+def test_hosted_macos_probe_fails_closed_before_gui_capture() -> None:
+    probe = read("scripts/ci/macos/probe-hosted-runner.sh")
+
+    for requirement in (
+        'GITHUB_ACTIONS:-}" == true',
+        'RUNNER_ENVIRONMENT:-}" == github-hosted',
+        'GITHUB_EVENT_NAME:-}" == workflow_dispatch',
+        "current user must be runner",
+        "console user must be runner",
+        "SSH sessions cannot seed or certify hosted TCC state",
+        "csrutil status",
+        "System Integrity Protection must be disabled",
+        'launchctl print "gui/${CURRENT_UID}"',
+        "pgrep -x WindowServer",
+    ):
+        assert requirement in probe
+
+    assert "trap write_environment EXIT" in probe
+    assert "AXIsProcessTrusted" in read("scripts/ci/macos/verify-hosted-window.swift")
+    assert "CGPreflightScreenCaptureAccess" in read(
+        "scripts/ci/macos/verify-hosted-window.swift"
+    )
+
+
+def test_hosted_macos_probe_proves_textedit_window_content() -> None:
+    probe = read("scripts/ci/macos/probe-hosted-runner.sh")
+    verifier = read("scripts/ci/macos/verify-hosted-window.swift")
+
+    assert "CUA HOSTED MACOS PROBE 3725" in probe
+    assert "open -a TextEdit" in probe
+    assert '"marker_recognized"' in verifier
+    assert "VNRecognizeTextRequest" in verifier
+    assert '"owner": window.owningApplication?.applicationName' in verifier
+    assert 'result.get("window", {}).get("owner") == "TextEdit"' in probe
+    assert "textedit-window.png" in probe
+
+
+def test_script_ci_runs_when_hosted_macos_contract_changes() -> None:
+    workflow = read(".github/workflows/ci-test-scripts.yml")
+
+    assert '      - ".github/workflows/e2e-rust-macos.yml"' in workflow
+    assert '      - "scripts/ci/macos/**"' in workflow

--- a/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
+++ b/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
@@ -25,6 +25,7 @@ def test_hosted_macos_probe_is_manual_exact_sha_and_least_privilege() -> None:
     assert "ref: ${{ inputs.source_sha }}" in workflow
     assert "^[0-9a-fA-F]{40}$" in workflow
     assert "persist-credentials: false" in workflow
+    assert "github.run_id }}-${{ github.run_attempt" in workflow
 
     for action in ("actions/checkout", "actions/upload-artifact"):
         line = next(line for line in workflow.splitlines() if f"uses: {action}@" in line)
@@ -61,13 +62,17 @@ def test_hosted_macos_probe_proves_textedit_window_content() -> None:
     probe = read("scripts/ci/macos/probe-hosted-runner.sh")
     verifier = read("scripts/ci/macos/verify-hosted-window.swift")
 
-    assert "CUA HOSTED MACOS PROBE 3725" in probe
+    assert "CUA HOSTED MACOS GUI PROBE" in probe
     assert "open -a TextEdit" in probe
     assert '"marker_recognized"' in verifier
     assert "VNRecognizeTextRequest" in verifier
+    assert "SCContentFilter(display:" in verifier
+    assert '"permission_attribution_scope"' in verifier
     assert '"owner": window.owningApplication?.applicationName' in verifier
     assert 'result.get("window", {}).get("owner") == "TextEdit"' in probe
+    assert 'result.get("window", {}).get("name") == "probe.txt"' in probe
     assert "textedit-window.png" in probe
+    assert "display.png" in probe
 
 
 def test_script_ci_runs_when_hosted_macos_contract_changes() -> None:
@@ -75,3 +80,7 @@ def test_script_ci_runs_when_hosted_macos_contract_changes() -> None:
 
     assert '      - ".github/workflows/e2e-rust-macos.yml"' in workflow
     assert '      - "scripts/ci/macos/**"' in workflow
+
+    guide = read("scripts/ci/README.md")
+    assert "e2e-rust-macos.yml" in guide
+    assert "does not\nestablish `CuaDriverLocal.app` TCC authorization" in guide

--- a/.github/workflows/ci-test-scripts.yml
+++ b/.github/workflows/ci-test-scripts.yml
@@ -32,13 +32,14 @@ on:
       - ".github/workflows/ci-test-scripts.yml"
       - ".github/workflows/periodic-cua-sandbox-live.yml"
       - ".github/workflows/ci-contributor-attribution.yml"
+      - ".github/workflows/e2e-rust-macos.yml"
       - "docs/release-backfill-runbook.md"
       - "libs/cua-driver/scripts/**"
       - "libs/cua-driver/tests/fixtures/apps/cross-platform/electron/build.sh"
       - "libs/cua-driver/tests/fixtures/apps/cross-platform/electron/package-lock.json"
       - "libs/cua-driver/tests/fixtures/apps/cross-platform/tauri/build.sh"
       - "libs/cua-driver/tests/runners/macos-lume/**"
-      - "scripts/ci/macos/run-rust-e2e.sh"
+      - "scripts/ci/macos/**"
 
 jobs:
   test:

--- a/.github/workflows/e2e-rust-macos.yml
+++ b/.github/workflows/e2e-rust-macos.yml
@@ -1,0 +1,70 @@
+name: "E2E: Rust macOS hosted probe"
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: "Full 40-character commit SHA to probe"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-rust-macos-probe-${{ inputs.source_sha }}
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    name: hosted environment probe
+    runs-on: macos-26
+    timeout-minutes: 20
+    env:
+      CUA_E2E_SOURCE_SHA: ${{ inputs.source_sha }}
+      CUA_MACOS_HOSTED_PROBE_DIR: ${{ runner.temp }}/cua-macos-hosted-probe
+
+    steps:
+      - name: Validate requested source SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${CUA_E2E_SOURCE_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "source_sha must be a full 40-character commit SHA" >&2
+            exit 2
+          fi
+
+      - name: Check out exact source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          expected_sha="$(printf '%s' "${CUA_E2E_SOURCE_SHA}" | tr '[:upper:]' '[:lower:]')"
+          if [[ "${actual_sha}" != "${expected_sha}" ]]; then
+            echo "checked out ${actual_sha}, expected ${CUA_E2E_SOURCE_SHA}" >&2
+            exit 2
+          fi
+          if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
+            echo "hosted macOS probe requires a clean checkout" >&2
+            exit 2
+          fi
+
+      - name: Probe hosted macOS GUI environment
+        shell: bash
+        run: scripts/ci/macos/probe-hosted-runner.sh
+
+      - name: Upload hosted environment evidence
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.2
+        with:
+          name: cua-driver-macos-hosted-probe-${{ inputs.source_sha }}
+          path: ${{ runner.temp }}/cua-macos-hosted-probe
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/e2e-rust-macos.yml
+++ b/.github/workflows/e2e-rust-macos.yml
@@ -25,6 +25,13 @@ jobs:
       CUA_MACOS_HOSTED_PROBE_DIR: ${{ runner.temp }}/cua-macos-hosted-probe
 
     steps:
+      - name: Initialize evidence directory
+        shell: bash
+        run: |
+          mkdir -p "${CUA_MACOS_HOSTED_PROBE_DIR}"
+          printf 'requested_source_sha=%s\n' "${CUA_E2E_SOURCE_SHA}" \
+            > "${CUA_MACOS_HOSTED_PROBE_DIR}/request.txt"
+
       - name: Validate requested source SHA
         shell: bash
         run: |
@@ -64,7 +71,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.2
         with:
-          name: cua-driver-macos-hosted-probe-${{ inputs.source_sha }}
+          name: cua-driver-macos-hosted-probe-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/cua-macos-hosted-probe
           if-no-files-found: error
           retention-days: 14

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -130,9 +130,16 @@ complete repo-local matrix.
 The maintainer-facing macOS command is
 `libs/cua-driver/tests/runners/macos-lume/run-all.sh`. It verifies the private
 Lume seed, installs the exact committed source, and then delegates to the thin
-`macos/run-rust-e2e.sh` matrix runner above. There is no GitHub-hosted macOS GUI
-job. Pass `--standalone-browser` to run the optional installed Chrome/Edge
-browser matrix after the canonical repo-local harness matrix.
+`macos/run-rust-e2e.sh` matrix runner above. Pass `--standalone-browser` to run
+the optional installed Chrome/Edge browser matrix after the canonical repo-local
+harness matrix.
+
+The manual `.github/workflows/e2e-rust-macos.yml` workflow probes a fresh
+GitHub-hosted macOS 26 runner before hosted matrix support is enabled. It records
+the image, SIP state, desktop session, display geometry, and OCR-verified
+TextEdit window and display captures for one exact source SHA. Permission checks
+describe only the temporary probe process; a green probe process does not
+establish `CuaDriverLocal.app` TCC authorization or replace the Lume gate.
 
 Run the Wayland wrapper through `nix develop .#cua-driver-wayland-e2e`. It
 creates a pure Wayland session with Xwayland disabled and delegates every

--- a/scripts/ci/macos/probe-hosted-runner.sh
+++ b/scripts/ci/macos/probe-hosted-runner.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Fail closed unless this is a fresh, manually dispatched GitHub-hosted GUI runner.
+set -euo pipefail
+
+ARTIFACT_DIR="${CUA_MACOS_HOSTED_PROBE_DIR:?CUA_MACOS_HOSTED_PROBE_DIR is required}"
+SOURCE_SHA="${CUA_E2E_SOURCE_SHA:?CUA_E2E_SOURCE_SHA is required}"
+mkdir -p "${ARTIFACT_DIR}"
+
+PROBE_STATUS=failed
+PROBE_MESSAGE="probe did not complete"
+SWIFT_RESULT="${ARTIFACT_DIR}/window-capture.json"
+SYSTEM_LOG="${ARTIFACT_DIR}/system.txt"
+
+write_environment() {
+  PROBE_STATUS="${PROBE_STATUS}" \
+  PROBE_MESSAGE="${PROBE_MESSAGE}" \
+  SWIFT_RESULT="${SWIFT_RESULT}" \
+  SYSTEM_LOG="${SYSTEM_LOG}" \
+  python3 - "${ARTIFACT_DIR}/environment.json" <<'PY'
+import json
+import os
+from pathlib import Path
+import platform
+
+swift_result = Path(os.environ["SWIFT_RESULT"])
+payload = {
+    "schema": "cua-driver/macos-hosted-probe@v1",
+    "status": os.environ["PROBE_STATUS"],
+    "message": os.environ["PROBE_MESSAGE"],
+    "source_sha": os.environ.get("CUA_E2E_SOURCE_SHA", ""),
+    "github": {
+        "actions": os.environ.get("GITHUB_ACTIONS", ""),
+        "event_name": os.environ.get("GITHUB_EVENT_NAME", ""),
+        "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+        "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+        "runner_environment": os.environ.get("RUNNER_ENVIRONMENT", ""),
+        "runner_image": os.environ.get("ImageOS", ""),
+        "runner_image_version": os.environ.get("ImageVersion", ""),
+    },
+    "system": {
+        "architecture": platform.machine(),
+        "macos_version": platform.mac_ver()[0],
+        "system_log": os.environ["SYSTEM_LOG"],
+    },
+}
+if swift_result.is_file():
+    try:
+        payload["window_capture"] = json.loads(swift_result.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        payload["window_capture_error"] = str(exc)
+Path(__import__("sys").argv[1]).write_text(json.dumps(payload, indent=2) + "\n")
+PY
+}
+trap write_environment EXIT
+
+fail() {
+  PROBE_MESSAGE="$1"
+  echo "${PROBE_MESSAGE}" >&2
+  exit 1
+}
+
+[[ "${GITHUB_ACTIONS:-}" == true ]] || fail "GITHUB_ACTIONS must be true"
+[[ "${RUNNER_ENVIRONMENT:-}" == github-hosted ]] || fail "runner must be GitHub-hosted"
+[[ "${CI:-}" == true ]] || fail "CI must be true"
+[[ "${GITHUB_EVENT_NAME:-}" == workflow_dispatch ]] || fail "probe must be manually dispatched"
+[[ "${SOURCE_SHA}" =~ ^[0-9a-fA-F]{40}$ ]] || fail "source SHA must contain 40 hexadecimal characters"
+[[ -z "${SSH_CONNECTION:-}${SSH_CLIENT:-}${SSH_TTY:-}" ]] || fail "SSH sessions cannot seed or certify hosted TCC state"
+
+CURRENT_USER="$(id -un)"
+CONSOLE_USER="$(stat -f '%Su' /dev/console)"
+[[ "${CURRENT_USER}" == runner ]] || fail "current user must be runner, got ${CURRENT_USER}"
+[[ "${CONSOLE_USER}" == runner ]] || fail "console user must be runner, got ${CONSOLE_USER}"
+
+CURRENT_UID="$(id -u)"
+launchctl print "gui/${CURRENT_UID}" >/dev/null 2>&1 || fail "Aqua gui/${CURRENT_UID} launch domain is unavailable"
+pgrep -x WindowServer >/dev/null || fail "WindowServer is unavailable"
+
+SIP_STATUS="$(csrutil status 2>&1 || true)"
+[[ "${SIP_STATUS}" == *disabled* ]] || fail "System Integrity Protection must be disabled on the disposable hosted runner: ${SIP_STATUS}"
+
+{
+  echo "source_sha=${SOURCE_SHA}"
+  echo "current_user=${CURRENT_USER}"
+  echo "console_user=${CONSOLE_USER}"
+  echo "uid=${CURRENT_UID}"
+  echo "architecture=$(uname -m)"
+  echo "kernel=$(uname -a)"
+  echo "macos_version=$(sw_vers -productVersion)"
+  echo "macos_build=$(sw_vers -buildVersion)"
+  echo "sip_status=${SIP_STATUS}"
+  echo "runner_image=${ImageOS:-unknown}"
+  echo "runner_image_version=${ImageVersion:-unknown}"
+  echo "memory_bytes=$(sysctl -n hw.memsize)"
+  echo "logical_cpus=$(sysctl -n hw.logicalcpu)"
+  df -h /
+  launchctl print "gui/${CURRENT_UID}" | sed -n '1,20p'
+  pgrep -lf WindowServer
+} > "${SYSTEM_LOG}"
+
+MARKER="CUA HOSTED MACOS PROBE 3725"
+DOCUMENT="${ARTIFACT_DIR}/probe.txt"
+printf '%s\n\n%s\n\n%s\n' "${MARKER}" "${MARKER}" "${MARKER}" > "${DOCUMENT}"
+
+open -a TextEdit "${DOCUMENT}"
+for _ in {1..30}; do
+  if osascript -e 'tell application "System Events" to tell process "TextEdit" to get frontmost' >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+osascript <<'APPLESCRIPT'
+tell application "TextEdit" to activate
+tell application "System Events"
+  tell process "TextEdit"
+    set frontmost to true
+    set position of front window to {140, 120}
+    set size of front window to {900, 620}
+  end tell
+end tell
+APPLESCRIPT
+sleep 2
+
+xcrun swift scripts/ci/macos/verify-hosted-window.swift \
+  --marker "${MARKER}" \
+  --output "${ARTIFACT_DIR}/textedit-window.png" \
+  > "${SWIFT_RESULT}"
+
+python3 - "${SWIFT_RESULT}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+result = json.loads(Path(sys.argv[1]).read_text())
+required = (
+    result.get("accessibility_trusted") is True,
+    result.get("screen_capture_preflight") is True,
+    result.get("marker_recognized") is True,
+    result.get("window", {}).get("owner") == "TextEdit",
+    result.get("window", {}).get("width", 0) >= 600,
+    result.get("window", {}).get("height", 0) >= 400,
+)
+if not all(required):
+    raise SystemExit(f"hosted GUI probe failed: {result}")
+PY
+
+PROBE_STATUS=passed
+PROBE_MESSAGE="hosted macOS GUI environment and TextEdit window capture passed"
+echo "${PROBE_MESSAGE}"

--- a/scripts/ci/macos/probe-hosted-runner.sh
+++ b/scripts/ci/macos/probe-hosted-runner.sh
@@ -6,6 +6,9 @@ ARTIFACT_DIR="${CUA_MACOS_HOSTED_PROBE_DIR:?CUA_MACOS_HOSTED_PROBE_DIR is requir
 SOURCE_SHA="${CUA_E2E_SOURCE_SHA:?CUA_E2E_SOURCE_SHA is required}"
 mkdir -p "${ARTIFACT_DIR}"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
 PROBE_STATUS=failed
 PROBE_MESSAGE="probe did not complete"
 SWIFT_RESULT="${ARTIFACT_DIR}/window-capture.json"
@@ -52,11 +55,35 @@ Path(__import__("sys").argv[1]).write_text(json.dumps(payload, indent=2) + "\n")
 PY
 }
 trap write_environment EXIT
+write_environment
 
 fail() {
   PROBE_MESSAGE="$1"
   echo "${PROBE_MESSAGE}" >&2
   exit 1
+}
+
+run_with_deadline() {
+  local seconds="$1"
+  shift
+  "$@" &
+  local command_pid=$!
+  (
+    sleep "${seconds}"
+    kill -TERM "${command_pid}" 2>/dev/null || true
+  ) &
+  local watchdog_pid=$!
+  local command_status=0
+  set +e
+  wait "${command_pid}"
+  command_status=$?
+  set -e
+  kill "${watchdog_pid}" 2>/dev/null || true
+  wait "${watchdog_pid}" 2>/dev/null || true
+  if [[ "${command_status}" == 143 ]]; then
+    return 124
+  fi
+  return "${command_status}"
 }
 
 [[ "${GITHUB_ACTIONS:-}" == true ]] || fail "GITHUB_ACTIONS must be true"
@@ -76,7 +103,6 @@ launchctl print "gui/${CURRENT_UID}" >/dev/null 2>&1 || fail "Aqua gui/${CURRENT
 pgrep -x WindowServer >/dev/null || fail "WindowServer is unavailable"
 
 SIP_STATUS="$(csrutil status 2>&1 || true)"
-[[ "${SIP_STATUS}" == *disabled* ]] || fail "System Integrity Protection must be disabled on the disposable hosted runner: ${SIP_STATUS}"
 
 {
   echo "source_sha=${SOURCE_SHA}"
@@ -93,37 +119,56 @@ SIP_STATUS="$(csrutil status 2>&1 || true)"
   echo "memory_bytes=$(sysctl -n hw.memsize)"
   echo "logical_cpus=$(sysctl -n hw.logicalcpu)"
   df -h /
+  system_profiler SPDisplaysDataType -json
   launchctl print "gui/${CURRENT_UID}" | sed -n '1,20p'
-  pgrep -lf WindowServer
+  pgrep -lf WindowServer || true
 } > "${SYSTEM_LOG}"
+write_environment
 
-MARKER="CUA HOSTED MACOS PROBE 3725"
+[[ "${SIP_STATUS}" == *"System Integrity Protection status: disabled"* ]] \
+  || fail "System Integrity Protection must be disabled on the disposable hosted runner: ${SIP_STATUS}"
+
+MARKER="CUA HOSTED MACOS GUI PROBE"
 DOCUMENT="${ARTIFACT_DIR}/probe.txt"
 printf '%s\n\n%s\n\n%s\n' "${MARKER}" "${MARKER}" "${MARKER}" > "${DOCUMENT}"
 
 open -a TextEdit "${DOCUMENT}"
 for _ in {1..30}; do
-  if osascript -e 'tell application "System Events" to tell process "TextEdit" to get frontmost' >/dev/null 2>&1; then
+  FRONTMOST="$(osascript -e 'tell application "System Events" to tell process "TextEdit" to get frontmost' 2>/dev/null || true)"
+  if [[ "${FRONTMOST}" == true ]]; then
     break
   fi
   sleep 1
 done
-osascript <<'APPLESCRIPT'
+[[ "${FRONTMOST:-}" == true ]] || fail "TextEdit did not become frontmost"
+
+if ! run_with_deadline 30 osascript > "${ARTIFACT_DIR}/textedit-automation.log" 2>&1 <<'APPLESCRIPT'
 tell application "TextEdit" to activate
+tell application "Finder" to set desktopBounds to bounds of window of desktop
+set targetWidth to (item 3 of desktopBounds) - 120
+set targetHeight to (item 4 of desktopBounds) - 140
+if targetWidth > 800 then set targetWidth to 800
+if targetHeight > 600 then set targetHeight to 600
 tell application "System Events"
   tell process "TextEdit"
     set frontmost to true
-    set position of front window to {140, 120}
-    set size of front window to {900, 620}
+    set position of front window to {60, 80}
+    set size of front window to {targetWidth, targetHeight}
   end tell
 end tell
 APPLESCRIPT
-sleep 2
+then
+  fail "TextEdit window automation failed or timed out"
+fi
 
-xcrun swift scripts/ci/macos/verify-hosted-window.swift \
+if ! run_with_deadline 180 xcrun swift "${REPO_ROOT}/scripts/ci/macos/verify-hosted-window.swift" \
   --marker "${MARKER}" \
   --output "${ARTIFACT_DIR}/textedit-window.png" \
-  > "${SWIFT_RESULT}"
+  --display-output "${ARTIFACT_DIR}/display.png" \
+  > "${SWIFT_RESULT}" 2> "${ARTIFACT_DIR}/window-capture.stderr.log"
+then
+  fail "ScreenCaptureKit window/display verification failed or timed out"
+fi
 
 python3 - "${SWIFT_RESULT}" <<'PY'
 import json
@@ -135,9 +180,11 @@ required = (
     result.get("accessibility_trusted") is True,
     result.get("screen_capture_preflight") is True,
     result.get("marker_recognized") is True,
+    result.get("display_capture", {}).get("marker_recognized") is True,
     result.get("window", {}).get("owner") == "TextEdit",
-    result.get("window", {}).get("width", 0) >= 600,
-    result.get("window", {}).get("height", 0) >= 400,
+    result.get("window", {}).get("name") == "probe.txt",
+    result.get("window", {}).get("width", 0) >= 400,
+    result.get("window", {}).get("height", 0) >= 250,
 )
 if not all(required):
     raise SystemExit(f"hosted GUI probe failed: {result}")

--- a/scripts/ci/macos/verify-hosted-window.swift
+++ b/scripts/ci/macos/verify-hosted-window.swift
@@ -1,0 +1,146 @@
+import ApplicationServices
+import CoreGraphics
+import Foundation
+import ImageIO
+import ScreenCaptureKit
+import UniformTypeIdentifiers
+import Vision
+
+struct Arguments {
+    let marker: String
+    let output: URL
+
+    init() throws {
+        var marker: String?
+        var output: String?
+        var index = 1
+        while index < CommandLine.arguments.count {
+            switch CommandLine.arguments[index] {
+            case "--marker" where index + 1 < CommandLine.arguments.count:
+                index += 1
+                marker = CommandLine.arguments[index]
+            case "--output" where index + 1 < CommandLine.arguments.count:
+                index += 1
+                output = CommandLine.arguments[index]
+            default:
+                throw ProbeError("unknown or incomplete argument: \(CommandLine.arguments[index])")
+            }
+            index += 1
+        }
+        guard let marker, let output else {
+            throw ProbeError("usage: verify-hosted-window.swift --marker TEXT --output PATH")
+        }
+        self.marker = marker
+        self.output = URL(fileURLWithPath: output)
+    }
+}
+
+struct ProbeError: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) { self.description = description }
+}
+
+func normalize(_ value: String) -> String {
+    value.uppercased().filter { $0.isLetter || $0.isNumber }
+}
+
+func textEditWindow() async throws -> SCWindow {
+    let content = try await SCShareableContent.excludingDesktopWindows(
+        false,
+        onScreenWindowsOnly: true
+    )
+    let candidates = content.windows.filter { window in
+        window.owningApplication?.applicationName == "TextEdit"
+            && window.windowLayer == 0
+            && window.frame.width >= 600
+            && window.frame.height >= 400
+    }
+    guard let window = candidates.max(by: {
+        $0.frame.width * $0.frame.height < $1.frame.width * $1.frame.height
+    }) else {
+        throw ProbeError("no large, on-screen TextEdit window was found")
+    }
+    return window
+}
+
+func captureWindow(_ window: SCWindow) async throws -> CGImage {
+    let filter = SCContentFilter(desktopIndependentWindow: window)
+    let configuration = SCStreamConfiguration()
+    configuration.width = max(1, Int(window.frame.width * 2))
+    configuration.height = max(1, Int(window.frame.height * 2))
+    configuration.showsCursor = false
+    return try await SCScreenshotManager.captureImage(
+        contentFilter: filter,
+        configuration: configuration
+    )
+}
+
+func writePNG(_ image: CGImage, to output: URL) throws {
+    guard let destination = CGImageDestinationCreateWithURL(
+        output as CFURL,
+        UTType.png.identifier as CFString,
+        1,
+        nil
+    ) else {
+        throw ProbeError("could not create PNG destination")
+    }
+    CGImageDestinationAddImage(destination, image, nil)
+    guard CGImageDestinationFinalize(destination) else {
+        throw ProbeError("could not write PNG")
+    }
+}
+
+func recognizeText(in image: CGImage) throws -> String {
+    let request = VNRecognizeTextRequest()
+    request.recognitionLevel = .accurate
+    request.usesLanguageCorrection = false
+    let handler = VNImageRequestHandler(cgImage: image, options: [:])
+    try handler.perform([request])
+    return (request.results ?? []).compactMap { observation in
+        observation.topCandidates(1).first?.string
+    }.joined(separator: "\n")
+}
+
+func runProbe() async throws {
+    let arguments = try Arguments()
+    let accessibilityTrusted = AXIsProcessTrusted()
+    let screenCapturePreflight = CGPreflightScreenCaptureAccess()
+    let window = try await textEditWindow()
+    let image = try await captureWindow(window)
+    try writePNG(image, to: arguments.output)
+    let recognizedText = try recognizeText(in: image)
+    let markerRecognized = normalize(recognizedText).contains(normalize(arguments.marker))
+
+    let result: [String: Any] = [
+        "schema": "cua-driver/macos-hosted-window-capture@v1",
+        "accessibility_trusted": accessibilityTrusted,
+        "screen_capture_preflight": screenCapturePreflight,
+        "marker_recognized": markerRecognized,
+        "recognized_text": recognizedText,
+        "image": ["width": image.width, "height": image.height],
+        "window": [
+            "id": window.windowID,
+            "owner": window.owningApplication?.applicationName ?? "",
+            "name": window.title ?? "",
+            "width": window.frame.width,
+            "height": window.frame.height,
+        ],
+    ]
+    let encoded = try JSONSerialization.data(withJSONObject: result, options: [.prettyPrinted, .sortedKeys])
+    FileHandle.standardOutput.write(encoded)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+    if !accessibilityTrusted || !screenCapturePreflight || !markerRecognized {
+        throw ProbeError("permission preflight or marker recognition failed")
+    }
+}
+
+Task {
+    do {
+        try await runProbe()
+        exit(0)
+    } catch {
+        FileHandle.standardError.write(Data("hosted macOS window verification failed: \(error)\n".utf8))
+        exit(1)
+    }
+}
+dispatchMain()

--- a/scripts/ci/macos/verify-hosted-window.swift
+++ b/scripts/ci/macos/verify-hosted-window.swift
@@ -9,10 +9,12 @@ import Vision
 struct Arguments {
     let marker: String
     let output: URL
+    let displayOutput: URL
 
     init() throws {
         var marker: String?
         var output: String?
+        var displayOutput: String?
         var index = 1
         while index < CommandLine.arguments.count {
             switch CommandLine.arguments[index] {
@@ -22,16 +24,22 @@ struct Arguments {
             case "--output" where index + 1 < CommandLine.arguments.count:
                 index += 1
                 output = CommandLine.arguments[index]
+            case "--display-output" where index + 1 < CommandLine.arguments.count:
+                index += 1
+                displayOutput = CommandLine.arguments[index]
             default:
                 throw ProbeError("unknown or incomplete argument: \(CommandLine.arguments[index])")
             }
             index += 1
         }
-        guard let marker, let output else {
-            throw ProbeError("usage: verify-hosted-window.swift --marker TEXT --output PATH")
+        guard let marker, let output, let displayOutput else {
+            throw ProbeError(
+                "usage: verify-hosted-window.swift --marker TEXT --output PATH --display-output PATH"
+            )
         }
         self.marker = marker
         self.output = URL(fileURLWithPath: output)
+        self.displayOutput = URL(fileURLWithPath: displayOutput)
     }
 }
 
@@ -44,16 +52,17 @@ func normalize(_ value: String) -> String {
     value.uppercased().filter { $0.isLetter || $0.isNumber }
 }
 
-func textEditWindow() async throws -> SCWindow {
-    let content = try await SCShareableContent.excludingDesktopWindows(
-        false,
-        onScreenWindowsOnly: true
-    )
+func shareableContent() async throws -> SCShareableContent {
+    try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+}
+
+func textEditWindow(in content: SCShareableContent) throws -> SCWindow {
     let candidates = content.windows.filter { window in
         window.owningApplication?.applicationName == "TextEdit"
             && window.windowLayer == 0
-            && window.frame.width >= 600
-            && window.frame.height >= 400
+            && window.title == "probe.txt"
+            && window.frame.width >= 400
+            && window.frame.height >= 250
     }
     guard let window = candidates.max(by: {
         $0.frame.width * $0.frame.height < $1.frame.width * $1.frame.height
@@ -66,8 +75,20 @@ func textEditWindow() async throws -> SCWindow {
 func captureWindow(_ window: SCWindow) async throws -> CGImage {
     let filter = SCContentFilter(desktopIndependentWindow: window)
     let configuration = SCStreamConfiguration()
-    configuration.width = max(1, Int(window.frame.width * 2))
-    configuration.height = max(1, Int(window.frame.height * 2))
+    configuration.width = max(1, Int(window.frame.width))
+    configuration.height = max(1, Int(window.frame.height))
+    configuration.showsCursor = false
+    return try await SCScreenshotManager.captureImage(
+        contentFilter: filter,
+        configuration: configuration
+    )
+}
+
+func captureDisplay(_ display: SCDisplay) async throws -> CGImage {
+    let filter = SCContentFilter(display: display, excludingWindows: [])
+    let configuration = SCStreamConfiguration()
+    configuration.width = display.width
+    configuration.height = display.height
     configuration.showsCursor = false
     return try await SCScreenshotManager.captureImage(
         contentFilter: filter,
@@ -105,11 +126,19 @@ func runProbe() async throws {
     let arguments = try Arguments()
     let accessibilityTrusted = AXIsProcessTrusted()
     let screenCapturePreflight = CGPreflightScreenCaptureAccess()
-    let window = try await textEditWindow()
+    let content = try await shareableContent()
+    let window = try textEditWindow(in: content)
+    guard let display = content.displays.first(where: { $0.frame.intersects(window.frame) }) else {
+        throw ProbeError("no display contains the TextEdit probe window")
+    }
     let image = try await captureWindow(window)
     try writePNG(image, to: arguments.output)
     let recognizedText = try recognizeText(in: image)
     let markerRecognized = normalize(recognizedText).contains(normalize(arguments.marker))
+    let displayImage = try await captureDisplay(display)
+    try writePNG(displayImage, to: arguments.displayOutput)
+    let displayText = try recognizeText(in: displayImage)
+    let displayMarkerRecognized = normalize(displayText).contains(normalize(arguments.marker))
 
     let result: [String: Any] = [
         "schema": "cua-driver/macos-hosted-window-capture@v1",
@@ -117,7 +146,19 @@ func runProbe() async throws {
         "screen_capture_preflight": screenCapturePreflight,
         "marker_recognized": markerRecognized,
         "recognized_text": recognizedText,
+        "permission_attribution_scope": "probe process only; does not establish CuaDriverLocal.app TCC",
+        "probe_executable": Bundle.main.executableURL?.path ?? CommandLine.arguments[0],
+        "probe_process_id": ProcessInfo.processInfo.processIdentifier,
         "image": ["width": image.width, "height": image.height],
+        "display_capture": [
+            "id": display.displayID,
+            "width": display.width,
+            "height": display.height,
+            "image_width": displayImage.width,
+            "image_height": displayImage.height,
+            "marker_recognized": displayMarkerRecognized,
+            "recognized_text": displayText,
+        ],
         "window": [
             "id": window.windowID,
             "owner": window.owningApplication?.applicationName ?? "",
@@ -129,7 +170,7 @@ func runProbe() async throws {
     let encoded = try JSONSerialization.data(withJSONObject: result, options: [.prettyPrinted, .sortedKeys])
     FileHandle.standardOutput.write(encoded)
     FileHandle.standardOutput.write(Data("\n".utf8))
-    if !accessibilityTrusted || !screenCapturePreflight || !markerRecognized {
+    if !accessibilityTrusted || !screenCapturePreflight || !markerRecognized || !displayMarkerRecognized {
         throw ProbeError("permission preflight or marker recognition failed")
     }
 }


### PR DESCRIPTION
GitHub-hosted macOS 26 may provide a real Aqua desktop and preseeded TCC state, but Cua Driver has no repository-owned check that fails when those assumptions change. This first increment registers a manual workflow on the default branch and records a fail-closed GUI environment probe at one exact source SHA.

The probe requires a fresh GitHub-hosted manual-dispatch context, the `runner` console user, an Aqua launch domain, WindowServer, no SSH session, and disabled SIP. It launches TextEdit and uses ScreenCaptureKit plus Vision OCR to prove that both the deterministic TextEdit window and the containing display show the expected document marker, covering the wallpaper-only failure class in #870. Environment JSON, system and display details, OCR output, logs, and both PNGs upload even when the probe fails. The evidence explicitly limits permission attribution to the probe process; it does not claim app-bundle TCC authorization.

This is the registration increment required before a pull-request revision of a new `workflow_dispatch` file can be executed. A follow-up will add temporary certificate-backed app signing, app-specific TCC rows, daemon attribution checks, and the shared/native/capture matrix after the merged probe passes on a fresh runner.

Refs #3725.

## Scope boundaries

- The existing Lume wrapper remains the canonical maintainer macOS gate.
- This does not transplant the obsolete harness proposed in #2062 or the private orchestration from #3571.
- The workflow has read-only contents permission, uses pinned actions, and consumes no secrets, OIDC, or self-hosted infrastructure.

## Validation

- `xcrun swiftc -warnings-as-errors -typecheck scripts/ci/macos/verify-hosted-window.swift`
- `bash -n scripts/ci/macos/probe-hosted-runner.sh`
- `shellcheck scripts/ci/macos/probe-hosted-runner.sh`
- `uvx --from pytest pytest .github/scripts/tests/test_macos_hosted_e2e_workflow.py -q` (4 passed)
- Complete `.github/scripts/tests` suite: 296 tests and 99 subtests passed.
- YAML parse, `git diff --check`, and local fail-closed artifact smoke passed.
- Claude Opus 5 adversarial review identified evidence-ordering, SIP matching, rerun artifact, geometry, window-identity, display-capture, timeout, attribution, and documentation gaps; candidate `1d7ee885a` addresses each material finding.

The live GitHub-hosted probe is intentionally pending until this workflow is merged into the default branch.

