### PR TITLE
ci(lume): preserve repository-wide latest during publication

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -924,7 +924,6 @@ fi
     def test_lume_uses_the_same_draft_finalizer(self) -> None:
         workflow = self.read(".github/workflows/cd-swift-lume.yml")
 
-        self.assertIn("--make-latest", workflow)
         self.assertIn("github_release.py", workflow)
         self.assertNotIn("softprops/action-gh-release", workflow)
         self.assertNotIn("bake-lume-version", workflow)

--- a/.github/scripts/tests/test_lume_release_publication.py
+++ b/.github/scripts/tests/test_lume_release_publication.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+from pathlib import Path
+import subprocess
+import sys
+from threading import Thread
+from urllib.parse import parse_qs, urlsplit
+from urllib.request import urlopen
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[3]
+REPOSITORY = "trycua/cua"
+TAG = "lume-v1.2.3"
+SHA = "a" * 40
+API_PATH = f"/repos/{REPOSITORY}"
+
+
+@pytest.fixture
+def github_api():
+    previous_latest = {"id": 99, "tag_name": "cua-driver-rs-v9.0.0", "draft": False}
+    release = {"id": 7, "tag_name": TAG, "draft": True, "prerelease": False, "body": ""}
+    latest = dict(previous_latest)
+    assets = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+        def respond(self, value, status=200):
+            data = json.dumps(value).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def do_GET(self):
+            path = urlsplit(self.path).path
+            if path == f"{API_PATH}/git/ref/tags/{TAG}":
+                self.respond({"object": {"type": "commit", "sha": SHA}})
+            elif path == f"{API_PATH}/releases":
+                self.respond([release, previous_latest])
+            elif path == f"{API_PATH}/releases/latest":
+                self.respond(latest)
+            elif path == f"{API_PATH}/releases/tags/{TAG}":
+                self.respond(release)
+            elif path == f"{API_PATH}/releases/7/assets":
+                self.respond(assets)
+            else:
+                self.respond({"message": f"Unexpected GET {self.path}"}, 404)
+
+        def do_POST(self):
+            url = urlsplit(self.path)
+            if url.path != f"{API_PATH}/releases/7/assets":
+                self.respond({"message": f"Unexpected POST {self.path}"}, 404)
+                return
+            data = self.rfile.read(int(self.headers["Content-Length"]))
+            asset = {
+                "id": len(assets) + 1,
+                "name": parse_qs(url.query)["name"][0],
+                "size": len(data),
+                "state": "uploaded",
+            }
+            assets.append(asset)
+            self.respond(asset, 201)
+
+        def do_PATCH(self):
+            if self.path != f"{API_PATH}/releases/7":
+                self.respond({"message": f"Unexpected PATCH {self.path}"}, 404)
+                return
+            payload = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            release.update({key: value for key, value in payload.items() if key != "make_latest"})
+            if payload.get("make_latest") == "true":
+                latest.clear()
+                latest.update(release)
+            self.respond(release)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    base_url = f"http://127.0.0.1:{server.server_port}"
+    release["upload_url"] = f"{base_url}{API_PATH}/releases/7/assets{{?name,label}}"
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield base_url
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def get_json(base_url, path):
+    with urlopen(f"{base_url}{API_PATH}{path}", timeout=5) as response:
+        return json.load(response)
+
+
+def test_stable_lume_publication_preserves_repository_latest(tmp_path, github_api):
+    workflow = yaml.safe_load((ROOT / ".github/workflows/cd-swift-lume.yml").read_text())
+    commands = [
+        step["run"]
+        for step in workflow["jobs"]["release"]["steps"]
+        if "github_release.py" in step.get("run", "")
+    ]
+    assert len(commands) == 1
+    command = commands[0]
+    for expression, value in {
+        "${{ github.repository }}": REPOSITORY,
+        "${{ github.ref_name }}": TAG,
+        "${{ github.sha }}": SHA,
+    }.items():
+        command = command.replace(expression, value)
+    assert "${{" not in command
+    (tmp_path / ".github").symlink_to(ROOT / ".github", target_is_directory=True)
+    (tmp_path / "bin").mkdir()
+    (tmp_path / "bin/python3").symlink_to(sys.executable)
+    (tmp_path / "release-metadata").mkdir()
+    (tmp_path / "release-metadata/release-body.md").write_text("Lume release with attribution")
+    (tmp_path / "release-upload").mkdir()
+    (tmp_path / "release-upload/lume.tar.gz").write_bytes(b"fixture archive")
+    before = get_json(github_api, "/releases/latest")
+
+    result = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", command],
+        cwd=tmp_path,
+        env={
+            "PATH": f"{tmp_path / 'bin'}:/usr/bin:/bin",
+            "HOME": str(tmp_path),
+            "GH_TOKEN": "local-fixture-token",
+            "GITHUB_API_URL": github_api,
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    published = get_json(github_api, f"/releases/tags/{TAG}")
+    assert published["draft"] is False
+    assert published["prerelease"] is False
+    assert published["body"] == "Lume release with attribution"
+    after = get_json(github_api, "/releases/latest")
+    assert after["id"] == before["id"], (
+        f"Lume publication changed repository Latest from {before['tag_name']} "
+        f"to {after['tag_name']}"
+    )

--- a/.github/scripts/tests/test_lume_release_publication.py
+++ b/.github/scripts/tests/test_lume_release_publication.py
@@ -6,8 +6,7 @@ from pathlib import Path
 import subprocess
 import sys
 from threading import Thread
-from urllib.parse import parse_qs, urlsplit
-from urllib.request import urlopen
+from urllib.parse import urlsplit
 
 import pytest
 import yaml
@@ -22,10 +21,8 @@ API_PATH = f"/repos/{REPOSITORY}"
 
 @pytest.fixture
 def github_api():
-    previous_latest = {"id": 99, "tag_name": "cua-driver-rs-v9.0.0", "draft": False}
     release = {"id": 7, "tag_name": TAG, "draft": True, "prerelease": False, "body": ""}
-    latest = dict(previous_latest)
-    assets = []
+    publication_requests = []
 
     class Handler(BaseHTTPRequestHandler):
         def log_message(self, *_args):
@@ -44,13 +41,9 @@ def github_api():
             if path == f"{API_PATH}/git/ref/tags/{TAG}":
                 self.respond({"object": {"type": "commit", "sha": SHA}})
             elif path == f"{API_PATH}/releases":
-                self.respond([release, previous_latest])
-            elif path == f"{API_PATH}/releases/latest":
-                self.respond(latest)
-            elif path == f"{API_PATH}/releases/tags/{TAG}":
-                self.respond(release)
+                self.respond([release])
             elif path == f"{API_PATH}/releases/7/assets":
-                self.respond(assets)
+                self.respond([])
             else:
                 self.respond({"message": f"Unexpected GET {self.path}"}, 404)
 
@@ -59,26 +52,16 @@ def github_api():
             if url.path != f"{API_PATH}/releases/7/assets":
                 self.respond({"message": f"Unexpected POST {self.path}"}, 404)
                 return
-            data = self.rfile.read(int(self.headers["Content-Length"]))
-            asset = {
-                "id": len(assets) + 1,
-                "name": parse_qs(url.query)["name"][0],
-                "size": len(data),
-                "state": "uploaded",
-            }
-            assets.append(asset)
-            self.respond(asset, 201)
+            self.rfile.read(int(self.headers["Content-Length"]))
+            self.respond({"id": 1}, 201)
 
         def do_PATCH(self):
             if self.path != f"{API_PATH}/releases/7":
                 self.respond({"message": f"Unexpected PATCH {self.path}"}, 404)
                 return
             payload = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
-            release.update({key: value for key, value in payload.items() if key != "make_latest"})
-            if payload.get("make_latest") == "true":
-                latest.clear()
-                latest.update(release)
-            self.respond(release)
+            publication_requests.append(payload)
+            self.respond({**release, **payload})
 
     server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
     base_url = f"http://127.0.0.1:{server.server_port}"
@@ -86,19 +69,15 @@ def github_api():
     thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        yield base_url
+        yield base_url, publication_requests
     finally:
         server.shutdown()
         server.server_close()
         thread.join(timeout=5)
 
 
-def get_json(base_url, path):
-    with urlopen(f"{base_url}{API_PATH}{path}", timeout=5) as response:
-        return json.load(response)
-
-
-def test_stable_lume_publication_preserves_repository_latest(tmp_path, github_api):
+def test_stable_lume_publication_explicitly_disables_latest_promotion(tmp_path, github_api):
+    base_url, publication_requests = github_api
     workflow = yaml.safe_load((ROOT / ".github/workflows/cd-swift-lume.yml").read_text())
     commands = [
         step["run"]
@@ -121,7 +100,6 @@ def test_stable_lume_publication_preserves_repository_latest(tmp_path, github_ap
     (tmp_path / "release-metadata/release-body.md").write_text("Lume release with attribution")
     (tmp_path / "release-upload").mkdir()
     (tmp_path / "release-upload/lume.tar.gz").write_bytes(b"fixture archive")
-    before = get_json(github_api, "/releases/latest")
 
     result = subprocess.run(
         ["/bin/bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", command],
@@ -130,7 +108,7 @@ def test_stable_lume_publication_preserves_repository_latest(tmp_path, github_ap
             "PATH": f"{tmp_path / 'bin'}:/usr/bin:/bin",
             "HOME": str(tmp_path),
             "GH_TOKEN": "local-fixture-token",
-            "GITHUB_API_URL": github_api,
+            "GITHUB_API_URL": base_url,
         },
         capture_output=True,
         text=True,
@@ -138,12 +116,11 @@ def test_stable_lume_publication_preserves_repository_latest(tmp_path, github_ap
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
-    published = get_json(github_api, f"/releases/tags/{TAG}")
-    assert published["draft"] is False
-    assert published["prerelease"] is False
-    assert published["body"] == "Lume release with attribution"
-    after = get_json(github_api, "/releases/latest")
-    assert after["id"] == before["id"], (
-        f"Lume publication changed repository Latest from {before['tag_name']} "
-        f"to {after['tag_name']}"
-    )
+    assert publication_requests == [
+        {
+            "body": "Lume release with attribution",
+            "draft": False,
+            "prerelease": False,
+            "make_latest": "false",
+        }
+    ]

--- a/.github/workflows/cd-swift-lume.yml
+++ b/.github/workflows/cd-swift-lume.yml
@@ -343,5 +343,4 @@ jobs:
             --tag "${{ github.ref_name }}" \
             --sha "${{ github.sha }}" \
             --body release-metadata/release-body.md \
-            --asset-dir release-upload \
-            --make-latest
+            --asset-dir release-upload


### PR DESCRIPTION
## Summary

Refs #2611.

- Remove `--make-latest` from stable Lume publication. The existing release helper already defaults to false and sends `make_latest: "false"`; no helper API or runtime behavior is added.
- Add a regression that executes the actual workflow publication command through the real release CLI against a loopback GitHub HTTP fixture and asserts the exact publication PATCH, including explicit `make_latest: "false"`.
- Simplify the fixture by removing the simulated Latest pointer, asset inventory, and readback helper; observe the outgoing HTTP contract directly.
- Keep stable publication, release-body handling, tag verification, and the upstream asset/notarization/attribution pipeline unchanged.

This is intentionally a minimal, non-releasing workflow fix: one workflow edit, one new behavioral regression, and deletion of one obsolete assertion in the existing release-wiring test. Installer changes, optional unused-constant cleanup, and the local technical spec are excluded.

## TDD evidence

Base: `084f3480792342875254e338679c5050dd379e3e`.

The regression was run before any production changes. Publication succeeded, but the final assertion failed:

```text
Lume publication changed repository Latest from cua-driver-rs-v9.0.0 to lume-v1.2.3
assert 7 == 99
1 failed
```

Deleting only the workflow flag and preceding continuation made the unchanged regression pass: **1 passed**. The loopback fixture uses dummy credentials and does not contact GitHub or publish real releases.

The initial green contents were committed as `4edce52e948296d96db07351f9613256772e20c1`. CI then exposed an existing wiring test that required the old `--make-latest` behavior. That failure was reproduced locally before removing only its obsolete assertion; the shared-finalizer wiring checks remain intact.

Current candidate: `df9bcc7ac56cfb60bf65db39a27be46ba263defb`.

Review found that the original fixture accepted an omitted `make_latest` field even though GitHub defaults newly published releases to Latest. The simplified test is 23 lines shorter and compares the actual outgoing PATCH with the required stable-publication payload.

Mutation checks were run in scratch copies, leaving production files untouched:

| Variant | Result |
| --- | --- |
| Omit `make_latest` from the publication payload | **Red**: missing required `"false"` |
| Restore the correct helper and fixed workflow | **Green** |
| Restore the original workflow's `--make-latest` flag | **Red**: `"true"` differs from `"false"` |

The original behavioral red evidence above is retained; the final test now verifies the external request directly rather than simulating GitHub's Latest state.

- Full local scripts test owner: **298 passed**, including the new regression and existing release-helper/installer-selection tests. No executable diff between that run and the candidate commit.
- Previous candidate `f30645dc2`: hosted [CI: Test Scripts run 34645214982](https://github.com/trycua/cua/actions/runs/34645214982) **passed**, including scripts tests, uninstall tests, offline Sandbox release preview, and historical backfill validation.
- Current candidate hosted [CI: Test Scripts run 34645808460](https://github.com/trycua/cua/actions/runs/34645808460): **passed**, including all scripts tests, uninstall tests, offline Sandbox release preview, and historical backfill validation.
- Additional local driver installer-script suite: **160 passed, 6 skipped, 4 failed**. The four failures are existing uninstall-autostart cases whose fixtures leave host process discovery real; the uninstaller refused with `daemon_stop_incomplete`. No host daemon was stopped and no unrelated installer code was changed. The same hosted CI step passed.

```bash
python -m pytest -q --override-ini='addopts=' \
  .github/scripts/tests/test_lume_release_publication.py
```

Local toolchain: Python 3.11.16, pytest 8.4.2, PyYAML 6.0.3. The isolated environment emits one unrelated warning for the root `asyncio_mode` setting because pytest-asyncio is not installed.

## Progress and remaining review

- [x] Revalidate the issue and competing work; use a canonical-repository branch.
- [x] Capture a real red regression before applying the minimal green change.
- [x] Run the unchanged regression green and `git diff --check`.
- [x] Simplify the fixture and prove it rejects both omitted `make_latest` and explicit promotion.
- [x] Run the full release scripts test owner and relevant existing installer/helper checks; record the separate local uninstall limitation above.
- [x] Inspect ordinary PR CI on the simplified candidate SHA; the scripts job passed.

No live publication, Apple signing/notarization, or complete installer certification is claimed. The test proves the workflow/helper behavior against a controlled API model, not GitHub's live implementation. Desktop E2E is unrelated to this workflow-only change.

Agent-assisted implementation. The simplification changes tests only; the production fix remains deletion of the workflow's promotion flag.


