### PR TITLE
fix(cua-driver): capture macOS desktops without relying on PATH

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/tests/macos_capture_environment_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/macos_capture_environment_test.rs
@@ -1,46 +1,86 @@
 #![cfg(target_os = "macos")]
 
-use cua_driver_testkit::RawDriver;
-use serde_json::{json, Value};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
-fn call(driver: &mut RawDriver, name: &str, arguments: Value) -> Value {
-    driver.send(&json!({
-        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
-        "params": {"name": name, "arguments": arguments}
-    }));
-    let response = driver.recv();
-    assert!(response.get("error").is_none(), "{name}: {response}");
-    assert_ne!(response["result"]["isError"], true, "{name}: {response}");
-    response["result"].clone()
+use cua_driver_testkit::{driver_binary, Driver, McpDriver};
+use serde_json::json;
+
+struct StopDaemon<'a> {
+    binary: &'a Path,
+    socket: &'a Path,
+}
+
+impl Drop for StopDaemon<'_> {
+    fn drop(&mut self) {
+        let _ = Command::new(self.binary)
+            .args(["stop", "--socket"])
+            .arg(self.socket)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
 }
 
 #[test]
 #[ignore = "requires an unlocked macOS desktop and a TCC-authorized installed driver"]
 fn desktop_capture_does_not_require_sbin_on_path() {
+    let binary = driver_binary().canonicalize().expect("installed driver");
+    let app = binary.ancestors().nth(3).expect("installed app bundle");
+    assert_eq!(app.extension().and_then(|s| s.to_str()), Some("app"));
     for path in ["/usr/bin:/bin:/usr/sbin:/sbin", "/usr/bin:/bin"] {
         eprintln!("desktop capture with daemon PATH={path}");
-        let mut driver = RawDriver::spawn_with_env(&[
-            ("PATH", path),
-            ("CUA_DRIVER_PERMISSION_MODE", "unrestricted"),
-            ("CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS", "1"),
-        ])
-        .expect("start the installed driver with the selected PATH");
-        driver.send(&json!({"jsonrpc": "2.0", "id": 0, "method": "initialize", "params": {}}));
-        assert!(driver.recv().get("result").is_some());
-        call(
-            &mut driver,
+        let output = tempfile::tempdir_in("/tmp").unwrap();
+        let socket = output.path().join("d.sock");
+        let _stop = StopDaemon {
+            binary: &binary,
+            socket: &socket,
+        };
+        assert!(Command::new("/usr/bin/open")
+            .args([
+                "-n",
+                "-g",
+                "--env",
+                &format!("PATH={path}"),
+                "--env",
+                "CUA_DRIVER_RS_TELEMETRY_ENABLED=false"
+            ])
+            .arg(app)
+            .args(["--args", "serve", "--socket"])
+            .arg(&socket)
+            .args([
+                "--permission-mode",
+                "unrestricted",
+                "--dangerously-bypass-approvals",
+                "--no-overlay"
+            ])
+            .status()
+            .expect("launch the installed app")
+            .success());
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !socket.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "owned daemon did not create its socket"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        let mut driver = McpDriver::spawn_daemon_proxy_unrecorded(socket.to_str().unwrap())
+            .expect("connect to the owned daemon");
+        let session = driver.call(
             "start_session",
             json!({"session": "capture-path", "capture_scope": "desktop"}),
         );
-        let output = tempfile::tempdir().unwrap();
+        assert!(!session.is_error(), "{}", session.text());
         let png = output.path().join("desktop.png");
-        let result = call(
-            &mut driver,
+        let result = driver.call(
             "get_desktop_state",
             json!({"session": "capture-path", "screenshot_out_file": png}),
         );
+        assert!(!result.is_error(), "{}", result.text());
         let image = image::open(&png).expect("decode the captured desktop PNG");
-        let metadata = &result["structuredContent"];
+        let metadata = result.structured();
         assert_eq!(metadata["screenshot_mime_type"], "image/png");
         assert_eq!(metadata["screenshot_width"], image.width());
         assert_eq!(metadata["screenshot_height"], image.height());

--- a/libs/cua-driver/rust/crates/cua-driver/tests/macos_capture_environment_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/macos_capture_environment_test.rs
@@ -1,0 +1,49 @@
+#![cfg(target_os = "macos")]
+
+use cua_driver_testkit::RawDriver;
+use serde_json::{json, Value};
+
+fn call(driver: &mut RawDriver, name: &str, arguments: Value) -> Value {
+    driver.send(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": name, "arguments": arguments}
+    }));
+    let response = driver.recv();
+    assert!(response.get("error").is_none(), "{name}: {response}");
+    assert_ne!(response["result"]["isError"], true, "{name}: {response}");
+    response["result"].clone()
+}
+
+#[test]
+#[ignore = "requires an unlocked macOS desktop and a TCC-authorized installed driver"]
+fn desktop_capture_does_not_require_sbin_on_path() {
+    for path in ["/usr/bin:/bin:/usr/sbin:/sbin", "/usr/bin:/bin"] {
+        eprintln!("desktop capture with daemon PATH={path}");
+        let mut driver = RawDriver::spawn_with_env(&[
+            ("PATH", path),
+            ("CUA_DRIVER_PERMISSION_MODE", "unrestricted"),
+            ("CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS", "1"),
+        ])
+        .expect("start the installed driver with the selected PATH");
+        driver.send(&json!({"jsonrpc": "2.0", "id": 0, "method": "initialize", "params": {}}));
+        assert!(driver.recv().get("result").is_some());
+        call(
+            &mut driver,
+            "start_session",
+            json!({"session": "capture-path", "capture_scope": "desktop"}),
+        );
+        let output = tempfile::tempdir().unwrap();
+        let png = output.path().join("desktop.png");
+        let result = call(
+            &mut driver,
+            "get_desktop_state",
+            json!({"session": "capture-path", "screenshot_out_file": png}),
+        );
+        let image = image::open(&png).expect("decode the captured desktop PNG");
+        let metadata = &result["structuredContent"];
+        assert_eq!(metadata["screenshot_mime_type"], "image/png");
+        assert_eq!(metadata["screenshot_width"], image.width());
+        assert_eq!(metadata["screenshot_height"], image.height());
+        eprintln!("decoded desktop PNG: {}x{}", image.width(), image.height());
+    }
+}

--- a/libs/cua-driver/rust/crates/platform-macos/src/capture.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/capture.rs
@@ -748,7 +748,7 @@ pub fn screenshot_display_bytes() -> anyhow::Result<Vec<u8>> {
     let capture = SecureCapturePath::new("display.png")?;
     let tmp_path = capture.file.to_string_lossy().into_owned();
 
-    let output = Command::new("screencapture")
+    let output = Command::new("/usr/sbin/screencapture")
         .args(["-x", &tmp_path])
         .output()?;
 

--- a/scripts/ci/macos/run-rust-e2e.sh
+++ b/scripts/ci/macos/run-rust-e2e.sh
@@ -398,7 +398,8 @@ fi
 if [[ "${SUITE}" == capture || "${SUITE}" == all ]]; then
   run_test capture-contract cargo test -p cua-driver --test capture_contract_test -- \
     --ignored --nocapture --test-threads=1
-  run_test capture-environment cargo test -p cua-driver --test macos_capture_environment_test -- \
+  run_test capture-environment env CUA_TEST_DRIVER_BIN="${MACOS_DAEMON_BIN}" \
+    cargo test -p cua-driver --test macos_capture_environment_test -- \
     --ignored --nocapture --test-threads=1
   run_test desktop-scope cargo test -p cua-driver --test desktop_scope_macos_test -- \
     --ignored --nocapture --test-threads=1

--- a/scripts/ci/macos/run-rust-e2e.sh
+++ b/scripts/ci/macos/run-rust-e2e.sh
@@ -398,6 +398,8 @@ fi
 if [[ "${SUITE}" == capture || "${SUITE}" == all ]]; then
   run_test capture-contract cargo test -p cua-driver --test capture_contract_test -- \
     --ignored --nocapture --test-threads=1
+  run_test capture-environment cargo test -p cua-driver --test macos_capture_environment_test -- \
+    --ignored --nocapture --test-threads=1
   run_test desktop-scope cargo test -p cua-driver --test desktop_scope_macos_test -- \
     --ignored --nocapture --test-threads=1
 fi


### PR DESCRIPTION
## Summary
- Fix desktop capture failing with ENOENT when the macOS daemon PATH omits `/usr/sbin`.
- One production-line change: invoke `/usr/sbin/screencapture`. Add public MCP coverage and wire it into the canonical macOS capture lane.

## Related work
Fixes #3754. #2281 concerns separate temporary-file cleanup.

RFC: not required; correct existing desktop capture without changing its public contract.

## Compatibility and risk
- macOS desktop capture only. Permissions, session scope, PNG geometry, temporary files, and error handling are unchanged. The window shell fallback is unchanged.
- No PATH mutation, retry, backend change, or new production abstraction. Rollback is the one-line lookup change.

## Validation
- Red `f45278bf6922a18f0b6b2948e993642abd660227`: normal PATH decoded a PNG; `/usr/bin:/bin` returned ENOENT. Green `66205b988e5d15efb08709ce225e30190b6a3ea1`: the unchanged test passed both environments.
- Complete canonical desktop matrix passed without retries at exact candidate `8a9efd250e586fae60ba17f51504117509106ec0` on 2026-09-14. No source changes followed certification.

| Platform | Delivered | Verified refusals | Failed / skipped | Evidence |
| --- | ---: | ---: | --- | --- |
| macOS / Lume | 154 | 9 | 0 / 0 | Installed wrapper run `20260914T111337Z-d95c3ff5` |
| Linux / X11 | 89 | 42 | 0 / 0 | [Full hosted matrix](https://github.com/trycua/cua/actions/runs/34837090421) |
| Windows / hosted interactive | 112 | 26 | 0 / 0 | [Full hosted matrix](https://github.com/trycua/cua/actions/runs/34837097684) |

- Both hosted installer lanes passed. The macOS PATH regression also passed inside the complete runner, decoding 1024x768 PNGs under both PATHs. All strict preflight, report, video, and standard-daemon restoration checks passed.
- macOS evidence is retained locally at `~/.local/share/cua-lume-e2e/runs/20260914T111337Z-d95c3ff5`; this is not a public download link. The wrapper used `cua-driver-browser-baseline-20260908-chrome152`, a retained-worker-derived local baseline, not a certified immutable private seed. The owned worker was stopped and retained; no other worker was modified.
- Standalone installed-browser and compositor-specific Wayland lanes were not run: this correction is macOS desktop-only. Ordinary PR CI and release metadata are green.

## Contributor and release checks
- [x] Focused scope and current description.
- [x] No RFC required.
- [x] Durable regression and exact-head native platform evidence included.
- [x] Conventional fix title for a patch release.
- [x] No external contribution included.
- [x] Releasing correction; no `no-release` label required.
