### PR TITLE
docs(cua-driver): document macOS semantic recording evidence

### DIFF
--- a/libs/cua-driver/rust/Skills/cua-driver/RECORDING.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/RECORDING.md
@@ -97,8 +97,9 @@ Each action writes to `turn-NNNNN/` (five-digit zero-padded counter):
   window's origin and any snapshot resize or zoom. Absent for non-click tools.
   It is also absent, and explicitly
   classified as not applicable, when the driver refuses a click before target
-  resolution; no input was aimed in that case. A successful plain Linux AT-SPI
-  or Windows UIA element click (Invoke, Toggle, SelectionItem, or ExpandCollapse)
+  resolution; no input was aimed in that case. A successful plain macOS AX,
+  Linux AT-SPI, or Windows UIA element click (Invoke, Toggle, SelectionItem, or
+  ExpandCollapse)
   can activate a control without a visible point, such as an offscreen button.
   In that case, `semantic_action_without_point` records why
   there is no marker. The action must carry explicit accessibility transport


### PR DESCRIPTION
## Summary

- Problem this solves: The recording contract documents non-spatial semantic element clicks for Linux AT-SPI and Windows UIA, but omits the equivalent macOS AX transport.
- What changed: Document macOS AX alongside the existing accessibility transports. The surrounding requirements and exclusions remain unchanged.

## Related work

Refs #3660

RFC (required for a public SDK, CLI, MCP, protocol, compatibility, permission,
or cross-component contract change):
Not required; this is documentation alignment for an existing recording contract.

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: Documentation only; no runtime, API, or release behavior changes.
- Risk and rollback: Minimal; revert the documentation change.

## Validation

- Focused tests and checks: `cargo test -p cua-driver-core --test recording_semantic_evidence`, `cargo test -p cua-driver-core`, `cargo fmt --all -- --check`, and `git diff --check`.
- Manual or platform evidence: The existing macOS semantic-evidence regression and strict validator predicate are present in the base branch.
- Known gaps or CI still required: The macOS native desktop matrix remains an upstream platform check.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [ ] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.
