### PR TITLE
ci(cua-driver): run hosted macOS desktop e2e

### DIFF
--- a/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
+++ b/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
@@ -123,6 +123,9 @@ def test_hosted_macos_runner_is_strict_and_uses_the_canonical_matrix() -> None:
     assert "security remove-trusted-cert" in runner
     assert "security delete-certificate" in runner
     assert "security set-key-partition-list" in runner
+    assert "set-keychain-settings -lut 21600" in runner
+    assert "run_bounded 30 codesign" in runner
+    assert "phase.txt" in runner
     assert "--require-stable-signing" in runner
     assert 'grep -Fq "certificate leaf"' in runner
     assert "seed-tcc-guest.sh" in runner

--- a/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
+++ b/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
@@ -1,4 +1,4 @@
-"""Contract tests for the manually dispatched GitHub-hosted macOS probe."""
+"""Contract tests for the manually dispatched GitHub-hosted macOS E2E lane."""
 
 from pathlib import Path
 
@@ -28,6 +28,13 @@ def test_hosted_macos_probe_is_manual_exact_sha_and_least_privilege() -> None:
     assert "github.run_id }}-${{ github.run_attempt" in workflow
     assert "CUA_MACOS_HOSTED_PROBE_DIR: ${{ runner.temp" not in workflow
     assert 'echo "CUA_MACOS_HOSTED_PROBE_DIR=${artifact_dir}" >> "${GITHUB_ENV}"' in workflow
+    assert "matrix:\n        lane: [shared, native, capture]" in workflow
+    assert "fail-fast: false" in workflow
+    assert "needs: probe" in workflow
+    assert "scripts/ci/macos/run-hosted-rust-e2e.sh" in workflow
+    assert "path: artifacts/cua-driver" in workflow
+    assert "needs: [probe, matrix]" in workflow
+    assert "cua-driver/macos-hosted-certification@v1" in workflow
 
     for action in ("actions/checkout", "actions/upload-artifact"):
         line = next(line for line in workflow.splitlines() if f"uses: {action}@" in line)
@@ -88,4 +95,47 @@ def test_script_ci_runs_when_hosted_macos_contract_changes() -> None:
 
     guide = read("scripts/ci/README.md")
     assert "e2e-rust-macos.yml" in guide
-    assert "does not\nestablish `CuaDriverLocal.app` TCC authorization" in guide
+    assert "temporary certificate-backed identity" in " ".join(guide.split())
+    assert "supplemental" in guide
+
+
+def test_hosted_macos_runner_is_strict_and_uses_the_canonical_matrix() -> None:
+    runner = read("scripts/ci/macos/run-hosted-rust-e2e.sh")
+
+    for requirement in (
+        'GITHUB_ACTIONS:-}" == true',
+        'GITHUB_EVENT_NAME:-}" == workflow_dispatch',
+        'RUNNER_ENVIRONMENT:-}" == github-hosted',
+        'ImageOS:-}" == macos26',
+        'CURRENT_USER}" == runner',
+        'CONSOLE_USER}" == runner',
+        'MODEL}" == VirtualMac*',
+        'SIP_STATUS}" == "System Integrity Protection status: disabled."',
+        '[[ ! -e "${LOCAL_APP}" ]]',
+        '[[ ! -e "${KEYCHAIN}" ]]',
+    ):
+        assert requirement in runner
+
+    assert "security create-keychain" in runner
+    assert "ensure_local_signing_identity" in runner
+    assert "security add-trusted-cert" in runner
+    assert "-p codeSign" in runner
+    assert "security remove-trusted-cert" in runner
+    assert "security delete-certificate" in runner
+    assert "security set-key-partition-list" in runner
+    assert "--require-stable-signing" in runner
+    assert 'grep -Fq "certificate leaf"' in runner
+    assert "seed-tcc-guest.sh" in runner
+    assert "--expected-client com.trycua.driver.local" in runner
+    assert "--dangerously-bypass-approvals" in runner
+    assert ".direct_capture_status == \"not_checked\"" in runner
+    assert '.source.attribution == "driver-daemon"' in runner
+    assert 'bash "${SCRIPT_DIR}/run-rust-e2e.sh"' in runner
+    assert 'CUA_E2E_MACOS_DAEMON_SOCKET="${DAEMON_SOCKET}"' in runner
+    assert '--socket "${DAEMON_SOCKET}"' in runner
+    assert 'trap \'exit 130\' INT' in runner
+    assert 'trap \'exit 143\' TERM' in runner
+    assert 'bash "${SCRIPT_DIR}/probe-hosted-runner.sh"' in runner
+    assert "watch_daemon" in runner
+    assert "permissions grant" not in runner
+    assert "cleanup-targets.txt" in runner

--- a/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
+++ b/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
@@ -23,6 +23,8 @@ def test_hosted_macos_probe_is_manual_exact_sha_and_least_privilege() -> None:
     assert "secrets." not in workflow
     assert "runs-on: macos-26" in workflow
     assert "ref: ${{ inputs.source_sha }}" in workflow
+    assert "CUA_E2E_WORKFLOW_SHA: ${{ github.sha }}" in workflow
+    assert "source_sha must match the selected workflow ref tip" in workflow
     assert "^[0-9a-fA-F]{40}$" in workflow
     assert "persist-credentials: false" in workflow
     assert "github.run_id }}-${{ github.run_attempt" in workflow
@@ -35,6 +37,8 @@ def test_hosted_macos_probe_is_manual_exact_sha_and_least_privilege() -> None:
     assert "path: artifacts/cua-driver" in workflow
     assert "needs: [probe, matrix]" in workflow
     assert "cua-driver/macos-hosted-certification@v1" in workflow
+    assert "workflow_ref: $workflow_ref" in workflow
+    assert "workflow_sha: $workflow_sha" in workflow
 
     for action in ("actions/checkout", "actions/upload-artifact"):
         line = next(line for line in workflow.splitlines() if f"uses: {action}@" in line)
@@ -85,6 +89,8 @@ def test_hosted_macos_probe_proves_textedit_window_content() -> None:
     assert 'result.get("window", {}).get("name") == "probe.txt"' in probe
     assert "textedit-window.png" in probe
     assert "display.png" in probe
+    assert 'tell application "TextEdit" to close every window saving no' in probe
+    assert 'tell application "TextEdit" to quit' in probe
 
 
 def test_script_ci_runs_when_hosted_macos_contract_changes() -> None:
@@ -119,6 +125,9 @@ def test_hosted_macos_runner_is_strict_and_uses_the_canonical_matrix() -> None:
     assert "security create-keychain" in runner
     assert "ensure_local_signing_identity" in runner
     assert "security add-trusted-cert" in runner
+    assert runner.index('TRUSTED_IDENTITY="${IDENTITY}"') < runner.index(
+        "security add-trusted-cert"
+    )
     assert "-p codeSign" in runner
     assert "security remove-trusted-cert" in runner
     assert "security delete-certificate" in runner
@@ -148,5 +157,8 @@ def test_hosted_macos_runner_is_strict_and_uses_the_canonical_matrix() -> None:
     assert 'trap \'exit 143\' TERM' in runner
     assert 'bash "${SCRIPT_DIR}/probe-hosted-runner.sh"' in runner
     assert "watch_daemon" in runner
+    assert "daemon status probe failed; confirming before restart" in runner
+    assert "The hosted daemon required a watchdog restart during the matrix" in runner
+    assert "cleanup-status.txt" in runner
     assert "permissions grant" not in runner
     assert "cleanup-targets.txt" in runner

--- a/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
+++ b/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
@@ -134,6 +134,9 @@ def test_hosted_macos_runner_is_strict_and_uses_the_canonical_matrix() -> None:
     assert "cleanup-attempts.txt" in runner
     assert "verify_system_certificate_absent" in runner
     assert "verify_code_signing_trust_absent" in runner
+    assert "security dump-trust-settings -d" in runner
+    assert "cleanup-trust-settings.txt" in runner
+    assert "security verify-cert" not in runner
     assert "security set-key-partition-list" in runner
     assert "set-keychain-settings -lut 21600" in runner
     assert 'security list-keychains -d user -s' in runner

--- a/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
+++ b/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
@@ -124,6 +124,8 @@ def test_hosted_macos_runner_is_strict_and_uses_the_canonical_matrix() -> None:
     assert "security delete-certificate" in runner
     assert "security set-key-partition-list" in runner
     assert "set-keychain-settings -lut 21600" in runner
+    assert 'security list-keychains -d user -s' in runner
+    assert '"${ORIGINAL_KEYCHAINS[@]}"' in runner
     assert "run_bounded 30 codesign" in runner
     assert "phase.txt" in runner
     assert "--require-stable-signing" in runner

--- a/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
+++ b/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
@@ -89,8 +89,8 @@ def test_hosted_macos_probe_proves_textedit_window_content() -> None:
     assert 'result.get("window", {}).get("name") == "probe.txt"' in probe
     assert "textedit-window.png" in probe
     assert "display.png" in probe
-    assert 'tell application "TextEdit" to close every window saving no' in probe
-    assert 'tell application "TextEdit" to quit' in probe
+    assert "run_with_deadline 30 /usr/bin/killall TextEdit" in probe
+    assert 'pgrep -x TextEdit' in probe
 
 
 def test_script_ci_runs_when_hosted_macos_contract_changes() -> None:

--- a/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
+++ b/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
@@ -130,6 +130,12 @@ def test_hosted_macos_runner_is_strict_and_uses_the_canonical_matrix() -> None:
     assert "phase.txt" in runner
     assert "--require-stable-signing" in runner
     assert 'grep -Fq "certificate leaf"' in runner
+    assert "ScreenCaptureApprovals.plist" in runner
+    assert 'SCREEN_CAPTURE_CLIENT="com.trycua.driver.local"' in runner
+    assert "kScreenCaptureApprovalLastAlerted" in runner
+    assert "kScreenCaptureApprovalLastUsed" in runner
+    assert "screen-capture-approval.txt" in runner
+    assert "killall -HUP replayd" in runner
     assert "seed-tcc-guest.sh" in runner
     assert "--expected-client com.trycua.driver.local" in runner
     assert "--dangerously-bypass-approvals" in runner

--- a/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
+++ b/.github/scripts/tests/test_macos_hosted_e2e_workflow.py
@@ -131,6 +131,9 @@ def test_hosted_macos_runner_is_strict_and_uses_the_canonical_matrix() -> None:
     assert "-p codeSign" in runner
     assert "security remove-trusted-cert" in runner
     assert "security delete-certificate" in runner
+    assert "cleanup-attempts.txt" in runner
+    assert "verify_system_certificate_absent" in runner
+    assert "verify_code_signing_trust_absent" in runner
     assert "security set-key-partition-list" in runner
     assert "set-keychain-settings -lut 21600" in runner
     assert 'security list-keychains -d user -s' in runner

--- a/.github/workflows/e2e-rust-macos.yml
+++ b/.github/workflows/e2e-rust-macos.yml
@@ -22,6 +22,7 @@ jobs:
     timeout-minutes: 20
     env:
       CUA_E2E_SOURCE_SHA: ${{ inputs.source_sha }}
+      CUA_E2E_WORKFLOW_SHA: ${{ github.sha }}
 
     steps:
       - name: Initialize evidence directory
@@ -39,6 +40,12 @@ jobs:
           set -euo pipefail
           if [[ ! "${CUA_E2E_SOURCE_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
             echo "source_sha must be a full 40-character commit SHA" >&2
+            exit 2
+          fi
+          source_sha_lower="$(printf '%s' "${CUA_E2E_SOURCE_SHA}" | tr '[:upper:]' '[:lower:]')"
+          workflow_sha_lower="$(printf '%s' "${CUA_E2E_WORKFLOW_SHA}" | tr '[:upper:]' '[:lower:]')"
+          if [[ "${source_sha_lower}" != "${workflow_sha_lower}" ]]; then
+            echo "source_sha must match the selected workflow ref tip (${CUA_E2E_WORKFLOW_SHA})" >&2
             exit 2
           fi
 
@@ -88,6 +95,7 @@ jobs:
         lane: [shared, native, capture]
     env:
       CUA_E2E_SOURCE_SHA: ${{ inputs.source_sha }}
+      CUA_E2E_WORKFLOW_SHA: ${{ github.sha }}
       CUA_E2E_INTERNAL_LANE: ${{ matrix.lane }}
 
     steps:
@@ -97,6 +105,12 @@ jobs:
           set -euo pipefail
           if [[ ! "${CUA_E2E_SOURCE_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
             echo "source_sha must be a full 40-character commit SHA" >&2
+            exit 2
+          fi
+          source_sha_lower="$(printf '%s' "${CUA_E2E_SOURCE_SHA}" | tr '[:upper:]' '[:lower:]')"
+          workflow_sha_lower="$(printf '%s' "${CUA_E2E_WORKFLOW_SHA}" | tr '[:upper:]' '[:lower:]')"
+          if [[ "${source_sha_lower}" != "${workflow_sha_lower}" ]]; then
+            echo "source_sha must match the selected workflow ref tip (${CUA_E2E_WORKFLOW_SHA})" >&2
             exit 2
           fi
 
@@ -159,6 +173,8 @@ jobs:
       SOURCE_SHA: ${{ inputs.source_sha }}
       PROBE_RESULT: ${{ needs.probe.result }}
       MATRIX_RESULT: ${{ needs.matrix.result }}
+      WORKFLOW_REF: ${{ github.workflow_ref }}
+      WORKFLOW_SHA: ${{ github.sha }}
     steps:
       - name: Record complete hosted result
         shell: bash
@@ -169,10 +185,13 @@ jobs:
             --arg source_sha "${SOURCE_SHA}" \
             --arg run_id "${GITHUB_RUN_ID}" \
             --arg run_attempt "${GITHUB_RUN_ATTEMPT}" \
+            --arg workflow_ref "${WORKFLOW_REF}" \
+            --arg workflow_sha "${WORKFLOW_SHA}" \
             --arg probe "${PROBE_RESULT}" \
             --arg matrix "${MATRIX_RESULT}" \
             '{schema: $schema, source_sha: $source_sha,
-              github: {run_id: $run_id, run_attempt: $run_attempt},
+              github: {run_id: $run_id, run_attempt: $run_attempt,
+                workflow_ref: $workflow_ref, workflow_sha: $workflow_sha},
               jobs: {probe: $probe, matrix: $matrix},
               passed: ($probe == "success" and $matrix == "success")}' \
             | tee certification.json

--- a/.github/workflows/e2e-rust-macos.yml
+++ b/.github/workflows/e2e-rust-macos.yml
@@ -1,10 +1,10 @@
-name: "E2E: Rust macOS hosted probe"
+name: "E2E: Rust macOS hosted"
 
 on:
   workflow_dispatch:
     inputs:
       source_sha:
-        description: "Full 40-character commit SHA to probe"
+        description: "Full 40-character commit SHA to certify"
         required: true
         type: string
 
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: e2e-rust-macos-probe-${{ inputs.source_sha }}
+  group: e2e-rust-macos-hosted-${{ inputs.source_sha }}
   cancel-in-progress: false
 
 jobs:
@@ -74,5 +74,115 @@ jobs:
         with:
           name: cua-driver-macos-hosted-probe-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/cua-macos-hosted-probe
+          if-no-files-found: error
+          retention-days: 14
+
+  matrix:
+    needs: probe
+    name: hosted ${{ matrix.lane }} lane
+    runs-on: macos-26
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        lane: [shared, native, capture]
+    env:
+      CUA_E2E_SOURCE_SHA: ${{ inputs.source_sha }}
+      CUA_E2E_INTERNAL_LANE: ${{ matrix.lane }}
+
+    steps:
+      - name: Validate requested source SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${CUA_E2E_SOURCE_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "source_sha must be a full 40-character commit SHA" >&2
+            exit 2
+          fi
+
+      - name: Check out exact source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact checkout and initialize build namespace
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          expected_sha="$(printf '%s' "${CUA_E2E_SOURCE_SHA}" | tr '[:upper:]' '[:lower:]')"
+          if [[ "${actual_sha}" != "${expected_sha}" ]]; then
+            echo "checked out ${actual_sha}, expected ${CUA_E2E_SOURCE_SHA}" >&2
+            exit 2
+          fi
+          if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
+            echo "hosted macOS E2E requires a clean checkout" >&2
+            exit 2
+          fi
+          target_dir="${RUNNER_TEMP}/cua-driver-target-${CUA_E2E_INTERNAL_LANE}"
+          echo "CARGO_TARGET_DIR=${target_dir}" >> "${GITHUB_ENV}"
+
+      - name: Install missing test dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          command -v ffmpeg >/dev/null 2>&1 || missing+=(ffmpeg)
+          command -v jq >/dev/null 2>&1 || missing+=(jq)
+          if ((${#missing[@]})); then
+            brew install "${missing[@]}"
+          fi
+
+      - name: Run hosted macOS lane
+        shell: bash
+        run: scripts/ci/macos/run-hosted-rust-e2e.sh
+
+      - name: Upload hosted macOS lane evidence
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.2
+        with:
+          name: rust-macos-hosted-${{ matrix.lane }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/cua-driver
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+
+  certify:
+    if: always()
+    needs: [probe, matrix]
+    name: hosted certification result
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      PROBE_RESULT: ${{ needs.probe.result }}
+      MATRIX_RESULT: ${{ needs.matrix.result }}
+    steps:
+      - name: Record complete hosted result
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg schema "cua-driver/macos-hosted-certification@v1" \
+            --arg source_sha "${SOURCE_SHA}" \
+            --arg run_id "${GITHUB_RUN_ID}" \
+            --arg run_attempt "${GITHUB_RUN_ATTEMPT}" \
+            --arg probe "${PROBE_RESULT}" \
+            --arg matrix "${MATRIX_RESULT}" \
+            '{schema: $schema, source_sha: $source_sha,
+              github: {run_id: $run_id, run_attempt: $run_attempt},
+              jobs: {probe: $probe, matrix: $matrix},
+              passed: ($probe == "success" and $matrix == "success")}' \
+            | tee certification.json
+          jq -e '.passed == true' certification.json >/dev/null
+
+      - name: Upload certification result
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.2
+        with:
+          name: rust-macos-hosted-certification-${{ github.run_id }}-${{ github.run_attempt }}
+          path: certification.json
           if-no-files-found: error
           retention-days: 14

--- a/libs/cua-driver/docs/test-harnesses-guide.md
+++ b/libs/cua-driver/docs/test-harnesses-guide.md
@@ -281,7 +281,11 @@ background delivery is tested.
 
 ### macOS
 
-Runner: `libs/cua-driver/tests/runners/macos-lume/run-all.sh`
+Canonical runner: `libs/cua-driver/tests/runners/macos-lume/run-all.sh`
+
+Supplemental hosted runner: manually dispatch
+`.github/workflows/e2e-rust-macos.yml` with an exact 40-character source SHA.
+Its probe must pass before independent shared, native, and capture jobs run.
 
 | Runner area               | Rust test                              | Real harness or app                     |
 | ------------------------- | -------------------------------------- | --------------------------------------- |
@@ -301,6 +305,16 @@ canonical logged-in macOS lane, but they do not replace repo-local fixtures.
 The maintainer wrapper provisions the exact source build and verifies the
 private Lume seed's TCC/signing contract before delegating the behavior matrix
 to `scripts/ci/macos/run-rust-e2e.sh`.
+
+The hosted wrapper uses the same behavior matrix on fresh `macos-26` runners.
+It requires the GitHub-hosted Aqua session and SIP-off VirtualMac environment,
+creates a temporary code-signing Keychain, installs a certificate-signed local
+app, seeds only Accessibility and Screen Capture for that app's exact csreq, and
+verifies that permission status is attributed to the driver daemon before any
+test begins. The temporary certificate trust is removed during job cleanup.
+Hosted results remain supplemental until the image and signing
+identity provide the same release-parity guarantees as the maintained Lume
+seed.
 
 ### Linux
 

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -134,12 +134,26 @@ Lume seed, installs the exact committed source, and then delegates to the thin
 the optional installed Chrome/Edge browser matrix after the canonical repo-local
 harness matrix.
 
-The manual `.github/workflows/e2e-rust-macos.yml` workflow probes a fresh
-GitHub-hosted macOS 26 runner before hosted matrix support is enabled. It records
-the image, SIP state, desktop session, display geometry, and OCR-verified
-TextEdit window and display captures for one exact source SHA. Permission checks
-describe only the temporary probe process; a green probe process does not
-establish `CuaDriverLocal.app` TCC authorization or replace the Lume gate.
+The manual `.github/workflows/e2e-rust-macos.yml` workflow first probes a fresh
+GitHub-hosted macOS 26 runner. It records the image, SIP state, desktop session,
+display geometry, and OCR-verified TextEdit window and display captures for one
+exact source SHA. Probe permission checks describe only the temporary probe
+process. Dispatch only a reviewed commit SHA; the selected source is executable
+test code and the bootstrap uses the hosted runner's passwordless sudo policy.
+
+After that prerequisite passes, three fresh hosted runners execute the shared,
+native, and capture partitions through `macos/run-hosted-rust-e2e.sh`. Each
+runner refuses unexpected hosts or pre-existing app state, creates a temporary
+certificate-backed identity and Keychain, installs the exact source as
+`CuaDriverLocal.app`, seeds only its Accessibility and Screen Capture TCC rows,
+verifies the daemon-attributed permission result, and delegates to
+`macos/run-rust-e2e.sh`. The lane uploads bootstrap, structured result, log, and
+video evidence even on failure. The certificate is trusted only on that
+ephemeral runner and removed during cleanup. The lane is supplemental while the
+hosted image and temporary identity differ from the release-parity Lume seed; it
+does not replace the Lume gate. Hosted jobs omit the Lume-only encrypted history
+gate and `--experimental-history`; the desktop behavior matrix does not depend
+on them.
 
 Run the Wayland wrapper through `nix develop .#cua-driver-wayland-e2e`. It
 creates a pure Wayland session with Xwayland disabled and delegates every

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -148,12 +148,14 @@ certificate-backed identity and Keychain, installs the exact source as
 `CuaDriverLocal.app`, seeds only its Accessibility and Screen Capture TCC rows,
 verifies the daemon-attributed permission result, and delegates to
 `macos/run-rust-e2e.sh`. The lane uploads bootstrap, structured result, log, and
-video evidence even on failure. The certificate is trusted only on that
-ephemeral runner and removed during cleanup. The lane is supplemental while the
-hosted image and temporary identity differ from the release-parity Lume seed; it
-does not replace the Lume gate. Hosted jobs omit the Lume-only encrypted history
-gate and `--experimental-history`; the desktop behavior matrix does not depend
-on them.
+video evidence even on failure. Signing and trust operations have hard
+deadlines, and a sacrificial binary proves the temporary identity works before
+the release build begins. The certificate is trusted only on that ephemeral
+runner and its removal is attempted with a bounded cleanup. The lane is
+supplemental while the hosted image and temporary identity differ from the
+release-parity Lume seed; it does not replace the Lume gate. Hosted jobs omit the
+Lume-only encrypted history gate and `--experimental-history`; the desktop
+behavior matrix does not depend on them.
 
 Run the Wayland wrapper through `nix develop .#cua-driver-wayland-e2e`. It
 creates a pure Wayland session with Xwayland disabled and delegates every

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -146,9 +146,13 @@ native, and capture partitions through `macos/run-hosted-rust-e2e.sh`. Each
 runner refuses unexpected hosts or pre-existing app state, creates a temporary
 certificate-backed identity and Keychain, installs the exact source as
 `CuaDriverLocal.app`, seeds only its Accessibility and Screen Capture TCC rows,
+records the app's separate `replayd` approval before its first direct capture,
 verifies the daemon-attributed permission result, and delegates to
-`macos/run-rust-e2e.sh`. The lane uploads bootstrap, structured result, log, and
-video evidence even on failure. Signing and trust operations have hard
+`macos/run-rust-e2e.sh`. GitHub's image-level approval covers the hosted runner
+agent, while the bundled driver is its own responsible ScreenCaptureKit client
+and would otherwise show the private-window-picker reminder over the headed
+test. The lane uploads bootstrap, structured result, log, and video evidence
+even on failure. Signing and trust operations have hard
 deadlines, and a sacrificial binary proves the temporary identity works before
 the release build begins. The certificate is trusted only on that ephemeral
 runner and its removal is attempted with a bounded cleanup. The lane is

--- a/scripts/ci/macos/probe-hosted-runner.sh
+++ b/scripts/ci/macos/probe-hosted-runner.sh
@@ -14,7 +14,7 @@ PROBE_MESSAGE="probe did not complete"
 SWIFT_RESULT="${ARTIFACT_DIR}/window-capture.json"
 SYSTEM_LOG="${ARTIFACT_DIR}/system.txt"
 WINDOW_METADATA="${ARTIFACT_DIR}/window.json"
-PROBE_BINARY="${ARTIFACT_DIR}/verify-hosted-window"
+PROBE_BINARY="${RUNNER_TEMP:?RUNNER_TEMP is required}/verify-hosted-window"
 
 write_environment() {
   PROBE_STATUS="${PROBE_STATUS}" \

--- a/scripts/ci/macos/probe-hosted-runner.sh
+++ b/scripts/ci/macos/probe-hosted-runner.sh
@@ -221,6 +221,12 @@ if not all(required):
     raise SystemExit(f"hosted GUI probe failed: {result}")
 PY
 
+if ! run_with_deadline 30 osascript \
+  -e 'tell application "TextEdit" to close every window saving no' \
+  -e 'tell application "TextEdit" to quit'; then
+  fail "TextEdit probe cleanup failed or timed out"
+fi
+
 PROBE_STATUS=passed
 PROBE_MESSAGE="hosted macOS GUI environment and TextEdit window capture passed"
 echo "${PROBE_MESSAGE}"

--- a/scripts/ci/macos/probe-hosted-runner.sh
+++ b/scripts/ci/macos/probe-hosted-runner.sh
@@ -221,11 +221,15 @@ if not all(required):
     raise SystemExit(f"hosted GUI probe failed: {result}")
 PY
 
-if ! run_with_deadline 30 osascript \
-  -e 'tell application "TextEdit" to close every window saving no' \
-  -e 'tell application "TextEdit" to quit'; then
+if ! run_with_deadline 30 /usr/bin/killall TextEdit; then
   fail "TextEdit probe cleanup failed or timed out"
 fi
+for _ in {1..10}; do
+  /usr/bin/pgrep -x TextEdit >/dev/null 2>&1 || break
+  sleep 1
+done
+/usr/bin/pgrep -x TextEdit >/dev/null 2>&1 \
+  && fail "TextEdit remained running after probe cleanup"
 
 PROBE_STATUS=passed
 PROBE_MESSAGE="hosted macOS GUI environment and TextEdit window capture passed"

--- a/scripts/ci/macos/run-hosted-rust-e2e.sh
+++ b/scripts/ci/macos/run-hosted-rust-e2e.sh
@@ -61,9 +61,17 @@ capture_diagnostics() {
     [[ "${certificates}" != *"${TRUSTED_IDENTITY}"* ]]
   }
   verify_code_signing_trust_absent() {
-    [[ -s "${CERTIFICATE_PEM}" ]] || return 1
-    ! security verify-cert -c "${CERTIFICATE_PEM}" -p codeSign \
-      >/dev/null 2>&1
+    local trust_dump
+    local trust_status
+    trust_dump="$(run_bounded 20 sudo -n security dump-trust-settings -d 2>&1)"
+    trust_status=$?
+    printf '%s\n' "${trust_dump}" \
+      > "${BOOTSTRAP_DIR}/cleanup-trust-settings.txt"
+    if [[ "${trust_status}" != 0 \
+        && "${trust_dump}" != *"No Trust Settings were found."* ]]; then
+      return 1
+    fi
+    [[ "${trust_dump}" != *"${CUA_LOCAL_SIGN_CN}"* ]]
   }
   trap - EXIT
   set +e
@@ -100,8 +108,8 @@ capture_diagnostics() {
   fi
   if [[ "${TRUSTED_IDENTITY}" =~ ^[0-9A-Fa-f]{40}$ ]]; then
     # Tahoe's trust-removal helper can be terminated after removing the trust
-    # row. Record that attempt, then judge cleanup from independent absence and
-    # trust-evaluation checks after every certificate copy is gone.
+    # row. Record that attempt, then judge cleanup from independent certificate
+    # and admin Trust Settings checks after every certificate copy is gone.
     record_cleanup_attempt remove_trust run_bounded 20 \
       sudo -n security remove-trusted-cert -d "${CERTIFICATE_PEM}" \
       >/dev/null 2>&1

--- a/scripts/ci/macos/run-hosted-rust-e2e.sh
+++ b/scripts/ci/macos/run-hosted-rust-e2e.sh
@@ -18,6 +18,17 @@ TRUSTED_IDENTITY=""
 WATCHDOG_PID=""
 RUN_START="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
+run_bounded() {
+  local seconds="$1"
+  shift
+  /usr/bin/perl -e 'alarm shift; exec @ARGV' "${seconds}" "$@"
+}
+
+mark_phase() {
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" \
+    | tee "${BOOTSTRAP_DIR}/phase.txt"
+}
+
 capture_diagnostics() {
   local command_status=$?
   trap - EXIT
@@ -54,13 +65,13 @@ capture_diagnostics() {
       > "${BOOTSTRAP_DIR}/unified-log.txt" 2>&1
   fi
   if [[ "${TRUSTED_IDENTITY}" =~ ^[0-9A-Fa-f]{40}$ ]]; then
-    sudo -n security remove-trusted-cert -d "${CERTIFICATE_PEM}" \
+    run_bounded 20 sudo -n security remove-trusted-cert -d "${CERTIFICATE_PEM}" \
       >/dev/null 2>&1
-    sudo -n security delete-certificate -Z "${TRUSTED_IDENTITY}" \
+    run_bounded 20 sudo -n security delete-certificate -Z "${TRUSTED_IDENTITY}" \
       /Library/Keychains/System.keychain >/dev/null 2>&1
   fi
   if [[ -n "${KEYCHAIN}" && -f "${KEYCHAIN}" ]]; then
-    security delete-keychain "${KEYCHAIN}" >/dev/null 2>&1
+    run_bounded 20 security delete-keychain "${KEYCHAIN}" >/dev/null 2>&1
   fi
   exit "${command_status}"
 }
@@ -164,13 +175,15 @@ Installer recursive cleanup is limited to source-derived task-owned paths:
 EOF
 
 export CUA_MACOS_HOSTED_PROBE_DIR="${BOOTSTRAP_DIR}/gui-probe"
+mark_phase "gui-probe"
 bash "${SCRIPT_DIR}/probe-hosted-runner.sh"
 
 mkdir -p "${CARGO_TARGET_DIR}"
 KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
-security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN}"
-security set-keychain-settings "${KEYCHAIN}"
-security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN}"
+mark_phase "signing-bootstrap"
+run_bounded 30 security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN}"
+run_bounded 30 security set-keychain-settings -lut 21600 "${KEYCHAIN}"
+run_bounded 30 security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN}"
 
 export CUA_DRIVER_LOCAL_HOME="${RUNNER_TEMP}/cua-driver-local"
 export CUA_DRIVER_LOCAL_INSTALL_DIR="${RUNNER_TEMP}/cua-driver-bin"
@@ -187,10 +200,10 @@ IDENTITY="$(ensure_local_signing_identity)"
 CERTIFICATE_PEM="${RUNNER_TEMP}/cua-driver-hosted-signing.pem"
 security find-certificate -c "${CUA_LOCAL_SIGN_CN}" -p "${KEYCHAIN}" \
   > "${CERTIFICATE_PEM}"
-sudo -n security add-trusted-cert -d -r trustRoot \
+run_bounded 30 sudo -n security add-trusted-cert -d -r trustRoot \
   -p codeSign -k /Library/Keychains/System.keychain "${CERTIFICATE_PEM}"
 TRUSTED_IDENTITY="${IDENTITY}"
-security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+run_bounded 30 security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
   -k "${KEYCHAIN_PASSWORD}" "${KEYCHAIN}" >/dev/null
 security find-identity -v -p codesigning "${KEYCHAIN}" \
   | grep -Fq "${IDENTITY}" \
@@ -198,6 +211,17 @@ security find-identity -v -p codesigning "${KEYCHAIN}" \
 export CUA_DRIVER_LOCAL_SIGNING_IDENTITY="${IDENTITY}"
 printf '%s\n' "${IDENTITY}" > "${BOOTSTRAP_DIR}/signing-identity-sha1.txt"
 
+SIGNING_PROBE="${RUNNER_TEMP}/cua-driver-signing-probe"
+cp /bin/echo "${SIGNING_PROBE}"
+run_bounded 30 codesign --force --sign "${IDENTITY}" \
+  --keychain "${KEYCHAIN}" "${SIGNING_PROBE}"
+codesign --verify --strict "${SIGNING_PROBE}"
+codesign -d -r- "${SIGNING_PROBE}" \
+  > "${BOOTSTRAP_DIR}/signing-probe-requirement.txt" 2>&1
+grep -Fq "certificate leaf" "${BOOTSTRAP_DIR}/signing-probe-requirement.txt" \
+  || fail "temporary signing probe is not certificate-backed"
+
+mark_phase "install-local"
 echo "[INSTALL] Building and installing ${SOURCE_SHA} with a temporary certificate identity"
 bash "${DRIVER_ROOT}/scripts/install-local.sh" \
   --release --require-stable-signing \
@@ -210,12 +234,14 @@ grep -Fq "certificate leaf" "${BOOTSTRAP_DIR}/codesign-requirement.txt" \
 codesign --verify --deep --strict "${LOCAL_APP}"
 
 echo "[TCC] Seeding only Accessibility and Screen Capture for the installed app"
+mark_phase "seed-tcc"
 bash "${TCC_SEEDER}" \
   --app "${LOCAL_APP}" \
   --expected-client com.trycua.driver.local \
   2>&1 | tee "${BOOTSTRAP_DIR}/seed-tcc.log"
 
 echo "[DAEMON] Launching the installed app in unrestricted disposable-worker mode"
+mark_phase "daemon-start"
 open -n -g "${LOCAL_APP}" --args \
   --socket "${DAEMON_SOCKET}" \
   serve \
@@ -278,5 +304,6 @@ WATCHDOG_PID=$!
 export CUA_E2E_INSTALLED_DRIVER_BIN="${INSTALLED_BIN}"
 export CUA_E2E_MACOS_DAEMON_SOCKET="${DAEMON_SOCKET}"
 export CUA_E2E_FRESH_FIXTURE_STATE=1
+mark_phase "matrix-${LANE}"
 echo "[E2E] Running hosted macOS ${LANE} lane"
 bash "${SCRIPT_DIR}/run-rust-e2e.sh"

--- a/scripts/ci/macos/run-hosted-rust-e2e.sh
+++ b/scripts/ci/macos/run-hosted-rust-e2e.sh
@@ -47,6 +47,24 @@ capture_diagnostics() {
       cleanup_failed=1
     fi
   }
+  record_cleanup_attempt() {
+    local label="$1"
+    shift
+    "$@"
+    printf '%s=%s\n' "${label}" "$?" \
+      >> "${BOOTSTRAP_DIR}/cleanup-attempts.txt"
+  }
+  verify_system_certificate_absent() {
+    local certificates
+    certificates="$(security find-certificate -Z -a \
+      /Library/Keychains/System.keychain 2>/dev/null || true)"
+    [[ "${certificates}" != *"${TRUSTED_IDENTITY}"* ]]
+  }
+  verify_code_signing_trust_absent() {
+    [[ -s "${CERTIFICATE_PEM}" ]] || return 1
+    ! security verify-cert -c "${CERTIFICATE_PEM}" -p codeSign \
+      >/dev/null 2>&1
+  }
   trap - EXIT
   set +e
   mkdir -p "${BOOTSTRAP_DIR}"
@@ -81,7 +99,10 @@ capture_diagnostics() {
       > "${BOOTSTRAP_DIR}/unified-log.txt" 2>&1
   fi
   if [[ "${TRUSTED_IDENTITY}" =~ ^[0-9A-Fa-f]{40}$ ]]; then
-    record_cleanup remove_trust run_bounded 20 \
+    # Tahoe's trust-removal helper can be terminated after removing the trust
+    # row. Record that attempt, then judge cleanup from independent absence and
+    # trust-evaluation checks after every certificate copy is gone.
+    record_cleanup_attempt remove_trust run_bounded 20 \
       sudo -n security remove-trusted-cert -d "${CERTIFICATE_PEM}" \
       >/dev/null 2>&1
     record_cleanup delete_system_certificate run_bounded 20 \
@@ -96,6 +117,12 @@ capture_diagnostics() {
   if [[ -n "${KEYCHAIN}" && -f "${KEYCHAIN}" ]]; then
     record_cleanup delete_temporary_keychain run_bounded 20 \
       security delete-keychain "${KEYCHAIN}" >/dev/null 2>&1
+  fi
+  if [[ "${TRUSTED_IDENTITY}" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+    record_cleanup verify_system_certificate_absent \
+      verify_system_certificate_absent
+    record_cleanup verify_code_signing_trust_absent \
+      verify_code_signing_trust_absent
   fi
   if [[ "${cleanup_failed}" == 1 && "${command_status}" == 0 ]]; then
     command_status=1

--- a/scripts/ci/macos/run-hosted-rust-e2e.sh
+++ b/scripts/ci/macos/run-hosted-rust-e2e.sh
@@ -32,8 +32,21 @@ mark_phase() {
     | tee "${BOOTSTRAP_DIR}/phase.txt"
 }
 
+# shellcheck disable=SC2329 # Invoked through the EXIT trap below.
 capture_diagnostics() {
   local command_status=$?
+  local cleanup_failed=0
+  record_cleanup() {
+    local label="$1"
+    shift
+    "$@"
+    local cleanup_status=$?
+    printf '%s=%s\n' "${label}" "${cleanup_status}" \
+      >> "${BOOTSTRAP_DIR}/cleanup-status.txt"
+    if [[ "${cleanup_status}" != 0 ]]; then
+      cleanup_failed=1
+    fi
+  }
   trap - EXIT
   set +e
   mkdir -p "${BOOTSTRAP_DIR}"
@@ -68,17 +81,24 @@ capture_diagnostics() {
       > "${BOOTSTRAP_DIR}/unified-log.txt" 2>&1
   fi
   if [[ "${TRUSTED_IDENTITY}" =~ ^[0-9A-Fa-f]{40}$ ]]; then
-    run_bounded 20 sudo -n security remove-trusted-cert -d "${CERTIFICATE_PEM}" \
+    record_cleanup remove_trust run_bounded 20 \
+      sudo -n security remove-trusted-cert -d "${CERTIFICATE_PEM}" \
       >/dev/null 2>&1
-    run_bounded 20 sudo -n security delete-certificate -Z "${TRUSTED_IDENTITY}" \
+    record_cleanup delete_system_certificate run_bounded 20 \
+      sudo -n security delete-certificate -Z "${TRUSTED_IDENTITY}" \
       /Library/Keychains/System.keychain >/dev/null 2>&1
   fi
   if ((${#ORIGINAL_KEYCHAINS[@]})); then
-    run_bounded 20 security list-keychains -d user -s \
+    record_cleanup restore_keychain_search_list run_bounded 20 \
+      security list-keychains -d user -s \
       "${ORIGINAL_KEYCHAINS[@]}" >/dev/null 2>&1
   fi
   if [[ -n "${KEYCHAIN}" && -f "${KEYCHAIN}" ]]; then
-    run_bounded 20 security delete-keychain "${KEYCHAIN}" >/dev/null 2>&1
+    record_cleanup delete_temporary_keychain run_bounded 20 \
+      security delete-keychain "${KEYCHAIN}" >/dev/null 2>&1
+  fi
+  if [[ "${cleanup_failed}" == 1 && "${command_status}" == 0 ]]; then
+    command_status=1
   fi
   exit "${command_status}"
 }
@@ -213,9 +233,9 @@ IDENTITY="$(ensure_local_signing_identity)"
 CERTIFICATE_PEM="${RUNNER_TEMP}/cua-driver-hosted-signing.pem"
 security find-certificate -c "${CUA_LOCAL_SIGN_CN}" -p "${KEYCHAIN}" \
   > "${CERTIFICATE_PEM}"
+TRUSTED_IDENTITY="${IDENTITY}"
 run_bounded 30 sudo -n security add-trusted-cert -d -r trustRoot \
   -p codeSign -k /Library/Keychains/System.keychain "${CERTIFICATE_PEM}"
-TRUSTED_IDENTITY="${IDENTITY}"
 run_bounded 30 security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
   -k "${KEYCHAIN_PASSWORD}" "${KEYCHAIN}" >/dev/null
 security find-identity -v -p codesigning "${KEYCHAIN}" \
@@ -313,7 +333,18 @@ watch_daemon() {
   while sleep 3; do
     daemon_status="$("${INSTALLED_BIN}" --socket "${DAEMON_SOCKET}" status 2>&1 || true)"
     if [[ "${daemon_status}" != *"permission mode: unrestricted"* ]]; then
-      printf '%s daemon unavailable or not unrestricted; restarting\n' \
+      printf '%s daemon status probe failed; confirming before restart\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      printf '%s\n' "${daemon_status}"
+      for _ in {1..3}; do
+        sleep 1
+        daemon_status="$("${INSTALLED_BIN}" --socket "${DAEMON_SOCKET}" status 2>&1 || true)"
+        [[ "${daemon_status}" == *"permission mode: unrestricted"* ]] && break
+      done
+      if [[ "${daemon_status}" == *"permission mode: unrestricted"* ]]; then
+        continue
+      fi
+      printf '%s daemon remained unavailable or not unrestricted; restarting\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
       printf '%s\n' "${daemon_status}"
       "${INSTALLED_BIN}" --socket "${DAEMON_SOCKET}" stop >/dev/null 2>&1 || true
@@ -322,7 +353,7 @@ watch_daemon() {
         serve \
         --permission-mode unrestricted \
         --dangerously-bypass-approvals
-      for _ in {1..15}; do
+      for _ in {1..60}; do
         sleep 1
         daemon_status="$("${INSTALLED_BIN}" --socket "${DAEMON_SOCKET}" status 2>&1 || true)"
         [[ "${daemon_status}" == *"permission mode: unrestricted"* ]] && break
@@ -338,4 +369,13 @@ export CUA_E2E_MACOS_DAEMON_SOCKET="${DAEMON_SOCKET}"
 export CUA_E2E_FRESH_FIXTURE_STATE=1
 mark_phase "matrix-${LANE}"
 echo "[E2E] Running hosted macOS ${LANE} lane"
-bash "${SCRIPT_DIR}/run-rust-e2e.sh"
+MATRIX_STATUS=0
+bash "${SCRIPT_DIR}/run-rust-e2e.sh" || MATRIX_STATUS=$?
+kill "${WATCHDOG_PID}" >/dev/null 2>&1 || true
+wait "${WATCHDOG_PID}" 2>/dev/null || true
+WATCHDOG_PID=""
+if grep -Fq "restarting" "${BOOTSTRAP_DIR}/daemon-watchdog.log"; then
+  echo "The hosted daemon required a watchdog restart during the matrix" >&2
+  MATRIX_STATUS=1
+fi
+exit "${MATRIX_STATUS}"

--- a/scripts/ci/macos/run-hosted-rust-e2e.sh
+++ b/scripts/ci/macos/run-hosted-rust-e2e.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# Prepare a fresh GitHub-hosted macOS 26 runner and run one canonical E2E lane.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+DRIVER_ROOT="${REPO_ROOT}/libs/cua-driver"
+LOCAL_APP="/Applications/CuaDriverLocal.app"
+INSTALLED_BIN="${LOCAL_APP}/Contents/MacOS/cua-driver-local"
+TCC_SEEDER="${DRIVER_ROOT}/tests/runners/macos-lume/seed-tcc-guest.sh"
+LANE="${CUA_E2E_INTERNAL_LANE:-}"
+BOOTSTRAP_DIR="${REPO_ROOT}/artifacts/cua-driver/macos-hosted-bootstrap"
+KEYCHAIN="${RUNNER_TEMP:-}/cua-driver-hosted-signing.keychain-db"
+DAEMON_SOCKET="${HOME}/Library/Caches/cua-driver-local/cua-driver-local.sock"
+KEYCHAIN_PASSWORD=""
+DAEMON_STARTED=0
+TRUSTED_IDENTITY=""
+WATCHDOG_PID=""
+RUN_START="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+capture_diagnostics() {
+  local command_status=$?
+  trap - EXIT
+  set +e
+  mkdir -p "${BOOTSTRAP_DIR}"
+  printf '%s\n' "${command_status}" > "${BOOTSTRAP_DIR}/exit-status.txt"
+  if [[ -n "${WATCHDOG_PID}" ]]; then
+    kill "${WATCHDOG_PID}" >/dev/null 2>&1
+    wait "${WATCHDOG_PID}" 2>/dev/null
+  fi
+  pgrep -lf 'cua-driver-local|tccd|WindowServer' \
+    > "${BOOTSTRAP_DIR}/relevant-processes.txt" 2>&1
+  launchctl print "gui/$(id -u)" > "${BOOTSTRAP_DIR}/launchd-gui.txt" 2>&1
+  if [[ -x "${INSTALLED_BIN}" ]]; then
+    "${INSTALLED_BIN}" --socket "${DAEMON_SOCKET}" status \
+      > "${BOOTSTRAP_DIR}/daemon-status.txt" 2>&1
+    "${INSTALLED_BIN}" --socket "${DAEMON_SOCKET}" permissions status --json \
+      > "${BOOTSTRAP_DIR}/permissions-final.json" 2> "${BOOTSTRAP_DIR}/permissions-final.err"
+    codesign -dvvv -r- "${LOCAL_APP}" \
+      > "${BOOTSTRAP_DIR}/codesign-final.txt" 2>&1
+    if [[ "${DAEMON_STARTED}" == 1 ]]; then
+      "${INSTALLED_BIN}" --socket "${DAEMON_SOCKET}" stop >/dev/null 2>&1
+    fi
+  fi
+  if [[ "${command_status}" == 0 ]]; then
+    /usr/bin/perl -e 'alarm shift; exec @ARGV' 60 \
+      /usr/bin/log show --last 15m --style compact \
+      --predicate 'process == "cua-driver-local" OR process == "tccd"' \
+      > "${BOOTSTRAP_DIR}/unified-log.txt" 2>&1
+  else
+    /usr/bin/perl -e 'alarm shift; exec @ARGV' 60 \
+      /usr/bin/log show --start "${RUN_START}" --style compact \
+      --predicate 'process == "cua-driver-local" OR process == "tccd"' \
+      > "${BOOTSTRAP_DIR}/unified-log.txt" 2>&1
+  fi
+  if [[ "${TRUSTED_IDENTITY}" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+    sudo -n security remove-trusted-cert -d "${CERTIFICATE_PEM}" \
+      >/dev/null 2>&1
+    sudo -n security delete-certificate -Z "${TRUSTED_IDENTITY}" \
+      /Library/Keychains/System.keychain >/dev/null 2>&1
+  fi
+  if [[ -n "${KEYCHAIN}" && -f "${KEYCHAIN}" ]]; then
+    security delete-keychain "${KEYCHAIN}" >/dev/null 2>&1
+  fi
+  exit "${command_status}"
+}
+trap capture_diagnostics EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+fail() {
+  echo "hosted-macos-e2e: $*" >&2
+  exit 2
+}
+
+capture_command_output() {
+  local output_file="$1"
+  shift
+  "$@" > "${output_file}" 2>&1
+}
+
+[[ "$(uname -s)" == Darwin ]] || fail "requires macOS"
+[[ "${GITHUB_ACTIONS:-}" == true ]] || fail "requires GitHub Actions"
+[[ "${GITHUB_EVENT_NAME:-}" == workflow_dispatch ]] \
+  || fail "runs only from workflow_dispatch"
+[[ "${RUNNER_ENVIRONMENT:-}" == github-hosted ]] \
+  || fail "requires a GitHub-hosted runner"
+[[ "${RUNNER_OS:-}" == macOS ]] || fail "requires RUNNER_OS=macOS"
+[[ "${ImageOS:-}" == macos26 ]] || fail "requires the macos-26 runner image"
+[[ -z "${SSH_CONNECTION:-}" && -z "${SSH_TTY:-}" ]] \
+  || fail "SSH sessions cannot seed or certify hosted TCC state"
+case "${LANE}" in
+  shared|native|capture) ;;
+  *) fail "CUA_E2E_INTERNAL_LANE must be shared, native, or capture" ;;
+esac
+
+CURRENT_USER="$(id -un)"
+CONSOLE_USER="$(stat -f '%Su' /dev/console)"
+[[ "${CURRENT_USER}" == runner && "${CONSOLE_USER}" == runner ]] \
+  || fail "expected runner as current and console user; got ${CURRENT_USER}/${CONSOLE_USER}"
+launchctl print "gui/$(id -u)" >/dev/null 2>&1 \
+  || fail "no Aqua launchd GUI domain is available"
+
+SIP_STATUS="$(csrutil status 2>&1 || true)"
+[[ "${SIP_STATUS}" == "System Integrity Protection status: disabled." ]] \
+  || fail "requires SIP disabled; got: ${SIP_STATUS}"
+MODEL="$(sysctl -n hw.model 2>/dev/null || true)"
+[[ "${MODEL}" == VirtualMac* ]] \
+  || fail "expected an isolated VirtualMac runner; got hw.model=${MODEL:-unknown}"
+
+for command_name in cargo codesign ffmpeg ffprobe git jq node npm openssl \
+    security sqlite3 xcrun; do
+  command -v "${command_name}" >/dev/null 2>&1 \
+    || fail "missing hosted runner dependency: ${command_name}"
+done
+[[ -n "${RUNNER_TEMP:-}" && "${RUNNER_TEMP}" == /* ]] \
+  || fail "RUNNER_TEMP must be an absolute path"
+[[ "${CARGO_TARGET_DIR:-}" == /* ]] \
+  || fail "CARGO_TARGET_DIR must be an absolute, per-job directory"
+[[ ! -e "${CARGO_TARGET_DIR}" ]] \
+  || fail "refusing to reuse Cargo target directory ${CARGO_TARGET_DIR}"
+[[ ! -e "${LOCAL_APP}" ]] \
+  || fail "refusing a runner with a pre-existing ${LOCAL_APP}"
+[[ ! -e "${KEYCHAIN}" ]] \
+  || fail "refusing a runner with a pre-existing signing keychain"
+sudo -n -v >/dev/null 2>&1 \
+  || fail "requires the hosted runner's noninteractive sudo policy"
+
+SOURCE_SHA="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+[[ "${CUA_E2E_SOURCE_SHA:-}" =~ ^[0-9a-fA-F]{40}$ ]] \
+  || fail "CUA_E2E_SOURCE_SHA must be a full commit SHA"
+EXPECTED_SHA="$(printf '%s' "${CUA_E2E_SOURCE_SHA}" | tr '[:upper:]' '[:lower:]')"
+[[ "${SOURCE_SHA}" == "${EXPECTED_SHA}" ]] \
+  || fail "checked out ${SOURCE_SHA}, expected ${CUA_E2E_SOURCE_SHA}"
+[[ -z "$(git -C "${REPO_ROOT}" status --porcelain --untracked-files=normal)" ]] \
+  || fail "requires a clean exact-SHA checkout"
+
+mkdir -p "${BOOTSTRAP_DIR}"
+{
+  printf 'source_sha=%s\n' "${SOURCE_SHA}"
+  printf 'lane=%s\n' "${LANE}"
+  printf 'current_user=%s\n' "${CURRENT_USER}"
+  printf 'console_user=%s\n' "${CONSOLE_USER}"
+  printf 'model=%s\n' "${MODEL}"
+  printf 'sip=%s\n' "${SIP_STATUS}"
+  printf 'image_os=%s\n' "${ImageOS}"
+  printf 'image_version=%s\n' "${ImageVersion:-unknown}"
+  sw_vers
+  rustc --version
+  node --version
+  xcode-select -p
+  ffmpeg -version 2>&1 | sed -n '1p'
+  ffprobe -version 2>&1 | sed -n '1p'
+  jq --version
+} > "${BOOTSTRAP_DIR}/environment.txt"
+
+cat > "${BOOTSTRAP_DIR}/cleanup-targets.txt" <<EOF
+Installer recursive cleanup is limited to source-derived task-owned paths:
+- ${RUNNER_TEMP}/cua-driver-local/packages/releases/0.0.0-local-release-*/Skills/cua-driver
+- ${RUNNER_TEMP}/cua-driver-local/packages/releases/0.0.0-local-release-*/CuaDriverLocal.app
+- /Applications/CuaDriverLocal.app.install-backup.<pid>
+- /Applications/CuaDriverLocal.app only while restoring a failed fresh-runner install
+- mktemp signing and csreq directories under the runner's temporary directory
+EOF
+
+export CUA_MACOS_HOSTED_PROBE_DIR="${BOOTSTRAP_DIR}/gui-probe"
+bash "${SCRIPT_DIR}/probe-hosted-runner.sh"
+
+mkdir -p "${CARGO_TARGET_DIR}"
+KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
+security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN}"
+security set-keychain-settings "${KEYCHAIN}"
+security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN}"
+
+export CUA_DRIVER_LOCAL_HOME="${RUNNER_TEMP}/cua-driver-local"
+export CUA_DRIVER_LOCAL_INSTALL_DIR="${RUNNER_TEMP}/cua-driver-bin"
+export CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN="${KEYCHAIN}"
+export CUA_DRIVER_SOURCE_SHA="${SOURCE_SHA}"
+
+export OS=Darwin
+export BOLD="" NORMAL="" RED="" GREEN="" BLUE="" YELLOW=""
+# shellcheck disable=SC1090,SC1091
+. "${DRIVER_ROOT}/scripts/_local-signing.sh"
+IDENTITY="$(ensure_local_signing_identity)"
+[[ "${IDENTITY}" =~ ^[0-9A-Fa-f]{40}$ ]] \
+  || fail "could not create the temporary code-signing identity"
+CERTIFICATE_PEM="${RUNNER_TEMP}/cua-driver-hosted-signing.pem"
+security find-certificate -c "${CUA_LOCAL_SIGN_CN}" -p "${KEYCHAIN}" \
+  > "${CERTIFICATE_PEM}"
+sudo -n security add-trusted-cert -d -r trustRoot \
+  -p codeSign -k /Library/Keychains/System.keychain "${CERTIFICATE_PEM}"
+TRUSTED_IDENTITY="${IDENTITY}"
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+  -k "${KEYCHAIN_PASSWORD}" "${KEYCHAIN}" >/dev/null
+security find-identity -v -p codesigning "${KEYCHAIN}" \
+  | grep -Fq "${IDENTITY}" \
+  || fail "temporary identity is not valid for code signing"
+export CUA_DRIVER_LOCAL_SIGNING_IDENTITY="${IDENTITY}"
+printf '%s\n' "${IDENTITY}" > "${BOOTSTRAP_DIR}/signing-identity-sha1.txt"
+
+echo "[INSTALL] Building and installing ${SOURCE_SHA} with a temporary certificate identity"
+bash "${DRIVER_ROOT}/scripts/install-local.sh" \
+  --release --require-stable-signing \
+  2>&1 | tee "${BOOTSTRAP_DIR}/install-local.log"
+
+capture_command_output "${BOOTSTRAP_DIR}/codesign-requirement.txt" \
+  codesign -d -r- "${LOCAL_APP}"
+grep -Fq "certificate leaf" "${BOOTSTRAP_DIR}/codesign-requirement.txt" \
+  || fail "installed app does not have a certificate-backed designated requirement"
+codesign --verify --deep --strict "${LOCAL_APP}"
+
+echo "[TCC] Seeding only Accessibility and Screen Capture for the installed app"
+bash "${TCC_SEEDER}" \
+  --app "${LOCAL_APP}" \
+  --expected-client com.trycua.driver.local \
+  2>&1 | tee "${BOOTSTRAP_DIR}/seed-tcc.log"
+
+echo "[DAEMON] Launching the installed app in unrestricted disposable-worker mode"
+open -n -g "${LOCAL_APP}" --args \
+  --socket "${DAEMON_SOCKET}" \
+  serve \
+  --permission-mode unrestricted \
+  --dangerously-bypass-approvals
+DAEMON_STARTED=1
+
+PERMISSIONS_READY=0
+for _ in {1..20}; do
+  if "${INSTALLED_BIN}" --socket "${DAEMON_SOCKET}" permissions status --json \
+      > "${BOOTSTRAP_DIR}/permissions.json" 2> "${BOOTSTRAP_DIR}/permissions.err" \
+      && jq -e '
+        .accessibility == true
+        and .screen_recording == true
+        and .screen_recording_capturable == null
+        and .direct_capture_status == "not_checked"
+        and .source.attribution == "driver-daemon"
+      ' "${BOOTSTRAP_DIR}/permissions.json" >/dev/null; then
+    PERMISSIONS_READY=1
+    break
+  fi
+  sleep 1
+done
+[[ "${PERMISSIONS_READY}" == 1 ]] \
+  || fail "installed daemon did not report the seeded app-specific permissions"
+[[ -S "${DAEMON_SOCKET}" ]] || fail "installed daemon socket is missing"
+
+"${INSTALLED_BIN}" --socket "${DAEMON_SOCKET}" call get_config '{}' \
+  > "${BOOTSTRAP_DIR}/driver-config.json"
+grep -Fq "${SOURCE_SHA}" "${BOOTSTRAP_DIR}/driver-config.json" \
+  || fail "installed daemon did not report the requested source SHA"
+"${INSTALLED_BIN}" --socket "${DAEMON_SOCKET}" list_apps '{}' \
+  > "${BOOTSTRAP_DIR}/driver-list-apps.json"
+
+watch_daemon() {
+  local daemon_status
+  while sleep 3; do
+    daemon_status="$("${INSTALLED_BIN}" --socket "${DAEMON_SOCKET}" status 2>&1 || true)"
+    if [[ "${daemon_status}" != *"permission mode: unrestricted"* ]]; then
+      printf '%s daemon unavailable or not unrestricted; restarting\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      printf '%s\n' "${daemon_status}"
+      "${INSTALLED_BIN}" --socket "${DAEMON_SOCKET}" stop >/dev/null 2>&1 || true
+      open -n -g "${LOCAL_APP}" --args \
+        --socket "${DAEMON_SOCKET}" \
+        serve \
+        --permission-mode unrestricted \
+        --dangerously-bypass-approvals
+      for _ in {1..15}; do
+        sleep 1
+        daemon_status="$("${INSTALLED_BIN}" --socket "${DAEMON_SOCKET}" status 2>&1 || true)"
+        [[ "${daemon_status}" == *"permission mode: unrestricted"* ]] && break
+      done
+    fi
+  done
+}
+watch_daemon >> "${BOOTSTRAP_DIR}/daemon-watchdog.log" 2>&1 &
+WATCHDOG_PID=$!
+
+export CUA_E2E_INSTALLED_DRIVER_BIN="${INSTALLED_BIN}"
+export CUA_E2E_MACOS_DAEMON_SOCKET="${DAEMON_SOCKET}"
+export CUA_E2E_FRESH_FIXTURE_STATE=1
+echo "[E2E] Running hosted macOS ${LANE} lane"
+bash "${SCRIPT_DIR}/run-rust-e2e.sh"

--- a/scripts/ci/macos/run-hosted-rust-e2e.sh
+++ b/scripts/ci/macos/run-hosted-rust-e2e.sh
@@ -17,6 +17,7 @@ DAEMON_STARTED=0
 TRUSTED_IDENTITY=""
 WATCHDOG_PID=""
 RUN_START="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+ORIGINAL_KEYCHAINS=()
 
 run_bounded() {
   local seconds="$1"
@@ -69,6 +70,10 @@ capture_diagnostics() {
       >/dev/null 2>&1
     run_bounded 20 sudo -n security delete-certificate -Z "${TRUSTED_IDENTITY}" \
       /Library/Keychains/System.keychain >/dev/null 2>&1
+  fi
+  if ((${#ORIGINAL_KEYCHAINS[@]})); then
+    run_bounded 20 security list-keychains -d user -s \
+      "${ORIGINAL_KEYCHAINS[@]}" >/dev/null 2>&1
   fi
   if [[ -n "${KEYCHAIN}" && -f "${KEYCHAIN}" ]]; then
     run_bounded 20 security delete-keychain "${KEYCHAIN}" >/dev/null 2>&1
@@ -184,6 +189,12 @@ mark_phase "signing-bootstrap"
 run_bounded 30 security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN}"
 run_bounded 30 security set-keychain-settings -lut 21600 "${KEYCHAIN}"
 run_bounded 30 security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN}"
+while IFS= read -r keychain_entry; do
+  [[ -n "${keychain_entry}" ]] && ORIGINAL_KEYCHAINS+=("${keychain_entry}")
+done < <(security list-keychains -d user \
+  | sed -E 's/^[[:space:]]*"//; s/"[[:space:]]*$//')
+run_bounded 30 security list-keychains -d user -s \
+  "${KEYCHAIN}" "${ORIGINAL_KEYCHAINS[@]}"
 
 export CUA_DRIVER_LOCAL_HOME="${RUNNER_TEMP}/cua-driver-local"
 export CUA_DRIVER_LOCAL_INSTALL_DIR="${RUNNER_TEMP}/cua-driver-bin"

--- a/scripts/ci/macos/run-hosted-rust-e2e.sh
+++ b/scripts/ci/macos/run-hosted-rust-e2e.sh
@@ -12,6 +12,8 @@ LANE="${CUA_E2E_INTERNAL_LANE:-}"
 BOOTSTRAP_DIR="${REPO_ROOT}/artifacts/cua-driver/macos-hosted-bootstrap"
 KEYCHAIN="${RUNNER_TEMP:-}/cua-driver-hosted-signing.keychain-db"
 DAEMON_SOCKET="${HOME}/Library/Caches/cua-driver-local/cua-driver-local.sock"
+SCREEN_CAPTURE_APPROVALS="${HOME}/Library/Group Containers/group.com.apple.replayd/ScreenCaptureApprovals.plist"
+SCREEN_CAPTURE_CLIENT="com.trycua.driver.local"
 KEYCHAIN_PASSWORD=""
 DAEMON_STARTED=0
 TRUSTED_IDENTITY=""
@@ -243,6 +245,26 @@ capture_command_output "${BOOTSTRAP_DIR}/codesign-requirement.txt" \
 grep -Fq "certificate leaf" "${BOOTSTRAP_DIR}/codesign-requirement.txt" \
   || fail "installed app does not have a certificate-backed designated requirement"
 codesign --verify --deep --strict "${LOCAL_APP}"
+
+# macOS 15+ separately reminds each responsible app before direct capture,
+# even when Screen Recording is granted. The hosted image pre-approves its
+# runner agent, but this signed app is the responsible ScreenCaptureKit client.
+echo "[CAPTURE] Suppressing the app-specific private-window-picker reminder"
+mark_phase "screen-capture-approval"
+mkdir -p "$(dirname "${SCREEN_CAPTURE_APPROVALS}")"
+defaults write "${SCREEN_CAPTURE_APPROVALS}" "${SCREEN_CAPTURE_CLIENT}" -dict \
+  kScreenCaptureApprovalLastAlerted -date "3024-01-01 00:00:00 +0000" \
+  kScreenCaptureApprovalLastUsed -date "3024-01-01 00:00:00 +0000"
+killall -HUP replayd >/dev/null 2>&1 || true
+killall -u "${CURRENT_USER}" cfprefsd >/dev/null 2>&1 || true
+defaults read "${SCREEN_CAPTURE_APPROVALS}" "${SCREEN_CAPTURE_CLIENT}" \
+  > "${BOOTSTRAP_DIR}/screen-capture-approval.txt"
+grep -Fq "kScreenCaptureApprovalLastAlerted" \
+  "${BOOTSTRAP_DIR}/screen-capture-approval.txt" \
+  || fail "app-specific screen capture reminder approval was not stored"
+grep -Fq "kScreenCaptureApprovalLastUsed" \
+  "${BOOTSTRAP_DIR}/screen-capture-approval.txt" \
+  || fail "app-specific screen capture last-used approval was not stored"
 
 echo "[TCC] Seeding only Accessibility and Screen Capture for the installed app"
 mark_phase "seed-tcc"

--- a/scripts/ci/macos/run-hosted-rust-e2e.sh
+++ b/scripts/ci/macos/run-hosted-rust-e2e.sh
@@ -256,7 +256,6 @@ defaults write "${SCREEN_CAPTURE_APPROVALS}" "${SCREEN_CAPTURE_CLIENT}" -dict \
   kScreenCaptureApprovalLastAlerted -date "3024-01-01 00:00:00 +0000" \
   kScreenCaptureApprovalLastUsed -date "3024-01-01 00:00:00 +0000"
 killall -HUP replayd >/dev/null 2>&1 || true
-killall -u "${CURRENT_USER}" cfprefsd >/dev/null 2>&1 || true
 defaults read "${SCREEN_CAPTURE_APPROVALS}" "${SCREEN_CAPTURE_CLIENT}" \
   > "${BOOTSTRAP_DIR}/screen-capture-approval.txt"
 grep -Fq "kScreenCaptureApprovalLastAlerted" \
@@ -283,7 +282,7 @@ open -n -g "${LOCAL_APP}" --args \
 DAEMON_STARTED=1
 
 PERMISSIONS_READY=0
-for _ in {1..20}; do
+for _ in {1..60}; do
   if "${INSTALLED_BIN}" --socket "${DAEMON_SOCKET}" permissions status --json \
       > "${BOOTSTRAP_DIR}/permissions.json" 2> "${BOOTSTRAP_DIR}/permissions.err" \
       && jq -e '


### PR DESCRIPTION
GitHub-hosted `macos-26` runners can now execute Cua Driver's real desktop E2E lanes through a manual, exact-SHA workflow. The workflow proves the hosted Aqua/WindowServer environment, creates a temporary certificate-backed app identity, seeds only guest-local Accessibility and Screen Capture rows, verifies daemon attribution, runs shared/native/capture on separate fresh allocations, and fails closed on daemon restart, test failure, or incomplete cleanup. Lume remains the canonical macOS release-parity gate.

Closes #3725

## Implementation

- Extend `.github/workflows/e2e-rust-macos.yml` from a probe into a manual exact-SHA probe plus shared, native, and capture matrix.
- Require GitHub-hosted `macos-26`, an Aqua console session, SIP disabled, and `VirtualMac*` before guest-local TCC changes.
- Create an ephemeral signing keychain and certificate-backed `CuaDriverLocal.app`, seed its exact designated requirement, and launch the unrestricted test daemon through LaunchServices.
- Record runner, permissions, signing, replayd approval, daemon, matrix, and cleanup evidence; reject watchdog restarts and missing cleanup postconditions.
- Document the hosted lane as supplemental to the logged-in Lume wrapper and retain Lume-only encrypted-history coverage.

## Validation

Final PR candidate: `7548e80cd6f70e5d7ee283e19779cf534add21ef`

- Ordinary PR CI: contributor attribution, test scripts, Fleet mirror guard, release metadata, and installer compatibility passed.
- Hosted macOS: [run 34566033890](https://github.com/trycua/cua/actions/runs/34566033890) passed at the exact candidate SHA. Shared delivered 119 cells with 7 expected refusals; native delivered 27 with 1 expected refusal; capture delivered 7 with none. All lanes had zero failures/skips, no daemon watchdog restart, and complete signing/trust cleanup. The certification artifact records `passed: true` and the exact source/workflow SHA.
- Canonical Lume macOS: `libs/cua-driver/tests/runners/macos-lume/run-all.sh --standalone-browser` completed at the pre-sync candidate `ad5dafda5`: native and capture passed, while shared reproduced six existing Driver defects tracked in #3389, #2906, and #2202 (Electron background text/editor and foreground drag across Electron/Tauri/WKWebView). Those failures are outside this six-file CI/docs change; the hosted exact-SHA lanes above are green.
- Linux: [run 34561128283](https://github.com/trycua/cua/actions/runs/34561128283) at `f2275e0d5b8ebada5efa1f90517d8a7b266f415d` passed the complete source/shared/native/capture/installer matrix.
- Windows: [run 34561111600](https://github.com/trycua/cua/actions/runs/34561111600) at `f2275e0d5b8ebada5efa1f90517d8a7b266f415d` passed shared/native/capture/installer with zero failures. [Installer replay 34564452081](https://github.com/trycua/cua/actions/runs/34564452081) at pre-sync candidate `ad5dafda5` passed. The only later base delta is the unrelated sandbox 0.7.0 release metadata and package version, which does not affect the Windows installer or Driver desktop behavior.
- Local checks: `bash -n`, `shellcheck`, five focused workflow tests, and `git diff --check` passed.

The Linux and Windows behavior evidence remains applicable because the later PR commits modify only the hosted macOS workflow/bootstrap and its focused contract test. The rebase onto current `main` additionally introduced the published installer-version update and sandbox shared-client change; neither changes the Linux/macOS desktop harness or Driver product source. The affected Windows installer lane is replayed above at the final candidate.

## Limits

- The hosted workflow is manual and supplemental; it does not replace the Lume maintainer gate.
- Hosted jobs omit the Lume-only encrypted-history and experimental-history coverage.
- The workflow does not use repository secrets, OIDC, self-hosted runners, or public-event privileged infrastructure.
