### PR TITLE
chore(releases): verify Peter Steinberger attribution

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -34,6 +34,7 @@
     "rwendt1337@gmail.com": "r33drichards",
     "rsyuzyov@gmail.com": "rsyuzyov",
     "sarinajin.li@gmail.com": "sarinali",
+    "steipete@gmail.com": "steipete",
     "umtcgnd@gmail.com": "c8dhjp4tyv-bit",
     "zane.chee.2023@scis.smu.edu.sg": "injaneity",
     "zongxin_yang@hms.harvard.edu": "z-x-yang"


### PR DESCRIPTION
## Summary

- map Peter Steinberger's preserved commit email to his GitHub handle
- unblock contributor-safe release attribution for Cua Driver 0.28.1 (#3738)

Identity is verified by #3709; its source commit is authored by `steipete` with the exact email recorded in this override.

## Validation

- `python3 -m json.tool .github/release-attribution-config.json`
- `uv run --frozen --group test python -m pytest .github/scripts/tests/test_release_attribution.py .github/scripts/tests/test_pr_attribution.py` (36 passed)
- `git diff --check`