### PR TITLE
fix(cua-driver): link skills for fresh Codex and Claude installs

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
@@ -56,10 +56,11 @@
 //!   version-controlled). Hermes' own `computer-use` skill teaches its wrapper
 //!   vocabulary; the cua-driver pack provides the platform deep dives.
 //!
-//! Only acts on a given agent when its parent skills dir already
-//! exists (i.e. the agent itself is installed). Never clobbers an
-//! existing `<agent_skills>/cua-driver` link — preserves dev users'
-//! hand-rolled symlinks.
+//! Acts on a given agent when its parent skills dir already exists. For
+//! Claude Code and Codex, whose fresh installs may not create that directory,
+//! the explicit `skills install` verb also creates it when the client's own
+//! home directory proves that client is installed. Never clobbers an existing
+//! `<agent_skills>/cua-driver` link — preserves dev users' hand-rolled symlinks.
 
 use anyhow::{anyhow, bail, Context, Result};
 use std::fs;
@@ -176,6 +177,9 @@ struct Agent {
     label: &'static str,
     /// User-relative parent skills dir, expanded at runtime per OS.
     parent: AgentParent,
+    /// A client-owned path that positively identifies an installation. When
+    /// present, `skills install` may create the missing parent skills dir.
+    install_marker: Option<&'static str>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -202,28 +206,34 @@ const AGENTS: &[Agent] = &[
     Agent {
         label: "Claude Code",
         parent: AgentParent::Home(".claude/skills"),
+        install_marker: Some(".claude"),
     },
     Agent {
         label: "Codex",
         parent: AgentParent::Home(".agents/skills"),
+        install_marker: Some(".codex"),
     },
     Agent {
         label: "Prime Agent",
         parent: AgentParent::Home(".prime/agent/skills"),
+        install_marker: None,
     },
     Agent {
         label: "OpenClaw",
         parent: AgentParent::Home(".openclaw/skills"),
+        install_marker: None,
     },
     #[cfg(windows)]
     Agent {
         label: "OpenCode",
         parent: AgentParent::AppData("opencode/skills"),
+        install_marker: None,
     },
     #[cfg(not(windows))]
     Agent {
         label: "OpenCode",
         parent: AgentParent::Home(".config/opencode/skills"),
+        install_marker: None,
     },
     // Antigravity CLI + Antigravity IDE share the `.gemini/skills/` dir
     // (the same path Gemini CLI used pre-May-2026). Registering the
@@ -231,6 +241,7 @@ const AGENTS: &[Agent] = &[
     Agent {
         label: "Antigravity",
         parent: AgentParent::Home(".gemini/skills"),
+        install_marker: None,
     },
     // Hermes (NousResearch/hermes-agent) resolves user skills from its
     // effective home at agent load time. `HERMES_HOME` can select a custom
@@ -241,6 +252,7 @@ const AGENTS: &[Agent] = &[
     Agent {
         label: "Hermes",
         parent: AgentParent::Hermes,
+        install_marker: None,
     },
 ];
 
@@ -320,8 +332,15 @@ impl Agent {
             }
         }
     }
-    fn link_path(&self) -> Result<PathBuf> {
-        Ok(self.parent_path()?.join(SKILL_PACK_NAME))
+    fn install_marker_path(&self) -> Result<Option<PathBuf>> {
+        let Some(marker) = self.install_marker else {
+            return Ok(None);
+        };
+        #[cfg(windows)]
+        let base = std::env::var("USERPROFILE").map_err(|_| anyhow!("USERPROFILE not set"))?;
+        #[cfg(not(windows))]
+        let base = std::env::var("HOME").map_err(|_| anyhow!("HOME not set"))?;
+        Ok(Some(PathBuf::from(base).join(marker)))
     }
 }
 
@@ -387,16 +406,16 @@ fn install(flags: &[String], force: bool) -> Result<()> {
         );
     }
 
-    let mut linked_any = false;
+    let mut detected_any = false;
     for agent in AGENTS {
         match link_agent(*agent, &local) {
-            Ok(true) => linked_any = true,
-            Ok(false) => {}
+            Ok(LinkStatus::Created | LinkStatus::Existing) => detected_any = true,
+            Ok(LinkStatus::NotDetected) => {}
             Err(e) => eprintln!("  warning: failed to link {}: {e}", agent.label),
         }
     }
-    if !linked_any {
-        println!("(No agent skills dirs present yet — install Claude Code / Codex / Prime Agent / OpenClaw / OpenCode / Antigravity / Hermes then re-run.)");
+    if !detected_any {
+        println!("(No supported agent installation or skills directory detected. Install an agent, then re-run.)");
     }
     Ok(())
 }
@@ -492,14 +511,55 @@ fn sweep_legacy_skill_pack() {
     }
 }
 
-/// Returns `Ok(true)` when a new link was created, `Ok(false)` when
-/// skipped (parent dir missing, link already there, etc.).
-fn link_agent(agent: Agent, local_skill_dir: &Path) -> Result<bool> {
-    let parent = agent.parent_path()?;
-    if !parent.exists() {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LinkStatus {
+    Created,
+    Existing,
+    NotDetected,
+}
+
+fn ensure_skills_parent(parent: &Path, install_marker: Option<&Path>) -> Result<bool> {
+    if parent.is_dir() {
+        return Ok(true);
+    }
+    if parent.symlink_metadata().is_ok() {
+        bail!(
+            "skills path exists but is not a directory: {}",
+            parent.display()
+        );
+    }
+    if !install_marker.is_some_and(Path::is_dir) {
         return Ok(false);
     }
-    let link = agent.link_path()?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("create skills directory {}", parent.display()))?;
+    Ok(true)
+}
+
+/// Links one detected agent and reports whether the link was created, already
+/// present, or skipped because neither a skills directory nor installation
+/// marker exists.
+fn link_agent(agent: Agent, local_skill_dir: &Path) -> Result<LinkStatus> {
+    let parent = agent.parent_path()?;
+    let install_marker = agent.install_marker_path()?;
+    link_agent_paths(
+        agent.label,
+        &parent,
+        install_marker.as_deref(),
+        local_skill_dir,
+    )
+}
+
+fn link_agent_paths(
+    agent_label: &str,
+    parent: &Path,
+    install_marker: Option<&Path>,
+    local_skill_dir: &Path,
+) -> Result<LinkStatus> {
+    if !ensure_skills_parent(parent, install_marker)? {
+        return Ok(LinkStatus::NotDetected);
+    }
+    let link = parent.join(SKILL_PACK_NAME);
     // Four states for `link`:
     //   1. doesn't exist at all                 → create
     //   2. exists + resolves                    → already linked (skip)
@@ -515,10 +575,10 @@ fn link_agent(agent: Agent, local_skill_dir: &Path) -> Result<bool> {
     if has_metadata && resolves {
         println!(
             "  {} skill link already exists at {} (skipping)",
-            agent.label,
+            agent_label,
             link.display()
         );
-        return Ok(false);
+        return Ok(LinkStatus::Existing);
     }
     if has_metadata && !resolves && is_symlink_or_junction(&link) {
         // Dangling link/junction — target was removed (typical after
@@ -527,14 +587,14 @@ fn link_agent(agent: Agent, local_skill_dir: &Path) -> Result<bool> {
         if let Err(e) = remove_link(&link) {
             eprintln!(
                 "  warning: could not remove stale {} link at {}: {e}",
-                agent.label,
+                agent_label,
                 link.display()
             );
-            return Ok(false);
+            return Ok(LinkStatus::Existing);
         }
         println!(
             "  cleaned up stale {} link at {}",
-            agent.label,
+            agent_label,
             link.display()
         );
     }
@@ -545,8 +605,8 @@ fn link_agent(agent: Agent, local_skill_dir: &Path) -> Result<bool> {
             local_skill_dir.display()
         )
     })?;
-    println!("  ✅ linked {} skill at {}", agent.label, link.display());
-    Ok(true)
+    println!("  ✅ linked {} skill at {}", agent_label, link.display());
+    Ok(LinkStatus::Created)
 }
 
 #[cfg(windows)]
@@ -868,11 +928,92 @@ fn print_path() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        extract_tar_gz, resolve_hermes_skills_dir, skill_release_url, unix_hermes_home,
-        windows_hermes_home, AgentParent, AGENTS, SKILL_FILES,
+        ensure_skills_parent, extract_tar_gz, link_agent_paths, resolve_hermes_skills_dir,
+        skill_release_url, unix_hermes_home, windows_hermes_home, AgentParent, LinkStatus, AGENTS,
+        SKILL_FILES,
     };
     use std::path::PathBuf;
     use tempfile::tempdir;
+
+    #[test]
+    fn fresh_codex_and_claude_markers_are_explicit() {
+        let claude = AGENTS
+            .iter()
+            .find(|agent| agent.label == "Claude Code")
+            .unwrap();
+        let codex = AGENTS.iter().find(|agent| agent.label == "Codex").unwrap();
+
+        assert!(matches!(claude.install_marker, Some(".claude")));
+        assert!(matches!(codex.install_marker, Some(".codex")));
+    }
+
+    #[test]
+    fn missing_skills_parent_is_created_only_for_detected_client() {
+        let home = tempdir().unwrap();
+        let parent = home.path().join(".agents/skills");
+        let marker = home.path().join(".codex");
+
+        assert!(!ensure_skills_parent(&parent, Some(&marker)).unwrap());
+        assert!(!parent.exists());
+
+        std::fs::create_dir(&marker).unwrap();
+        assert!(ensure_skills_parent(&parent, Some(&marker)).unwrap());
+        assert!(parent.is_dir());
+    }
+
+    #[test]
+    fn existing_skills_parent_needs_no_client_marker() {
+        let home = tempdir().unwrap();
+        let parent = home.path().join("custom/skills");
+        std::fs::create_dir_all(&parent).unwrap();
+
+        assert!(ensure_skills_parent(&parent, None).unwrap());
+    }
+
+    #[test]
+    fn detected_client_links_once_and_rerun_reports_existing_link() {
+        let home = tempdir().unwrap();
+        let parent = home.path().join(".claude/skills");
+        let marker = home.path().join(".claude");
+        let local_skill = home.path().join(".cua-driver/skills/cua-driver");
+        std::fs::create_dir_all(&marker).unwrap();
+        std::fs::create_dir_all(&local_skill).unwrap();
+
+        assert_eq!(
+            link_agent_paths("Claude Code", &parent, Some(&marker), &local_skill).unwrap(),
+            LinkStatus::Created
+        );
+        assert_eq!(
+            link_agent_paths("Claude Code", &parent, Some(&marker), &local_skill).unwrap(),
+            LinkStatus::Existing
+        );
+        assert!(parent.join("cua-driver").exists());
+    }
+
+    #[test]
+    fn missing_parent_and_marker_are_not_detected() {
+        let home = tempdir().unwrap();
+        let parent = home.path().join(".agents/skills");
+        let marker = home.path().join(".codex");
+        let local_skill = home.path().join("skill");
+        std::fs::create_dir(&local_skill).unwrap();
+
+        assert_eq!(
+            link_agent_paths("Codex", &parent, Some(&marker), &local_skill).unwrap(),
+            LinkStatus::NotDetected
+        );
+        assert!(!parent.exists());
+    }
+
+    #[test]
+    fn non_directory_parent_is_rejected() {
+        let home = tempdir().unwrap();
+        let parent = home.path().join("skills");
+        std::fs::write(&parent, b"occupied").unwrap();
+
+        let error = ensure_skills_parent(&parent, None).unwrap_err();
+        assert!(error.to_string().contains("exists but is not a directory"));
+    }
 
     #[test]
     fn prime_agent_target_matches_its_native_global_skill_directory() {


### PR DESCRIPTION
## Summary

- Problem this solves: fresh Codex and Claude Code installs can have their client homes without `~/.agents/skills` or `~/.claude/skills`. `cua-driver skills install` then installs the pack but links neither client and incorrectly tells the user to install clients that are already present. The same fallback appears on fully linked reruns because it tracked only links created during that invocation.
- What changed: the explicit `skills install` verb recognizes the client-owned `.codex` and `.claude` marker directories, creates only the corresponding missing skills parent, and distinguishes created, existing, and undetected link states. Other clients retain the existing parent-directory-only behavior.

Before, a clean account needed manual `mkdir` commands and a second install. After, one `cua-driver skills install` links both detected clients, while an idempotent rerun reports the existing links without the false fallback.

## Related work

Fixes #3740
Refs #3741

RFC: not required. This is a bounded correction to the existing opt-in `skills install` behavior. It does not change the skill format, MCP protocol, runtime permissions, or another client integration.

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: `skills install` can create `skills` beneath a positively detected Codex or Claude client home. It still does not create directories for unrelated clients or overwrite an existing link or real directory. Path resolution uses `HOME` on macOS/Linux and `USERPROFILE` on Windows.
- Risk and rollback: users with custom client config roots still follow the existing explicit-parent path. Revert this commit to restore parent-directory-only linking.

## Validation

- Focused tests and checks: `cargo fmt --all -- --check`; `cargo test -p cua-driver --bin cua-driver skills::` (29 passed); `git diff --check`.
- Manual or platform evidence: source-built fake-home smoke with both client markers and no skills parents created only the Claude and Codex parents, linked both, and reported both existing links on rerun. The released 0.28.0 behavior was reproduced first on a clean macOS VM.
- Known gaps: none in scope. Ordinary cross-platform PR CI passed, including Windows unit and compile coverage for the junction implementation.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This corrective change does not require a new RFC.
- [x] Focused tests and manual evidence are included.
- [x] The `fix(cua-driver)` title correctly requests a patch release.
- [x] No external contribution is included.
- [x] Release-tracked behavior changed and the title is releasing; `no-release` is not applied.

