### PR TITLE
docs(sandbox): correct Fleet controller download URL

### DIFF
--- a/docs/content/docs/how-to-guides/sandbox/run-openai-agents-api-on-cloud-fleet.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/run-openai-agents-api-on-cloud-fleet.mdx
@@ -89,7 +89,7 @@ store them in the image or commit them to source control.
 Download the verified controller:
 
 ```bash
-curl -fsSLO https://cua.ai/scripts/openai-agents-fleet/run_openai_agents_fleet.py
+curl -fsSLO https://cua.ai/docs-assets/scripts/openai-agents-fleet/run_openai_agents_fleet.py
 ```
 
 Run the controller. It generates a unique disposable pool name for each run:

--- a/docs/scripts/tests/test_openai_agents_fleet_example.py
+++ b/docs/scripts/tests/test_openai_agents_fleet_example.py
@@ -94,5 +94,6 @@ def test_controller_registers_cua_driver_as_required_stdio_mcp() -> None:
 def test_guide_links_the_download_and_navigation_entry() -> None:
     guide = GUIDE.read_text()
     meta = META.read_text()
-    assert "https://cua.ai/scripts/openai-agents-fleet/run_openai_agents_fleet.py" in guide
+    assert "https://cua.ai/docs-assets/scripts/openai-agents-fleet/run_openai_agents_fleet.py" in guide
+    assert "https://cua.ai/scripts/openai-agents-fleet/" not in guide
     assert '"run-openai-agents-api-on-cloud-fleet"' in meta


### PR DESCRIPTION
## Summary

Correct the downloadable controller URL in the Agents API Fleet guide to the production docs asset path, `/docs-assets/scripts/openai-agents-fleet/run_openai_agents_fleet.py`.

The controller bytes and integration behavior are unchanged. This follows up on #3745 during publication verification.

Refs #3744

## Validation

- Focused guide-link regression test and docs link/hygiene checks.
- Confirm the production asset matches the live-tested controller byte for byte.
- No product or release-tracked files changed; documentation-only correction.
