### PR TITLE
ci(cua-driver): fix hosted probe runner context

### DIFF
--- a/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
+++ b/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
@@ -26,6 +26,8 @@ def test_hosted_macos_probe_is_manual_exact_sha_and_least_privilege() -> None:
     assert "^[0-9a-fA-F]{40}$" in workflow
     assert "persist-credentials: false" in workflow
     assert "github.run_id }}-${{ github.run_attempt" in workflow
+    assert "CUA_MACOS_HOSTED_PROBE_DIR: ${{ runner.temp" not in workflow
+    assert 'echo "CUA_MACOS_HOSTED_PROBE_DIR=${artifact_dir}" >> "${GITHUB_ENV}"' in workflow
 
     for action in ("actions/checkout", "actions/upload-artifact"):
         line = next(line for line in workflow.splitlines() if f"uses: {action}@" in line)

--- a/.github/workflows/e2e-rust-macos.yml
+++ b/.github/workflows/e2e-rust-macos.yml
@@ -22,15 +22,16 @@ jobs:
     timeout-minutes: 20
     env:
       CUA_E2E_SOURCE_SHA: ${{ inputs.source_sha }}
-      CUA_MACOS_HOSTED_PROBE_DIR: ${{ runner.temp }}/cua-macos-hosted-probe
 
     steps:
       - name: Initialize evidence directory
         shell: bash
         run: |
-          mkdir -p "${CUA_MACOS_HOSTED_PROBE_DIR}"
+          artifact_dir="${RUNNER_TEMP}/cua-macos-hosted-probe"
+          echo "CUA_MACOS_HOSTED_PROBE_DIR=${artifact_dir}" >> "${GITHUB_ENV}"
+          mkdir -p "${artifact_dir}"
           printf 'requested_source_sha=%s\n' "${CUA_E2E_SOURCE_SHA}" \
-            > "${CUA_MACOS_HOSTED_PROBE_DIR}/request.txt"
+            > "${artifact_dir}/request.txt"
 
       - name: Validate requested source SHA
         shell: bash


### PR DESCRIPTION
The newly merged hosted macOS probe could not be dispatched because GitHub rejects `runner.temp` in job-level `env`. This derives the evidence directory from `$RUNNER_TEMP` in the first step, exports it through `$GITHUB_ENV` for subsequent steps, and adds a contract regression.

Refs #3725.

Validation: four focused workflow contracts pass, the workflow parses as YAML, and `git diff --check` passes. The prior dispatch failed during workflow parsing before allocating a runner or executing repository code.
