### PR TITLE
test(cua-driver): preserve foreground pixel route evidence

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/action_record.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/action_record.rs
@@ -1734,6 +1734,34 @@ mod tests {
     }
 
     #[test]
+    fn foreground_cgevent_path_is_preserved_when_effect_is_unverifiable() {
+        let record = ActionExecutionRecord::from_legacy(
+            "click",
+            &serde_json::json!({"delivery_mode": "foreground"}),
+            &serde_json::json!({
+                "path": "cgevent_fg",
+                "verified": false,
+                "effect": "unverifiable",
+            }),
+        )
+        .expect("foreground CGEvent result should normalize");
+
+        assert_eq!(record.transport, ActionTransport::MacosCgEventHid);
+        assert_eq!(record.actual_delivery, Some(ActualDelivery::Foreground));
+
+        let public = record.public_result().expect("public ActionResult");
+        assert_eq!(
+            public.effect,
+            cua_driver_contract::ActionEffect::Unverifiable
+        );
+        assert_eq!(public.route, cua_driver_contract::ActionRoute::GlobalInput);
+        assert_eq!(
+            public.delivery.map(|delivery| delivery.mode),
+            Some(cua_driver_contract::ActionDeliveryMode::Foreground)
+        );
+    }
+
+    #[test]
     fn producer_emitted_delivery_wins_over_requested_delivery() {
         let record = ActionExecutionRecord::from_legacy(
             "scroll",


### PR DESCRIPTION
## Summary

- Problem this solves: Foreground macOS pixel clicks can have an unverifiable effect while still producing meaningful transport and delivery metadata.
- What changed: Add a regression contract that preserves the `cgevent_fg` path as foreground global input during action normalization.

## Related work

Refs #3697

RFC: not required; this is focused regression coverage for an existing action-result contract.

## Reviewers

@injaneity, @f-trycua

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: No runtime behavior or public API changes; the test covers the existing foreground action-result projection.
- Risk and rollback: Low; the change is test-only and can be reverted independently.

## Validation

- Focused tests and checks: `cargo test -p cua-driver-core --lib` (629 passed); `cargo fmt --all -- --check`; `git diff --check`.
- Manual or platform evidence: No local macOS or Firefox runtime was available; the contract test runs on Linux.
- Known gaps or CI still required: The canonical macOS Firefox foreground pixel-click harness must run upstream to validate native event delivery and page state.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [ ] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.

The final diff changes only `libs/cua-driver/rust/crates/cua-driver-core/src/action_record.rs`; no documentation or production code changes are included. The non-releasing `no-release` label remains to be applied if required by release metadata checks.