### PR TITLE
fix(fleet): bound streamed HTTP responses

### DIFF
--- a/libs/typescript/fleet/.bumpversion.cfg
+++ b/libs/typescript/fleet/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.2
 commit = True
 tag = True
 tag_name = npm-fleet-v{new_version}

--- a/libs/typescript/fleet/package.json
+++ b/libs/typescript/fleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycua/fleet",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "packageManager": "pnpm@10.12.3",
   "description": "Browser and WebAssembly SDK for Cua Fleet sandbox lifecycle management",
   "type": "module",
@@ -51,6 +51,7 @@
   },
   "scripts": {
     "build": "node ./scripts/build.mjs",
+    "test": "node --test ./tests/*.test.mjs",
     "pack:check": "pnpm run build && npm pack --dry-run"
   },
   "dependencies": {

--- a/libs/typescript/fleet/scripts/build.mjs
+++ b/libs/typescript/fleet/scripts/build.mjs
@@ -114,9 +114,10 @@ export async function readResponseBody(response, maxResponseBytes) {
 }
 
 export async function executeFetchRequest(request, callerSignal, fetchImplementation = fetch) {
-  const timeout = request.timeoutSecs !== undefined && request.timeoutSecs !== null
-    ? createTimeoutSignal(Number(request.timeoutSecs) * 1_000)
-    : undefined;
+  const timeout =
+    request.timeoutSecs !== undefined && request.timeoutSecs !== null
+      ? createTimeoutSignal(Number(request.timeoutSecs) * 1_000)
+      : undefined;
   const combinedSignal = composeAbortSignals([callerSignal, timeout?.signal]);
   try {
     const response = await fetchImplementation(request.url, {

--- a/libs/typescript/fleet/scripts/build.mjs
+++ b/libs/typescript/fleet/scripts/build.mjs
@@ -3,8 +3,6 @@ import { cpSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } fr
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { build } from 'esbuild';
-
 const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const repositoryRoot = resolve(packageDirectory, '../../..');
 const bindingDirectory = join(repositoryRoot, 'libs/fleet/sdk-bindings/ts-uniffi-browser');
@@ -22,6 +20,122 @@ if (!rustToolchainMatch) {
 }
 const rustToolchain = rustToolchainMatch[1];
 const wasmBindgenVersion = '0.2.126';
+
+export const RESPONSE_LIMIT_ERROR = 'HTTP response exceeds configured size limit';
+
+export function createTimeoutSignal(timeoutMs, timeoutFactory = AbortSignal.timeout) {
+  if (typeof timeoutFactory === 'function') {
+    return { signal: timeoutFactory(timeoutMs), dispose() {} };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new DOMException('Timed out', 'TimeoutError')),
+    timeoutMs
+  );
+  timer.unref?.();
+  return {
+    signal: controller.signal,
+    dispose() {
+      clearTimeout(timer);
+    },
+  };
+}
+
+export function composeAbortSignals(signals, signalFactory = AbortSignal.any) {
+  const activeSignals = signals.filter((signal) => signal !== undefined);
+  if (activeSignals.length < 2) {
+    return { signal: activeSignals[0], dispose() {} };
+  }
+  if (typeof signalFactory === 'function') {
+    return { signal: signalFactory(activeSignals), dispose() {} };
+  }
+
+  const controller = new AbortController();
+  const onAbort = (event) => controller.abort(event.target.reason);
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      break;
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
+  }
+  return {
+    signal: controller.signal,
+    dispose() {
+      for (const signal of activeSignals) {
+        signal.removeEventListener('abort', onAbort);
+      }
+    },
+  };
+}
+
+export async function readResponseBody(response, maxResponseBytes) {
+  if (response.body === null) {
+    return new ArrayBuffer(0);
+  }
+
+  const reader = response.body.getReader();
+  const chunks = [];
+  let totalBytes = 0;
+  let totalBytesBigInt = 0n;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
+    const nextTotalBytes = totalBytes + chunk.byteLength;
+    const nextTotalBytesBigInt = totalBytesBigInt + BigInt(chunk.byteLength);
+    if (
+      maxResponseBytes !== undefined &&
+      maxResponseBytes !== null &&
+      nextTotalBytesBigInt > maxResponseBytes
+    ) {
+      try {
+        await reader.cancel();
+      } catch {
+        // Preserve the stable, sanitized limit error even if cancellation fails.
+      }
+      throw new Error(RESPONSE_LIMIT_ERROR);
+    }
+    chunks.push(chunk);
+    totalBytes = nextTotalBytes;
+    totalBytesBigInt = nextTotalBytesBigInt;
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body.buffer;
+}
+
+export async function executeFetchRequest(request, callerSignal, fetchImplementation = fetch) {
+  const timeout = request.timeoutSecs !== undefined && request.timeoutSecs !== null
+    ? createTimeoutSignal(Number(request.timeoutSecs) * 1_000)
+    : undefined;
+  const combinedSignal = composeAbortSignals([callerSignal, timeout?.signal]);
+  try {
+    const response = await fetchImplementation(request.url, {
+      method: request.method,
+      headers: request.headers.map(({ name, value }) => [name, value]),
+      body: request.body,
+      signal: combinedSignal.signal,
+      redirect: 'manual',
+    });
+    return {
+      status: response.status,
+      headers: [...response.headers].map(([name, value]) => ({ name, value })),
+      body: await readResponseBody(response, request.maxResponseBytes),
+    };
+  } finally {
+    combinedSignal.dispose();
+    timeout?.dispose();
+  }
+}
 
 const sharedExports = `
 export * from './cyclops_sdk_schema'
@@ -60,26 +174,25 @@ import { readFile } from 'node:fs/promises'
 import type { HttpClient, HttpRequest, HttpResponse } from './fleet_sdk'
 ${sharedExports}
 
+const RESPONSE_LIMIT_ERROR = ${JSON.stringify(RESPONSE_LIMIT_ERROR)}
+
+${createTimeoutSignal.toString()}
+
+${composeAbortSignals.toString()}
+
+${readResponseBody.toString()}
+
+${executeFetchRequest.toString()}
+
 export class FetchHttpClient implements HttpClient {
   async execute(
     request: HttpRequest,
     asyncOpts_?: { signal: AbortSignal },
   ): Promise<HttpResponse> {
-    const timeoutSignal = request.timeoutSecs
-      ? AbortSignal.timeout(Number(request.timeoutSecs) * 1_000)
-      : undefined
-    const response = await fetch(request.url, {
-      method: request.method,
-      headers: request.headers.map(({ name, value }) => [name, value] as [string, string]),
-      body: request.body,
-      signal: asyncOpts_?.signal ?? timeoutSignal,
-      redirect: 'manual',
-    })
-    return {
-      status: response.status,
-      headers: [...response.headers].map(([name, value]) => ({ name, value })),
-      body: await response.arrayBuffer(),
-    }
+    return executeFetchRequest(
+      request as HttpRequest & { maxResponseBytes?: bigint },
+      asyncOpts_?.signal,
+    )
   }
 }
 
@@ -127,101 +240,109 @@ function normalizeDeclarationImports(source) {
     });
 }
 
-rmSync(distributionDirectory, { force: true, recursive: true });
-mkdirSync(distributionDirectory, { recursive: true });
+async function main() {
+  const { build } = await import('esbuild');
 
-run('rustup', ['toolchain', 'install', rustToolchain, '--profile', 'minimal']);
-run('rustup', ['target', 'add', 'wasm32-unknown-unknown', '--toolchain', rustToolchain]);
-if (!hasWasmBindgenVersion()) {
-  run('cargo', [
-    `+${rustToolchain}`,
-    'install',
-    'wasm-bindgen-cli',
-    '--version',
-    wasmBindgenVersion,
-    '--locked',
-  ]);
+  rmSync(distributionDirectory, { force: true, recursive: true });
+  mkdirSync(distributionDirectory, { recursive: true });
+
+  run('rustup', ['toolchain', 'install', rustToolchain, '--profile', 'minimal']);
+  run('rustup', ['target', 'add', 'wasm32-unknown-unknown', '--toolchain', rustToolchain]);
+  if (!hasWasmBindgenVersion()) {
+    run('cargo', [
+      `+${rustToolchain}`,
+      'install',
+      'wasm-bindgen-cli',
+      '--version',
+      wasmBindgenVersion,
+      '--locked',
+    ]);
+  }
+
+  run('npm', ['ci'], bindingDirectory);
+  run('npm', ['run', 'build:wasm'], bindingDirectory);
+  writeFileSync(browserEntry, browserSource);
+  writeFileSync(nodeEntry, nodeSource);
+
+  try {
+    await build({
+      entryPoints: { browser: browserEntry },
+      bundle: true,
+      format: 'esm',
+      platform: 'browser',
+      target: ['es2022'],
+      outdir: distributionDirectory,
+      assetNames: 'fleet',
+      loader: {
+        '.wasm': 'file',
+      },
+    });
+
+    await build({
+      entryPoints: { node: nodeEntry },
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      target: ['node20'],
+      outdir: distributionDirectory,
+      assetNames: 'fleet',
+      loader: {
+        '.wasm': 'file',
+      },
+    });
+
+    const typescript = join(packageDirectory, 'node_modules/.bin/tsc');
+    run(typescript, [
+      '--declaration',
+      '--emitDeclarationOnly',
+      '--outDir',
+      declarationsDirectory,
+      '--module',
+      'esnext',
+      '--moduleResolution',
+      'bundler',
+      '--target',
+      'es2022',
+      '--types',
+      'node',
+      '--skipLibCheck',
+      '--allowArbitraryExtensions',
+      'true',
+      browserEntry,
+      nodeEntry,
+    ]);
+
+    const declarationFiles = [
+      'cyclops_sdk_schema-ffi.d.ts',
+      'cyclops_sdk_schema.d.ts',
+      'fleet_sdk-ffi.d.ts',
+      'fleet_sdk.d.ts',
+    ];
+    for (const file of declarationFiles) {
+      cpSync(join(declarationsDirectory, file), join(distributionDirectory, file));
+    }
+    renameSync(
+      join(declarationsDirectory, 'package.browser.d.ts'),
+      join(distributionDirectory, 'browser.d.ts')
+    );
+    renameSync(
+      join(declarationsDirectory, 'package.node.d.ts'),
+      join(distributionDirectory, 'node.d.ts')
+    );
+    for (const file of [...declarationFiles, 'browser.d.ts', 'node.d.ts']) {
+      const declarationPath = join(distributionDirectory, file);
+      writeFileSync(
+        declarationPath,
+        normalizeDeclarationImports(readFileSync(declarationPath, 'utf8'))
+      );
+    }
+  } finally {
+    rmSync(browserEntry, { force: true });
+    rmSync(nodeEntry, { force: true });
+    rmSync(declarationsDirectory, { force: true, recursive: true });
+  }
 }
 
-run('npm', ['ci'], bindingDirectory);
-run('npm', ['run', 'build:wasm'], bindingDirectory);
-writeFileSync(browserEntry, browserSource);
-writeFileSync(nodeEntry, nodeSource);
-
-try {
-  await build({
-    entryPoints: { browser: browserEntry },
-    bundle: true,
-    format: 'esm',
-    platform: 'browser',
-    target: ['es2022'],
-    outdir: distributionDirectory,
-    assetNames: 'fleet',
-    loader: {
-      '.wasm': 'file',
-    },
-  });
-
-  await build({
-    entryPoints: { node: nodeEntry },
-    bundle: true,
-    format: 'esm',
-    platform: 'node',
-    target: ['node20'],
-    outdir: distributionDirectory,
-    assetNames: 'fleet',
-    loader: {
-      '.wasm': 'file',
-    },
-  });
-
-  const typescript = join(packageDirectory, 'node_modules/.bin/tsc');
-  run(typescript, [
-    '--declaration',
-    '--emitDeclarationOnly',
-    '--outDir',
-    declarationsDirectory,
-    '--module',
-    'esnext',
-    '--moduleResolution',
-    'bundler',
-    '--target',
-    'es2022',
-    '--types',
-    'node',
-    '--skipLibCheck',
-    '--allowArbitraryExtensions',
-    'true',
-    browserEntry,
-    nodeEntry,
-  ]);
-
-  const declarationFiles = [
-    'cyclops_sdk_schema-ffi.d.ts',
-    'cyclops_sdk_schema.d.ts',
-    'fleet_sdk-ffi.d.ts',
-    'fleet_sdk.d.ts',
-  ];
-  for (const file of declarationFiles) {
-    cpSync(join(declarationsDirectory, file), join(distributionDirectory, file));
-  }
-  renameSync(
-    join(declarationsDirectory, 'package.browser.d.ts'),
-    join(distributionDirectory, 'browser.d.ts')
-  );
-  renameSync(
-    join(declarationsDirectory, 'package.node.d.ts'),
-    join(distributionDirectory, 'node.d.ts')
-  );
-  for (const file of [...declarationFiles, 'browser.d.ts', 'node.d.ts']) {
-    const declarationPath = join(distributionDirectory, file);
-    writeFileSync(
-      declarationPath,
-      normalizeDeclarationImports(readFileSync(declarationPath, 'utf8'))
-    );
-  }
-} finally {
-  rmSync(browserEntry, { force: true });
-  rmSync(nodeEntry, { force: true });
-  rmSync(declarationsDirectory, { force: true, recursive: true });
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
 }

--- a/libs/typescript/fleet/tests/fetch-http-client.test.mjs
+++ b/libs/typescript/fleet/tests/fetch-http-client.test.mjs
@@ -30,7 +30,7 @@ function chunkedResponse(chunks, headers = {}) {
         controller.close();
       },
     }),
-    { status: 200, headers },
+    { status: 200, headers }
   );
 }
 
@@ -52,7 +52,7 @@ test('accepts an exact-size chunked body without Content-Length', async () => {
   const result = await executeFetchRequest(
     request({ maxResponseBytes: 6n }),
     undefined,
-    fetchReturning(chunkedResponse(['ab', 'cdef'])),
+    fetchReturning(chunkedResponse(['ab', 'cdef']))
   );
 
   assert.equal(decoder.decode(result.body), 'abcdef');
@@ -63,9 +63,9 @@ test('rejects a chunked body as soon as it exceeds the limit', async () => {
     executeFetchRequest(
       request({ maxResponseBytes: 5n }),
       undefined,
-      fetchReturning(chunkedResponse(['abc', 'def'])),
+      fetchReturning(chunkedResponse(['abc', 'def']))
     ),
-    { message: RESPONSE_LIMIT_ERROR },
+    { message: RESPONSE_LIMIT_ERROR }
   );
 });
 
@@ -73,12 +73,8 @@ test('uses streamed bytes rather than a lying Content-Length', async () => {
   const response = chunkedResponse(['ab', 'cd'], { 'content-length': '1' });
 
   await assert.rejects(
-    executeFetchRequest(
-      request({ maxResponseBytes: 3n }),
-      undefined,
-      fetchReturning(response),
-    ),
-    { message: RESPONSE_LIMIT_ERROR },
+    executeFetchRequest(request({ maxResponseBytes: 3n }), undefined, fetchReturning(response)),
+    { message: RESPONSE_LIMIT_ERROR }
   );
 });
 
@@ -86,7 +82,7 @@ test('leaves response size unlimited when maxResponseBytes is omitted', async ()
   const result = await executeFetchRequest(
     request(),
     undefined,
-    fetchReturning(chunkedResponse(['un', 'limited'])),
+    fetchReturning(chunkedResponse(['un', 'limited']))
   );
 
   assert.equal(decoder.decode(result.body), 'unlimited');
@@ -96,7 +92,7 @@ test('treats maxResponseBytes zero as an empty-body-only limit', async () => {
   const empty = await executeFetchRequest(
     request({ maxResponseBytes: 0n }),
     undefined,
-    fetchReturning(chunkedResponse([])),
+    fetchReturning(chunkedResponse([]))
   );
   assert.equal(empty.body.byteLength, 0);
 
@@ -104,9 +100,9 @@ test('treats maxResponseBytes zero as an empty-body-only limit', async () => {
     executeFetchRequest(
       request({ maxResponseBytes: 0n }),
       undefined,
-      fetchReturning(chunkedResponse(['x'])),
+      fetchReturning(chunkedResponse(['x']))
     ),
-    { message: RESPONSE_LIMIT_ERROR },
+    { message: RESPONSE_LIMIT_ERROR }
   );
 });
 
@@ -122,7 +118,7 @@ test('cancels the reader and does not leak response details on overflow', async 
         cancelled = true;
         throw new Error(`cancel failed: ${secret}`);
       },
-    }),
+    })
   );
 
   const error = await executeFetchRequest(
@@ -131,10 +127,10 @@ test('cancels the reader and does not leak response details on overflow', async 
       maxResponseBytes: 1n,
     }),
     undefined,
-    fetchReturning(response),
+    fetchReturning(response)
   ).then(
     () => assert.fail('expected the response limit to reject'),
-    (caught) => caught,
+    (caught) => caught
   );
 
   assert.equal(cancelled, true);
@@ -147,7 +143,7 @@ test('caller cancellation remains effective when a timeout is configured', async
   const pending = executeFetchRequest(
     request({ timeoutSecs: 10n }),
     controller.signal,
-    fetchUntilAborted,
+    fetchUntilAborted
   );
   controller.abort(new DOMException('caller cancelled', 'AbortError'));
 
@@ -161,18 +157,16 @@ test('caller cancellation remains effective while the response body is streaming
       new ReadableStream({
         start(bodyController) {
           bodyController.enqueue(encoder.encode('partial'));
-          signal.addEventListener(
-            'abort',
-            () => bodyController.error(signal.reason),
-            { once: true },
-          );
+          signal.addEventListener('abort', () => bodyController.error(signal.reason), {
+            once: true,
+          });
         },
-      }),
+      })
     );
   const pending = executeFetchRequest(
     request({ timeoutSecs: 10n }),
     controller.signal,
-    streamingFetch,
+    streamingFetch
   );
   controller.abort(new DOMException('caller cancelled', 'AbortError'));
 
@@ -182,14 +176,14 @@ test('caller cancellation remains effective while the response body is streaming
 test('configured timeout aborts a pending request', async () => {
   await assert.rejects(
     executeFetchRequest(request({ timeoutSecs: 1n }), undefined, fetchUntilAborted),
-    { name: 'TimeoutError' },
+    { name: 'TimeoutError' }
   );
 });
 
 test('timeoutSecs zero is an explicit immediate timeout', async () => {
   await assert.rejects(
     executeFetchRequest(request({ timeoutSecs: 0n }), undefined, fetchUntilAborted),
-    { name: 'TimeoutError' },
+    { name: 'TimeoutError' }
   );
 });
 

--- a/libs/typescript/fleet/tests/fetch-http-client.test.mjs
+++ b/libs/typescript/fleet/tests/fetch-http-client.test.mjs
@@ -1,0 +1,213 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  RESPONSE_LIMIT_ERROR,
+  composeAbortSignals,
+  createTimeoutSignal,
+  executeFetchRequest,
+} from '../scripts/build.mjs';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function request(overrides = {}) {
+  return {
+    method: 'GET',
+    url: 'https://example.invalid/resource',
+    headers: [],
+    ...overrides,
+  };
+}
+
+function chunkedResponse(chunks, headers = {}) {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    }),
+    { status: 200, headers },
+  );
+}
+
+function fetchReturning(response) {
+  return async () => response;
+}
+
+function fetchUntilAborted(_url, { signal }) {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+  });
+}
+
+test('accepts an exact-size chunked body without Content-Length', async () => {
+  const result = await executeFetchRequest(
+    request({ maxResponseBytes: 6n }),
+    undefined,
+    fetchReturning(chunkedResponse(['ab', 'cdef'])),
+  );
+
+  assert.equal(decoder.decode(result.body), 'abcdef');
+});
+
+test('rejects a chunked body as soon as it exceeds the limit', async () => {
+  await assert.rejects(
+    executeFetchRequest(
+      request({ maxResponseBytes: 5n }),
+      undefined,
+      fetchReturning(chunkedResponse(['abc', 'def'])),
+    ),
+    { message: RESPONSE_LIMIT_ERROR },
+  );
+});
+
+test('uses streamed bytes rather than a lying Content-Length', async () => {
+  const response = chunkedResponse(['ab', 'cd'], { 'content-length': '1' });
+
+  await assert.rejects(
+    executeFetchRequest(
+      request({ maxResponseBytes: 3n }),
+      undefined,
+      fetchReturning(response),
+    ),
+    { message: RESPONSE_LIMIT_ERROR },
+  );
+});
+
+test('leaves response size unlimited when maxResponseBytes is omitted', async () => {
+  const result = await executeFetchRequest(
+    request(),
+    undefined,
+    fetchReturning(chunkedResponse(['un', 'limited'])),
+  );
+
+  assert.equal(decoder.decode(result.body), 'unlimited');
+});
+
+test('treats maxResponseBytes zero as an empty-body-only limit', async () => {
+  const empty = await executeFetchRequest(
+    request({ maxResponseBytes: 0n }),
+    undefined,
+    fetchReturning(chunkedResponse([])),
+  );
+  assert.equal(empty.body.byteLength, 0);
+
+  await assert.rejects(
+    executeFetchRequest(
+      request({ maxResponseBytes: 0n }),
+      undefined,
+      fetchReturning(chunkedResponse(['x'])),
+    ),
+    { message: RESPONSE_LIMIT_ERROR },
+  );
+});
+
+test('cancels the reader and does not leak response details on overflow', async () => {
+  const secret = 'customer-token-and-body';
+  let cancelled = false;
+  const response = new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(secret));
+      },
+      cancel() {
+        cancelled = true;
+        throw new Error(`cancel failed: ${secret}`);
+      },
+    }),
+  );
+
+  const error = await executeFetchRequest(
+    request({
+      url: `https://example.invalid/resource?token=${secret}`,
+      maxResponseBytes: 1n,
+    }),
+    undefined,
+    fetchReturning(response),
+  ).then(
+    () => assert.fail('expected the response limit to reject'),
+    (caught) => caught,
+  );
+
+  assert.equal(cancelled, true);
+  assert.equal(error.message, RESPONSE_LIMIT_ERROR);
+  assert.equal(error.message.includes(secret), false);
+});
+
+test('caller cancellation remains effective when a timeout is configured', async () => {
+  const controller = new AbortController();
+  const pending = executeFetchRequest(
+    request({ timeoutSecs: 10n }),
+    controller.signal,
+    fetchUntilAborted,
+  );
+  controller.abort(new DOMException('caller cancelled', 'AbortError'));
+
+  await assert.rejects(pending, { name: 'AbortError' });
+});
+
+test('caller cancellation remains effective while the response body is streaming', async () => {
+  const controller = new AbortController();
+  const streamingFetch = async (_url, { signal }) =>
+    new Response(
+      new ReadableStream({
+        start(bodyController) {
+          bodyController.enqueue(encoder.encode('partial'));
+          signal.addEventListener(
+            'abort',
+            () => bodyController.error(signal.reason),
+            { once: true },
+          );
+        },
+      }),
+    );
+  const pending = executeFetchRequest(
+    request({ timeoutSecs: 10n }),
+    controller.signal,
+    streamingFetch,
+  );
+  controller.abort(new DOMException('caller cancelled', 'AbortError'));
+
+  await assert.rejects(pending, { name: 'AbortError' });
+});
+
+test('configured timeout aborts a pending request', async () => {
+  await assert.rejects(
+    executeFetchRequest(request({ timeoutSecs: 1n }), undefined, fetchUntilAborted),
+    { name: 'TimeoutError' },
+  );
+});
+
+test('timeoutSecs zero is an explicit immediate timeout', async () => {
+  await assert.rejects(
+    executeFetchRequest(request({ timeoutSecs: 0n }), undefined, fetchUntilAborted),
+    { name: 'TimeoutError' },
+  );
+});
+
+test('signal composition fallback preserves either abort source', () => {
+  const caller = new AbortController();
+  const timeout = new AbortController();
+  const combined = composeAbortSignals([caller.signal, timeout.signal], null);
+
+  timeout.abort(new DOMException('timed out', 'TimeoutError'));
+  assert.equal(combined.signal.aborted, true);
+  assert.equal(combined.signal.reason.name, 'TimeoutError');
+  combined.dispose();
+});
+
+test('timeout fallback aborts without AbortSignal.timeout', async () => {
+  const timeout = createTimeoutSignal(1, null);
+  await new Promise((resolve) => timeout.signal.addEventListener('abort', resolve, { once: true }));
+
+  assert.equal(timeout.signal.reason.name, 'TimeoutError');
+  timeout.dispose();
+});


### PR DESCRIPTION
## Scope

Release @trycua/fleet 0.1.2 with incremental response-body limits for the mirrored Fleet HttpRequest.maxResponseBytes contract. Preserve omitted-limit behavior, treat zero as empty-body-only, keep manual redirects, and compose caller cancellation with request timeouts.

## Changes

- Stream Fetch response bodies instead of calling arrayBuffer before enforcing the limit.
- Cancel oversized readers and return the stable sanitized limit error.
- Add fallback-safe timeout and AbortSignal composition.
- Add 12 adversarial Node transport tests and align package/bumpversion metadata at 0.1.2.

## Validation

- 12/12 focused Node tests pass.
- Full browser/Node Fleet package build passes against the mirrored canonical Fleet commit c918c7e5d.
- Built Node bundle import smoke passes.
- npm pack --dry-run reports @trycua/fleet@0.1.2 with the expected 12 files.
- pnpm audit --prod reports no known vulnerabilities.
- package.json and .bumpversion.cfg version consistency passes.
- git diff --check passes.

## Release and risk

The limit is additive and omitted by default. Generated bindings/native libraries still need matched versions. This PR only changes the public TypeScript Fleet transport; Python wheels are released separately from trycua/cloud. Rollback is to keep npm-fleet-v0.1.1 and revert these commits. No production service, image, credential, or infrastructure change is included.