### PR TITLE
fix(cli): resolve compatible Sandbox dependency

### DIFF
--- a/.github/workflows/ci-py-cli.yml
+++ b/.github/workflows/ci-py-cli.yml
@@ -1,0 +1,94 @@
+name: "CI: cua-cli"
+
+on:
+  pull_request:
+    paths:
+      - "libs/python/cua-cli/**"
+      - ".github/workflows/ci-py-cli.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Cua
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+
+      - name: Install cua-cli and test dependencies
+        working-directory: libs/python/cua-cli
+        run: uv sync --frozen --extra dev
+
+      - name: Run cua-cli unit tests
+        working-directory: libs/python/cua-cli
+        run: uv run --frozen --extra dev pytest -q
+
+  wheel-dependency-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Cua
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+
+      - name: Build cua-cli wheel
+        run: |
+          python -m pip install build
+          python -m build --wheel --outdir "$RUNNER_TEMP/cua-cli-dist" libs/python/cua-cli
+
+      - name: Install wheel with released dependencies
+        run: |
+          python -m venv "$RUNNER_TEMP/cua-cli-wheel-smoke"
+          "$RUNNER_TEMP/cua-cli-wheel-smoke/bin/python" -m pip install --upgrade pip
+          "$RUNNER_TEMP/cua-cli-wheel-smoke/bin/python" -m pip install \
+            --index-url https://pypi.org/simple \
+            --extra-index-url https://wheels.cua.ai/simple \
+            packaging \
+            "$RUNNER_TEMP"/cua-cli-dist/*.whl
+          "$RUNNER_TEMP/cua-cli-wheel-smoke/bin/python" -m pip check
+
+      - name: Verify the resolved Sandbox API
+        env:
+          REPOSITORY_WORKSPACE: ${{ github.workspace }}
+        run: |
+          cd "$RUNNER_TEMP"
+          "$RUNNER_TEMP/cua-cli-wheel-smoke/bin/python" -I - <<'PY'
+          import inspect
+          import os
+          from importlib.metadata import distribution, version
+          from pathlib import Path
+
+          from cua_sandbox import Sandbox
+          from packaging.requirements import Requirement
+
+          requirement = next(
+              Requirement(value)
+              for value in distribution("cua-cli").requires or ()
+              if Requirement(value).name == "cua-sandbox"
+          )
+          resolved_version = version("cua-sandbox")
+          if not requirement.specifier.contains(resolved_version, prereleases=True):
+              raise SystemExit(
+                  f"cua-sandbox {resolved_version} does not satisfy {requirement.specifier}"
+              )
+
+          signature = inspect.signature(Sandbox.create)
+          if "pool" not in signature.parameters:
+              raise SystemExit(f"Sandbox.create lacks pool=: {signature}")
+
+          source = Path(inspect.getfile(Sandbox)).resolve()
+          workspace = Path(os.environ["REPOSITORY_WORKSPACE"]).resolve()
+          if source == workspace or workspace in source.parents:
+              raise SystemExit(f"Sandbox imported from monorepo source: {source}")
+
+          print(f"resolved cua-sandbox {resolved_version}: Sandbox.create{signature}")
+          print(f"loaded Sandbox from {source}")
+          PY

--- a/libs/python/cua-cli/pyproject.toml
+++ b/libs/python/cua-cli/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.12,<3.14"
 
 dependencies = [
     # Sandbox lifecycle commands
-    "cua-sandbox>=0.1.28,<0.2.0",
+    "cua-sandbox>=0.7.0,<0.8.0",
     # Core CUA packages
     "cua-computer>=0.5.0",
     "cua-core>=0.3.0,<0.4.0",

--- a/libs/python/cua-cli/uv.lock
+++ b/libs/python/cua-cli/uv.lock
@@ -571,19 +571,19 @@ wheels = [
 
 [[package]]
 name = "cua-fleet"
-version = "0.1.14"
+version = "0.1.17"
 source = { registry = "https://wheels.cua.ai/simple" }
 wheels = [
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d370f83773574da8edcca080e9d86aec8eb7ed758d6c551b900482a8575f6810" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e19784c0ce8aa2d9a77bf096fc6ff10e990842f05c67bdfb96a16ecd5e7123e2" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.14-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:d6ea25902cf9ffc89779530b6ae7cff5413383ea7dc3c632a4fb47e00699a6d4" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.14-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:2dc70e98b3e8c691bf0fff0494b0a85d2405e872f1ca99dbfa2680473cea565b" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.14-py3-none-win_amd64.whl", hash = "sha256:3e73327b7c99dc95a4b4194628d3575a8707cab77d6929ed1bf34a82192a4464" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a8908b5c7f0f3c75d09b908b58867d43270f69d3726bb0d90316443f2265d0e3" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6aea577f21343326aeb06df03c07df65df8dd2f3b0097e02f25a7bc6b9d2c458" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.17-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:bda49298c77c65eb349e8420f9237f6b7fb2fd25203747df98a9513b98fd5d73" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.17-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:4cdbc89e850d841481713abf1e8bf9719b2e33b3c31f26bbea5f63e1ead3c6c0" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.17-py3-none-win_amd64.whl", hash = "sha256:ee4c139b1c0cebe1702114a34fd0fd60d216c5862d9fdc3472bb8b9879ac9eae" },
 ]
 
 [[package]]
 name = "cua-sandbox"
-version = "0.4.3"
+version = "0.7.0"
 source = { editable = "../cua-sandbox" }
 dependencies = [
     { name = "cua-auto" },
@@ -591,10 +591,12 @@ dependencies = [
     { name = "cua-fleet" },
     { name = "grpcio" },
     { name = "httpx" },
+    { name = "jsonschema" },
     { name = "oras" },
     { name = "paramiko" },
     { name = "protobuf" },
     { name = "pycdlib" },
+    { name = "pydantic" },
     { name = "vncdotool" },
     { name = "websockets" },
 ]
@@ -603,13 +605,16 @@ dependencies = [
 requires-dist = [
     { name = "cua-auto", specifier = ">=0.1.2" },
     { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
-    { name = "cua-fleet", specifier = "==0.1.14" },
+    { name = "cua-driver", marker = "extra == 'driver'", specifier = "==0.27.0" },
+    { name = "cua-fleet", specifier = "==0.1.17" },
     { name = "grpcio", specifier = "==1.78.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "jsonschema", specifier = ">=4.23,<5.0" },
     { name = "oras", specifier = ">=0.2.40" },
     { name = "paramiko", specifier = ">=5.0.0" },
     { name = "protobuf", specifier = "==6.33.6" },
     { name = "pycdlib", specifier = ">=1.14.0" },
+    { name = "pydantic", specifier = ">=2.11,<3.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
@@ -617,13 +622,15 @@ requires-dist = [
     { name = "webbrowser-open", marker = "extra == 'auth'", specifier = ">=0.0.1" },
     { name = "websockets", specifier = ">=12.0" },
 ]
-provides-extras = ["auth", "dev"]
+provides-extras = ["driver", "auth", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "cua-agent", editable = "../agent" },
+    { name = "datamodel-code-generator", specifier = "==0.74.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pyyaml", specifier = ">=6.0,<7.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- require the released Sandbox SDK generation that implements Fleet pool claims
- refresh the CLI lock to compatible Sandbox and Fleet packages
- add isolated built-wheel CI that verifies the resolved Sandbox API outside the monorepo

## Validation

- `uv run --frozen --extra dev pytest -q` — 191 passed
- clean Python 3.12 built-wheel install — `pip check` passed and `Sandbox.create(pool=...)` verified from installed wheels
- `git diff --check origin/main...HEAD`

## Release impact

This is a CLI compatibility fix and should produce a CLI patch release after merge. Publishing that release is not part of this PR execution and remains separately gated.
