### PR TITLE
test(cua-driver): share binary selection with docs policy checks

### DIFF
--- a/.github/workflows/ci-check-docs.yml
+++ b/.github/workflows/ci-check-docs.yml
@@ -83,7 +83,7 @@ jobs:
         run: node docs/node_modules/tsx/dist/cli.mjs scripts/docs-generators/runner.ts --library cua-driver --check
       - name: Verify docs extraction preserves policy-filtered discovery
         if: steps.scope.outputs.selected == 'true' && matrix.library == 'cua-driver'
-        run: node docs/node_modules/tsx/dist/cli.mjs --test scripts/docs-generators/cua-driver-policy.test.ts
+        run: node docs/node_modules/tsx/dist/cli.mjs --test scripts/docs-generators/cua-driver-policy.test.ts scripts/docs-generators/cua-driver-policy-binary.test.ts
 
   check-docs-sync:
     name: Check Documentation Sync

--- a/scripts/docs-generators/cua-driver-policy-binary.test.ts
+++ b/scripts/docs-generators/cua-driver-policy-binary.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { cpSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+import { resolveDriverBinary } from './cua-driver';
+
+test('native policy checks use the explicit binary without a default build', (t) => {
+  const directory = mkdtempSync(join(tmpdir(), 'cua-docs-binary-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const source = join(directory, 'scripts', 'docs-generators');
+  cpSync(__dirname, source, { recursive: true });
+  mkdirSync(join(directory, 'libs', 'cua-driver', 'rust'), { recursive: true });
+  const result = spawnSync(
+    process.execPath,
+    [
+      ...process.execArgv,
+      '--test',
+      '--test-reporter=tap',
+      join(source, 'cua-driver-policy.test.ts'),
+    ],
+    {
+      cwd: directory,
+      env: {
+        ...process.env,
+        NODE_TEST_CONTEXT: undefined,
+        CUA_DRIVER_BINARY: resolve(resolveDriverBinary()),
+      },
+      encoding: 'utf8',
+      timeout: 60_000,
+    }
+  );
+  assert.ifError(result.error);
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /^# pass 1\r?$/m);
+});

--- a/scripts/docs-generators/cua-driver-policy.test.ts
+++ b/scripts/docs-generators/cua-driver-policy.test.ts
@@ -2,9 +2,9 @@ import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
 import test from 'node:test';
-import { extractDocumentation, type DumpDocsOutput } from './cua-driver';
+import { extractDocumentation, resolveDriverBinary, type DumpDocsOutput } from './cua-driver';
 
 test('native docs are complete while ordinary discovery remains policy-filtered', (t) => {
   const directory = mkdtempSync(join(tmpdir(), 'cua-docs-policy-'));
@@ -12,11 +12,7 @@ test('native docs are complete while ordinary discovery remains policy-filtered'
   const policy = join(directory, 'policy.yaml');
   const content = 'allow:\n  tools: [get_window_state]\n';
   writeFileSync(policy, content);
-  const binary = resolve(
-    __dirname,
-    '../../libs/cua-driver/rust/target/release',
-    process.platform === 'win32' ? 'cua-driver.exe' : 'cua-driver'
-  );
+  const binary = resolveDriverBinary();
   const environment = {
     ...process.env,
     CUA_DRIVER_POLICY_FILE: policy,

--- a/scripts/docs-generators/cua-driver.ts
+++ b/scripts/docs-generators/cua-driver.ts
@@ -114,6 +114,10 @@ const CUA_DRIVER_BIN = path.join(
 const DOCS_OUTPUT_DIR = path.join(ROOT_DIR, 'docs', 'content', 'docs', 'reference', 'cua-driver');
 const TAG_PREFIX = 'cua-driver-rs-v';
 
+export function resolveDriverBinary(): string {
+  return process.env.CUA_DRIVER_BINARY || CUA_DRIVER_BIN;
+}
+
 export type GitRunner = (command: string, args: readonly string[]) => string;
 
 // ============================================================================
@@ -226,7 +230,7 @@ async function main() {
 
   // Step 2: Extract all docs in a single invocation
   console.log('\nExtracting documentation...');
-  const binary = process.env.CUA_DRIVER_BINARY || CUA_DRIVER_BIN;
+  const binary = resolveDriverBinary();
   const dumpDocs = extractDocumentation(binary);
   console.log(`   Found ${dumpDocs.cli.commands.length} CLI commands`);
   console.log(`   Found ${dumpDocs.mcp.tools.length} MCP tools`);


### PR DESCRIPTION
## Summary

- Problem this solves: the native docs-policy test ignored `CUA_DRIVER_BINARY` and looked for a default release executable even when the generator used an explicit external binary.
- What changed: share binary selection through the existing generator module and delete the test's duplicate default-path construction. A checked-in subprocess regression runs the original policy-test command in an isolated source tree with no default binary and a real external executable. All original policy assertions remain unchanged.

## Related work

Refs #3747.

Related: #3723 handles docs workflow allocation. This PR only adds the regression to the existing native policy-test step; it does not change runner allocation.

RFC: not required; this is internal documentation/test tooling, with no published driver API or contract change.

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: the policy test now honors the generator's existing override. Unset/empty overrides retain the platform-specific default. Invalid explicit paths still fail without fallback. No runtime driver, permission, migration, build, or generated-content changes.
- Risk and rollback: limited to binary selection in docs tooling. Revert the two-file change to restore prior behavior. No new configuration framework or dependency.

## Validation

- Focused tests and checks: observed red with a valid external binary and absent default (`ENOENT` at the ignored default path); the identical invocation passed after the minimal fix. At `7a3d45a6dfcaef673616f873077b32fdccf5c402`, **13 generator tests pass**, including the new subprocess regression. Restoring the original policy-test file byte-for-byte (blob `9b5b198992ab30e240d61f0381eafcbf2743e5b3`) makes that regression fail with `ENOENT` at the isolated default path; restoring shared selection makes it pass. The updated two-test CI command also passes with no outer override and a valid default binary, proving that the new test supplies its own override scenario. Prettier and diff checks pass.
- Manual or platform evidence: macOS checks passed for an external binary, a path containing spaces, unset/empty overrides, and an invalid override with a valid default (expected failure). These compatibility checks used the identical two-file patch before moving onto current main. The real test binary is Cua Driver 0.25.0; this is not current-driver native certification.
- Known gaps or CI still required: CI pending. Windows/Linux execution and a full generator build/render were not performed. Native docs CI now executes the checked-in isolated override regression on each selected platform, even when the outer job uses a default build. An initial local fixture attempt omitted the extractor's Rust working directory; that setup failure was retained, the empty directory was added without adding a default executable, and the final fixture was verified red and green.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [x] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.

No external contribution is included. This is documentation/test tooling, not a component release; the conditional release-label requirement is not applicable.
