### PR TITLE
test(cua-driver): cover MCP startup control disconnect

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
@@ -1287,6 +1287,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn startup_control_disconnect_does_not_leave_initialize_waiting() {
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            supervise_control_connection(async {}, async {
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                Ok::<_, anyhow::Error>(())
+            }),
+        )
+        .await
+        .expect("control disconnect must end startup promptly")
+        .unwrap_err();
+
+        assert!(result.to_string().contains("reconnect the MCP client"));
+    }
+
+    #[tokio::test]
     async fn proxy_loop_returns_promptly_on_clean_eof() {
         let reader = BufReader::new(&b""[..]);
         let mut writer = Vec::new();


### PR DESCRIPTION
## Summary

- Problem this solves: Keep MCP initialization from waiting when the daemon control session closes.
- What changed: Add focused regression coverage for startup failure on control disconnect.

## Related work

Refs #3523

RFC (required for a public SDK, CLI, MCP, protocol, compatibility, permission, or cross-component contract change): Not required; this is test-only coverage for behavior already present on the base branch.

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: No production behavior or public contract changed.
- Risk and rollback: Test-only change; revert the test if needed.

## Validation

- Focused tests and checks: `cargo fmt --check` and `git diff --check` passed. The focused crate test was blocked because the host lacks `x11.pc`.
- Manual or platform evidence: The test exercises the existing proxy supervision path; native macOS TCC validation was unavailable on Linux.
- Known gaps or CI still required: Dependency-complete Rust test execution and macOS TCC/platform CI remain required.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [ ] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [ ] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.