### PR TITLE
test(cua-driver): isolate intermittent recorder shutdown

### DIFF
--- a/.github/workflows/e2e-rust-windows.yml
+++ b/.github/workflows/e2e-rust-windows.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        instance: [1, 2, 3]
+        instance: [1]
     if: inputs.lane == 'all' || inputs.lane == 'native'
     name: "Windows / native WPF + WinUI3 + WebView2"
     needs: source
@@ -101,42 +101,11 @@ jobs:
       - name: Ensure FFmpeg for trajectory video
         shell: pwsh
         run: .\scripts\ci\windows\setup-ffmpeg.ps1
-      - name: Observe bounded canonical recording preflights
+      - name: Contrast queued shutdown with closed and held stdin
         shell: pwsh
-        env:
-          CUA_E2E_INTERNAL_LANE: native
         run: |
-          $source = Get-Content -Raw scripts/ci/windows/run-rust-e2e.ps1
-          $boundary = 'function Invoke-CargoTest {'
-          $index = $source.IndexOf($boundary)
-          if ($index -lt 0 -or $source.LastIndexOf($boundary) -ne $index) { throw 'Canonical preflight boundary changed' }
-          $probe = Join-Path $PWD 'scripts/ci/windows/recorder-preflight-diagnostic.ps1'
-          Set-Content $probe $source.Substring(0, $index)
-          $observations = Join-Path $PWD 'artifacts/recorder-observations'
-          New-Item -ItemType Directory -Force $observations | Out-Null
-          try {
-            foreach ($attempt in 1..20) {
-              $destination = Join-Path $observations ('observation-{0:d2}' -f $attempt)
-              $watch = [Diagnostics.Stopwatch]::StartNew()
-              $failure = $null
-              try {
-                if ($attempt -eq 1) { & $probe -RequireGui } else { & $probe -RequireGui -NoBuild }
-              } catch {
-                $failure = $_.ToString()
-              } finally {
-                if (Test-Path artifacts/cua-driver/windows) {
-                  Move-Item artifacts/cua-driver/windows $destination
-                } else {
-                  New-Item -ItemType Directory -Force $destination | Out-Null
-                }
-                @{ observation = $attempt; elapsed_ms = $watch.ElapsedMilliseconds; failure = $failure; source_sha = $env:CUA_E2E_SOURCE_SHA } |
-                  ConvertTo-Json | Set-Content (Join-Path $destination 'observation.json')
-              }
-              if ($null -ne $failure) { throw $failure }
-            }
-          } finally {
-            Remove-Item $probe -ErrorAction SilentlyContinue
-          }
+          .\scripts\ci\windows\verify-user-session.ps1
+          .\scripts\ci\windows\diagnose-recorder-pipe.ps1
       - name: Preserve every diagnostic observation
         if: always()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08

--- a/.github/workflows/e2e-rust-windows.yml
+++ b/.github/workflows/e2e-rust-windows.yml
@@ -83,6 +83,10 @@ jobs:
           retention-days: 14
 
   native:
+    strategy:
+      fail-fast: false
+      matrix:
+        instance: [1, 2, 3]
     if: inputs.lane == 'all' || inputs.lane == 'native'
     name: "Windows / native WPF + WinUI3 + WebView2"
     needs: source
@@ -111,12 +115,12 @@ jobs:
           $observations = Join-Path $PWD 'artifacts/recorder-observations'
           New-Item -ItemType Directory -Force $observations | Out-Null
           try {
-            foreach ($attempt in 1..12) {
+            foreach ($attempt in 1..20) {
               $destination = Join-Path $observations ('observation-{0:d2}' -f $attempt)
               $watch = [Diagnostics.Stopwatch]::StartNew()
               $failure = $null
               $load = @()
-              $underLoad = $attempt -ge 2 -and $attempt -le 11
+              $underLoad = $false
               if ($underLoad) {
                 $program = '$watch = [Diagnostics.Stopwatch]::StartNew(); while ($watch.Elapsed.TotalSeconds -lt 120) { for ($i = 0; $i -lt 100000; $i++) { $null = [Math]::Sqrt($i) } }'
                 $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($program))
@@ -150,7 +154,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
-          name: recorder-observations
+          name: recorder-observations-${{ matrix.instance }}
           path: artifacts/recorder-observations
           if-no-files-found: error
           retention-days: 14
@@ -162,7 +166,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
-          name: rust-windows-native
+          name: rust-windows-native-${{ matrix.instance }}
           path: artifacts/cua-driver/windows
           if-no-files-found: ignore
           compression-level: 0

--- a/.github/workflows/e2e-rust-windows.yml
+++ b/.github/workflows/e2e-rust-windows.yml
@@ -97,11 +97,50 @@ jobs:
       - name: Ensure FFmpeg for trajectory video
         shell: pwsh
         run: .\scripts\ci\windows\setup-ffmpeg.ps1
-      - name: Run native Rust harnesses
+      - name: Observe bounded canonical recording preflights
         shell: pwsh
         env:
           CUA_E2E_INTERNAL_LANE: native
-        run: .\scripts\ci\windows\run-rust-e2e.ps1 -RequireGui
+        run: |
+          $source = Get-Content -Raw scripts/ci/windows/run-rust-e2e.ps1
+          $boundary = 'function Invoke-CargoTest {'
+          $index = $source.IndexOf($boundary)
+          if ($index -lt 0 -or $source.LastIndexOf($boundary) -ne $index) { throw 'Canonical preflight boundary changed' }
+          $probe = Join-Path $PWD 'scripts/ci/windows/recorder-preflight-diagnostic.ps1'
+          Set-Content $probe $source.Substring(0, $index)
+          $observations = Join-Path $PWD 'artifacts/recorder-observations'
+          New-Item -ItemType Directory -Force $observations | Out-Null
+          try {
+            foreach ($attempt in 1..20) {
+              $destination = Join-Path $observations ('observation-{0:d2}' -f $attempt)
+              $watch = [Diagnostics.Stopwatch]::StartNew()
+              $failure = $null
+              try {
+                if ($attempt -eq 1) { & $probe -RequireGui } else { & $probe -RequireGui -NoBuild }
+              } catch {
+                $failure = $_.ToString()
+              } finally {
+                if (Test-Path artifacts/cua-driver/windows) {
+                  Move-Item artifacts/cua-driver/windows $destination
+                } else {
+                  New-Item -ItemType Directory -Force $destination | Out-Null
+                }
+                @{ observation = $attempt; elapsed_ms = $watch.ElapsedMilliseconds; failure = $failure; source_sha = $env:CUA_E2E_SOURCE_SHA } |
+                  ConvertTo-Json | Set-Content (Join-Path $destination 'observation.json')
+              }
+              if ($null -ne $failure) { throw $failure }
+            }
+          } finally {
+            Remove-Item $probe -ErrorAction SilentlyContinue
+          }
+      - name: Preserve every diagnostic observation
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        with:
+          name: recorder-observations
+          path: artifacts/recorder-observations
+          if-no-files-found: error
+          retention-days: 14
       - name: Collect logs
         if: always()
         shell: pwsh

--- a/.github/workflows/e2e-rust-windows.yml
+++ b/.github/workflows/e2e-rust-windows.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        instance: [1]
+        instance: [shim, direct]
     if: inputs.lane == 'all' || inputs.lane == 'native'
     name: "Windows / native WPF + WinUI3 + WebView2"
     needs: source
@@ -101,11 +101,29 @@ jobs:
       - name: Ensure FFmpeg for trajectory video
         shell: pwsh
         run: .\scripts\ci\windows\setup-ffmpeg.ps1
-      - name: Contrast queued shutdown with closed and held stdin
+      - name: Observe public recording tools across short lifetimes
         shell: pwsh
+        env:
+          ENCODER_ROUTE: ${{ matrix.instance }}
         run: |
           .\scripts\ci\windows\verify-user-session.ps1
-          .\scripts\ci\windows\diagnose-recorder-pipe.ps1
+          $root = Join-Path $PWD 'artifacts/recorder-observations'
+          New-Item -ItemType Directory -Force $root | Out-Null
+          if ($env:ENCODER_ROUTE -eq 'direct') {
+            $encoder = @(Get-ChildItem C:/ProgramData/chocolatey/lib/ffmpeg -Filter ffmpeg.exe -Recurse)
+            if ($encoder.Count -ne 1) { throw 'Expected one package-owned FFmpeg executable' }
+            $env:PATH = "$($encoder[0].DirectoryName);$env:PATH"
+          }
+          Get-FileHash (Get-Command ffmpeg.exe).Source | ConvertTo-Json | Set-Content (Join-Path $root 'encoder.json')
+          $env:CUA_RECORDING_DIAGNOSTIC_ROOT = $root
+          Push-Location libs/cua-driver/rust
+          try {
+            & cargo test --locked -p cua-driver-core --test recording_lifetime_diagnostic -- --ignored --exact real_encoder_short_lifetime_observations --nocapture --test-threads=1 2>&1 |
+              Tee-Object (Join-Path $root 'observations.log')
+            if ($LASTEXITCODE -ne 0) { throw 'Public recording lifecycle failure captured' }
+          } finally {
+            Pop-Location
+          }
       - name: Preserve every diagnostic observation
         if: always()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08

--- a/.github/workflows/e2e-rust-windows.yml
+++ b/.github/workflows/e2e-rust-windows.yml
@@ -119,30 +119,17 @@ jobs:
               $destination = Join-Path $observations ('observation-{0:d2}' -f $attempt)
               $watch = [Diagnostics.Stopwatch]::StartNew()
               $failure = $null
-              $load = @()
-              $underLoad = $false
-              if ($underLoad) {
-                $program = '$watch = [Diagnostics.Stopwatch]::StartNew(); while ($watch.Elapsed.TotalSeconds -lt 120) { for ($i = 0; $i -lt 100000; $i++) { $null = [Math]::Sqrt($i) } }'
-                $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($program))
-                foreach ($cpu in 1..([Environment]::ProcessorCount)) {
-                  $load += Start-Process pwsh -ArgumentList @('-NoProfile', '-NonInteractive', '-EncodedCommand', $encoded) -PassThru -WindowStyle Hidden
-                }
-                Start-Sleep -Seconds 2
-              }
               try {
                 if ($attempt -eq 1) { & $probe -RequireGui } else { & $probe -RequireGui -NoBuild }
               } catch {
                 $failure = $_.ToString()
               } finally {
-                foreach ($process in $load) {
-                  if (-not $process.HasExited) { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue }
-                }
                 if (Test-Path artifacts/cua-driver/windows) {
                   Move-Item artifacts/cua-driver/windows $destination
                 } else {
                   New-Item -ItemType Directory -Force $destination | Out-Null
                 }
-                @{ observation = $attempt; cpu_pressure = $underLoad; load_processes = $load.Count; elapsed_ms = $watch.ElapsedMilliseconds; failure = $failure; source_sha = $env:CUA_E2E_SOURCE_SHA } |
+                @{ observation = $attempt; elapsed_ms = $watch.ElapsedMilliseconds; failure = $failure; source_sha = $env:CUA_E2E_SOURCE_SHA } |
                   ConvertTo-Json | Set-Content (Join-Path $destination 'observation.json')
               }
               if ($null -ne $failure) { throw $failure }

--- a/.github/workflows/e2e-rust-windows.yml
+++ b/.github/workflows/e2e-rust-windows.yml
@@ -111,21 +111,34 @@ jobs:
           $observations = Join-Path $PWD 'artifacts/recorder-observations'
           New-Item -ItemType Directory -Force $observations | Out-Null
           try {
-            foreach ($attempt in 1..20) {
+            foreach ($attempt in 1..12) {
               $destination = Join-Path $observations ('observation-{0:d2}' -f $attempt)
               $watch = [Diagnostics.Stopwatch]::StartNew()
               $failure = $null
+              $load = @()
+              $underLoad = $attempt -ge 2 -and $attempt -le 11
+              if ($underLoad) {
+                $program = '$watch = [Diagnostics.Stopwatch]::StartNew(); while ($watch.Elapsed.TotalSeconds -lt 120) { for ($i = 0; $i -lt 100000; $i++) { $null = [Math]::Sqrt($i) } }'
+                $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($program))
+                foreach ($cpu in 1..([Environment]::ProcessorCount)) {
+                  $load += Start-Process pwsh -ArgumentList @('-NoProfile', '-NonInteractive', '-EncodedCommand', $encoded) -PassThru -WindowStyle Hidden
+                }
+                Start-Sleep -Seconds 2
+              }
               try {
                 if ($attempt -eq 1) { & $probe -RequireGui } else { & $probe -RequireGui -NoBuild }
               } catch {
                 $failure = $_.ToString()
               } finally {
+                foreach ($process in $load) {
+                  if (-not $process.HasExited) { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue }
+                }
                 if (Test-Path artifacts/cua-driver/windows) {
                   Move-Item artifacts/cua-driver/windows $destination
                 } else {
                   New-Item -ItemType Directory -Force $destination | Out-Null
                 }
-                @{ observation = $attempt; elapsed_ms = $watch.ElapsedMilliseconds; failure = $failure; source_sha = $env:CUA_E2E_SOURCE_SHA } |
+                @{ observation = $attempt; cpu_pressure = $underLoad; load_processes = $load.Count; elapsed_ms = $watch.ElapsedMilliseconds; failure = $failure; source_sha = $env:CUA_E2E_SOURCE_SHA } |
                   ConvertTo-Json | Set-Content (Join-Path $destination 'observation.json')
               }
               if ($null -ne $failure) { throw $failure }

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/video_ffmpeg.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/video_ffmpeg.rs
@@ -139,13 +139,11 @@ impl VideoBackend for FfmpegVideoBackend {
     fn stop(mut self: Box<Self>) -> anyhow::Result<VideoMetadata> {
         let elapsed = self.started_at.elapsed();
         let shutdown_started = Instant::now();
-        let before_stop = self.child.try_wait();
-        tracing::warn!(target: "recording", pid = self.child.id(), ?before_stop, "shutdown diagnostic before stdin");
-        if let Some(mut stdin) = self.child.stdin.take() {
+        let stdin_results = self.child.stdin.take().map(|mut stdin| {
             let write_result = stdin.write_all(b"q\n");
             let flush_result = stdin.flush();
-            tracing::warn!(target: "recording", ?write_result, ?flush_result, "shutdown diagnostic stdin");
-        }
+            (write_result, flush_result)
+        });
 
         let shutdown_timeout = Duration::from_millis(3000);
         let deadline = Instant::now() + shutdown_timeout;
@@ -170,7 +168,7 @@ impl VideoBackend for FfmpegVideoBackend {
                 None => std::thread::sleep(Duration::from_millis(80)),
             }
         };
-        tracing::warn!(target: "recording", elapsed_ms = shutdown_started.elapsed().as_millis() as u64, ?result, "shutdown diagnostic result");
+        tracing::warn!(target: "recording", elapsed_ms = shutdown_started.elapsed().as_millis() as u64, ?stdin_results, ?result, "shutdown diagnostic result");
         if let Some(handle) = self.stderr_thread.take() {
             let stderr = handle.join().unwrap_or_default();
             if let Err(error) = &result {

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/video_ffmpeg.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/video_ffmpeg.rs
@@ -138,9 +138,13 @@ impl FfmpegVideoBackend {
 impl VideoBackend for FfmpegVideoBackend {
     fn stop(mut self: Box<Self>) -> anyhow::Result<VideoMetadata> {
         let elapsed = self.started_at.elapsed();
+        let shutdown_started = Instant::now();
+        let before_stop = self.child.try_wait();
+        tracing::warn!(target: "recording", pid = self.child.id(), ?before_stop, "shutdown diagnostic before stdin");
         if let Some(mut stdin) = self.child.stdin.take() {
-            let _ = stdin.write_all(b"q\n");
-            let _ = stdin.flush();
+            let write_result = stdin.write_all(b"q\n");
+            let flush_result = stdin.flush();
+            tracing::warn!(target: "recording", ?write_result, ?flush_result, "shutdown diagnostic stdin");
         }
 
         let shutdown_timeout = Duration::from_millis(3000);
@@ -155,8 +159,9 @@ impl VideoBackend for FfmpegVideoBackend {
                     break Err(anyhow::anyhow!("ffmpeg exited with {cause}"));
                 }
                 None if Instant::now() > deadline => {
-                    let _ = self.child.kill();
-                    let _ = self.child.wait();
+                    let kill_result = self.child.kill();
+                    let wait_result = self.child.wait();
+                    tracing::warn!(target: "recording", ?kill_result, ?wait_result, "shutdown diagnostic forced termination");
                     break Err(anyhow::anyhow!(
                         "ffmpeg shutdown timed out after {} ms",
                         shutdown_timeout.as_millis()
@@ -165,6 +170,7 @@ impl VideoBackend for FfmpegVideoBackend {
                 None => std::thread::sleep(Duration::from_millis(80)),
             }
         };
+        tracing::warn!(target: "recording", elapsed_ms = shutdown_started.elapsed().as_millis() as u64, ?result, "shutdown diagnostic result");
         if let Some(handle) = self.stderr_thread.take() {
             let stderr = handle.join().unwrap_or_default();
             if let Err(error) = &result {

--- a/libs/cua-driver/rust/crates/cua-driver-core/tests/recording_lifetime_diagnostic.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/tests/recording_lifetime_diagnostic.rs
@@ -1,0 +1,62 @@
+use std::{
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use cua_driver_core::{
+    recording::RecordingSession,
+    recording_tools::{GetRecordingStateTool, StartRecordingTool, StopRecordingTool},
+    tool::Tool,
+    video::set_video_backend_factory,
+    video_ffmpeg::FfmpegVideoBackendFactory,
+};
+use serde_json::json;
+
+#[tokio::test]
+#[ignore]
+async fn real_encoder_short_lifetime_observations() {
+    assert!(cfg!(target_os = "windows"));
+    let root = PathBuf::from(std::env::var_os("CUA_RECORDING_DIAGNOSTIC_ROOT").unwrap());
+    std::fs::create_dir_all(&root).unwrap();
+    set_video_backend_factory(Box::new(FfmpegVideoBackendFactory));
+    for sequence in 0..500_u64 {
+        let output = root.join(format!("observation-{sequence:04}"));
+        std::fs::create_dir_all(&output).unwrap();
+        let session = Arc::new(RecordingSession::new());
+        let hold_ms = (sequence * 37) % 201;
+        let started = StartRecordingTool::new(session.clone())
+            .invoke(json!({"output_dir": output, "record_video": true}))
+            .await;
+        std::fs::write(
+            output.join("start.json"),
+            serde_json::to_vec_pretty(&started).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            started.structured_content.as_ref().unwrap()["video_active"],
+            true,
+            "{started:?}"
+        );
+        std::thread::sleep(Duration::from_millis(hold_ms));
+        let clock = Instant::now();
+        let stopped = StopRecordingTool::new(session.clone())
+            .invoke(json!({}))
+            .await;
+        let elapsed_ms = clock.elapsed().as_millis();
+        let state = GetRecordingStateTool::new(session).invoke(json!({})).await;
+        let stopped = serde_json::to_value(stopped).unwrap();
+        let state = state.structured_content.unwrap();
+        let row = json!({"sequence": sequence, "hold_ms": hold_ms, "stop_elapsed_ms": elapsed_ms, "stop": stopped, "state": state});
+        std::fs::write(
+            output.join("observation.json"),
+            serde_json::to_vec_pretty(&row).unwrap(),
+        )
+        .unwrap();
+        eprintln!(
+            "recording observation {sequence} hold_ms={hold_ms} stop_elapsed_ms={elapsed_ms}"
+        );
+        assert_ne!(stopped["isError"], true, "{row}");
+        assert!(state["last_video_path"].is_string(), "{row}");
+    }
+}

--- a/scripts/ci/windows/diagnose-recorder-pipe.ps1
+++ b/scripts/ci/windows/diagnose-recorder-pipe.ps1
@@ -1,0 +1,73 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+Add-Type @'
+using System;
+using System.Runtime.InteropServices;
+public static class EncoderPause {
+    [DllImport("ntdll.dll")] public static extern int NtSuspendProcess(IntPtr handle);
+    [DllImport("ntdll.dll")] public static extern int NtResumeProcess(IntPtr handle);
+}
+'@
+$root = Join-Path $PWD 'artifacts/recorder-observations'
+New-Item -ItemType Directory -Force $root | Out-Null
+$shim = (Get-Command ffmpeg.exe).Source
+$direct = @(Get-ChildItem C:/ProgramData/chocolatey/lib/ffmpeg -Filter ffmpeg.exe -Recurse)
+if ($direct.Count -ne 1) { throw 'Expected one package-owned FFmpeg executable' }
+$results = @()
+foreach ($route in @('shim', 'direct')) {
+    foreach ($close in @($false, $true)) {
+        foreach ($iteration in 1..5) {
+            $label = "$route-close-$close-$iteration"
+            $destination = Join-Path $root $label
+            New-Item -ItemType Directory -Force $destination | Out-Null
+            $info = [Diagnostics.ProcessStartInfo]::new()
+            $info.FileName = if ($route -eq 'shim') { $shim } else { $direct[0].FullName }
+            $info.UseShellExecute = $false
+            $info.RedirectStandardInput = $true
+            $info.RedirectStandardError = $true
+            $info.RedirectStandardOutput = $true
+            foreach ($argument in @('-y','-loglevel','error','-f','gdigrab','-framerate','30','-draw_mouse','1','-i','desktop','-vf','pad=ceil(iw/2)*2:ceil(ih/2)*2','-c:v','libx264','-preset','ultrafast','-pix_fmt','yuv420p','-movflags','+faststart','-g','30',(Join-Path $destination 'recording.mp4'))) {
+                $info.ArgumentList.Add($argument)
+            }
+            $process = [Diagnostics.Process]::Start($info)
+            $stderr = $process.StandardError.ReadToEndAsync()
+            $stdout = $process.StandardOutput.ReadToEndAsync()
+            $encoder = $null
+            $suspended = $false
+            try {
+                Start-Sleep -Milliseconds 1800
+                if ($process.HasExited) { throw "Encoder exited before observation: $($process.ExitCode)" }
+                if ($route -eq 'shim') {
+                    $children = @(Get-CimInstance Win32_Process -Filter "ParentProcessId = $($process.Id)" | Where-Object Name -eq 'ffmpeg.exe')
+                    if ($children.Count -ne 1) { throw 'Expected one FFmpeg child of shim' }
+                    $encoder = [Diagnostics.Process]::GetProcessById($children[0].ProcessId)
+                } else { $encoder = $process }
+                $suspendStatus = [EncoderPause]::NtSuspendProcess($encoder.Handle)
+                if ($suspendStatus -ne 0) { throw "NtSuspendProcess failed: $suspendStatus" }
+                $suspended = $true
+                $process.StandardInput.Write("q`n")
+                $process.StandardInput.Flush()
+                if ($close) { $process.StandardInput.Close() }
+                Start-Sleep -Milliseconds 100
+                $resumeStatus = [EncoderPause]::NtResumeProcess($encoder.Handle)
+                if ($resumeStatus -ne 0) { throw "NtResumeProcess failed: $resumeStatus" }
+                $suspended = $false
+                $watch = [Diagnostics.Stopwatch]::StartNew()
+                $exited = $process.WaitForExit(3000)
+                $row = @{ route = $route; close_stdin = $close; iteration = $iteration; exited = $exited; elapsed_ms = $watch.ElapsedMilliseconds; exit_code = $(if ($exited) { $process.ExitCode } else { $null }); encoder_pid = $encoder.Id; wrapper_pid = $process.Id }
+                if (-not $exited) { $process.Kill($true); $process.WaitForExit() }
+                $stderr.GetAwaiter().GetResult() | Set-Content (Join-Path $destination 'stderr.txt')
+                $stdout.GetAwaiter().GetResult() | Set-Content (Join-Path $destination 'stdout.txt')
+                $row | ConvertTo-Json | Tee-Object -FilePath (Join-Path $destination 'observation.json')
+                $results += $row
+            } finally {
+                if ($suspended) { $null = [EncoderPause]::NtResumeProcess($encoder.Handle) }
+                if (-not $process.HasExited) { $process.Kill($true); $process.WaitForExit() }
+                $process.Dispose()
+            }
+        }
+    }
+}
+$results | ConvertTo-Json | Set-Content (Join-Path $root 'results.json')
+Get-FileHash $shim, $direct[0].FullName | ConvertTo-Json | Set-Content (Join-Path $root 'executable-hashes.json')
+if (@($results | Where-Object { -not $_.exited -or $_.exit_code -ne 0 }).Count -gt 0) { throw 'Encoder shutdown failure captured; see retained observations' }


### PR DESCRIPTION
Refs #3713

## Scope
Maintainer-selected diagnostic/TDD workstream, not a product fix or release candidate. Agreed seams: public recording tools, real external encoder process, canonical Windows recording preflight. The three-second shutdown deadline, encoder arguments, and strict video acceptance remain unchanged. Temporary workflow extracts only the canonical preflight prefix, builds fixtures once per runner, preserves every observation separately, and stops that runner on its first failure. Hosted runs only; no privileged self-hosted dispatch.

## Evidence
| Exact diagnostic SHA | Experiment | Outcome | Run |
| --- | --- | --- | --- |
| 63179b5e7 | 20 idle canonical preflights, one host | 20 passed; shutdown 80–563 ms | [34596514676](https://github.com/trycua/cua/actions/runs/34596514676) |
| 3ce4392c9 | idle control, ten CPU-loaded preflights, idle control | 12 passed; loaded shutdown 160–788 ms | [34598157982](https://github.com/trycua/cua/actions/runs/34598157982) |
| 12dfc364f | three independent fresh runners, 20 preflights each | 60 passed; shutdown 80–1686 ms | [34609640671](https://github.com/trycua/cua/actions/runs/34609640671) |
| e871f7bd1 | remove pre-stop probe/logging; three fresh runners, 20 each | 60 passed; shutdown 80–563 ms | [34611769652](https://github.com/trycua/cua/actions/runs/34611769652) |

152 total diagnostic observations, none reproduced the failure. These are clustered observations, not 152 independent-machine trials or a reliability guarantee. Recorded stdin operations succeeded; no forced kills. Each completed canonical preflight independently validates recording/media evidence. All recordings, traces, source SHAs, and per-observation receipts are in recorder-observations artifacts (instance suffixes for matrix runs), also retained locally at /Users/administrator/3713-evidence/. No full native behavior matrix was run by these diagnostic workflows; the green summary job is not desktop certification.

Separate prior baseline: main eca08d3144c663edba6cdd395bf9957b2b5a5209 passed native preflight and 43 native cases in 34579403297.

## Current implementation and limits
Current head defers shutdown logging until after the wait result; the earlier extra pre-stop try_wait and logging were removed to test instrumentation perturbation. The CPU-pressure code is removed from current head; its tested commit and artifacts remain. Observations still cannot establish the old failure cause: historical logs collapsed nonzero exit and timeout, and no historical child exit trace exists. No evidence supports extending the deadline, bypassing the Chocolatey shim, or weakening video acceptance.

## Status / next step
Draft, root cause unresolved, no evidence-backed red regression or product fix. Diagnostic changes must not ship as-is. Another identical warm-loop run is unlikely to be useful: next investigation should recover a failing historical-equivalent environment/executable provenance or capture the next naturally failing native preflight with the shipped #3714 error distinction, then build the smallest deterministic public-tool regression. No retries to relabel a failed gate green. Accidental initial empty-marker dispatch 34596492814 was cancelled and is not evidence. No release claim; no-release label applies only to this diagnostic draft.


## Historical-source replay and environment mismatch

A further controlled replay ran the exact original failing main product SHA `bd4c10020cd7cac07c0d19b0f53ba4b007fbcb15`, without diagnostic product instrumentation, using the draft workflow only as an external preflight runner. [Run 34633677564](https://github.com/trycua/cua/actions/runs/34633677564): 60/60 preflights passed across three hosted machines; every log reports one test passed and the recording finalized. Product SHA is retained in every observation receipt. This brings the follow-up to 212 passing diagnostic preflight observations, not a demonstrated repair or a reproducibility rate for independent machines.

New verified confound: original failed job 102947618595 used `windows-2025-vs2026` image **20260824.214.3**. Recent diagnostics and original-source replay use **20260907.229.1**. The original passing main run 34307741070 also used the older image, so the image version alone is not established as causal. Both image manifests report Windows Server build 33296 and Chocolatey 2.7.4; both run logs report FFmpeg 9.0.1. Do not attribute this to an OS-version or FFmpeg-version change based on those values.

The exact old product also passes on the new image, so recent product changes or added tracing are not required for these observed passes. The historical failure still cannot be classified as encoder exit versus timeout. No new failed shutdown was captured. The next useful boundary is historical environment/executable provenance, not another identical warm-loop batch. The old runner-image release exposes metadata/SBOM assets, not a downloadable VM disk; no equivalent retained Windows host was identified in available Fleet inventory. Obtaining a historical-equivalent runner/snapshot or a fresh natural failure with #3714 diagnostics remains the concrete blocker to causal isolation.

No tech spec for a product fix has been generated: user requested that only after isolation. This draft remains diagnostic-only, unready, and not a release claim.



## Encoder pipe-lifetime isolation experiment

Current diagnostic head `d2285f49e` changes the temporary workflow from preflight loops to a small external-process experiment; it does not execute the native behavior matrix. [Run 34636737714](https://github.com/trycua/cua/actions/runs/34636737714) ran 20 fixed observations: actual Chocolatey shim versus direct FFmpeg, each with stdin held open versus immediately closed, five per condition. The owned FFmpeg process was suspended before queuing `q`, then resumed after 100 ms, so it could not consume the shutdown byte before the writer-close decision. This deliberately controls scheduling rather than hoping to hit a race. Same gdigrab/encoding arguments and three-second wait; subprocess stdout is separately captured in this diagnostic, unlike production null stdout. No upstream reference code was copied into the implementation.

All 20 exited normally with code 0 in 289–440 ms after resume. No forced kills. This negative control does not support lost queued shutdown input on immediate pipe close in the tested environment. Stdin-close changes are therefore not justified by this evidence. Raw per-condition MP4s, stderr/stdout, executable hashes, and receipts are retained in recorder-observations-1 and locally under /Users/administrator/3713-evidence/34636737714/.

Additional source trace: preflight drops the sentinel before stopping recording, but the driver-owned child reaper runs only after McpDriver::drop calls stop_e2e_recording. Source inspection does not establish premature daemon teardown as the cause. The original artifact has a finalized moov layout, but that does not prove child process success; historical exit/timeout classification remains missing. Still no reproduced #3713 shutdown failure and no causal tech spec.



## Public-tool short-lifetime sweep

At `a58a9376e`, [run 34637929345](https://github.com/trycua/cua/actions/runs/34637929345) exercised the agreed public `StartRecordingTool -> StopRecordingTool -> GetRecordingStateTool` seam with the actual Windows FFmpeg backend. Two isolated hosted jobs used the Chocolatey shim and the package-owned direct executable respectively. Each performed 500 sequential recording lifecycles, sweeping post-start hold times through 0–200 ms via a fixed modular sequence, stopping immediately on any error and retaining each start/stop/state response and MP4. This targets short-lifetime polling/scheduling phases and same-process reuse rather than repeating the full GUI matrix.

Verified results: 500/500 shim lifecycles and 500/500 direct lifecycles returned successful stops and retained video paths. Maximum public stop latency: shim 675 ms, direct 661 ms. No reproduced shutdown error. These are API/process observations; this sweep does not independently decode every MP4 or certify GUI behavior. Artifacts: recorder-observations-shim and recorder-observations-direct, plus local /Users/administrator/3713-evidence/34637929345/.

Current branch adds an ignored, explicitly invoked diagnostic test at the confirmed public seam. It is not an evidence-backed red regression for #3713 and must not be represented as one. The draft workflow currently runs this sweep instead of native GUI cases. No implementation-ready fix spec has been authored because a failure mechanism remains unverified. Historical missing exit/timeout data cannot be recovered from the retained generic error, MP4 layout, or these successful controls.
